### PR TITLE
fix(web): clear the copy-confirmation timer on unmount

### DIFF
--- a/packages/web/src/__tests__/hooks/use-copy-to-clipboard.test.ts
+++ b/packages/web/src/__tests__/hooks/use-copy-to-clipboard.test.ts
@@ -132,6 +132,48 @@ describe("useCopyToClipboard", () => {
     }
   });
 
+  it("clears the pending reset on unmount", async () => {
+    // The reset timer otherwise outlives the component and calls setIsCopied on
+    // a torn-down tree — in jsdom that lands after environment teardown as
+    // "ReferenceError: window is not defined", failing an otherwise green run.
+    const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("restarts the reset window on a second copy instead of racing the first", async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy("first");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await result.current.copy("second");
+    });
+
+    // The first copy's timer would fire here and blank the fresh confirmation.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.isCopied).toBe(false);
+  });
+
   it("returns false and stays not-copied when clipboard and execCommand both fail", async () => {
     Object.defineProperty(navigator, "clipboard", {
       value: undefined,

--- a/packages/web/src/__tests__/hooks/use-copy-to-clipboard.test.ts
+++ b/packages/web/src/__tests__/hooks/use-copy-to-clipboard.test.ts
@@ -148,6 +148,37 @@ describe("useCopyToClipboard", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("schedules no reset when the unmount beats the pending clipboard write", async () => {
+    // The unmount cleanup runs before the write resolves, so it has no timer to
+    // clear yet. Without a mounted guard the resolved write then schedules one
+    // anyway — orphaned past the cleanup, and nobody left to clear it.
+    let resolveWrite!: () => void;
+    writeText.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      })
+    );
+
+    const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+    let copying!: Promise<boolean>;
+    act(() => {
+      copying = result.current.copy("hello");
+    });
+
+    unmount();
+
+    let returned: boolean | undefined;
+    await act(async () => {
+      resolveWrite();
+      returned = await copying;
+    });
+
+    expect(vi.getTimerCount()).toBe(0);
+    // The copy itself did succeed — only the state update is skipped.
+    expect(returned).toBe(true);
+  });
+
   it("restarts the reset window on a second copy instead of racing the first", async () => {
     const { result } = renderHook(() => useCopyToClipboard());
 

--- a/packages/web/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/web/src/hooks/use-copy-to-clipboard.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * Copy text to the clipboard, robust to non-secure contexts.
@@ -12,12 +12,16 @@ import { useState } from "react";
  */
 export function useCopyToClipboard({ copiedDuration = 2000 }: { copiedDuration?: number } = {}) {
   const [isCopied, setIsCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(resetTimer.current), []);
 
   async function copy(text: string): Promise<boolean> {
     const ok = await writeToClipboard(text);
     if (ok) {
       setIsCopied(true);
-      setTimeout(() => setIsCopied(false), copiedDuration);
+      clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setIsCopied(false), copiedDuration);
     }
     return ok;
   }

--- a/packages/web/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/web/src/hooks/use-copy-to-clipboard.ts
@@ -13,12 +13,21 @@ import { useEffect, useRef, useState } from "react";
 export function useCopyToClipboard({ copiedDuration = 2000 }: { copiedDuration?: number } = {}) {
   const [isCopied, setIsCopied] = useState(false);
   const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const mounted = useRef(true);
 
-  useEffect(() => () => clearTimeout(resetTimer.current), []);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      clearTimeout(resetTimer.current);
+    };
+  }, []);
 
   async function copy(text: string): Promise<boolean> {
     const ok = await writeToClipboard(text);
-    if (ok) {
+    // The write is async, so the component may be gone by now — in which case the
+    // cleanup has already run and would not catch a timer scheduled after it.
+    if (ok && mounted.current) {
       setIsCopied(true);
       clearTimeout(resetTimer.current);
       resetTimer.current = setTimeout(() => setIsCopied(false), copiedDuration);


### PR DESCRIPTION
## Problem

`useCopyToClipboard` starts a `setTimeout` to reset `isCopied` back to `false`, but never holds onto the timeout id. Nothing clears it when the component unmounts, so the callback fires on a torn-down tree.

What that actually costs, in order of severity:

1. **A user-visible race.** Rapid successive copies race: the first copy's timer is never cancelled, so it blanks the *second* copy's "Copied!" confirmation after the first's deadline instead of the second getting its full window. This is the only defect here a user can see, and it was found while writing the tests — the original report had it as a footnote.
2. **`pnpm test` intermittently exits 1 with every test file green.** Vitest reports `Unhandled Errors: 1 error / Uncaught Exception: ReferenceError: window is not defined`, stack pointing at `use-copy-to-clipboard.ts:20` → `dispatchSetState` → `resolveUpdatePriority`, originating from `audit-log-table.test.tsx`. The timer survives the jsdom environment teardown, and `resolveUpdatePriority` then reads a `window` that no longer exists. Reproduced 2026-07-17, 1 of 4 full runs — load/timing dependent, likelier on a cold vite transform cache.
3. **A `setState` on an unmounted component** in every consumer (audit log table, invite dialog, user detail sheet, integrations dialog, markdown message actions). Worth fixing, but calibrated: React 19 makes this a silent no-op — the warning was removed back in React 18 — and the retention is bounded by the timer's own 2–3s lifetime. In a real browser it is harmless. It is the *test* environment where it turns into a hard failure, per 2 above.

## Fix

Hold the timeout id in a `useRef`, clear it in a `useEffect` cleanup on unmount, and clear any pending reset before starting a new one.

Plus a second, narrower path to the same defect, found in review: `copy()` awaits the clipboard write **before** touching state. If the tree goes away during that await, the cleanup has already run and has no timer to clear yet — and the resolved write then schedules one anyway, orphaned past the cleanup with nothing left to clear it. Reachable where the tree can vanish mid-write: a code block inside a streaming message (`markdown-text`), or a dialog closed right after the click (`add-integration-dialog`). A `mounted` ref guards the state update; `copy()` still returns the truthful result, since the copy did succeed — only the confirmation is skipped.

## Tests

Three tests added to `use-copy-to-clipboard.test.ts`, each verified red before its fix:

- `clears the pending reset on unmount` — asserts `vi.getTimerCount()` drops to 0 after unmount (was 1).
- `schedules no reset when the unmount beats the pending clipboard write` — holds the write open, unmounts mid-flight, asserts no timer is scheduled once it resolves (was 1).
- `restarts the reset window on a second copy instead of racing the first` — asserts the second copy keeps its confirmation past the first timer's deadline (was blanked at 500ms).

## Verification

- `pnpm vitest run src/__tests__/hooks/use-copy-to-clipboard.test.ts` — 11 passed.
- Consumer components (audit-log-table, invite-dialog, settings-users, user-detail-sheet, add-integration-dialog) — 135 passed.
- Full `pnpm test` — 652 files / 8823 tests passed, no failures, no unhandled errors.
- `pnpm -C packages/web typecheck` (type-checks test files) — clean.
- `pnpm lint` and `prettier --check` — clean on both changed files.

One caveat worth stating plainly: a single green run proves nothing against a 1-in-4 flake. The deterministic `getTimerCount()` assertions are the actual proof that the timers are cleared, not the green suite.

Split out of #807 (eval dataset release mechanics, docs-and-tooling only), where it was out of scope.
