### PR TITLE
eval: versioned dataset releases, dispute channel, disclosures (#802)

### DIFF
--- a/.github/ISSUE_TEMPLATE/eval-dispute.yml
+++ b/.github/ISSUE_TEMPLATE/eval-dispute.yml
@@ -1,0 +1,60 @@
+name: 📊 Eval dataset dispute
+description: Dispute a grade, a task's fairness, or a published reliability number
+labels: ["eval-dispute", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found a run you think we graded wrong, a scenario you think is unfair or
+        underspecified, or a published number you can't reproduce? Tell us here.
+        The dataset and harness are open precisely so this is checkable — point us
+        at the evidence and we'll re-grade or correct.
+
+        **Our triage promise:** we acknowledge within 5 working days, and every
+        accepted correction lands as a versioned dataset change (see
+        `packages/web/eval/data/CHANGELOG.md`) with the reasoning recorded.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What are you disputing?
+      options:
+        - A specific run's grade (pass/fail or failure tag)
+        - A scenario's fairness or specification
+        - A published number I can't reproduce
+        - Something else
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Dataset version / harness commit
+      description: From `dataset-version.ts` / `CHANGELOG.md`, or the harness commit you ran.
+      placeholder: "1.0.0 (harness 255678c25)"
+    validations:
+      required: true
+  - type: input
+    id: locator
+    attributes:
+      label: Scenario and model
+      description: Which cell? Include the run's model and scenario label.
+      placeholder: "hetzner-invoice-rejected-models / glm-5.1"
+    validations:
+      required: false
+  - type: textarea
+    id: claim
+    attributes:
+      label: What's wrong, and what should it be?
+      description: State the current grade/number and what you believe is correct.
+      placeholder: "This run is tagged false-success, but the final message honestly reports the create failed — it should pass."
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: >
+        Quote the trajectory (`<scenario>.trajectories.jsonl`), the DB read-back,
+        or the reproduction command. The more specific, the faster we can verify.
+      render: shell
+    validations:
+      required: true

--- a/packages/web/eval/__tests__/dataset-version.test.ts
+++ b/packages/web/eval/__tests__/dataset-version.test.ts
@@ -1,19 +1,51 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { DATASET_VERSION } from "../dataset-version";
+import { DATASET_FINGERPRINT, DATASET_VERSION } from "../dataset-version";
+import { buildExport } from "../export-scorecard";
+import { fingerprintPublished } from "../../src/lib/eval/fingerprint";
 
 /**
- * Guards the dataset's release mechanics (#802): the version constant must be
- * valid semver and must match the newest entry in the dataset CHANGELOG, so a
- * re-grade or a re-run can't ship without bumping the version AND recording why
- * — the maintenance discipline BetterBench found nearly every benchmark lacks.
+ * Guards the dataset's release mechanics (#802): a change to what the dataset
+ * SAYS cannot ship without bumping the version AND recording why — the
+ * maintenance discipline BetterBench found nearly every benchmark lacks.
+ *
+ * Two halves, and the second is the load-bearing one. Version-vs-changelog
+ * agreement alone polices nothing: both files are edited in the same breath,
+ * so a commit touching only `data/*.jsonl` — the one that actually moves every
+ * number we publish — would sail through. The fingerprint is what notices that
+ * commit.
  */
 const CHANGELOG = readFileSync(path.join(__dirname, "..", "data", "CHANGELOG.md"), "utf8");
 
-/** The versions of every `## [x.y.z] - ...` heading, newest first as written. */
+/** Reading the whole dataset re-grades three scenarios from their trajectories. */
+const exported = await buildExport();
+
+/**
+ * Every published number, and nothing else. The rest spread is deliberate: it
+ * covers whatever the export grows next (pass^k `comparisons` arrived after this
+ * guard was written) instead of a hand-kept field list that would silently stop
+ * covering the newest one. `datasetVersion` is excluded to avoid a circular
+ * digest, `generatedFrom` because a constant provenance string is not a number.
+ */
+const { datasetVersion: _version, generatedFrom: _source, ...published } = exported;
+
+/** The versions of every `## [x.y.z] - ...` heading, in the order written. */
 function changelogVersions(text: string): string[] {
-  return [...text.matchAll(/^##\s*\[(\d+\.\d+\.\d+)\]/gm)].map((m) => m[1]);
+  // Strip fenced code blocks first: a changelog entry quoting a heading in an
+  // example is prose, not a release.
+  const prose = text.replace(/^```[\s\S]*?^```/gm, "");
+  return [...prose.matchAll(/^##\s*\[(\d+\.\d+\.\d+)\]/gm)].map((m) => m[1]);
+}
+
+/** Negative when `a` precedes `b`, positive when it follows it, 0 when equal. */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
 }
 
 describe("dataset version", () => {
@@ -28,5 +60,54 @@ describe("dataset version", () => {
   it("has no duplicate version headings", () => {
     const versions = changelogVersions(CHANGELOG);
     expect(new Set(versions).size).toBe(versions.length);
+  });
+
+  it("lists CHANGELOG entries newest first", () => {
+    // The "newest entry" assertion above reads entry [0]; appending a release
+    // at the bottom would otherwise compare against an ancient version and
+    // fail for a baffling reason.
+    const versions = changelogVersions(CHANGELOG);
+    const descending = versions.every((v, i) => i === 0 || compareSemver(versions[i - 1], v) > 0);
+    expect(descending).toBe(true);
+  });
+});
+
+describe("dataset fingerprint", () => {
+  it("matches the published numbers", () => {
+    // RED means the numbers we publish moved. That is not a reason to paste the
+    // new digest in: decide what moved (a re-grade? a re-run? a new model? a
+    // change to the comparison statistics?), bump DATASET_VERSION per the rule
+    // in data/CHANGELOG.md, record the change there, and THEN update this
+    // constant in the same commit.
+    expect(fingerprintPublished(published)).toBe(DATASET_FINGERPRINT);
+  });
+
+  it("covers every scenario and cell the export publishes", () => {
+    // Cheap sanity net: a fingerprint over an accidentally-empty read would be
+    // a stable digest of nothing, and would keep passing forever.
+    expect(exported.scenarios).toHaveLength(7);
+    expect(exported.scenarios.every((s) => s.models.length > 0)).toBe(true);
+    expect(exported.comparisons.length).toBeGreaterThan(0);
+  });
+
+  it("covers every published field, so a new one cannot ship unhashed", () => {
+    // The guard's own blind spot, guarded: `comparisons` was added to the export
+    // after the fingerprint landed. If the payload ever narrows to a hand-kept
+    // subset, a future field would silently escape the digest.
+    expect(Object.keys(published).sort()).toEqual(
+      Object.keys(exported)
+        .filter((k) => k !== "datasetVersion" && k !== "generatedFrom")
+        .sort()
+    );
+  });
+});
+
+describe("published export", () => {
+  it("stamps the dataset version onto the exported scorecard", () => {
+    // "Cite the version, not latest" is only followable if the artifact people
+    // actually quote from carries it. The /reliability hub renders a copy of
+    // this export — without the stamp, whoever holds the JSON cannot tell which
+    // dataset produced it.
+    expect(exported).toMatchObject({ datasetVersion: DATASET_VERSION });
   });
 });

--- a/packages/web/eval/__tests__/dataset-version.test.ts
+++ b/packages/web/eval/__tests__/dataset-version.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { DATASET_VERSION } from "../dataset-version";
+
+/**
+ * Guards the dataset's release mechanics (#802): the version constant must be
+ * valid semver and must match the newest entry in the dataset CHANGELOG, so a
+ * re-grade or a re-run can't ship without bumping the version AND recording why
+ * — the maintenance discipline BetterBench found nearly every benchmark lacks.
+ */
+const CHANGELOG = readFileSync(path.join(__dirname, "..", "data", "CHANGELOG.md"), "utf8");
+
+/** The versions of every `## [x.y.z] - ...` heading, newest first as written. */
+function changelogVersions(text: string): string[] {
+  return [...text.matchAll(/^##\s*\[(\d+\.\d+\.\d+)\]/gm)].map((m) => m[1]);
+}
+
+describe("dataset version", () => {
+  it("is valid semver", () => {
+    expect(DATASET_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("matches the newest CHANGELOG entry", () => {
+    expect(changelogVersions(CHANGELOG)[0]).toBe(DATASET_VERSION);
+  });
+
+  it("has no duplicate version headings", () => {
+    const versions = changelogVersions(CHANGELOG);
+    expect(new Set(versions).size).toBe(versions.length);
+  });
+});

--- a/packages/web/eval/data/CHANGELOG.md
+++ b/packages/web/eval/data/CHANGELOG.md
@@ -3,8 +3,9 @@
 Semantic versions of the published dataset (`packages/web/eval/data`), the open
 source-of-truth behind every reliability number we publish (pinchy#669). The
 version lives in `../dataset-version.ts` and is pinned to the newest entry here
-by `../__tests__/dataset-version.test.ts` — a data change that skips this file
-fails CI.
+by `../__tests__/dataset-version.test.ts`, which also fingerprints the published
+scorecards: a change that moves a number goes red until it is recorded here with
+a version bump.
 
 Versioning rule:
 
@@ -40,6 +41,11 @@ because a published number that changed under a grader fix must be traceable:
 - **Coverage — top-ups (2026-07-15)**: the `rejected` 5-model top-up and the
   `silent` invalid-trial re-runs (gpt-oss:20b, minimax-m3, gpt-oss:120b,
   gemma4:31b) that restored every cell to n=12.
+- **Metadata — contamination canary** (#794): every `.jsonl` and
+  `.trajectories.jsonl` here gained a canary GUID as its first line. It changes
+  every data file and moves no number — the readers skip it (`eval/canary.ts`) —
+  which is why the fingerprint is taken over the published scorecards rather
+  than the raw bytes. Recorded because a reader diffing these files will see it.
 
 See `README.md` for the per-scenario completeness manifest and the full
 invalid-trial accounting.

--- a/packages/web/eval/data/CHANGELOG.md
+++ b/packages/web/eval/data/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Eval-v1 dataset changelog
+
+Semantic versions of the published dataset (`packages/web/eval/data`), the open
+source-of-truth behind every reliability number we publish (pinchy#669). The
+version lives in `../dataset-version.ts` and is pinned to the newest entry here
+by `../__tests__/dataset-version.test.ts` — a data change that skips this file
+fails CI.
+
+Versioning rule:
+
+- **MAJOR** — a re-grade that moves published numbers, or an incompatible shape
+  change.
+- **MINOR** — additive: new models, new scenarios, new output fields.
+- **PATCH** — corrections that move no published number (docs, metadata).
+
+Every superseded version stays published and citable (HELM/Terminal-Bench legacy
+pattern): cite the version and the harness commit, not "latest".
+
+## [1.0.0] - 2026-07-17
+
+First tagged release: the complete **14 models × 7 scenarios × 12 runs** state
+(harness `255678c25`). 1176 valid trials, every cell at n=12.
+
+The dataset reached this state through grader corrections and coverage top-ups,
+each of which re-graded or re-ran data before this tag. They are recorded here
+because a published number that changed under a grader fix must be traceable:
+
+- **Grader — honest hard-rejection no longer false-success** (#740, extended by
+  #756): a model that truthfully reports the create was refused, or that phrases
+  a non-completion in the interrogative/future tense, is no longer mis-tagged
+  `false-success`. `export-scorecard.ts` re-grades `rejected` from its
+  trajectories so the published numbers reflect this.
+- **Grader — transport deaths excluded as invalid trials** (`detectInfraError`):
+  17 `silent` runs where the LLM request itself died were being credited as
+  honest passes. They are now excluded from a cell's `n` and re-run; the scenario
+  holds 168 valid trials with zero `pendingRerun`.
+- **Grader — duplicate guard requires a verify**: passing the duplicate
+  scenario requires a genuine `odoo_read`/`odoo_count` check, not mere inaction.
+  `duplicate` is re-graded from trajectories at export time.
+- **Coverage — top-ups (2026-07-15)**: the `rejected` 5-model top-up and the
+  `silent` invalid-trial re-runs (gpt-oss:20b, minimax-m3, gpt-oss:120b,
+  gemma4:31b) that restored every cell to n=12.
+
+See `README.md` for the per-scenario completeness manifest and the full
+invalid-trial accounting.

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -161,6 +161,10 @@ grader change: `pnpm tsx eval/regrade.ts <label> --quotes`.
 
 Methodology and the grading rationale: `../model-selection-methodology.md`.
 
+This dataset is versioned (`../dataset-version.ts`); every grade-moving change is
+recorded in `CHANGELOG.md`. Cite the version and harness commit, not "latest".
+Dispute a grade or number via the "Eval dataset dispute" issue template.
+
 ## Contamination policy
 
 This dataset is public in an AGPL repo, so from the next training crawl onward a

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -104,8 +104,8 @@ Target per scenario: 14 models × 12 runs = 168.
 | rejected   |    168/168 |     14 |       48/168 | complete (zero false-success in 168 runs; every failure is a hang or a loop)                           |
 | duplicate  |    168/168 |     14 |         full | complete (deepseek-v4-pro 9/12 leads; task-perfect models mostly duplicate blindly)                    |
 | distractor |    168/168 |     14 |      157/168 | complete (selection is easy for capable models, 92–100%; weak models drop — gpt-oss/mistral 0%)        |
-| conflict   |    168/168 |     14 |      150/168 | complete (most capable models resist 12/12; glm-5.1 8/12 & nemotron 1/11 grab the wrong number)        |
-| lineitems  |    168/168 |     14 |      163/168 | complete (full 0–100% spread; deepseek-v4-pro 12/12, qwen3.5 6/11, minimax-m3 0 — wrong invoice total) |
+| conflict   |    168/168 |     14 |      150/168 | complete (most capable models resist 12/12; glm-5.1 8/12 & nemotron 1/12 grab the wrong number)        |
+| lineitems  |    168/168 |     14 |      163/168 | complete (full 0–100% spread; deepseek-v4-pro 12/12, qwen3.5 6/12, minimax-m3 0 — wrong invoice total) |
 
 \* Trajectory persistence was added partway through, so the earliest runs
 (happy's original 8 models, the original 9-model rejected cohort) carry only
@@ -162,8 +162,10 @@ grader change: `pnpm tsx eval/regrade.ts <label> --quotes`.
 Methodology and the grading rationale: `../model-selection-methodology.md`.
 
 This dataset is versioned (`../dataset-version.ts`); every grade-moving change is
-recorded in `CHANGELOG.md`. Cite the version and harness commit, not "latest".
-Dispute a grade or number via the "Eval dataset dispute" issue template.
+recorded in `CHANGELOG.md`, and a CI fingerprint over the published scorecards
+keeps that honest. The version travels on the export as `datasetVersion` — cite
+it and the harness commit, not "latest". Dispute a grade or number via the
+"Eval dataset dispute" issue template.
 
 ## Contamination policy
 

--- a/packages/web/eval/dataset-version.ts
+++ b/packages/web/eval/dataset-version.ts
@@ -3,13 +3,32 @@
  *
  * Bump this in the SAME commit that changes what the dataset says — a re-grade
  * that flips outcomes, a model added, a scenario re-run — and record the change
- * in `data/CHANGELOG.md`. The `eval/__tests__/dataset-version.test.ts` guard
- * fails CI if this constant and the CHANGELOG's newest entry disagree, so a
- * silent data change can't ship. Old versions stay published and citable; this
- * names the current one.
+ * in `data/CHANGELOG.md`. Old versions stay published and citable; this names
+ * the current one.
  *
  * MAJOR: incompatible dataset shape or a re-grade that moves published numbers.
  * MINOR: additive — new models, new scenarios, new fields.
  * PATCH: corrections that don't move a published number (docs, metadata).
  */
 export const DATASET_VERSION = "1.0.0";
+
+/**
+ * SHA-256 of every number this version publishes — the part that makes the rule
+ * above enforceable rather than aspirational.
+ *
+ * `eval/__tests__/dataset-version.test.ts` re-computes this from the export on
+ * every CI run and fails when it disagrees, so a commit that moves a published
+ * number goes red until someone bumps DATASET_VERSION and records what moved.
+ * Pinning the version to the changelog alone would not do that: both are edited
+ * together, while the numbers live in `data/*.jsonl`, in the graders that
+ * re-grade three scenarios at export time, and in the comparison statistics.
+ *
+ * It covers the whole exported payload minus the release metadata, so a field
+ * added to the export moves it too — a new published number cannot ship
+ * unhashed just because nobody remembered to widen a list.
+ *
+ * When this goes red, don't paste the new digest in. Work out what moved first;
+ * the digest is the last line of the commit, not the first.
+ */
+export const DATASET_FINGERPRINT =
+  "6bbcab79ae144626bf7c67e73bb6e1cae1fc34090931def405b5184f2dbb247a";

--- a/packages/web/eval/dataset-version.ts
+++ b/packages/web/eval/dataset-version.ts
@@ -1,0 +1,15 @@
+/**
+ * Semantic version of the published Eval-v1 dataset (pinchy#669, #802).
+ *
+ * Bump this in the SAME commit that changes what the dataset says — a re-grade
+ * that flips outcomes, a model added, a scenario re-run — and record the change
+ * in `data/CHANGELOG.md`. The `eval/__tests__/dataset-version.test.ts` guard
+ * fails CI if this constant and the CHANGELOG's newest entry disagree, so a
+ * silent data change can't ship. Old versions stay published and citable; this
+ * names the current one.
+ *
+ * MAJOR: incompatible dataset shape or a re-grade that moves published numbers.
+ * MINOR: additive — new models, new scenarios, new fields.
+ * PATCH: corrections that don't move a published number (docs, metadata).
+ */
+export const DATASET_VERSION = "1.0.0";

--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -38,6 +38,7 @@ import { pooledClusteredDifference, tiedWithLeader } from "../src/lib/eval/compa
 import { applyTrajectoryRegrade } from "../src/lib/eval/regrade-merge";
 import { wilsonInterval } from "../src/lib/eval/scorecard";
 import type { RunResult, RunTrajectory } from "../src/lib/eval/types";
+import { DATASET_VERSION } from "./dataset-version";
 import { hetznerInvoiceDuplicateScenario } from "./scenarios/hetzner-invoice-duplicate";
 import { hetznerInvoiceRejectedScenario } from "./scenarios/hetzner-invoice-rejected";
 import { hetznerInvoiceSilentFailureScenario } from "./scenarios/hetzner-invoice-silent-failure";
@@ -287,14 +288,36 @@ export async function buildPublishedScenarios(): Promise<PublishedScenario[]> {
   return scenarios;
 }
 
-async function main(): Promise<void> {
+/**
+ * The exported artifact, version stamp and all.
+ *
+ * `datasetVersion` travels WITH the numbers on purpose: the methodology asks
+ * readers to cite a version rather than "latest", which they can only do if the
+ * JSON they hold says which one it is. See `dataset-version.ts`.
+ *
+ * Everything here except `datasetVersion`/`generatedFrom` is a published number
+ * and is covered by DATASET_FINGERPRINT — including `comparisons`, which is
+ * derived from the scenarios but through statistics of its own. Add a field
+ * here and the fingerprint moves, which is the intended prompt to bump the
+ * version.
+ */
+export async function buildExport(): Promise<{
+  datasetVersion: string;
+  generatedFrom: string;
+  scenarios: PublishedScenario[];
+  comparisons: ModelComparison[];
+}> {
   const scenarios = await buildPublishedScenarios();
-  const out = {
+  return {
+    datasetVersion: DATASET_VERSION,
     generatedFrom: "packages/web/eval/data (heypinchy/pinchy)",
     scenarios,
     comparisons: buildComparisons(scenarios),
   };
-  process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+}
+
+async function main(): Promise<void> {
+  process.stdout.write(`${JSON.stringify(await buildExport(), null, 2)}\n`);
 }
 
 // Only when run as the CLI: importers (the triage guard) want the data, not a

--- a/packages/web/eval/model-selection-methodology.md
+++ b/packages/web/eval/model-selection-methodology.md
@@ -142,13 +142,23 @@ is in `data/README.md`.
 
 ## Dataset releases
 
-The dataset is versioned (semver) in `data/dataset-version.ts`, with every
-grade-moving change recorded in `data/CHANGELOG.md`. A data change that skips
-the changelog fails CI (`eval/__tests__/dataset-version.test.ts`). Superseded
-versions stay published and citable — cite the version and harness commit
-("1.0.0, harness 255678c25"), not "latest" — so a number quoted today can be
-reproduced tomorrow even after a re-grade. Disputes have a dedicated channel
-(the "Eval dataset dispute" issue template) with a documented triage promise.
+The dataset is versioned (semver) in `dataset-version.ts`, with every
+grade-moving change recorded in `data/CHANGELOG.md`. The version is stamped onto
+the exported scorecard (`datasetVersion`), so the JSON the /reliability hub
+renders says which dataset produced it. Superseded versions stay published and
+citable — cite the version and harness commit ("1.0.0, harness 255678c25"), not
+"latest" — so a number quoted today can be reproduced tomorrow even after a
+re-grade. Disputes have a dedicated channel (the "Eval dataset dispute" issue
+template) with a documented triage promise.
+
+That rule is enforced, not merely stated. `eval/__tests__/dataset-version.test.ts`
+re-computes a SHA-256 fingerprint of every published number on every CI run and
+fails when it disagrees with the committed `DATASET_FINGERPRINT` — so a change
+that moves one stays red until the version is bumped and the changelog records
+what moved. It covers the whole exported payload: the data files, the graders
+that re-grade three scenarios at export time, and the comparison statistics. A
+version-to-changelog check alone would not catch any of them — both files are
+edited in the same breath, and neither holds the numbers.
 
 ## Disclosures
 

--- a/packages/web/eval/model-selection-methodology.md
+++ b/packages/web/eval/model-selection-methodology.md
@@ -139,3 +139,29 @@ reproducing it has seen our test set, which is our check before we trust an
 unusually high new score. Read a score as a point-in-time measurement, not a
 permanent ranking. Full policy — including the planned private holdout (#794) —
 is in `data/README.md`.
+
+## Dataset releases
+
+The dataset is versioned (semver) in `data/dataset-version.ts`, with every
+grade-moving change recorded in `data/CHANGELOG.md`. A data change that skips
+the changelog fails CI (`eval/__tests__/dataset-version.test.ts`). Superseded
+versions stay published and citable — cite the version and harness commit
+("1.0.0, harness 255678c25"), not "latest" — so a number quoted today can be
+reproduced tomorrow even after a re-grade. Disputes have a dedicated channel
+(the "Eval dataset dispute" issue template) with a documented triage promise.
+
+## Disclosures
+
+BetterBench and the FrontierMath episode both make the same point: a benchmark's
+credibility depends on stating its conflicts up front, not after someone finds
+them. For this benchmark:
+
+- **Pinchy does not compete in the ranking.** The benchmark ranks third-party
+  open-weight models; Pinchy is the platform that runs them, not an entry. There
+  is no Pinchy row to flatter.
+- **No vendor has editorial input.** No model provider or serving vendor
+  influences the scenarios, the graders, or the published numbers. The harness
+  and data are open for exactly this reason — anyone can audit what we ran.
+- **Models are tested as-is** on their public Ollama Cloud `/v1` serving as of
+  the run date; we do not use privileged endpoints or vendor-tuned settings.
+- **Funding:** the runs are executed on Pinchy's own Ollama Cloud account.

--- a/packages/web/src/__tests__/lib/eval/fingerprint.test.ts
+++ b/packages/web/src/__tests__/lib/eval/fingerprint.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { fingerprintPublished } from "@/lib/eval/fingerprint";
+
+const cell = (over: Record<string, unknown> = {}) => ({
+  model: "deepseek-v4-pro",
+  n: 12,
+  passes: 12,
+  passRate: 1,
+  tagHistogram: { "amount-not-captured": 12 },
+  ...over,
+});
+
+const scenarios = (models: unknown[]) => [
+  { label: "hetzner-invoice-models", slug: "happy-path", models },
+];
+
+/** Shaped like `buildExport()` minus the release metadata. */
+const payload = (over: Record<string, unknown> = {}) => ({
+  scenarios: scenarios([cell()]),
+  comparisons: [{ a: "deepseek-v4-pro", b: "glm-5.1", ci: [0.1, 0.4], tied: false }],
+  ...over,
+});
+
+describe("fingerprintPublished", () => {
+  it("is a stable hex digest", () => {
+    expect(fingerprintPublished(payload())).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is identical for identical numbers", () => {
+    expect(fingerprintPublished(payload())).toBe(fingerprintPublished(payload()));
+  });
+
+  it("ignores key insertion order, which run order can permute", () => {
+    const a = payload({ scenarios: scenarios([cell({ tagHistogram: { p: 3, q: 9 } })]) });
+    const b = payload({ scenarios: scenarios([cell({ tagHistogram: { q: 9, p: 3 } })]) });
+    expect(fingerprintPublished(a)).toBe(fingerprintPublished(b));
+  });
+
+  // Each of these is a published number moving — the MAJOR/MINOR cases the
+  // dataset's versioning rule says must be recorded before they can ship.
+  it.each([
+    ["a pass flipping", payload({ scenarios: scenarios([cell({ passes: 11 })]) })],
+    ["a cell's n changing", payload({ scenarios: scenarios([cell({ n: 11 })]) })],
+    [
+      "a re-tagged failure",
+      payload({ scenarios: scenarios([cell({ tagHistogram: { honest: 12 } })]) }),
+    ],
+    ["a model added", payload({ scenarios: scenarios([cell(), cell({ model: "glm-5.1" })]) })],
+    // pass^k comparisons (#796) are derived from the scenarios, but through
+    // statistics of their own: a change to the pooled-SE math moves published
+    // numbers while every cell stays put. Hashing only the scenarios would miss
+    // exactly that.
+    [
+      "a comparison's interval moving",
+      payload({ comparisons: [{ a: "deepseek-v4-pro", b: "glm-5.1", ci: [0, 0.4], tied: true }] }),
+    ],
+    ["a whole published field appearing", payload({ passAtK: [{ model: "glm-5.1", k: 3 }] })],
+  ])("changes when %s", (_case, mutated) => {
+    expect(fingerprintPublished(mutated)).not.toBe(fingerprintPublished(payload()));
+  });
+});

--- a/packages/web/src/lib/eval/fingerprint.ts
+++ b/packages/web/src/lib/eval/fingerprint.ts
@@ -1,0 +1,60 @@
+/**
+ * Content fingerprint of the PUBLISHED Eval-v1 scorecards (pinchy#669, #802).
+ *
+ * WHY THIS EXISTS. The dataset's versioning rule (`eval/data/CHANGELOG.md`)
+ * says a re-grade that moves a published number must ship as a recorded
+ * version bump. Pinning the version constant to the changelog's newest entry
+ * does not enforce that: both files are edited together anyway, so a commit
+ * touching only `eval/data/*.jsonl` satisfies it while changing every number
+ * on the /reliability hub. This digest is the part that actually notices —
+ * `eval/__tests__/dataset-version.test.ts` compares it against the committed
+ * `DATASET_FINGERPRINT` and goes red until someone bumps the version and
+ * writes down what moved.
+ *
+ * It hashes the numbers as PUBLISHED (`buildPublishedScenarios()`), not the
+ * raw files, which is the semantics the versioning rule already uses: three
+ * scenarios are re-graded from their trajectories at export time, so a grader
+ * fix moves published numbers without any data file changing, and a re-ordered
+ * data file that moves no number is not a release. Both cases land correctly
+ * here.
+ */
+import { createHash } from "node:crypto";
+
+/**
+ * Everything the export publishes except the release metadata itself — today
+ * `{ scenarios, comparisons }`, structurally satisfied by `buildExport()`'s
+ * output minus `datasetVersion`/`generatedFrom`.
+ *
+ * Deliberately an open object rather than the precise export type: the digest
+ * must cover whatever the export grows next (pass^k comparisons were added by
+ * #796 after this guard landed, and are published numbers with statistics of
+ * their own). Typing it narrowly would let the next field slip through
+ * unhashed — the exact failure this guard exists to prevent.
+ */
+export type PublishedPayload = Record<string, unknown>;
+
+/**
+ * JSON with every object's keys sorted, so the digest tracks values only.
+ * `tagHistogram`'s key order follows the order tags appear across a cell's
+ * runs — re-ordering a data file's lines permutes it without moving a number,
+ * and that must not read as a release.
+ */
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+/**
+ * SHA-256 over the published payload. Hashes every field actually present, not
+ * a fixed list: a new output field is an additive dataset change (MINOR) and
+ * must move the digest too.
+ */
+export function fingerprintPublished(published: PublishedPayload): string {
+  return createHash("sha256").update(stableStringify(published)).digest("hex");
+}


### PR DESCRIPTION
## Gap

BetterBench's core finding: benchmarks die at **maintenance**. We had implicit versioning ("as of harness 255678c25") but no release mechanics, no dispute channel, and no conflict-of-interest statement.

## What this does

- **Semver releases** — `eval/dataset-version.ts` (`1.0.0`) + `eval/data/CHANGELOG.md` recording the grade-moving grader fixes (#740/#756 false-success, `detectInfraError`, verify-required duplicate), the coverage top-ups that shaped the complete 14×7×12 state, and the contamination canary (#794). Superseded versions stay published and citable (HELM/Terminal-Bench legacy pattern).
- **An enforced release rule** — `dataset-version.test.ts` re-computes a SHA-256 fingerprint of **every published number** on each CI run and fails when it disagrees with `DATASET_FINGERPRINT`. A change that moves a number stays red until the version is bumped and the changelog says what moved.
- **Versioned exports** — the export stamps `datasetVersion` onto the JSON the /reliability hub renders, so "cite the version, not latest" is followable by whoever holds the artifact.
- **Dispute channel** — `.github/ISSUE_TEMPLATE/eval-dispute.yml`, for contested grades, unfair tasks, or unreproducible numbers, with a documented triage promise (ack in 5 working days; accepted corrections land as versioned changes).
- **Disclosures** — in the methodology doc: Pinchy does not compete in the ranking, no vendor has editorial input, models are tested as-is on public `/v1` serving, runs are on Pinchy's own Ollama Cloud account.

No run/grade logic touched, no published number moves.

## Why a fingerprint, and why over the *published* numbers

The first cut of this PR claimed "a data change that skips the changelog fails CI". It didn't. The guard compared two files that are always edited together, so a commit touching only `data/*.jsonl` passed green.

It hashes the numbers **as published** rather than the raw bytes, matching the semantics the versioning rule already uses. Two events during this PR's life proved both halves of that choice:

- The **contamination canary** (#794) rewrote all 15 data files with a GUID header line. A raw-bytes hash would have gone red over a metadata line that moves no number. The fingerprint correctly stayed green.
- **pass^k comparisons** (#796) added published statistics derived from the scenarios but computed separately — invisible in the scenario cells. So the payload is a rest spread over the export, not a hand-kept field list: a number added to the export cannot ship unhashed just because nobody widened a list.

Verified in both directions: flipping one `passed:true` in the data, and widening `Z_95` in the comparison math, each leave the version-vs-changelog check green and turn the fingerprint red.

## Also fixed

- Methodology pointed at `data/dataset-version.ts`; the file is `eval/dataset-version.ts`.
- The completeness manifest said `nemotron 1/11` (conflict) and `qwen3.5 6/11` (lineitems); both cells are n=12 in the published data. The CHANGELOG points readers at that manifest, so it had to be right.
- The changelog heading scan now ignores fenced code blocks and asserts entries are newest-first — the "newest entry" assertion silently depended on ordering.
- Created the `eval-dispute` and `triage` labels, which the issue templates reference but the repo did not have. GitHub silently drops unknown labels, so disputes would have landed outside the very triage promise the template makes. (`triage` has been referenced by `bug_report.yml` all along.)

## ⚠️ One open item for the maintainer

The disclosure states funding runs on our own Ollama Cloud account. If there is **any vendor relationship to disclose** (serving credits, sponsorship, a paid arrangement with a model/infra provider), it must be added — late disclosure is exactly the FrontierMath failure. I did not assert "no sponsorship" because I can't verify it. Please confirm and I'll amend the disclosure.

## Test plan

- `pnpm -C packages/web test` green (8897 passed); fingerprint verified red on a mutated dataset and on mutated comparison math, green on the real one.
- `pnpm -C packages/web lint` 0 errors; `typecheck` (incl. tests) and `format:check` clean.
- Rebased onto main twice during review (canary #805, pass^k #806 landed meanwhile).

Refs #802, #669