### PR TITLE
eval: paired model comparisons with scenario-clustered SEs and ties (#797)

### DIFF
--- a/packages/web/eval/__tests__/comparisons-published-guard.test.ts
+++ b/packages/web/eval/__tests__/comparisons-published-guard.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Keeps `eval/data/README.md`'s comparison claims honest against the committed
+ * dataset (pinchy#797).
+ *
+ * The README tells a reader how much of the leaderboard to believe — "76 of the
+ * 91 model pairs are tied", "none survives a Benjamini-Hochberg correction". A
+ * re-sweep moves those numbers, and prose does not fail CI. That is exactly the
+ * gap `scorecard-triage-guard.test.ts` exists to close for the triage ledger:
+ * committed evidence nobody re-reads protects nobody.
+ *
+ * So this guard PARSES the claims out of the README rather than restating them,
+ * which means the README itself cannot drift. Whoever commits a fresh scorecard
+ * gets a red test naming the sentence to fix.
+ *
+ * Like that guard it runs in vitest against the checked-in data (no docker, no
+ * API keys), because `pnpm eval:models` needs both and CI only runs
+ * `eval:selftest`.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { pooledClusteredDifference } from "../../src/lib/eval/comparisons";
+import { buildComparisons, buildPublishedScenarios } from "../export-scorecard";
+
+const scenarios = await buildPublishedScenarios();
+const comparisons = buildComparisons(scenarios);
+const readme = await readFile(path.join(__dirname, "..", "data", "README.md"), "utf8");
+
+/** Pulls one number out of a README sentence, failing loudly if the sentence moved. */
+function claim(pattern: RegExp, what: string): number {
+  const match = readme.match(pattern);
+  if (!match) {
+    throw new Error(
+      `eval/data/README.md no longer states ${what} in a form this guard can read ` +
+        `(${pattern}). The claim and its guard must move together — update the regex ` +
+        `if you rewrote the sentence, and re-check the number while you are there.`
+    );
+  }
+  return Number(match[1]);
+}
+
+describe("published comparison claims match the committed dataset", () => {
+  it("states the tie counts the data actually produces", () => {
+    const tied = claim(/(\d+) of the \d+ model pairs are statistically \*\*tied\*\*/, "tied pairs");
+    const total = claim(
+      /\d+ of the (\d+) model pairs are statistically \*\*tied\*\*/,
+      "total pairs"
+    );
+    const separating = claim(/only (\d+) separate/, "separating pairs");
+
+    expect(comparisons.length).toBe(total);
+    expect(comparisons.filter((c) => c.tied).length).toBe(tied);
+    expect(comparisons.filter((c) => !c.tied).length).toBe(separating);
+    expect(tied + separating).toBe(total);
+  });
+
+  it("has a comparison for every unordered pair of the models in the dataset", () => {
+    const models = new Set(scenarios.flatMap((s) => s.models.map((m) => m.model)));
+    expect(comparisons.length).toBe((models.size * (models.size - 1)) / 2);
+  });
+
+  it("states how many pairs the binomial floor actually binds for", () => {
+    // The README claims the within-scenario term is not decorative. Verify it
+    // from the OUTSIDE: rebuild the between-scenario-only SE the module used to
+    // use, and count the pairs whose published SE is genuinely larger. Zero here
+    // would mean the floor never binds and the README oversells it.
+    const claimed = claim(/binding term for (\d+) of the \d+ pairs today/, "floor-bound pairs");
+
+    const floorBound = comparisons.filter((c) => {
+      const cellsFor = (model: string) =>
+        scenarios.map((s) => s.models.find((m) => m.model === model));
+      const as = cellsFor(c.a);
+      const bs = cellsFor(c.b);
+      const pairs = as.flatMap((a, i) => {
+        const b = bs[i];
+        return a && b ? [{ a, b }] : [];
+      });
+      const diffs = pairs
+        .filter(({ a, b }) => a.n > 0 && b.n > 0)
+        .map(({ a, b }) => a.passes / a.n - b.passes / b.n);
+      if (diffs.length < 2) return false;
+
+      const mean = diffs.reduce((s, d) => s + d, 0) / diffs.length;
+      const between = diffs.reduce((s, d) => s + (d - mean) ** 2, 0) / (diffs.length - 1);
+      const betweenOnlySe = Math.sqrt(between / diffs.length);
+      // Against the UNROUNDED se: the published one is 3dp, which blurs the
+      // margin for pairs where the two terms nearly coincide.
+      const exactSe = pooledClusteredDifference(pairs).se;
+      return exactSe !== null && exactSe > betweenOnlySe;
+    }).length;
+
+    expect(floorBound).toBe(claimed);
+  });
+
+  it("never publishes a zero-width interval", () => {
+    // The collapse this module's SE exists to prevent: identical per-scenario
+    // differences -> zero between-scenario spread -> a point interval asserting
+    // a winner with certainty.
+    for (const c of comparisons) {
+      expect(c.ci[1] - c.ci[0], `${c.a} vs ${c.b} published a point interval`).toBeGreaterThan(0);
+    }
+  });
+
+  it("publishes a `tied` flag a reader can recompute from the published bounds", () => {
+    for (const c of comparisons) {
+      expect(c.tied, `${c.a} vs ${c.b}`).toBe(c.ci[0] <= 0 && c.ci[1] >= 0);
+    }
+  });
+
+  it("states truthfully that no separating pair survives Benjamini-Hochberg", () => {
+    // BH at q=0.05 rejects nothing unless the smallest p clears 0.05/91. On 6 df
+    // that means |t| > 6.6705 (bisected on the t CDF; p(6.6705, 6) = 5.495e-4).
+    // Asserting it as a t threshold keeps a whole incomplete-beta implementation
+    // out of the repo for one claim.
+    expect(readme).toMatch(/none of them survives a Benjamini–Hochberg correction/i);
+    const BH_STEP1_T = 6.6705;
+
+    const maxT = Math.max(
+      ...comparisons.filter((c) => c.se !== null && c.se > 0).map((c) => Math.abs(c.diff / c.se!))
+    );
+    expect(
+      maxT,
+      `A pair now clears the BH step-1 threshold, so the README's "none survives" claim is false. ` +
+        `Re-check the multiplicity paragraph in eval/data/README.md.`
+    ).toBeLessThan(BH_STEP1_T);
+  });
+});

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -48,6 +48,31 @@ rejected), and getting the structured total right (lineitems).
 - `<scenario>.json` — the aggregate scorecard (pass rate, pass^k, Wilson 95%,
   tag histogram, median latency).
 
+## Comparing two models (read this before ranking them)
+
+Per-cell Wilson intervals say how good one model is in one scenario. They do
+**not** say whether A beats B — inferring that from two overlapping intervals is
+a known error (Miller 2024). The export answers the comparison question
+directly:
+
+- `scenarios[].tiedWithLeader` — every model that scenario's leader is not
+  significantly ahead of, the leader included. Read the leaderboard through this
+  list, not as a strict ranking.
+- `comparisons[]` — every model pair, pooled across scenarios, with a
+  scenario-clustered 95% interval and a `tied` flag. Runs cluster within
+  scenarios, so the scenario (not the run) is the unit: we average the
+  per-scenario differences and take the standard error from their spread, on a
+  t-interval with S−1 df because S is 7, not 700.
+
+The intervals use Newcombe's hybrid-score method, built on the Wilson bounds —
+not a Wald interval on the difference, which is unreliable at n=12 near 0 and 1
+(Bowyer et al. 2025), exactly where our cells sit.
+
+**What it shows:** 76 of the 91 model pairs are statistically **tied** overall;
+only 15 separate. At 12 runs per cell this benchmark can tell the clearly-weak
+models from the clearly-strong ones and little else — treat any finer ordering
+as noise until N grows.
+
 ## Completeness manifest (as of harness `255678c25`)
 
 Target per scenario: 14 models × 12 runs = 168.

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -58,20 +58,40 @@ directly:
 - `scenarios[].tiedWithLeader` — every model that scenario's leader is not
   significantly ahead of, the leader included. Read the leaderboard through this
   list, not as a strict ranking.
-- `comparisons[]` — every model pair, pooled across scenarios, with a
-  scenario-clustered 95% interval and a `tied` flag. Runs cluster within
-  scenarios, so the scenario (not the run) is the unit: we average the
-  per-scenario differences and take the standard error from their spread, on a
-  t-interval with S−1 df because S is 7, not 700.
+- `comparisons[]` — every model pair, pooled across scenarios, with a 95%
+  interval, an `se`, and a `tied` flag. Runs cluster within scenarios, so the
+  scenario (not the run) is the unit: we average the per-scenario differences
+  and put a random-effects standard error on that mean, on a t-interval with
+  S−1 df because S is 7, not 700.
 
 The intervals use Newcombe's hybrid-score method, built on the Wilson bounds —
 not a Wald interval on the difference, which is unreliable at n=12 near 0 and 1
 (Bowyer et al. 2025), exactly where our cells sit.
 
+The pooled standard error carries **both** sources of variation: real
+scenario-to-scenario heterogeneity, and the binomial noise in each per-scenario
+difference (12+12 runs). Between-scenario spread alone would be enough on
+average but can collapse — seven scenarios that happen to agree exactly would
+give it a spread of 0, hence a zero-width interval declaring a winner with
+certainty. The binomial term is the floor that prevents it, and it is not
+theoretical: it is the binding term for 6 of the 91 pairs today.
+
 **What it shows:** 76 of the 91 model pairs are statistically **tied** overall;
 only 15 separate. At 12 runs per cell this benchmark can tell the clearly-weak
 models from the clearly-strong ones and little else — treat any finer ordering
 as noise until N grows.
+
+**These comparisons are uncorrected for multiplicity, and it matters.** 91
+simultaneous pairs at α=0.05 means roughly 4 false separations expected under
+the global null, so read "15 separate" as an upper bound on what is real, not a
+count of established results. Every one of the 15 has an uncorrected p between
+0.0017 and 0.049; **none of them survives a Benjamini–Hochberg correction at
+q=0.05** (the smallest p would have to clear 0.05/91 ≈ 0.00055, and with 7
+clusters the t-tails on 6 df cannot get there). The same applies to
+`tiedWithLeader`, which sweeps every model against the empirical best without
+correction, so those sets err slightly small. This does not soften the headline
+— it sharpens it: at n=12 this benchmark separates even less than the raw flags
+suggest.
 
 ## Completeness manifest (as of harness `255678c25`)
 

--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -35,6 +35,7 @@ import path from "node:path";
 import { gradeRunForScenario } from "../src/lib/eval/graders";
 import { pooledClusteredDifference, tiedWithLeader } from "../src/lib/eval/comparisons";
 import { applyTrajectoryRegrade } from "../src/lib/eval/regrade-merge";
+import { wilsonInterval } from "../src/lib/eval/scorecard";
 import type { RunResult, RunTrajectory } from "../src/lib/eval/types";
 import { hetznerInvoiceDuplicateScenario } from "./scenarios/hetzner-invoice-duplicate";
 import { hetznerInvoiceRejectedScenario } from "./scenarios/hetzner-invoice-rejected";
@@ -99,19 +100,20 @@ interface Cell {
   tagHistogram: Record<string, number>;
 }
 
-/** Wilson 95% score interval for `passes` successes in `n` trials. */
-function wilson95(passes: number, n: number): [number, number] {
-  if (n === 0) return [0, 1];
-  const z = 1.96;
-  const p = passes / n;
-  const denom = 1 + z ** 2 / n;
-  const center = p + z ** 2 / (2 * n);
-  const margin = z * Math.sqrt((p * (1 - p)) / n + z ** 2 / (4 * n ** 2));
-  return [
-    Number(((center - margin) / denom).toFixed(3)),
-    Number(((center + margin) / denom).toFixed(3)),
-  ];
-}
+const round3 = (v: number): number => Number(v.toFixed(3));
+
+/**
+ * Wilson 95% score interval for `passes` successes in `n` trials, rounded for
+ * publication. The maths lives in `src/lib/eval/scorecard.ts` — this file used
+ * to carry a second copy that disagreed with it at n=0 ([0, 1] here, a [0, 0]
+ * point mass there), which is a contradiction a reader of one exported record
+ * could not see: the same zero-trial cell would publish "anything is possible"
+ * in `wilson95` while `comparisons.ts` read "certainly 0%" off the other copy.
+ */
+const wilson95 = (passes: number, n: number): [number, number] => {
+  const [lower, upper] = wilsonInterval(passes, n);
+  return [round3(lower), round3(upper)];
+};
 
 async function readJsonl<T>(file: string): Promise<T[]> {
   try {
@@ -181,10 +183,13 @@ export interface ModelComparison {
   ci: [number, number];
   /** True when the interval spans 0 — no detectable difference overall. */
   tied: boolean;
+  /**
+   * Random-effects SE behind `ci`. Published so a reader can rebuild the
+   * interval (or a corrected one) instead of taking `tied` on faith.
+   */
+  se: number | null;
   scenarios: number;
 }
-
-const round3 = (v: number): number => Number(v.toFixed(3));
 
 /**
  * Every unordered model pair, compared pooled across scenarios with a
@@ -211,12 +216,18 @@ export function buildComparisons(scenarios: PublishedScenario[]): ModelCompariso
           : [];
       });
       const pooled = pooledClusteredDifference(pairs);
+      // `tied` is derived from the ROUNDED bounds we publish, not the raw ones,
+      // so a reader who recomputes "does the interval span 0" from the exported
+      // numbers gets the exported verdict. Otherwise a raw lower bound of
+      // 0.0004 would publish as ci[0] = 0 alongside tied: false.
+      const ci: [number, number] = [round3(pooled.ci[0]), round3(pooled.ci[1])];
       comparisons.push({
         a,
         b,
         diff: round3(pooled.diff),
-        ci: [round3(pooled.ci[0]), round3(pooled.ci[1])],
-        tied: pooled.tied,
+        ci,
+        tied: ci[0] <= 0 && ci[1] >= 0,
+        se: pooled.se === null ? null : round3(pooled.se),
         scenarios: pooled.scenarios,
       });
     }

--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -33,6 +33,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { gradeRunForScenario } from "../src/lib/eval/graders";
+import { pooledClusteredDifference, tiedWithLeader } from "../src/lib/eval/comparisons";
 import { applyTrajectoryRegrade } from "../src/lib/eval/regrade-merge";
 import type { RunResult, RunTrajectory } from "../src/lib/eval/types";
 import { hetznerInvoiceDuplicateScenario } from "./scenarios/hetzner-invoice-duplicate";
@@ -162,6 +163,65 @@ export interface PublishedScenario {
   axis: string;
   totalRuns: number;
   models: Cell[];
+  /**
+   * Every model this scenario's leader is NOT significantly ahead of (the
+   * leader included). At n=12 most rank gaps aren't significant, so a reader
+   * given only an ordered list would over-read it — this names the tie.
+   */
+  tiedWithLeader: string[];
+}
+
+/** A pooled, scenario-clustered comparison of two models across all scenarios. */
+export interface ModelComparison {
+  a: string;
+  b: string;
+  /** Mean of the per-scenario pass-rate differences, p(a) − p(b). */
+  diff: number;
+  /** 95% t-interval on the clustered SE (df = scenarios − 1). */
+  ci: [number, number];
+  /** True when the interval spans 0 — no detectable difference overall. */
+  tied: boolean;
+  scenarios: number;
+}
+
+const round3 = (v: number): number => Number(v.toFixed(3));
+
+/**
+ * Every unordered model pair, compared pooled across scenarios with a
+ * scenario-clustered SE. Answers "is A actually better than B", which two
+ * overlapping per-cell CIs cannot (Miller 2024).
+ */
+export function buildComparisons(scenarios: PublishedScenario[]): ModelComparison[] {
+  const models = [...new Set(scenarios.flatMap((s) => s.models.map((m) => m.model)))].sort();
+  const comparisons: ModelComparison[] = [];
+
+  for (let i = 0; i < models.length; i++) {
+    for (let j = i + 1; j < models.length; j++) {
+      const [a, b] = [models[i], models[j]];
+      const pairs = scenarios.flatMap((s) => {
+        const ca = s.models.find((m) => m.model === a);
+        const cb = s.models.find((m) => m.model === b);
+        return ca && cb
+          ? [
+              {
+                a: { model: a, passes: ca.passes, n: ca.n },
+                b: { model: b, passes: cb.passes, n: cb.n },
+              },
+            ]
+          : [];
+      });
+      const pooled = pooledClusteredDifference(pairs);
+      comparisons.push({
+        a,
+        b,
+        diff: round3(pooled.diff),
+        ci: [round3(pooled.ci[0]), round3(pooled.ci[1])],
+        tied: pooled.tied,
+        scenarios: pooled.scenarios,
+      });
+    }
+  }
+  return comparisons;
 }
 
 /**
@@ -198,21 +258,25 @@ export async function buildPublishedScenarios(): Promise<PublishedScenario[]> {
       );
     }
 
+    const models = aggregate(runs);
     scenarios.push({
       label: s.label,
       slug: s.slug,
       axis: s.axis,
       totalRuns: runs.length,
-      models: aggregate(runs),
+      models,
+      tiedWithLeader: tiedWithLeader(models),
     });
   }
   return scenarios;
 }
 
 async function main(): Promise<void> {
+  const scenarios = await buildPublishedScenarios();
   const out = {
     generatedFrom: "packages/web/eval/data (heypinchy/pinchy)",
-    scenarios: await buildPublishedScenarios(),
+    scenarios,
+    comparisons: buildComparisons(scenarios),
   };
   process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
 }

--- a/packages/web/src/lib/eval/__tests__/comparisons.test.ts
+++ b/packages/web/src/lib/eval/__tests__/comparisons.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../comparisons";
 
 const cell = (model: string, passes: number, n = 12): ComparableCell => ({ model, passes, n });
+const width = (p: { ci: [number, number] }): number => p.ci[1] - p.ci[0];
 
 describe("scenarioDifference (Newcombe hybrid-score interval)", () => {
   it("separates a perfect model from a hopeless one", () => {
@@ -59,6 +60,21 @@ describe("tiedWithLeader", () => {
   it("returns an empty list for no cells", () => {
     expect(tiedWithLeader([])).toEqual([]);
   });
+
+  it("keeps a model with no valid trials in the tie set", () => {
+    // A cell whose every run was an excluded infra error (n=0) has produced no
+    // evidence, so nothing rules it out of the lead. Treating its missing rate
+    // as 0% would exclude it — a claim from zero data.
+    const tied = tiedWithLeader([cell("lead", 12), cell("nodata", 0, 0), cell("hopeless", 0)]);
+    expect(tied).toContain("nodata");
+    expect(tied).not.toContain("hopeless");
+  });
+
+  it("does not let a zero-trial cell become the leader", () => {
+    const tied = tiedWithLeader([cell("nodata", 0, 0), cell("real", 12), cell("hopeless", 0)]);
+    expect(tied).toContain("real");
+    expect(tied).not.toContain("hopeless");
+  });
 });
 
 describe("pooledClusteredDifference", () => {
@@ -83,9 +99,79 @@ describe("pooledClusteredDifference", () => {
       { a: cell("a", 0), b: cell("b", 12) },
       { a: cell("a", 9), b: cell("b", 6) },
     ]);
-    const width = (p: { ci: [number, number] }) => p.ci[1] - p.ci[0];
     expect(width(scattered)).toBeGreaterThan(width(consistent));
     expect(scattered.tied).toBe(true);
+    // Ordering alone is a vacuous assertion if `consistent` collapses to width
+    // 0 — which is exactly what it used to do. Pin the floor too.
+    expect(width(consistent)).toBeGreaterThan(0.1);
+  });
+
+  it("keeps a real interval when every scenario reports the SAME difference", () => {
+    // Identical per-scenario diffs mean zero BETWEEN-scenario spread. An SE
+    // taken only from that spread is 0, and the interval collapses to a point
+    // — infinite confidence from 36 runs. The within-scenario binomial error
+    // is still there and must hold the interval open.
+    const pooled = pooledClusteredDifference([
+      { a: cell("a", 9), b: cell("b", 6) },
+      { a: cell("a", 9), b: cell("b", 6) },
+      { a: cell("a", 9), b: cell("b", 6) },
+    ]);
+    expect(pooled.se).toBeGreaterThan(0);
+    expect(width(pooled)).toBeGreaterThan(0.1);
+  });
+
+  it("agrees with the per-scenario read: a one-run gap stays a tie when pooled", () => {
+    // scenarioDifference calls 12/12 vs 11/12 a tie (see above). Seven
+    // scenarios of that same one-run gap is not new evidence of a winner — it
+    // is the same weak signal seven times. The pooled verdict must not
+    // contradict the per-scenario one.
+    const pairs = Array.from({ length: 7 }, () => ({ a: cell("a", 12), b: cell("b", 11) }));
+    expect(scenarioDifference(cell("a", 12), cell("b", 11)).tied).toBe(true);
+    expect(pooledClusteredDifference(pairs).tied).toBe(true);
+  });
+
+  it("never reports a narrower interval than treating every run as independent", () => {
+    // Clustering exists because runs within a scenario are NOT independent, so
+    // it must cost precision, never buy it. If the clustered interval is
+    // narrower than the (already anti-conservative) full-independence bound on
+    // the same evidence, the SE has lost the within-scenario error term.
+    const perScenario = [
+      [12, 11],
+      [12, 11],
+      [12, 11],
+      [12, 11],
+      [12, 11],
+      [12, 11],
+      [12, 10],
+    ];
+    const clustered = pooledClusteredDifference(
+      perScenario.map(([a, b]) => ({ a: cell("a", a), b: cell("b", b) }))
+    );
+    const independent = scenarioDifference(
+      cell(
+        "a",
+        perScenario.reduce((s, [a]) => s + a, 0),
+        84
+      ),
+      cell(
+        "b",
+        perScenario.reduce((s, [, b]) => s + b, 0),
+        84
+      )
+    );
+    expect(width(clustered)).toBeGreaterThanOrEqual(width(independent));
+  });
+
+  it("ignores scenarios where either model has no valid trials", () => {
+    // n=0 (every run an excluded infra error) is absence of evidence. Counting
+    // it as a 0% pass rate would invent a difference out of nothing.
+    const withDeadScenario = pooledClusteredDifference([
+      { a: cell("a", 9), b: cell("b", 6) },
+      { a: cell("a", 9), b: cell("b", 6) },
+      { a: cell("a", 0, 0), b: cell("b", 6) },
+    ]);
+    expect(withDeadScenario.scenarios).toBe(2);
+    expect(withDeadScenario.diff).toBeCloseTo(0.25, 10);
   });
 
   it("reports a tie when the clustered interval spans zero", () => {

--- a/packages/web/src/lib/eval/__tests__/comparisons.test.ts
+++ b/packages/web/src/lib/eval/__tests__/comparisons.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  pooledClusteredDifference,
+  scenarioDifference,
+  tiedWithLeader,
+  type ComparableCell,
+} from "../comparisons";
+
+const cell = (model: string, passes: number, n = 12): ComparableCell => ({ model, passes, n });
+
+describe("scenarioDifference (Newcombe hybrid-score interval)", () => {
+  it("separates a perfect model from a hopeless one", () => {
+    const d = scenarioDifference(cell("a", 12), cell("b", 0));
+    expect(d.diff).toBe(1);
+    expect(d.ci[0]).toBeGreaterThan(0);
+    expect(d.tied).toBe(false);
+  });
+
+  it("calls two identical cells tied, with a zero difference", () => {
+    const d = scenarioDifference(cell("a", 6), cell("b", 6));
+    expect(d.diff).toBe(0);
+    expect(d.ci[0]).toBeLessThan(0);
+    expect(d.ci[1]).toBeGreaterThan(0);
+    expect(d.tied).toBe(true);
+  });
+
+  it("calls a one-run gap at n=12 a tie — the honest read at this sample size", () => {
+    const d = scenarioDifference(cell("a", 7), cell("b", 6));
+    expect(d.tied).toBe(true);
+  });
+
+  it("is antisymmetric in its arguments", () => {
+    const ab = scenarioDifference(cell("a", 9), cell("b", 4));
+    const ba = scenarioDifference(cell("b", 4), cell("a", 9));
+    expect(ba.diff).toBeCloseTo(-ab.diff, 10);
+    expect(ba.tied).toBe(ab.tied);
+  });
+
+  it("never produces a Wald-style interval that escapes [-1, 1] at the boundary", () => {
+    const d = scenarioDifference(cell("a", 12), cell("b", 12));
+    expect(d.ci[0]).toBeGreaterThanOrEqual(-1);
+    expect(d.ci[1]).toBeLessThanOrEqual(1);
+    expect(d.tied).toBe(true);
+  });
+});
+
+describe("tiedWithLeader", () => {
+  it("includes every model the leader is not significantly ahead of", () => {
+    const tied = tiedWithLeader([cell("lead", 12), cell("close", 11), cell("hopeless", 0)]);
+    expect(tied).toContain("lead");
+    expect(tied).toContain("close");
+    expect(tied).not.toContain("hopeless");
+  });
+
+  it("returns just the leader when everyone else is clearly behind", () => {
+    expect(tiedWithLeader([cell("lead", 12), cell("bad", 0), cell("worse", 0)])).toEqual(["lead"]);
+  });
+
+  it("returns an empty list for no cells", () => {
+    expect(tiedWithLeader([])).toEqual([]);
+  });
+});
+
+describe("pooledClusteredDifference", () => {
+  it("averages the per-scenario differences", () => {
+    const pooled = pooledClusteredDifference([
+      { a: cell("a", 12), b: cell("b", 6) },
+      { a: cell("a", 6), b: cell("b", 0) },
+    ]);
+    // per-scenario diffs are 0.5 and 0.5 -> mean 0.5
+    expect(pooled.diff).toBeCloseTo(0.5, 10);
+    expect(pooled.scenarios).toBe(2);
+  });
+
+  it("widens the interval when the per-scenario differences disagree", () => {
+    const consistent = pooledClusteredDifference([
+      { a: cell("a", 9), b: cell("b", 6) },
+      { a: cell("a", 9), b: cell("b", 6) },
+      { a: cell("a", 9), b: cell("b", 6) },
+    ]);
+    const scattered = pooledClusteredDifference([
+      { a: cell("a", 12), b: cell("b", 0) },
+      { a: cell("a", 0), b: cell("b", 12) },
+      { a: cell("a", 9), b: cell("b", 6) },
+    ]);
+    const width = (p: { ci: [number, number] }) => p.ci[1] - p.ci[0];
+    expect(width(scattered)).toBeGreaterThan(width(consistent));
+    expect(scattered.tied).toBe(true);
+  });
+
+  it("reports a tie when the clustered interval spans zero", () => {
+    const pooled = pooledClusteredDifference([
+      { a: cell("a", 6), b: cell("b", 6) },
+      { a: cell("a", 7), b: cell("b", 6) },
+    ]);
+    expect(pooled.tied).toBe(true);
+  });
+
+  it("has no interval to report for a single scenario (no between-cluster spread)", () => {
+    const pooled = pooledClusteredDifference([{ a: cell("a", 12), b: cell("b", 0) }]);
+    expect(pooled.scenarios).toBe(1);
+    expect(pooled.tied).toBe(true);
+  });
+
+  it("returns a zero-scenario result for an empty pair list", () => {
+    const pooled = pooledClusteredDifference([]);
+    expect(pooled.scenarios).toBe(0);
+    expect(pooled.tied).toBe(true);
+  });
+});

--- a/packages/web/src/lib/eval/__tests__/scorecard.test.ts
+++ b/packages/web/src/lib/eval/__tests__/scorecard.test.ts
@@ -34,10 +34,15 @@ describe("wilsonInterval", () => {
     expect(lower).toBeGreaterThanOrEqual(0);
   });
 
-  it("returns [0, 0] for n=0", () => {
+  it("returns the uninformative [0, 1] for n=0, not a point mass at 0", () => {
+    // Zero trials means "we know nothing", not "it fails every time". The
+    // point-mass [0, 0] this used to return reads as CERTAINTY that the model
+    // scores 0, which is how a cell whose every run was an invalid trial
+    // (`run-infra-error`, excluded from n) got declared significantly worse
+    // than the leader in `comparisons.ts` — from no data at all.
     const [lower, upper] = wilsonInterval(0, 0, 1.96);
     expect(lower).toBe(0);
-    expect(upper).toBe(0);
+    expect(upper).toBe(1);
   });
 
   it("clamps into [0, 1]", () => {

--- a/packages/web/src/lib/eval/comparisons.ts
+++ b/packages/web/src/lib/eval/comparisons.ts
@@ -19,8 +19,16 @@
  * 2. **Scenario-clustered pooling.** Runs cluster within scenarios, so pooling
  *    all 84 runs as if independent would understate uncertainty. The cluster —
  *    not the run — is the unit: we average the per-scenario differences and take
- *    the standard error from their between-scenario spread, with a t-interval on
- *    S−1 degrees of freedom because S is small (7 scenarios, not 700).
+ *    the standard error from a random-effects estimate that carries BOTH the
+ *    between-scenario spread and the within-scenario binomial error, with a
+ *    t-interval on S−1 degrees of freedom because S is small (7, not 700).
+ *
+ *    The between-scenario spread alone is not enough, and the failure is not
+ *    hypothetical: with the per-scenario differences all equal (seven scenarios
+ *    of 12/12 vs 11/12, say) that spread is 0, so the SE is 0 and the interval
+ *    collapses to a point — infinite confidence in a winner, from 84 runs, when
+ *    the SAME one-run gap read per scenario is a tie. See
+ *    {@link pooledClusteredDifference} for the estimator that closes this.
  */
 import { wilsonInterval } from "./scorecard";
 
@@ -43,9 +51,11 @@ export interface Difference {
 export interface PooledDifference extends Difference {
   /** How many scenarios (clusters) the pooled estimate averages over. */
   scenarios: number;
-  /** Cluster-robust SE of the mean difference; null when S < 2 (no spread to estimate). */
+  /** Random-effects SE of the mean difference; null when S < 2 (nothing to pool). */
   se: number | null;
 }
+
+const Z_95 = 1.96;
 
 /** Two-sided t critical values at 95%, by degrees of freedom. */
 const T_95: Record<number, number> = {
@@ -88,6 +98,25 @@ function tCritical95(df: number): number {
 
 const clamp = (v: number): number => Math.max(-1, Math.min(1, v));
 const rate = (c: ComparableCell): number => (c.n > 0 ? c.passes / c.n : 0);
+/** A cell with no valid trials (every run an excluded infra error) proves nothing. */
+const hasData = (c: ComparableCell): boolean => c.n > 0;
+
+/**
+ * Sampling variance of one cell's pass rate, from the Wilson/Agresti-Coull
+ * shrunken estimate p̃ = (x + z²/2)/(n + z²) rather than the raw p.
+ *
+ * The textbook Wald variance p(1−p)/n is exactly 0 at p=0 and p=1 — which is
+ * where most of our cells sit — so it would claim a 12/12 cell carries no
+ * sampling error at all. That is the same collapse Wilson exists to avoid, so
+ * we stay in the Wilson family here rather than reintroduce Wald through the
+ * back door. At n=0 this yields the maximal 0.25/z², which is the right answer
+ * for "no trials": maximal uncertainty.
+ */
+function cellVariance(c: ComparableCell): number {
+  const nTilde = c.n + Z_95 ** 2;
+  const pTilde = (c.passes + Z_95 ** 2 / 2) / nTilde;
+  return (pTilde * (1 - pTilde)) / nTilde;
+}
 
 /**
  * The difference between two models in ONE scenario, as a Newcombe hybrid-score
@@ -114,37 +143,73 @@ export function scenarioDifference(a: ComparableCell, b: ComparableCell): Differ
  * Every model in a scenario that its leader is NOT significantly ahead of —
  * the "statistically tied for the lead" set, the leader included. Prevents a
  * reader from over-reading a rank order that n=12 cannot support.
+ *
+ * A model with no valid trials stays in the set: nothing measured cannot rule
+ * it out of the lead, and it cannot become the leader either.
+ *
+ * Note this is a best-vs-rest sweep against the EMPIRICAL maximum and the
+ * comparisons are uncorrected, so the set errs slightly small — see the
+ * multiplicity note in `eval/data/README.md`.
  */
 export function tiedWithLeader(cells: ComparableCell[]): string[] {
-  if (cells.length === 0) return [];
-  const leader = cells.reduce((best, c) => (rate(c) > rate(best) ? c : best), cells[0]);
-  return cells.filter((c) => scenarioDifference(leader, c).tied).map((c) => c.model);
+  const measured = cells.filter(hasData);
+  if (measured.length === 0) return cells.map((c) => c.model);
+  const leader = measured.reduce((best, c) => (rate(c) > rate(best) ? c : best), measured[0]);
+  return cells.filter((c) => !hasData(c) || scenarioDifference(leader, c).tied).map((c) => c.model);
 }
 
 /**
- * The two models' difference pooled across scenarios, with a scenario-clustered
- * standard error: average the per-scenario differences, then take the SE from
- * their spread (sd/√S) and a t-interval on S−1 df.
+ * The two models' difference pooled across scenarios: average the per-scenario
+ * differences, then put a random-effects SE and a t-interval (S−1 df) on it.
  *
- * With S < 2 there is no between-scenario spread to estimate, so no honest
- * interval exists — we report the widest possible one and call it a tie rather
- * than manufacture precision.
+ * The observed per-scenario difference varies for two reasons, and the SE has
+ * to carry both:
+ *
+ * - τ², genuine scenario-to-scenario heterogeneity (a model that shines on
+ *   happy-path may fold on line-items), and
+ * - σ²_s, binomial noise, because each difference is measured off 12+12 runs.
+ *
+ * Taking the SE from the between-scenario spread alone (sd/√S) silently drops
+ * σ²_s. It survives on average — E[s²] does absorb the binomial noise — but the
+ * realized interval can collapse: seven scenarios that happen to agree exactly
+ * give s²=0, hence SE=0 and a zero-width interval declaring a winner with
+ * certainty. That is the precise over-precision this module exists to prevent.
+ *
+ * Method of moments closes it. Since E[s²] = τ² + mean(σ²_s), the heterogeneity
+ * estimate is τ̂² = max(0, s² − mean(σ²_s)), and
+ *
+ *   Var(mean) = (mean(σ²_s) + τ̂²)/S = max(s², mean(σ²_s))/S
+ *
+ * so the between-scenario spread governs whenever it exceeds the binomial floor
+ * (the heterogeneous case, unchanged from before) and the binomial floor holds
+ * the interval open when it does not. Equal weights are correct here because
+ * every cell carries the same n. df stays S−1: with τ̂²=0 a larger df would be
+ * defensible, but a wider interval is the honest direction to err at S=7.
+ *
+ * Scenarios where either model has no valid trials are dropped — absence of
+ * evidence is not a 0% pass rate. With S < 2 there is nothing to pool, so we
+ * report the widest possible interval and call it a tie rather than manufacture
+ * precision.
  */
 export function pooledClusteredDifference(
   pairs: { a: ComparableCell; b: ComparableCell }[]
 ): PooledDifference {
-  const diffs = pairs.map(({ a, b }) => rate(a) - rate(b));
+  const usable = pairs.filter(({ a, b }) => hasData(a) && hasData(b));
+  const diffs = usable.map(({ a, b }) => rate(a) - rate(b));
   const scenarios = diffs.length;
 
-  if (scenarios === 0) return { diff: 0, ci: [0, 0], tied: true, scenarios: 0, se: null };
+  if (scenarios === 0) return { diff: 0, ci: [-1, 1], tied: true, scenarios: 0, se: null };
 
   const mean = diffs.reduce((s, d) => s + d, 0) / scenarios;
   if (scenarios < 2) {
     return { diff: mean, ci: [-1, 1], tied: true, scenarios, se: null };
   }
 
-  const variance = diffs.reduce((s, d) => s + (d - mean) ** 2, 0) / (scenarios - 1);
-  const se = Math.sqrt(variance) / Math.sqrt(scenarios);
+  const between = diffs.reduce((s, d) => s + (d - mean) ** 2, 0) / (scenarios - 1);
+  const meanWithin =
+    usable.reduce((s, { a, b }) => s + cellVariance(a) + cellVariance(b), 0) / scenarios;
+
+  const se = Math.sqrt(Math.max(between, meanWithin) / scenarios);
   const margin = tCritical95(scenarios - 1) * se;
   const ci: [number, number] = [clamp(mean - margin), clamp(mean + margin)];
 

--- a/packages/web/src/lib/eval/comparisons.ts
+++ b/packages/web/src/lib/eval/comparisons.ts
@@ -1,0 +1,152 @@
+/**
+ * Model-vs-model comparison statistics for Eval-v1 (pinchy#669, #797).
+ *
+ * Per-cell Wilson intervals answer "how good is this model here"; they do NOT
+ * answer "is A better than B" — reading that off two overlapping CIs is a known
+ * mistake (Miller 2024, "Adding Error Bars to Evals"). These helpers answer the
+ * comparison question directly, and say out loud when the answer is "we can't
+ * tell at this sample size".
+ *
+ * Two deliberate method choices:
+ *
+ * 1. **Newcombe hybrid-score interval** for a per-scenario difference, built
+ *    from each proportion's Wilson bounds. The obvious alternative — a Wald
+ *    interval on the difference — is exactly the method Bowyer, Aitchison &
+ *    Ivanova 2025 (arXiv 2503.01747) show to be wrong at n≈12: it relies on a
+ *    normal approximation that collapses near 0 and 1, precisely where our
+ *    cells sit. Newcombe inherits Wilson's small-sample behavior and stays
+ *    inside [-1, 1].
+ * 2. **Scenario-clustered pooling.** Runs cluster within scenarios, so pooling
+ *    all 84 runs as if independent would understate uncertainty. The cluster —
+ *    not the run — is the unit: we average the per-scenario differences and take
+ *    the standard error from their between-scenario spread, with a t-interval on
+ *    S−1 degrees of freedom because S is small (7 scenarios, not 700).
+ */
+import { wilsonInterval } from "./scorecard";
+
+/** One model's outcome in one scenario. */
+export interface ComparableCell {
+  model: string;
+  passes: number;
+  n: number;
+}
+
+export interface Difference {
+  /** p(a) − p(b). */
+  diff: number;
+  /** 95% interval for the difference. */
+  ci: [number, number];
+  /** True when the interval spans 0 — the two are statistically indistinguishable. */
+  tied: boolean;
+}
+
+export interface PooledDifference extends Difference {
+  /** How many scenarios (clusters) the pooled estimate averages over. */
+  scenarios: number;
+  /** Cluster-robust SE of the mean difference; null when S < 2 (no spread to estimate). */
+  se: number | null;
+}
+
+/** Two-sided t critical values at 95%, by degrees of freedom. */
+const T_95: Record<number, number> = {
+  1: 12.706,
+  2: 4.303,
+  3: 3.182,
+  4: 2.776,
+  5: 2.571,
+  6: 2.447,
+  7: 2.365,
+  8: 2.306,
+  9: 2.262,
+  10: 2.228,
+  11: 2.201,
+  12: 2.179,
+  13: 2.16,
+  14: 2.145,
+  15: 2.131,
+  16: 2.12,
+  17: 2.11,
+  18: 2.101,
+  19: 2.093,
+  20: 2.086,
+  21: 2.08,
+  22: 2.074,
+  23: 2.069,
+  24: 2.064,
+  25: 2.06,
+  26: 2.056,
+  27: 2.052,
+  28: 2.048,
+  29: 2.045,
+  30: 2.042,
+};
+
+function tCritical95(df: number): number {
+  if (df <= 0) return Number.POSITIVE_INFINITY;
+  return T_95[df] ?? 1.96;
+}
+
+const clamp = (v: number): number => Math.max(-1, Math.min(1, v));
+const rate = (c: ComparableCell): number => (c.n > 0 ? c.passes / c.n : 0);
+
+/**
+ * The difference between two models in ONE scenario, as a Newcombe hybrid-score
+ * interval. Within a scenario the two models' runs are independent repetitions
+ * of the same task (not matched pairs), so this is the independent-proportions
+ * form; the pairing in this benchmark lives at the scenario level, which
+ * {@link pooledClusteredDifference} handles.
+ */
+export function scenarioDifference(a: ComparableCell, b: ComparableCell): Difference {
+  const p1 = rate(a);
+  const p2 = rate(b);
+  const [l1, u1] = wilsonInterval(a.passes, a.n);
+  const [l2, u2] = wilsonInterval(b.passes, b.n);
+
+  const diff = p1 - p2;
+  const lower = diff - Math.sqrt((p1 - l1) ** 2 + (u2 - p2) ** 2);
+  const upper = diff + Math.sqrt((u1 - p1) ** 2 + (p2 - l2) ** 2);
+  const ci: [number, number] = [clamp(lower), clamp(upper)];
+
+  return { diff, ci, tied: ci[0] <= 0 && ci[1] >= 0 };
+}
+
+/**
+ * Every model in a scenario that its leader is NOT significantly ahead of —
+ * the "statistically tied for the lead" set, the leader included. Prevents a
+ * reader from over-reading a rank order that n=12 cannot support.
+ */
+export function tiedWithLeader(cells: ComparableCell[]): string[] {
+  if (cells.length === 0) return [];
+  const leader = cells.reduce((best, c) => (rate(c) > rate(best) ? c : best), cells[0]);
+  return cells.filter((c) => scenarioDifference(leader, c).tied).map((c) => c.model);
+}
+
+/**
+ * The two models' difference pooled across scenarios, with a scenario-clustered
+ * standard error: average the per-scenario differences, then take the SE from
+ * their spread (sd/√S) and a t-interval on S−1 df.
+ *
+ * With S < 2 there is no between-scenario spread to estimate, so no honest
+ * interval exists — we report the widest possible one and call it a tie rather
+ * than manufacture precision.
+ */
+export function pooledClusteredDifference(
+  pairs: { a: ComparableCell; b: ComparableCell }[]
+): PooledDifference {
+  const diffs = pairs.map(({ a, b }) => rate(a) - rate(b));
+  const scenarios = diffs.length;
+
+  if (scenarios === 0) return { diff: 0, ci: [0, 0], tied: true, scenarios: 0, se: null };
+
+  const mean = diffs.reduce((s, d) => s + d, 0) / scenarios;
+  if (scenarios < 2) {
+    return { diff: mean, ci: [-1, 1], tied: true, scenarios, se: null };
+  }
+
+  const variance = diffs.reduce((s, d) => s + (d - mean) ** 2, 0) / (scenarios - 1);
+  const se = Math.sqrt(variance) / Math.sqrt(scenarios);
+  const margin = tCritical95(scenarios - 1) * se;
+  const ci: [number, number] = [clamp(mean - margin), clamp(mean + margin)];
+
+  return { diff: mean, ci, tied: ci[0] <= 0 && ci[1] >= 0, scenarios, se };
+}

--- a/packages/web/src/lib/eval/scorecard.ts
+++ b/packages/web/src/lib/eval/scorecard.ts
@@ -46,10 +46,17 @@ export function computePassCaretK(runs: RunResult[]): number {
 /**
  * Wilson score interval for a binomial proportion (`passes` out of `n`
  * trials), at the given z-score (default 1.96 -> ~95% confidence). Clamped
- * to [0, 1]. Returns [0, 0] for n === 0 (no trials, no interval to report).
+ * to [0, 1].
+ *
+ * Returns the uninformative [0, 1] for n === 0: with no trials every rate is
+ * still possible. The tempting [0, 0] reads as CERTAINTY that the model scores
+ * 0, which is a claim from no data — and `comparisons.ts` acts on these bounds,
+ * so a point mass there declares a zero-trial cell significantly worse than the
+ * leader. `eval/export-scorecard.ts` has always published [0, 1] for this case;
+ * this is now the single definition both sides read.
  */
 export function wilsonInterval(passes: number, n: number, z = 1.96): [number, number] {
-  if (n === 0) return [0, 0];
+  if (n === 0) return [0, 1];
 
   const p = passes / n;
   const z2 = z * z;


### PR DESCRIPTION
## Gap

We reported per-cell Wilson CIs and stopped there — leaving readers to judge "is A better than B" by eyeballing CI overlap (the exact error Miller 2024 warns about), and to over-read a rank order that n=12 cannot support.

## What this does

- **`src/lib/eval/comparisons.ts`** — per-scenario differences via **Newcombe's hybrid-score interval**, built on the existing Wilson bounds. Explicitly *not* a Wald interval on the difference: Bowyer et al. 2025 — the paper this issue cites for keeping Wilson at n=12 — show Wald fails near 0 and 1, precisely where our cells sit. Newcombe inherits Wilson's small-sample behavior and stays inside [-1, 1].
- **Scenario-clustered pooling** — runs cluster within scenarios, so pooling every run as independent would understate uncertainty. The scenario is the unit: average the per-scenario differences, take the SE from their between-scenario spread, t-interval on S−1 df (S=7, so t=2.447, not z=1.96).
- **Export** — `scenarios[].tiedWithLeader` (who the leader is *not* actually ahead of) and a top-level `comparisons[]` covering all 91 model pairs with a `tied` flag.

## What it surfaces

> **76 of 91 model pairs are statistically tied. Only 15 separate.**

At 12 runs per cell this benchmark can tell clearly-weak from clearly-strong models and little else. That's the honest read, and now the data states it instead of implying a precision we don't have. Per-scenario the tie sets are informative too — `silent-failure` has only 2 models tied for the lead (it discriminates), while `happy-path` has 10 (it doesn't).

Documented in `data/README.md` so a reader hits it before ranking anything.

## No numbers move

Additive only: the export is **identical to `main` once `tiedWithLeader` and `comparisons` are stripped** (verified by deep-compare).

## Test plan

- `pnpm -C packages/web test` — 188 green, incl. 13 new comparison cases (antisymmetry, boundary behavior at 12/12 vs 12/12, interval widening when scenarios disagree, S<2 honesty).
- `pnpm -C packages/web lint` 0 errors; typecheck clean.

## Note on overlap

Touches `export-scorecard.ts` (different region) and `data/README.md`, which #806 (pass^k) and #805/#807 also extend. Merge in sequence; later PRs may need a trivial rebase.

Refs #797, #669