### PR TITLE
feat(inbox-agent): make the sweep autonomous — scheduler, mailbox ports, boot wiring (#139)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1679,8 +1679,9 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml down -v
 
   imap-e2e:
-    # Runs the whole e2e/email testDir: email-imap.spec.ts against a real
-    # GreenMail server (SMTP+IMAP) fronted by the imap-mock control sidecar.
+    # Runs email-imap.spec.ts (the pinchy-email plugin's IMAP/SMTP tools) and
+    # inbox-sweep.spec.ts (the Inbox Agent's sweep dispatching unprompted)
+    # against a real GreenMail server fronted by the imap-mock control sidecar.
     name: IMAP E2E Tests
     runs-on: ubuntu-latest
     needs: [changes, build-image]

--- a/docker-compose.imap-test.yml
+++ b/docker-compose.imap-test.yml
@@ -61,12 +61,20 @@ services:
 
   pinchy:
     environment:
-      # The web app doesn't speak IMAP/SMTP directly, but tests may probe the
-      # mock host/port through the same env override the plugin uses.
+      # Probed by the web app's "test connection" path. NOTE: the Inbox Agent's
+      # sweep (inbox-sweep.spec.ts) does NOT ride on this override — it seeds a
+      # connection pointing straight at greenmail:3143 with security "none", so
+      # it exercises the real credential path (host out of the DB row) and needs
+      # no test-only branch in the sweep's IMAP port.
       - IMAP_MOCK_HOST=greenmail
       - IMAP_MOCK_PORT=3143
       - SMTP_MOCK_HOST=greenmail
       - SMTP_MOCK_PORT=3025
+      # Drive the reconciliation sweep on a 5s cadence instead of the 15-minute
+      # production one, so a spec can prove mail dispatches with no manual
+      # trigger. Same convention as CHANNEL_HEALTH_INTERVAL_MS.
+      - INBOX_SWEEP_INTERVAL_MS=5000
+      - INBOX_SWEEP_STARTUP_DELAY_MS=2000
       # Opt this test container into the insecure GreenMail redirect. The
       # adapter's *_MOCK_HOST override forces plaintext (secure:false); it only
       # takes effect with this explicit flag, so the TLS downgrade can never

--- a/packages/web/e2e/email/helpers.ts
+++ b/packages/web/e2e/email/helpers.ts
@@ -609,3 +609,121 @@ export async function getGreenmailMailboxMessages(address: string): Promise<
     await client.logout();
   }
 }
+
+/**
+ * An IMAP connection whose stored credentials point straight at GreenMail.
+ *
+ * Deliberately NOT the `IMAP_MOCK_HOST` env redirect the pinchy-email plugin
+ * uses: the Inbox Agent's sweep opens its mailbox from the credentials in the
+ * DB row, so seeding the real host here exercises that path end to end and
+ * keeps the sweep's IMAP port free of any test-only branch.
+ *
+ * `security: "none"` is what makes the port speak plaintext to GreenMail
+ * (tlsModeForPort maps it to secure:false) — GreenMail here has no TLS
+ * listener, and its auth is disabled, so any user/password authenticates.
+ */
+export async function createGreenmailImapConnectionInDb(
+  name = "E2E Sweep IMAP",
+  emailAddress = "mock@example.com"
+): Promise<{ id: string; type: string; name: string }> {
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl);
+
+  const credentials = {
+    // Resolved on the compose network — the web app (not the test runner)
+    // is what opens this connection.
+    imapHost: "greenmail",
+    imapPort: 3143,
+    smtpHost: "greenmail",
+    smtpPort: 3025,
+    username: emailAddress,
+    password: "mock-password",
+    security: "none",
+  };
+
+  const id = randomUUID();
+  const data = JSON.stringify({ emailAddress, provider: "imap" });
+  const [row] = await sql`
+    INSERT INTO integration_connections (id, type, name, description, credentials, status, data)
+    VALUES (${id}, 'imap', ${name}, 'E2E sweep IMAP connection', ${encryptCredentials(
+      JSON.stringify(credentials)
+    )}, 'active', ${data})
+    RETURNING id, type, name
+  `;
+
+  await sql.end();
+  return row as { id: string; type: string; name: string };
+}
+
+/**
+ * Seed an enabled email workflow plus its (workflow × connection) link.
+ *
+ * Seeded directly because no product surface creates workflows yet — the
+ * natural-language creation tool is #705. `sinceTs` is the watermark the sweep
+ * enforces, so it is backdated here; left at "now" it would race the seeded
+ * mail and drop it as historical.
+ */
+export async function seedEmailWorkflow(input: {
+  agentId: string;
+  connectionId: string;
+  name: string;
+  action: string;
+  filter?: Record<string, unknown>;
+  sinceTs?: Date;
+}): Promise<string> {
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl);
+
+  const id = randomUUID();
+  await sql`
+    INSERT INTO email_workflows (id, agent_id, name, filter, action, enabled, status)
+    VALUES (${id}, ${input.agentId}, ${input.name}, ${JSON.stringify(
+      input.filter ?? {}
+    )}::jsonb, ${input.action}, true, 'active')
+  `;
+  await sql`
+    INSERT INTO email_workflow_connections (workflow_id, connection_id, since_ts)
+    VALUES (${id}, ${input.connectionId}, ${input.sinceTs ?? new Date(Date.now() - 60 * 60_000)})
+  `;
+
+  await sql.end();
+  return id;
+}
+
+/**
+ * The workflow's ledger rows — the sweep's record of what it has processed.
+ *
+ * The ledger stores no subject or address: it is keyed by the provider's
+ * message id and deliberately holds no PII. `messageIdHeader` (the RFC 5322
+ * Message-ID) is what correlates a row back to a seeded mail.
+ */
+export async function getProcessedEmails(workflowId: string): Promise<
+  Array<{
+    providerMessageId: string;
+    messageIdHeader: string | null;
+    status: string;
+    outcome: Record<string, unknown> | null;
+    runId: string | null;
+  }>
+> {
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl);
+
+  const rows = await sql`
+    SELECT provider_message_id, message_id_header, status, outcome, run_id
+    FROM processed_emails
+    WHERE workflow_id = ${workflowId}
+  `;
+
+  await sql.end();
+  return rows.map((r) => ({
+    providerMessageId: r.provider_message_id as string,
+    messageIdHeader: (r.message_id_header ?? null) as string | null,
+    status: r.status as string,
+    outcome: (r.outcome ?? null) as Record<string, unknown> | null,
+    runId: (r.run_id ?? null) as string | null,
+  }));
+}

--- a/packages/web/e2e/email/helpers.ts
+++ b/packages/web/e2e/email/helpers.ts
@@ -660,9 +660,19 @@ export async function createGreenmailImapConnectionInDb(
  * Seed an enabled email workflow plus its (workflow × connection) link.
  *
  * Seeded directly because no product surface creates workflows yet — the
- * natural-language creation tool is #705. `sinceTs` is the watermark the sweep
- * enforces, so it is backdated here; left at "now" it would race the seeded
- * mail and drop it as historical.
+ * natural-language creation tool is #705.
+ *
+ * Two fields are load-bearing and easy to get wrong, because the loader drops a
+ * workflow that gets them wrong SILENTLY (no log, no status change — it just
+ * never runs):
+ *
+ * - `createdBy` must resolve to a real user. The loader derives the run's
+ *   notification recipients from it (a shared agent's workflow notifies its
+ *   creator) and skips any workflow whose recipient set comes out empty, since
+ *   dispatchEmails rejects an undeliverable unit. Defaults to the admin.
+ * - `sinceTs` is the watermark the sweep enforces. It is backdated an hour by
+ *   default; left at "now" it would race the mail seeded right after it and
+ *   drop it as historical.
  */
 export async function seedEmailWorkflow(input: {
   agentId: string;
@@ -671,17 +681,25 @@ export async function seedEmailWorkflow(input: {
   action: string;
   filter?: Record<string, unknown>;
   sinceTs?: Date;
+  createdBy?: string;
 }): Promise<string> {
   const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
   const { default: postgres } = await import("postgres");
   const sql = postgres(dbUrl);
 
+  let createdBy = input.createdBy;
+  if (!createdBy) {
+    const [admin] = await sql`SELECT id FROM "user" WHERE email = ${_adminEmail} LIMIT 1`;
+    if (!admin) throw new Error(`seedEmailWorkflow: no user found for ${_adminEmail}`);
+    createdBy = admin.id as string;
+  }
+
   const id = randomUUID();
   await sql`
-    INSERT INTO email_workflows (id, agent_id, name, filter, action, enabled, status)
+    INSERT INTO email_workflows (id, agent_id, name, filter, action, enabled, status, created_by)
     VALUES (${id}, ${input.agentId}, ${input.name}, ${JSON.stringify(
       input.filter ?? {}
-    )}::jsonb, ${input.action}, true, 'active')
+    )}::jsonb, ${input.action}, true, 'active', ${createdBy})
   `;
   await sql`
     INSERT INTO email_workflow_connections (workflow_id, connection_id, since_ts)

--- a/packages/web/e2e/email/inbox-sweep.spec.ts
+++ b/packages/web/e2e/email/inbox-sweep.spec.ts
@@ -135,8 +135,13 @@ test.describe("Inbox Agent — the sweep dispatches with no manual trigger", () 
           return rows[0]?.status ?? "none";
         },
         {
+          // Two very different failures land here, so name both: "none" means the
+          // sweep never claimed the mail (boot wiring missing, or the port cannot
+          // reach GreenMail), while a terminal "failed" means it ran and the run
+          // or its report was rejected. Reporting only the first would send the
+          // next reader hunting for a scheduler bug that isn't there.
           message:
-            "the sweep never dispatched the seeded mail — check that server.ts starts it and that the port reaches GreenMail",
+            "the sweep never finished the seeded mail — a last status of `none` means it never claimed it (check that server.ts starts it and that the port reaches GreenMail); `failed` means the run itself was rejected (check the fake-Ollama report shape)",
           timeout: 120_000,
           intervals: [2000],
         }

--- a/packages/web/e2e/email/inbox-sweep.spec.ts
+++ b/packages/web/e2e/email/inbox-sweep.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Inbox Agent (#139) — the reconciliation sweep, end to end and unprompted.
+ *
+ * Every layer below this is covered against an injected seam: the sweep engine
+ * against fake ports, the ports against a mocked fetch/imapflow, the run adapter
+ * against a mock gateway client. All of them share one blind spot — they are
+ * *called by the test*. The single claim none of them can make is the one the
+ * whole feature rests on:
+ *
+ *   mail lands in a real mailbox, and Pinchy acts on it with nobody asking.
+ *
+ * So this spec never triggers a sweep. It seeds a workflow and a message, then
+ * waits for Pinchy's own cadence (INBOX_SWEEP_INTERVAL_MS, 5s here instead of
+ * the 15-minute production interval) to notice. If the boot wiring in server.ts
+ * were missing or the port could not reach the mailbox, nothing would ever
+ * happen and this test would time out — which is exactly the failure that
+ * every green unit test would still hide.
+ *
+ * IMAP is the provider under test on purpose: GreenMail is a real IMAP server,
+ * so the port's one-connection lifecycle is exercised for real, and its host
+ * comes out of the connection's stored credentials rather than an env override.
+ */
+import { test, expect } from "@playwright/test";
+
+import {
+  FAKE_OLLAMA_INBOX_SWEEP_TRIGGER,
+  FAKE_OLLAMA_PORT,
+  startFakeOllama,
+} from "../shared/fake-ollama/fake-ollama-server";
+import { seedDefaultProviderToOllama } from "../shared/dispatch-probe";
+import { stackDbUrl } from "../shared/stack-db";
+import {
+  createGreenmailImapConnectionInDb,
+  getProcessedEmails,
+  login,
+  pinchyPost,
+  pinchyPut,
+  resetImapMailbox,
+  seedEmailWorkflow,
+  seedImapMessage,
+  seedSetup,
+  waitForImapMock,
+  waitForOpenClawConnected,
+  waitForPinchy,
+} from "./helpers";
+
+const MOCK_MAILBOX = "mock@example.com";
+
+test.describe("Inbox Agent — the sweep dispatches with no manual trigger", () => {
+  let cookie: string;
+  let agentId: string;
+  let connectionId: string;
+  let restoreSettings: (() => Promise<void>) | null = null;
+
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(240_000);
+
+    await waitForPinchy();
+    await waitForImapMock();
+    await seedSetup();
+
+    // The run is a normal OpenClaw chat turn, so it needs a provider: point the
+    // default at fake-Ollama on the host, which answers the inbox trigger with
+    // a report block (see FAKE_OLLAMA_INBOX_SWEEP_TRIGGER).
+    await startFakeOllama();
+    restoreSettings = await seedDefaultProviderToOllama(
+      process.env.DATABASE_URL || stackDbUrl(5434),
+      FAKE_OLLAMA_PORT
+    );
+
+    cookie = await login();
+
+    const conn = await createGreenmailImapConnectionInDb("E2E Sweep IMAP", MOCK_MAILBOX);
+    connectionId = conn.id;
+
+    const createRes = await pinchyPost(
+      "/api/agents",
+      { name: "E2E Inbox Sweep Agent", templateId: "custom" },
+      cookie
+    );
+    if (createRes.status !== 201)
+      throw new Error(`Agent creation failed: ${String(createRes.status)}`);
+    agentId = ((await createRes.json()) as { id: string }).id;
+
+    // The agent reads its own mail during the run, so it needs the grant —
+    // and this is what puts the plugin block into its OpenClaw config.
+    const permRes = await pinchyPut(
+      `/api/agents/${agentId}/integrations`,
+      { connectionId, permissions: [{ model: "email", operation: "read" }] },
+      cookie
+    );
+    if (permRes.status !== 200)
+      throw new Error(`Permissions grant failed: ${String(permRes.status)}`);
+
+    // The readiness gate defers every run until the agent is in OC's runtime;
+    // without this the first sweeps would defer and burn the spec's budget.
+    await waitForOpenClawConnected(cookie);
+  });
+
+  test.afterAll(async () => {
+    if (restoreSettings) await restoreSettings();
+  });
+
+  test("processes a mail nobody asked it to process", async () => {
+    test.setTimeout(180_000);
+
+    await resetImapMailbox();
+
+    const subject = `E2E sweep probe ${Date.now()}`;
+    const workflowId = await seedEmailWorkflow({
+      agentId,
+      connectionId,
+      name: "E2E Inbox Sweep",
+      // The trigger rides in the action: the run adapter renders it into the
+      // task message as `Task: <action>`, which is what fake-Ollama matches.
+      action: `${FAKE_OLLAMA_INBOX_SWEEP_TRIGGER}: file this invoice`,
+      // Scope to this run's mail only, so a stray message in the shared
+      // mailbox cannot make this test pass for the wrong reason.
+      filter: { subjectContains: [subject] },
+    });
+
+    await seedImapMessage({
+      to: MOCK_MAILBOX,
+      from: "supplier@example.com",
+      subject,
+      body: "Please find the invoice attached.",
+    });
+
+    // From here on the test does NOTHING but watch. Every state change below is
+    // Pinchy acting on its own cadence.
+    await expect
+      .poll(
+        async () => {
+          const rows = await getProcessedEmails(workflowId);
+          return rows[0]?.status ?? "none";
+        },
+        {
+          message:
+            "the sweep never dispatched the seeded mail — check that server.ts starts it and that the port reaches GreenMail",
+          timeout: 120_000,
+          intervals: [2000],
+        }
+      )
+      .toBe("done");
+
+    const rows = await getProcessedEmails(workflowId);
+    expect(rows).toHaveLength(1);
+    // The outcome proves the agent RAN and its report was parsed — not merely
+    // that a ledger row was claimed. A claim alone would also be `done`-less,
+    // but a wrong-shaped report would finalize `failed`, so pin the payload.
+    expect(rows[0].outcome).toMatchObject({ note: "e2e-inbox-sweep" });
+    expect(rows[0].runId).toBeTruthy();
+    expect(rows[0].messageIdHeader).toBeTruthy();
+  });
+});

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -199,6 +199,17 @@ const ODOO_READ_DENIED_RESPONSE = "Read attempted: coverage probe complete.";
 // against a mock that now actually validates many2one write values.
 const ODOO_CREATE_NESTED_LINES_TRIGGER = "E2E_ODOO_CREATE_NESTED_LINES_TOOL";
 const ODOO_CREATE_NESTED_LINES_RESPONSE = "Move created: coverage probe complete.";
+// Inbox Agent (#139). Unlike every trigger around it, this one answers with
+// plain TEXT and no tool call: an inbox run's result channel IS the final
+// assistant text, ending in one fenced JSON report (see run-adapter.ts —
+// real Gateways don't surface tool_use chunks through chat(), so a report tool
+// would be invisible). The trigger rides in the workflow's `action`, which the
+// adapter renders into the task message as `Task: <action>`.
+const INBOX_SWEEP_TRIGGER = "E2E_INBOX_SWEEP_RUN";
+const INBOX_SWEEP_RESPONSE = `Filed the invoice against the customer record.
+\`\`\`json
+{"status": "done", "title": "Invoice filed", "content": "Booked the attached invoice for the E2E sweep probe.", "outcome": {"note": "e2e-inbox-sweep"}}
+\`\`\``;
 const EMAIL_LIST_TRIGGER = "E2E_EMAIL_LIST_TOOL";
 const EMAIL_LIST_RESPONSE = "Emails listed: coverage probe complete.";
 const EMAIL_SEARCH_TRIGGER = "E2E_EMAIL_SEARCH_TOOL";
@@ -1452,6 +1463,14 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    // Inbox Agent run (#139): plain text ending in the fenced JSON report the
+    // run adapter parses. Only on this surface — an inbox run is dispatched by
+    // Pinchy through OC's pi-ai, which uses /v1/chat/completions.
+    if (lastContent.includes(INBOX_SWEEP_TRIGGER)) {
+      streamOpenAiText(res, INBOX_SWEEP_RESPONSE);
+      return;
+    }
+
     // Slow-stream trigger: Pinchy emits ollama as api: "openai-completions" so
     // OC's pi-ai uses /v1/chat/completions, not /api/chat. The slow-stream
     // handler must live on this path too or stream-persistence tests never
@@ -1570,6 +1589,7 @@ export const FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER = ODOO_SCHEDULE_ACTI
 export const FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE = ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_TRIGGER = ODOO_CREATE_NESTED_LINES_TRIGGER;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_RESPONSE = ODOO_CREATE_NESTED_LINES_RESPONSE;
+export const FAKE_OLLAMA_INBOX_SWEEP_TRIGGER = INBOX_SWEEP_TRIGGER;
 export const FAKE_OLLAMA_EMAIL_LIST_TOOL_TRIGGER = EMAIL_LIST_TRIGGER;
 export const FAKE_OLLAMA_EMAIL_LIST_TOOL_RESPONSE = EMAIL_LIST_RESPONSE;
 export const FAKE_OLLAMA_EMAIL_SEARCH_TOOL_TRIGGER = EMAIL_SEARCH_TRIGGER;

--- a/packages/web/playwright.email.config.ts
+++ b/packages/web/playwright.email.config.ts
@@ -7,12 +7,16 @@ import { defineConfig } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./e2e/email",
-  // Run only the OAuth-provider specs here. email-imap.spec.ts needs the
-  // GreenMail + imap-mock stack (docker-compose.imap-test.yml) which this
-  // job does NOT bring up — it runs under playwright.imap.config.ts /
-  // test:e2e:imap instead. Without this, the imap spec would run here against
-  // a stack with no imap mock and fail with "IMAP mock not ready".
-  testIgnore: "email-imap.spec.ts",
+  // Run only the OAuth-provider specs here. e2e/email is shared with
+  // playwright.imap.config.ts, which claims exactly the specs listed below:
+  // they need the GreenMail + imap-mock stack (docker-compose.imap-test.yml)
+  // that this job does NOT bring up, so running them here fails with "IMAP
+  // mock not ready".
+  //
+  // This is a denylist, so a NEW spec added to e2e/email runs here by default.
+  // Keep it in sync with playwright.imap.config.ts's testMatch — the two
+  // partition one directory, and a spec must appear in exactly one of them.
+  testIgnore: ["email-imap.spec.ts", "inbox-sweep.spec.ts"],
   fullyParallel: false,
   retries: 0,
   workers: 1,

--- a/packages/web/playwright.imap.config.ts
+++ b/packages/web/playwright.imap.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./e2e/email",
-  testMatch: "email-imap.spec.ts",
+  testMatch: /(email-imap|inbox-sweep)\.spec\.ts/,
   fullyParallel: false,
   retries: 0,
   workers: 1,

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -652,7 +652,12 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
     const { buildSweepDeps } = await import("./src/server/inbox-sweep-deps");
     const { runReconciliationSweep } = await import("./src/lib/email-workflows/sweep");
     const sweepDeps = buildSweepDeps(ocForWatchdog);
-    startInboxSweep(() => runReconciliationSweep(sweepDeps));
+    startInboxSweep(() => runReconciliationSweep(sweepDeps), {
+      // E2E only (same convention as CHANNEL_HEALTH_INTERVAL_MS): the 15-minute
+      // production cadence is far longer than any test can wait for.
+      intervalMs: Number(process.env.INBOX_SWEEP_INTERVAL_MS) || undefined,
+      startupDelayMs: Number(process.env.INBOX_SWEEP_STARTUP_DELAY_MS) || undefined,
+    });
     registerShutdownHandlers([
       () => {
         stopInboxSweep();

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -634,6 +634,32 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       },
     ]);
 
+    // Inbox Agent (#139): drive the reconciliation sweep on its own cadence.
+    // The sweep re-lists each email workflow's recent mail and dispatches
+    // whatever the ledger has not seen — the correctness path that makes the
+    // feature autonomous. It runs agents, so it belongs here (inside the
+    // gateway block) rather than beside the periodic jobs started above.
+    //
+    // Starting it before the handshake is safe by construction: while the
+    // gateway is disconnected the readiness gate defers every run rather than
+    // failing mail nobody examined (see createAgentReadinessGate). That is also
+    // why this is NOT hung off the `connected` event — that fires again on every
+    // reconnect, and a second startInboxSweep would leak another interval.
+    //
+    // Lazy import for the same reason as the jobs above: these modules pull in
+    // `@/db`, which must not be evaluated before bootInits() has completed.
+    const { startInboxSweep, stopInboxSweep } = await import("./src/server/inbox-sweep");
+    const { buildSweepDeps } = await import("./src/server/inbox-sweep-deps");
+    const { runReconciliationSweep } = await import("./src/lib/email-workflows/sweep");
+    const sweepDeps = buildSweepDeps(ocForWatchdog);
+    startInboxSweep(() => runReconciliationSweep(sweepDeps));
+    registerShutdownHandlers([
+      () => {
+        stopInboxSweep();
+        return Promise.resolve();
+      },
+    ]);
+
     let hasConnected = false;
     let errorLogged = false;
 

--- a/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
@@ -177,6 +177,54 @@ describe("reconciliation sweep — loader → lister → dispatcher", () => {
   });
 });
 
+describe("reconciliation sweep — port lifecycle", () => {
+  // A mailbox port can hold a real connection: the IMAP adapter opens ONE
+  // connection and serves `search` plus every `read` over it, because the lister
+  // does 1×search + N×read and a connection per message is not an option. Nothing
+  // else can close it — the port is created per (workflow × connection) inside
+  // the sweep and discarded there — so the sweep owns the lifecycle. `close` is
+  // optional: Graph/Gmail are stateless HTTP and simply don't implement it.
+  it("closes the port after a unit", async () => {
+    const { connection } = await seedDispatchableWorkflow();
+    let closed = 0;
+    const { createPort: base } = portFor(connection.id, [message()]);
+    const createPort = async (id: string): Promise<EmailPort> => ({
+      ...(await base(id)),
+      close: async () => {
+        closed++;
+      },
+    });
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(closed).toBeGreaterThan(0);
+  });
+
+  it("closes the port even when the unit fails — a dead mailbox must not leak its connection", async () => {
+    // The failure path is exactly where a leak would go unnoticed: an unreachable
+    // mailbox throws out of `search`, the sweep catches it at unit level and moves
+    // on. Without a `finally` the connection would be stranded on every bad pass,
+    // every cadence, forever.
+    await seedDispatchableWorkflow();
+    let closed = 0;
+    const createPort = async (): Promise<EmailPort> => ({
+      search: async () => {
+        throw new Error("mailbox unreachable");
+      },
+      read: async () => {
+        throw new Error("unreachable");
+      },
+      close: async () => {
+        closed++;
+      },
+    });
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(closed).toBeGreaterThan(0);
+  });
+});
+
 describe("reconciliation sweep — sinceTs watermark", () => {
   it("never processes mail older than the workflow's sinceTs, even inside the sweep window", async () => {
     // The failure mode from design §8, "New workflow on old mailbox": the sweep

--- a/packages/web/src/__tests__/lib/e2e-email-config-partition.test.ts
+++ b/packages/web/src/__tests__/lib/e2e-email-config-partition.test.ts
@@ -1,0 +1,100 @@
+// Drift guard: `e2e/email` is ONE directory served by TWO Playwright configs.
+//
+// - playwright.email.config.ts runs the OAuth-provider specs, on a stack with no
+//   mailbox. It claims the directory by DENYLIST (`testIgnore`), so a new spec
+//   runs there by default.
+// - playwright.imap.config.ts runs the specs that need the GreenMail + imap-mock
+//   stack. It claims them by ALLOWLIST (`testMatch`).
+//
+// The two must partition the directory exactly, and both drift directions hurt:
+//
+// - Ignored by email but NOT claimed by imap: the spec runs nowhere. Green CI,
+//   zero protection — the failure mode the no-untracked-skips and
+//   no-test-deletion guards exist to stop, reached from a third direction.
+// - Claimed by imap but NOT ignored by email: it runs twice, and the imap-less
+//   job fails with "IMAP mock not ready".
+//
+// Nothing else checks this: each config is individually valid whatever the other
+// says, and CI runs them in separate jobs that never compare notes. A brand-new
+// spec that neither mentions is fine by construction — the denylist runs it.
+import { readdirSync } from "fs";
+import { join } from "path";
+
+import { describe, it, expect } from "vitest";
+
+import emailConfig from "../../../playwright.email.config";
+import imapConfig from "../../../playwright.imap.config";
+
+const E2E_EMAIL_DIR = join(__dirname, "../../../e2e/email");
+
+function specFiles(): string[] {
+  return readdirSync(E2E_EMAIL_DIR)
+    .filter((f) => f.endsWith(".spec.ts"))
+    .sort();
+}
+
+/** The denylist as written in playwright.email.config.ts. */
+function emailIgnoreList(): string[] {
+  const ignore = emailConfig.testIgnore;
+  // Keep the guard honest about the shape it reads: a config that switched to a
+  // RegExp or a glob would sail past a naive `[].includes` check.
+  expect(
+    Array.isArray(ignore),
+    "playwright.email.config.ts testIgnore must stay a string array"
+  ).toBe(true);
+  return (ignore as string[]).map(String);
+}
+
+/** Does playwright.imap.config.ts's allowlist claim this spec? */
+function imapClaims(spec: string): boolean {
+  const match = imapConfig.testMatch;
+  expect(match instanceof RegExp, "playwright.imap.config.ts testMatch must stay a RegExp").toBe(
+    true
+  );
+  return (match as RegExp).test(spec);
+}
+
+describe("e2e/email is partitioned between the two Playwright configs", () => {
+  it("finds the specs it is guarding", () => {
+    // A guard that silently reads an empty directory proves nothing forever.
+    expect(specFiles().length).toBeGreaterThan(0);
+  });
+
+  it("runs every spec in exactly one config", () => {
+    const assignments = specFiles().map((spec) => {
+      const claimedByImap = imapClaims(spec);
+      const ignoredByEmail = emailIgnoreList().includes(spec);
+      return {
+        spec,
+        // The email config is a denylist: it runs whatever it does not ignore.
+        runsUnderEmail: !ignoredByEmail,
+        runsUnderImap: claimedByImap,
+      };
+    });
+
+    for (const a of assignments) {
+      const configs = [a.runsUnderEmail && "email", a.runsUnderImap && "imap"].filter(Boolean);
+      expect(
+        configs,
+        `${a.spec} must run under exactly one config, but runs under ${configs.length === 0 ? "neither" : configs.join(" AND ")}. ` +
+          `Add it to playwright.imap.config.ts's testMatch AND playwright.email.config.ts's testIgnore (it needs the GreenMail stack), or to neither (it does not).`
+      ).toHaveLength(1);
+    }
+  });
+
+  it("ignores nothing in the email config that the imap config does not claim", () => {
+    // The other drift direction: an entry left in testIgnore after its spec was
+    // renamed or deleted means the email config is quietly skipping a spec that
+    // no job picks up.
+    for (const ignored of emailIgnoreList()) {
+      expect(
+        specFiles(),
+        `playwright.email.config.ts ignores "${ignored}", which no longer exists in e2e/email`
+      ).toContain(ignored);
+      expect(
+        imapClaims(ignored),
+        `playwright.email.config.ts ignores "${ignored}", but playwright.imap.config.ts does not claim it — no job runs this spec`
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/port.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/port.test.ts
@@ -16,8 +16,13 @@ vi.mock("@/lib/email-workflows/ports/imap", () => ({
   createImapPort: vi.fn().mockReturnValue({ search: vi.fn(), read: vi.fn(), close: vi.fn() }),
 }));
 
+vi.mock("@/lib/email-workflows/ports/graph", () => ({
+  createGraphPort: vi.fn().mockReturnValue({ search: vi.fn(), read: vi.fn() }),
+}));
+
 import { resolveConnectionCredentials } from "@/lib/integrations/resolve-credentials";
 import { createImapPort } from "@/lib/email-workflows/ports/imap";
+import { createGraphPort } from "@/lib/email-workflows/ports/graph";
 import { createEmailPort } from "@/lib/email-workflows/port";
 
 describe("createEmailPort", () => {
@@ -33,6 +38,20 @@ describe("createEmailPort", () => {
 
     expect(resolveConnectionCredentials).toHaveBeenCalledWith("conn-1");
     expect(createImapPort).toHaveBeenCalledWith(credentials);
+    expect(port.search).toBeDefined();
+  });
+
+  it("builds a Graph port from a microsoft connection's decrypted credentials", async () => {
+    const credentials = {
+      accessToken: "tok",
+      refreshToken: "r",
+      expiresAt: "2026-07-18T00:00:00Z",
+    };
+    vi.mocked(resolveConnectionCredentials).mockResolvedValue({ type: "microsoft", credentials });
+
+    const port = await createEmailPort("conn-ms");
+
+    expect(createGraphPort).toHaveBeenCalledWith(credentials);
     expect(port.search).toBeDefined();
   });
 

--- a/packages/web/src/__tests__/lib/email-workflows/port.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/port.test.ts
@@ -1,0 +1,47 @@
+// Unit tests for createEmailPort — the sweep's `createPort` dependency in
+// production: connectionId -> decrypted credentials -> a provider-specific
+// EmailPort.
+//
+// The provider adapters are covered by their own tests (and end-to-end against
+// their mocks); what is proven here is the dispatch itself: the right adapter
+// for the connection's type, and a loud failure for a connection that is not a
+// mailbox at all.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/integrations/resolve-credentials", () => ({
+  resolveConnectionCredentials: vi.fn(),
+}));
+
+vi.mock("@/lib/email-workflows/ports/imap", () => ({
+  createImapPort: vi.fn().mockReturnValue({ search: vi.fn(), read: vi.fn(), close: vi.fn() }),
+}));
+
+import { resolveConnectionCredentials } from "@/lib/integrations/resolve-credentials";
+import { createImapPort } from "@/lib/email-workflows/ports/imap";
+import { createEmailPort } from "@/lib/email-workflows/port";
+
+describe("createEmailPort", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds an IMAP port from an imap connection's decrypted credentials", async () => {
+    const credentials = { imapHost: "mail.example.com", username: "u", password: "p" };
+    vi.mocked(resolveConnectionCredentials).mockResolvedValue({ type: "imap", credentials });
+
+    const port = await createEmailPort("conn-1");
+
+    expect(resolveConnectionCredentials).toHaveBeenCalledWith("conn-1");
+    expect(createImapPort).toHaveBeenCalledWith(credentials);
+    expect(port.search).toBeDefined();
+  });
+
+  it("throws for a connection that is not a mailbox", async () => {
+    // A workflow pointed at an Odoo or web-search connection is a configuration
+    // bug. Fail loudly at the sweep's unit level (surfacing as the workflow's
+    // `error` status) rather than returning a port that no-ops forever.
+    vi.mocked(resolveConnectionCredentials).mockResolvedValue({ type: "odoo", credentials: {} });
+
+    await expect(createEmailPort("conn-odoo")).rejects.toThrow(/not a mailbox|odoo/i);
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/port.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/port.test.ts
@@ -20,9 +20,14 @@ vi.mock("@/lib/email-workflows/ports/graph", () => ({
   createGraphPort: vi.fn().mockReturnValue({ search: vi.fn(), read: vi.fn() }),
 }));
 
+vi.mock("@/lib/email-workflows/ports/gmail", () => ({
+  createGmailPort: vi.fn().mockReturnValue({ search: vi.fn(), read: vi.fn() }),
+}));
+
 import { resolveConnectionCredentials } from "@/lib/integrations/resolve-credentials";
 import { createImapPort } from "@/lib/email-workflows/ports/imap";
 import { createGraphPort } from "@/lib/email-workflows/ports/graph";
+import { createGmailPort } from "@/lib/email-workflows/ports/gmail";
 import { createEmailPort } from "@/lib/email-workflows/port";
 
 describe("createEmailPort", () => {
@@ -52,6 +57,20 @@ describe("createEmailPort", () => {
     const port = await createEmailPort("conn-ms");
 
     expect(createGraphPort).toHaveBeenCalledWith(credentials);
+    expect(port.search).toBeDefined();
+  });
+
+  it("builds a Gmail port from a google connection's decrypted credentials", async () => {
+    const credentials = {
+      accessToken: "tok",
+      refreshToken: "r",
+      expiresAt: "2026-07-18T00:00:00Z",
+    };
+    vi.mocked(resolveConnectionCredentials).mockResolvedValue({ type: "google", credentials });
+
+    const port = await createEmailPort("conn-gmail");
+
+    expect(createGmailPort).toHaveBeenCalledWith(credentials);
     expect(port.search).toBeDefined();
   });
 

--- a/packages/web/src/__tests__/lib/email-workflows/ports/gmail.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/gmail.test.ts
@@ -198,3 +198,139 @@ describe("Gmail port — listing query", () => {
     await expect(port.search({ sinceDays: 14 })).resolves.toEqual([]);
   });
 });
+
+describe("Gmail port — label resolution", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function urlOf(callIndex: number): string {
+    return decodeURIComponent(String(fetchSpy.mock.calls[callIndex][0]));
+  }
+
+  it("resolves a user label's name to its opaque id", async () => {
+    // A system label's id IS its name (INBOX, SPAM, …), which is why upper-casing
+    // the folder worked at all. A user-created label's id is an opaque `Label_17`
+    // and its name is never a valid labelId — so `labelIds=RECEIPTS` is a 400 from
+    // Gmail, and every workflow watching a user label is dead on arrival.
+    fetchSpy
+      .mockResolvedValueOnce(
+        jsonResponse({
+          labels: [
+            { id: "INBOX", name: "INBOX", type: "system" },
+            { id: "Label_17", name: "Receipts", type: "user" },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ messages: [] }));
+    const port = createGmailPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "Receipts", limit: 50 });
+
+    expect(urlOf(0)).toContain("/users/me/labels");
+    expect(urlOf(1)).toContain("labelIds=Label_17");
+  });
+
+  it("spends no round trip on a system label", async () => {
+    // The overwhelmingly common case. A system label's id is its upper-cased
+    // name by definition, so resolving it over the wire would be pure latency.
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ messages: [] }));
+    const port = createGmailPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "inbox", limit: 50 });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(urlOf(0)).toContain("labelIds=INBOX");
+  });
+
+  it("resolves the label list once per port, not once per search", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ labels: [{ id: "Label_17", name: "Receipts" }] }))
+      // A fresh Response per call: a Response body can only be read once, so a
+      // single shared instance would fail the second search on the body, not on
+      // the behaviour under test.
+      .mockImplementation(async () => jsonResponse({ messages: [] }));
+    const port = createGmailPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "Receipts" });
+    await port.search({ sinceDays: 14, folder: "Receipts" });
+
+    const labelCalls = fetchSpy.mock.calls.filter((call: unknown[]) =>
+      String(call[0]).includes("/labels")
+    );
+    expect(labelCalls).toHaveLength(1);
+  });
+
+  it("fails loudly for a label the mailbox does not have", async () => {
+    // Never fall back to searching the whole mailbox or to INBOX: a workflow
+    // pointed at a renamed/deleted label must surface as the workflow's `error`
+    // status, not quietly act on the wrong mail.
+    fetchSpy.mockResolvedValue(jsonResponse({ labels: [{ id: "Label_17", name: "Receipts" }] }));
+    const port = createGmailPort(credentials);
+
+    await expect(port.search({ sinceDays: 14, folder: "Gone" })).rejects.toThrow(/Gone/);
+  });
+
+  it("reports the label's NAME on read, not its opaque id", async () => {
+    // matchesFilter compares `email.folder` against the workflow's configured
+    // folder — which is the name the user typed, never `Label_17`.
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ labels: [{ id: "Label_17", name: "Receipts" }] }))
+      .mockResolvedValueOnce(jsonResponse({ messages: [{ id: "m1" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ id: "m1", internalDate: "1752483600000", payload: { headers: [] } })
+      );
+    const port = createGmailPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "Receipts" });
+
+    await expect(port.read("m1")).resolves.toMatchObject({ folder: "Receipts" });
+  });
+});
+
+describe("Gmail port — folder round trip", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("reports the folder search scoped to, not the default label", async () => {
+    // LOAD-BEARING, and silent when wrong. `read` has no folder argument, so the
+    // port must remember what `search` scoped to — exactly as the IMAP port does
+    // with its open mailbox. Reporting the default instead makes matchesFilter's
+    // folder re-check (`email.folder !== filter.folder`) drop EVERY hydrated mail
+    // of a non-INBOX workflow: no error, no failed run, the workflow stays
+    // `active` and processes nothing. That is the sweep's worst failure mode.
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ messages: [{ id: "m1" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ id: "m1", internalDate: "1752483600000", payload: { headers: [] } })
+      );
+    const port = createGmailPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "SPAM", limit: 50 });
+    const mail = await port.read("m1");
+
+    expect(mail.folder).toBe("SPAM");
+  });
+
+  it("falls back to INBOX when read runs without a preceding scoped search", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ id: "m1", internalDate: "1752483600000", payload: { headers: [] } })
+    );
+    const port = createGmailPort(credentials);
+
+    await expect(port.read("m1")).resolves.toMatchObject({ folder: "INBOX" });
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/ports/gmail.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/gmail.test.ts
@@ -1,0 +1,200 @@
+// Unit tests for the Gmail mailbox port.
+//
+// Two halves: the pure mapping (Gmail's header-array + MIME-part-tree shape ->
+// the lister's EmailReadResult), and the listing query — where Gmail has a trap
+// the pinchy-email plugin already paid for (see the labelIds guard below).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { mapGmailMessage, createGmailPort } from "@/lib/email-workflows/ports/gmail";
+
+const credentials = {
+  accessToken: "test-access-token",
+  refreshToken: "test-refresh-token",
+  expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+};
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("Gmail port — mapGmailMessage", () => {
+  it("maps headers into an EmailReadResult", () => {
+    const mapped = mapGmailMessage({
+      folder: "INBOX",
+      message: {
+        id: "18c0ff33",
+        internalDate: "1752483600000",
+        payload: {
+          mimeType: "multipart/mixed",
+          headers: [
+            { name: "From", value: "Clemens Helm <clemens@example.com>" },
+            { name: "To", value: "billing@acme.test, ops@acme.test" },
+            { name: "Cc", value: "archive@acme.test" },
+            { name: "Subject", value: "Invoice 4711" },
+            { name: "Date", value: "Tue, 14 Jul 2026 09:00:00 +0000" },
+            { name: "Message-ID", value: "<msg-4711@example.com>" },
+          ],
+        },
+      },
+    });
+
+    expect(mapped.id).toBe("18c0ff33");
+    // Raw header values are passed through: the lister is what normalizes
+    // `Display Name <addr>` and splits the recipient list, and it already
+    // handles quoted names containing commas.
+    expect(mapped.from).toBe("Clemens Helm <clemens@example.com>");
+    expect(mapped.to).toBe("billing@acme.test, ops@acme.test");
+    expect(mapped.cc).toBe("archive@acme.test");
+    expect(mapped.subject).toBe("Invoice 4711");
+    expect(mapped.date).toBe("Tue, 14 Jul 2026 09:00:00 +0000");
+    expect(mapped.folder).toBe("INBOX");
+    expect(mapped.messageIdHeader).toBe("<msg-4711@example.com>");
+    expect(mapped.attachments).toEqual([]);
+  });
+
+  it("reads headers case-insensitively", () => {
+    // RFC 5322 header names are case-insensitive and Gmail echoes whatever the
+    // sender wrote, so a `MESSAGE-ID`/`from` spelling must not silently drop the
+    // field (a missing Message-ID is invisible; a missing Date is a dropped mail).
+    const mapped = mapGmailMessage({
+      folder: "INBOX",
+      message: {
+        id: "m1",
+        internalDate: "1752483600000",
+        payload: {
+          headers: [
+            { name: "from", value: "a@x.test" },
+            { name: "SUBJECT", value: "shouty" },
+            { name: "message-id", value: "<lower@x.test>" },
+          ],
+        },
+      },
+    });
+
+    expect(mapped.from).toBe("a@x.test");
+    expect(mapped.subject).toBe("shouty");
+    expect(mapped.messageIdHeader).toBe("<lower@x.test>");
+  });
+
+  it("falls back to internalDate when the message has no Date header", () => {
+    // Same trap as IMAP: without the fallback the lister rejects it as an
+    // unparseable date and its poison-message isolation drops a real email.
+    const mapped = mapGmailMessage({
+      folder: "INBOX",
+      message: {
+        id: "m2",
+        internalDate: "1752576600000", // ms since epoch, as a string
+        payload: { headers: [{ name: "From", value: "a@x.test" }] },
+      },
+    });
+
+    expect(mapped.date).toBe(new Date(1752576600000).toISOString());
+  });
+
+  it("collects real attachments from the part tree but skips inline parts", () => {
+    const mapped = mapGmailMessage({
+      folder: "INBOX",
+      message: {
+        id: "m3",
+        internalDate: "1752483600000",
+        payload: {
+          mimeType: "multipart/mixed",
+          headers: [],
+          parts: [
+            { mimeType: "text/plain", filename: "", headers: [] },
+            {
+              mimeType: "multipart/related",
+              filename: "",
+              headers: [],
+              parts: [
+                {
+                  mimeType: "image/png",
+                  filename: "logo.png",
+                  headers: [{ name: "Content-Disposition", value: 'inline; filename="logo.png"' }],
+                  body: { attachmentId: "a1" },
+                },
+              ],
+            },
+            {
+              mimeType: "application/pdf",
+              filename: "invoice.pdf",
+              headers: [
+                { name: "Content-Disposition", value: 'attachment; filename="invoice.pdf"' },
+              ],
+              body: { attachmentId: "a2" },
+            },
+          ],
+        },
+      },
+    });
+
+    // The inline logo is the HTML body's own image — counting it would fire
+    // every workflow's hasAttachment filter on ordinary newsletters.
+    expect(mapped.attachments).toEqual([{ mimeType: "application/pdf", filename: "invoice.pdf" }]);
+  });
+});
+
+describe("Gmail port — listing query", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValue(jsonResponse({ messages: [] }));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function urlOf(callIndex: number): string {
+    return decodeURIComponent(String(fetchSpy.mock.calls[callIndex][0]));
+  }
+
+  it("scopes the folder with the labelIds API param, never with the q query", async () => {
+    // LOAD-BEARING, and learned the hard way in the pinchy-email plugin: Gmail's
+    // `q` language only documents `in:trash`/`in:spam` for folder scoping.
+    // `label:INBOX` works only via undocumented aliasing in the q parser, and
+    // Gmail search excludes Trash/Spam by default — so scoping a folder through
+    // `q` risks SILENTLY EMPTY results. For a sweep, silently-empty is the worst
+    // possible failure: it reads as "nothing new" and the workflow looks healthy
+    // while quietly processing no mail at all. labelIds is the documented param.
+    const port = createGmailPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "INBOX", limit: 50 });
+
+    const url = urlOf(0);
+    expect(url).toContain("labelIds=INBOX");
+    expect(url).not.toMatch(/q=[^&]*(in:|label:)/);
+  });
+
+  it("bounds the window with newer_than and the volume with maxResults", async () => {
+    const port = createGmailPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "INBOX", limit: 50 });
+
+    const url = urlOf(0);
+    expect(url).toContain("newer_than:14d");
+    expect(url).toContain("maxResults=50");
+  });
+
+  it("surfaces a Gmail error instead of reporting an empty mailbox", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "Invalid Credentials" } }), { status: 401 })
+    );
+    const port = createGmailPort(credentials);
+
+    await expect(port.search({ sinceDays: 14 })).rejects.toThrow(/401|Invalid Credentials/i);
+  });
+
+  it("returns an empty list for a mailbox with no matching mail", async () => {
+    // Gmail omits `messages` entirely (rather than sending []) when nothing
+    // matches — a .map on undefined would crash the whole sweep unit.
+    fetchSpy.mockResolvedValue(jsonResponse({ resultSizeEstimate: 0 }));
+    const port = createGmailPort(credentials);
+
+    await expect(port.search({ sinceDays: 14 })).resolves.toEqual([]);
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/ports/graph.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/graph.test.ts
@@ -1,0 +1,191 @@
+// Unit tests for the Microsoft Graph mailbox port.
+//
+// Two things are proven here. First the pure mapping (Graph's message shape ->
+// the lister's EmailReadResult). Second — and more important — that every
+// request carries `Prefer: IdType="ImmutableId"`, which is a *correctness*
+// requirement for the ledger, not a nicety. See the drift guard below.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { mapGraphMessage, createGraphPort } from "@/lib/email-workflows/ports/graph";
+
+const credentials = {
+  accessToken: "test-access-token",
+  refreshToken: "test-refresh-token",
+  expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+};
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("Graph port — mapGraphMessage", () => {
+  it("maps a Graph message into an EmailReadResult", () => {
+    const mapped = mapGraphMessage({
+      folder: "inbox",
+      message: {
+        id: "AAMkAG-immutable-id",
+        subject: "Invoice 4711",
+        receivedDateTime: "2026-07-14T09:00:00Z",
+        internetMessageId: "<msg-4711@example.com>",
+        from: { emailAddress: { name: "Clemens Helm", address: "clemens@example.com" } },
+        toRecipients: [
+          { emailAddress: { address: "billing@acme.test" } },
+          { emailAddress: { address: "ops@acme.test" } },
+        ],
+        ccRecipients: [{ emailAddress: { address: "archive@acme.test" } }],
+        attachments: [
+          {
+            id: "att-1",
+            name: "invoice.pdf",
+            contentType: "application/pdf",
+            isInline: false,
+          },
+        ],
+      },
+    });
+
+    expect(mapped).toEqual({
+      id: "AAMkAG-immutable-id",
+      // Bare addresses, matching the IMAP port: the lister discards display
+      // names anyway and re-emitting them would need comma-quoting.
+      from: "clemens@example.com",
+      to: "billing@acme.test, ops@acme.test",
+      cc: "archive@acme.test",
+      subject: "Invoice 4711",
+      date: "2026-07-14T09:00:00Z",
+      folder: "inbox",
+      messageIdHeader: "<msg-4711@example.com>",
+      attachments: [{ mimeType: "application/pdf", filename: "invoice.pdf" }],
+    });
+  });
+
+  it("excludes inline attachments", () => {
+    // Graph reports an HTML mail's embedded logo as an attachment with
+    // isInline: true. Counting it would fire every hasAttachment filter on
+    // ordinary newsletters — the same trap as IMAP's disposition:inline.
+    const mapped = mapGraphMessage({
+      folder: "inbox",
+      message: {
+        id: "m1",
+        receivedDateTime: "2026-07-14T09:00:00Z",
+        attachments: [
+          { id: "a1", name: "logo.png", contentType: "image/png", isInline: true },
+          { id: "a2", name: "real.pdf", contentType: "application/pdf", isInline: false },
+        ],
+      },
+    });
+
+    expect(mapped.attachments).toEqual([{ mimeType: "application/pdf", filename: "real.pdf" }]);
+  });
+
+  it("yields blank fields rather than undefined for a sparse message", () => {
+    const mapped = mapGraphMessage({
+      folder: "archive",
+      message: { id: "m2", receivedDateTime: "2026-07-14T09:00:00Z" },
+    });
+
+    expect(mapped.from).toBe("");
+    expect(mapped.to).toBe("");
+    expect(mapped.cc).toBe("");
+    expect(mapped.subject).toBe("");
+    expect(mapped.attachments).toEqual([]);
+    expect(mapped.messageIdHeader).toBeUndefined();
+  });
+});
+
+describe("Graph port — immutable ids", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function headersOf(callIndex: number): Headers {
+    const init = fetchSpy.mock.calls[callIndex][1] as RequestInit;
+    return new Headers(init.headers);
+  }
+
+  it("asks Graph for immutable ids when listing", async () => {
+    // LOAD-BEARING. The ledger's claim key is (workflow, connection,
+    // providerMessageId). Graph's DEFAULT message ids change when a message
+    // moves between folders — so without this header, a user filing a processed
+    // mail into another folder makes it reappear under a new id, outside the
+    // ledger, and it gets processed a second time (a duplicate Odoo entry).
+    //
+    // The header must also stay CONSISTENT forever: ids minted in immutable mode
+    // are not interchangeable with default-mode ids. Removing this header later
+    // would invalidate every id already in the ledger at once — the sweep would
+    // see an entire window of "new" mail and re-dispatch all of it. That is why
+    // this is a guard, not a preference.
+    fetchSpy.mockResolvedValue(jsonResponse({ value: [{ id: "m1" }] }));
+    const port = createGraphPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "inbox", limit: 50 });
+
+    expect(headersOf(0).get("Prefer")).toBe('IdType="ImmutableId"');
+  });
+
+  it("asks Graph for immutable ids when reading", async () => {
+    // The read must agree with the list: an id minted in immutable mode is only
+    // valid in immutable mode.
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ id: "m1", receivedDateTime: "2026-07-14T09:00:00Z" })
+    );
+    const port = createGraphPort(credentials);
+
+    await port.read("m1");
+
+    expect(headersOf(0).get("Prefer")).toBe('IdType="ImmutableId"');
+  });
+});
+
+describe("Graph port — search query", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValue(jsonResponse({ value: [] }));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function urlOf(callIndex: number): string {
+    return decodeURIComponent(String(fetchSpy.mock.calls[callIndex][0]));
+  }
+
+  it("scopes the listing to the folder, the window and the limit", async () => {
+    const port = createGraphPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "inbox", limit: 50 });
+
+    const url = urlOf(0);
+    expect(url).toContain("/mailFolders/inbox/messages");
+    expect(url).toContain("$top=50");
+    // Graph requires the first $orderby property to lead the $filter — the
+    // plugin's graph-adapter hit this too. Ordering by receivedDateTime desc
+    // (newest first, so a bounded page keeps the most recent mail) means the
+    // receivedDateTime predicate must come first in the filter.
+    expect(url).toContain("$orderby=receivedDateTime desc");
+    expect(url).toMatch(/\$filter=receivedDateTime ge /);
+  });
+
+  it("surfaces a Graph error instead of reporting an empty mailbox", async () => {
+    // A 401/403 answered as "no mail" would read as "nothing new" and silently
+    // retire the workflow while its status stayed active.
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "Access token expired" } }), { status: 401 })
+    );
+    const port = createGraphPort(credentials);
+
+    await expect(port.search({ sinceDays: 14 })).rejects.toThrow(/401|Access token expired/i);
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/ports/graph.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/graph.test.ts
@@ -189,3 +189,42 @@ describe("Graph port — search query", () => {
     await expect(port.search({ sinceDays: 14 })).rejects.toThrow(/401|Access token expired/i);
   });
 });
+
+describe("Graph port — folder round trip", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("reports the folder search scoped to, not the default folder", async () => {
+    // LOAD-BEARING, and silent when wrong. `read` has no folder argument, so the
+    // port must remember what `search` scoped to — exactly as the IMAP port does
+    // with its open mailbox. Reporting the default instead makes matchesFilter's
+    // folder re-check (`email.folder !== filter.folder`) drop EVERY hydrated mail
+    // of a non-inbox workflow: no error, no failed run, the workflow stays
+    // `active` and processes nothing. That is the sweep's worst failure mode.
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ value: [{ id: "m1" }] }))
+      .mockResolvedValueOnce(jsonResponse({ id: "m1", receivedDateTime: "2026-07-14T09:00:00Z" }));
+    const port = createGraphPort(credentials);
+
+    await port.search({ sinceDays: 14, folder: "archive", limit: 50 });
+    const mail = await port.read("m1");
+
+    expect(mail.folder).toBe("archive");
+  });
+
+  it("falls back to inbox when read runs without a preceding scoped search", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ id: "m1", receivedDateTime: "2026-07-14T09:00:00Z" })
+    );
+    const port = createGraphPort(credentials);
+
+    await expect(port.read("m1")).resolves.toMatchObject({ folder: "inbox" });
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/ports/imap.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/imap.test.ts
@@ -1,0 +1,119 @@
+// Unit tests for the IMAP mailbox port's pure mapping layer: imapflow's parsed
+// ENVELOPE + BODYSTRUCTURE -> the lister's `EmailReadResult`.
+//
+// The mapping is the bug-prone half (address shapes, missing headers, nested
+// multipart attachment trees) and is pure, so it is unit-tested here against
+// real imapflow type shapes. The protocol half (connect / SEARCH / FETCH) is
+// exercised end-to-end against GreenMail, where a mock would only prove itself.
+import { describe, it, expect } from "vitest";
+
+import { mapImapMessage, collectAttachments } from "@/lib/email-workflows/ports/imap";
+
+describe("IMAP port — mapImapMessage", () => {
+  it("maps a full envelope into an EmailReadResult", () => {
+    const mapped = mapImapMessage({
+      uid: 42,
+      folder: "INBOX",
+      envelope: {
+        date: new Date("2026-07-14T09:00:00.000Z"),
+        subject: "Invoice 4711",
+        messageId: "<msg-4711@example.com>",
+        from: [{ name: "Clemens Helm", address: "clemens@example.com" }],
+        to: [{ name: "Billing", address: "billing@acme.test" }, { address: "ops@acme.test" }],
+        cc: [{ name: "Archive", address: "archive@acme.test" }],
+      },
+      bodyStructure: undefined,
+    });
+
+    expect(mapped).toEqual({
+      id: "42",
+      from: "clemens@example.com",
+      // Display names are deliberately dropped: the lister discards them anyway
+      // (it normalizes to bare addresses), and emitting them would mean quoting
+      // names that contain a comma to survive the lister's address split.
+      to: "billing@acme.test, ops@acme.test",
+      cc: "archive@acme.test",
+      subject: "Invoice 4711",
+      date: "2026-07-14T09:00:00.000Z",
+      folder: "INBOX",
+      messageIdHeader: "<msg-4711@example.com>",
+      attachments: [],
+    });
+  });
+
+  it("falls back to the server's internalDate when the message has no Date header", () => {
+    // A message without a Date header still has an IMAP INTERNALDATE. Without
+    // this fallback the lister would reject it as an unparseable date and its
+    // poison-message isolation would silently drop a perfectly real email.
+    const mapped = mapImapMessage({
+      uid: 7,
+      folder: "INBOX",
+      envelope: { subject: "no date header", from: [{ address: "a@x.test" }] },
+      internalDate: new Date("2026-07-15T10:30:00.000Z"),
+    });
+
+    expect(mapped.date).toBe("2026-07-15T10:30:00.000Z");
+  });
+
+  it("yields blank fields rather than undefined for a bare envelope", () => {
+    // The lister's normalize handles blank To/Cc (it drops empty tokens); what it
+    // cannot handle is `undefined` reaching `.split()`.
+    const mapped = mapImapMessage({ uid: 1, folder: "Archive", envelope: {} });
+
+    expect(mapped.from).toBe("");
+    expect(mapped.to).toBe("");
+    expect(mapped.cc).toBe("");
+    expect(mapped.subject).toBe("");
+    expect(mapped.folder).toBe("Archive");
+    expect(mapped.messageIdHeader).toBeUndefined();
+  });
+});
+
+describe("IMAP port — collectAttachments", () => {
+  it("collects attachments from a nested multipart tree", () => {
+    const attachments = collectAttachments({
+      type: "multipart/mixed",
+      childNodes: [
+        {
+          type: "multipart/alternative",
+          childNodes: [{ type: "text/plain" }, { type: "text/html" }],
+        },
+        {
+          type: "application/pdf",
+          disposition: "attachment",
+          dispositionParameters: { filename: "invoice.pdf" },
+        },
+      ],
+    });
+
+    expect(attachments).toEqual([{ mimeType: "application/pdf", filename: "invoice.pdf" }]);
+  });
+
+  it("does not treat an inline body part as an attachment", () => {
+    // The filter's hasAttachment gate would otherwise fire on every HTML mail
+    // with an inline image, dispatching runs nobody asked for.
+    const attachments = collectAttachments({
+      type: "multipart/related",
+      childNodes: [
+        { type: "text/html" },
+        {
+          type: "image/png",
+          disposition: "inline",
+          dispositionParameters: { filename: "logo.png" },
+        },
+      ],
+    });
+
+    expect(attachments).toEqual([]);
+  });
+
+  it("falls back to the Content-Type name when Content-Disposition carries no filename", () => {
+    const attachments = collectAttachments({
+      type: "application/pdf",
+      disposition: "attachment",
+      parameters: { name: "fallback.pdf" },
+    });
+
+    expect(attachments).toEqual([{ mimeType: "application/pdf", filename: "fallback.pdf" }]);
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/ports/imap.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/imap.test.ts
@@ -5,9 +5,36 @@
 // multipart attachment trees) and is pure, so it is unit-tested here against
 // real imapflow type shapes. The protocol half (connect / SEARCH / FETCH) is
 // exercised end-to-end against GreenMail, where a mock would only prove itself.
-import { describe, it, expect } from "vitest";
+//
+// The one exception is the connection bookkeeping at the bottom of this file:
+// what the port does when a connect FAILS is our logic, not imapflow's, and
+// GreenMail cannot exercise it — a healthy server never refuses a connection on
+// demand. That describe stubs imapflow for exactly that reason, and asserts on
+// the port's own state, never on the stub's protocol behaviour.
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { mapImapMessage, collectAttachments } from "@/lib/email-workflows/ports/imap";
+const { mockConnect, mockLogout, mockSearch, mockMailboxOpen } = vi.hoisted(() => ({
+  mockConnect: vi.fn(),
+  mockLogout: vi.fn(),
+  mockSearch: vi.fn(),
+  mockMailboxOpen: vi.fn(),
+}));
+
+vi.mock("imapflow", () => ({
+  ImapFlow: class {
+    connect = mockConnect;
+    logout = mockLogout;
+    search = mockSearch;
+    mailboxOpen = mockMailboxOpen;
+    fetchOne = vi.fn();
+  },
+}));
+
+import {
+  mapImapMessage,
+  collectAttachments,
+  createImapPort,
+} from "@/lib/email-workflows/ports/imap";
 
 describe("IMAP port — mapImapMessage", () => {
   it("maps a full envelope into an EmailReadResult", () => {
@@ -115,5 +142,63 @@ describe("IMAP port — collectAttachments", () => {
     });
 
     expect(attachments).toEqual([{ mimeType: "application/pdf", filename: "fallback.pdf" }]);
+  });
+});
+
+describe("IMAP port — connection bookkeeping", () => {
+  const credentials = {
+    imapHost: "mail.example.com",
+    imapPort: 993,
+    smtpHost: "mail.example.com",
+    smtpPort: 587,
+    username: "u",
+    password: "p",
+    security: "tls" as const,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConnect.mockResolvedValue(undefined);
+    mockMailboxOpen.mockResolvedValue(undefined);
+    mockSearch.mockResolvedValue([]);
+    mockLogout.mockResolvedValue(undefined);
+  });
+
+  it("keeps no half-open client after a failed connect", async () => {
+    // The sweep closes every port in a `finally`, including the one whose
+    // mailbox was unreachable. If the failed connect left the client cached, that
+    // close would call logout() on a socket that never opened — the sweep catches
+    // and logs it, so the cost is a misleading "failed to close the port" line on
+    // top of the real, already-reported connect failure. Worse, a retry on the
+    // same port would skip connect() entirely and act as if it were connected.
+    mockConnect.mockRejectedValue(new Error("ECONNREFUSED"));
+    const port = createImapPort(credentials);
+
+    await expect(port.search({ sinceDays: 14 })).rejects.toThrow(/ECONNREFUSED/);
+
+    await expect(port.close?.()).resolves.toBeUndefined();
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it("connects once and serves search + read over the same connection", async () => {
+    // The lister does 1×search + N×read per unit; a connection per message is not
+    // an option (this is why the port holds one at all).
+    const port = createImapPort(credentials);
+
+    await port.search({ sinceDays: 14 });
+    await port.search({ sinceDays: 14 });
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks for every message when no window is given, never for `since: undefined`", async () => {
+    // The sweep always passes sweepWindowDays, so this is defensive — but an
+    // undefined-valued `since` key is the kind of thing a search compiler is free
+    // to read as a malformed term rather than an absent one. Say "all" explicitly.
+    const port = createImapPort(credentials);
+
+    await port.search({});
+
+    expect(mockSearch).toHaveBeenCalledWith({ all: true }, { uid: true });
   });
 });

--- a/packages/web/src/__tests__/lib/integrations/resolve-credentials.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/resolve-credentials.test.ts
@@ -1,0 +1,102 @@
+// Unit tests for resolveConnectionCredentials — the credential-resolution seam
+// extracted from the internal credentials route so BOTH the route (mapping to
+// HTTP status codes) and the Inbox Agent's mailbox port (mapping to the sweep's
+// unit-level failure) share one decrypt + OAuth-refresh path.
+//
+// The contract the port depends on is *typed errors*, not HTTP status codes:
+// not-found / not-active / decrypt-failure each throw a distinct class so the
+// route can map them to 404 / 403 / 500 while the port lets them propagate to
+// the sweep as the workflow's `error` status. Mirrors the route test's mock
+// style (db/encryption/oauth stubbed) — the real decrypt + real DB coverage
+// lives in the port's integration tests against the provider mocks.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decrypt: vi.fn().mockReturnValue('{"accessToken":"test-token","refreshToken":"test-refresh"}'),
+  encrypt: vi.fn().mockReturnValue("re-encrypted-blob"),
+}));
+
+vi.mock("@/lib/integrations/oauth-token", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/integrations/oauth-token")>();
+  return { ...actual, isTokenExpired: vi.fn().mockReturnValue(false) };
+});
+
+vi.mock("@/lib/integrations/oauth-settings", () => ({
+  getOAuthSettings: vi.fn().mockResolvedValue(null),
+}));
+
+import { db } from "@/db";
+import { decrypt } from "@/lib/encryption";
+import {
+  resolveConnectionCredentials,
+  ConnectionNotFoundError,
+  ConnectionNotActiveError,
+  CredentialsDecryptError,
+} from "@/lib/integrations/resolve-credentials";
+
+function mockDbSelectResult(rows: unknown[]) {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>);
+}
+
+describe("resolveConnectionCredentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(decrypt).mockReturnValue(
+      '{"accessToken":"test-token","refreshToken":"test-refresh"}'
+    );
+  });
+
+  it("returns { type, credentials } for an active connection", async () => {
+    mockDbSelectResult([{ id: "conn-1", type: "imap", status: "active", credentials: "blob" }]);
+
+    const resolved = await resolveConnectionCredentials("conn-1");
+
+    expect(resolved.type).toBe("imap");
+    expect(resolved.credentials).toEqual({
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+    });
+  });
+
+  it("throws ConnectionNotFoundError when the connection does not exist", async () => {
+    mockDbSelectResult([]);
+
+    await expect(resolveConnectionCredentials("missing")).rejects.toBeInstanceOf(
+      ConnectionNotFoundError
+    );
+  });
+
+  it("throws ConnectionNotActiveError for a pending connection", async () => {
+    mockDbSelectResult([{ id: "conn-1", type: "imap", status: "pending", credentials: "blob" }]);
+
+    await expect(resolveConnectionCredentials("conn-1")).rejects.toBeInstanceOf(
+      ConnectionNotActiveError
+    );
+  });
+
+  it("throws CredentialsDecryptError when decryption fails", async () => {
+    mockDbSelectResult([{ id: "conn-1", type: "imap", status: "active", credentials: "corrupt" }]);
+    vi.mocked(decrypt).mockImplementation(() => {
+      throw new Error("bad ciphertext");
+    });
+
+    await expect(resolveConnectionCredentials("conn-1")).rejects.toBeInstanceOf(
+      CredentialsDecryptError
+    );
+  });
+});

--- a/packages/web/src/__tests__/server/inbox-sweep-deps.test.ts
+++ b/packages/web/src/__tests__/server/inbox-sweep-deps.test.ts
@@ -1,0 +1,138 @@
+// Unit tests for the sweep's production dependency wiring.
+//
+// The sweep engine and the OpenClaw run adapter are both covered by their own
+// tests against injected fakes. What is proven here is the seam between them:
+// the two dependencies this module builds for real (the agent's model, read
+// from Pinchy's DB; the runtime-readiness gate, asked of the live Gateway).
+//
+// The readiness gate carries a load-bearing decision — see the guard below.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAgentFindFirst } = vi.hoisted(() => ({
+  mockAgentFindFirst: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  db: { query: { agents: { findFirst: mockAgentFindFirst } } },
+}));
+
+import { createEmailPort } from "@/lib/email-workflows/port";
+import {
+  buildSweepDeps,
+  createAgentReadinessGate,
+  loadAgentModel,
+} from "@/server/inbox-sweep-deps";
+
+/** The slice of the gateway client the sweep's deps actually touch. */
+function makeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    chat: vi.fn(),
+    chatAbort: vi.fn(),
+    isConnected: true,
+    hasMethod: vi.fn().mockReturnValue(true),
+    agents: { list: vi.fn().mockResolvedValue({ agents: [] }) },
+    ...overrides,
+  } as unknown as Parameters<typeof buildSweepDeps>[0];
+}
+
+describe("loadAgentModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads the agent's configured model from Pinchy's DB", async () => {
+    mockAgentFindFirst.mockResolvedValue({ model: "ollama-cloud/gemini-3-flash" });
+
+    await expect(loadAgentModel("agent-1")).resolves.toBe("ollama-cloud/gemini-3-flash");
+  });
+
+  it("answers null for an agent that no longer exists", async () => {
+    // The run adapter turns null into a clear "no model configured" failure.
+    // Answering a bogus default instead would dispatch against the
+    // gateway-wide model and silently mis-attribute the run (#324).
+    mockAgentFindFirst.mockResolvedValue(undefined);
+
+    await expect(loadAgentModel("gone")).resolves.toBeNull();
+  });
+});
+
+describe("createAgentReadinessGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports ready once the agent is present in the runtime", async () => {
+    const client = makeClient({
+      agents: { list: vi.fn().mockResolvedValue({ agents: [{ id: "agent-1" }] }) },
+    });
+
+    await expect(createAgentReadinessGate(client)("agent-1")).resolves.toBe(true);
+  });
+
+  it("reports NOT ready when the agent never appears within the deadline", async () => {
+    // A real miss must stay `false`: the adapter defers, the row stays
+    // `processing`, and the next sweep retries it. Nothing is lost.
+    const client = makeClient();
+
+    await expect(createAgentReadinessGate(client, { deadlineMs: 0 })("agent-1")).resolves.toBe(
+      false
+    );
+  });
+
+  it("reports ready when the Gateway cannot answer readiness at all", async () => {
+    // LOAD-BEARING. `waitForAgentInRuntime` returns false for TWO different
+    // things: "the agent isn't there yet" and "this Gateway has no agents.list,
+    // so readiness is unobservable". The adapter treats false as "defer".
+    //
+    // Conflating them would be catastrophic and silent: on a Gateway without
+    // agents.list every email would be claimed, deferred, reset by the next
+    // sweep, re-claimed, deferred again — forever — while the workflow happily
+    // reports `active` and not one mail is ever processed.
+    //
+    // Unobservable is not "no". Proceed and let the run answer: a genuinely
+    // unknown agent id fails that run loudly instead of looping in silence.
+    const list = vi.fn().mockResolvedValue({ agents: [] });
+    const client = makeClient({
+      hasMethod: vi.fn().mockReturnValue(false),
+      agents: { list },
+    });
+
+    await expect(createAgentReadinessGate(client)("agent-1")).resolves.toBe(true);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("reports NOT ready while the Gateway is disconnected", async () => {
+    // LOAD-BEARING, and the reason `isConnected` is consulted before hasMethod:
+    // the client's advertised-method list is populated at the hello-ok
+    // handshake and is EMPTY until then, so a disconnected Gateway and an old
+    // one are indistinguishable through hasMethod alone.
+    //
+    // Reading a disconnected Gateway as "unobservable, proceed" would claim the
+    // email, fail the chat, and — since the dispatcher makes any run throw
+    // terminal — mark a never-examined mail `failed` and notify the user about
+    // it. Deferring instead costs one cadence and loses nothing.
+    //
+    // This bites on the ordinary path: the first sweep fires 30 s after boot,
+    // which a cold start or a config.apply cascade can easily outlast.
+    const list = vi.fn().mockResolvedValue({ agents: [] });
+    const client = makeClient({
+      isConnected: false,
+      hasMethod: vi.fn().mockReturnValue(false),
+      agents: { list },
+    });
+
+    await expect(createAgentReadinessGate(client)("agent-1")).resolves.toBe(false);
+    expect(list).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildSweepDeps", () => {
+  it("reaches real mailboxes through createEmailPort", async () => {
+    // The sweep is only as real as its port: wired to anything else, every
+    // pass would list an empty mailbox and report a clean bill of health.
+    const deps = buildSweepDeps(makeClient());
+
+    expect(deps.createPort).toBe(createEmailPort);
+    expect(typeof deps.runAgent).toBe("function");
+  });
+});

--- a/packages/web/src/__tests__/server/inbox-sweep.test.ts
+++ b/packages/web/src/__tests__/server/inbox-sweep.test.ts
@@ -133,4 +133,32 @@ describe("inbox sweep — scheduler wiring", () => {
     await vi.advanceTimersByTimeAsync(1000);
     expect(calls).toBe(2);
   });
+
+  it("a second start does not leak the first cadence", async () => {
+    // The timers live in module state, so a second start would overwrite the
+    // handles of the first — leaving an interval nobody holds a reference to,
+    // firing forever, un-stoppable, doubling every sweep's provider I/O. This is
+    // exactly the leak server.ts's comment cites as the reason the sweep is NOT
+    // hung off the gateway's `connected` event (which refires on every
+    // reconnect). Making start itself idempotent removes the footgun rather than
+    // relying on every future caller remembering it.
+    vi.useFakeTimers();
+    let calls = 0;
+    const runSweep = async (): Promise<void> => {
+      calls++;
+    };
+    startInboxSweep(runSweep, { intervalMs: 1000, startupDelayMs: 100 });
+    startInboxSweep(runSweep, { intervalMs: 1000, startupDelayMs: 100 });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(calls).toBe(1); // one kick, not two
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(calls).toBe(2); // one interval, not two
+
+    // And a single stop really stops everything: nothing was orphaned.
+    stopInboxSweep();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(calls).toBe(2);
+  });
 });

--- a/packages/web/src/__tests__/server/inbox-sweep.test.ts
+++ b/packages/web/src/__tests__/server/inbox-sweep.test.ts
@@ -1,0 +1,114 @@
+// Unit tests for the Inbox Agent reconciliation-sweep scheduler (Brick E).
+//
+// This is the in-process cadence that makes the sweep autonomous, mirroring the
+// established periodic-job pattern (`upload-gc.ts`, `audit-verify-job.ts`): a
+// `setInterval` plus a post-startup kick, each firing a re-entrancy-guarded run.
+//
+// The load-bearing new logic is the guard: the sweep re-lists a whole window and
+// hits provider rate limits, so a tick that fires while the previous sweep is
+// still in flight must be *skipped*, never run concurrently. The ledger already
+// makes overlap correct (atomic claim), but not free — so the guard is what stops
+// a slow pass from stacking redundant provider I/O on top of itself.
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  createGuardedSweepRunner,
+  startInboxSweep,
+  stopInboxSweep,
+  _isInboxSweepRunning,
+  SWEEP_STARTUP_DELAY_MS,
+  SWEEP_INTERVAL_MS,
+} from "@/server/inbox-sweep";
+
+describe("inbox sweep — re-entrancy guard", () => {
+  it("does not start a second sweep while one is already in flight", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const run = createGuardedSweepRunner(async () => {
+      calls++;
+      await gate; // stay in-flight until the test releases it
+    });
+
+    const first = run(); // sweep #1 starts and parks on the gate
+    const second = run(); // must be skipped — no concurrent sweep
+
+    expect(calls).toBe(1);
+
+    release();
+    await Promise.all([first, second]);
+
+    // Once the in-flight sweep has finished, a later tick runs a fresh sweep.
+    await run();
+    expect(calls).toBe(2);
+  });
+
+  it("isolates a throwing sweep: logs it, never rejects, and frees the guard for the next tick", async () => {
+    // The interval fires the runner as `void run()`, so a rejection would surface
+    // as an unhandled process-level rejection. A throw must also not leave the
+    // guard stuck `inFlight` — that would silently wedge every future sweep, the
+    // worst failure for a component whose whole job is "never lose an email".
+    const logged: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((...args) => {
+      logged.push(args.map(String).join(" "));
+    });
+    let calls = 0;
+    const run = createGuardedSweepRunner(async () => {
+      calls++;
+      throw new Error("boom");
+    });
+
+    try {
+      await expect(run()).resolves.toBeUndefined();
+      expect(logged.some((line) => line.includes("boom"))).toBe(true);
+
+      // The guard was freed despite the throw — the next tick runs a fresh sweep.
+      await run();
+      expect(calls).toBe(2);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("inbox sweep — scheduler wiring", () => {
+  afterEach(() => {
+    stopInboxSweep();
+    vi.useRealTimers();
+  });
+
+  it("_isInboxSweepRunning reflects start/stop", () => {
+    expect(_isInboxSweepRunning()).toBe(false);
+    startInboxSweep(async () => {});
+    expect(_isInboxSweepRunning()).toBe(true);
+    stopInboxSweep();
+    expect(_isInboxSweepRunning()).toBe(false);
+  });
+
+  it("fires the sweep on a post-startup kick and then on the interval, and stops cleanly", async () => {
+    // Mirrors upload-gc/audit-verify-job: nothing fires synchronously on start;
+    // a delayed kick runs the first pass (after the gateway/config settle), then
+    // the interval drives the cadence. stop() must clear both timers so a stopped
+    // scheduler never fires again — a leaked interval is exactly the timer leak
+    // the enterprise-banner flake taught us to guard against.
+    vi.useFakeTimers();
+    let calls = 0;
+    startInboxSweep(async () => {
+      calls++;
+    });
+
+    expect(calls).toBe(0); // nothing runs immediately
+
+    await vi.advanceTimersByTimeAsync(SWEEP_STARTUP_DELAY_MS);
+    expect(calls).toBe(1); // the post-startup kick
+
+    await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS);
+    expect(calls).toBe(2); // the recurring interval
+
+    stopInboxSweep();
+    await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS * 2);
+    expect(calls).toBe(2); // no further passes after stop
+  });
+});

--- a/packages/web/src/__tests__/server/inbox-sweep.test.ts
+++ b/packages/web/src/__tests__/server/inbox-sweep.test.ts
@@ -111,4 +111,26 @@ describe("inbox sweep — scheduler wiring", () => {
     await vi.advanceTimersByTimeAsync(SWEEP_INTERVAL_MS * 2);
     expect(calls).toBe(2); // no further passes after stop
   });
+
+  it("accepts an overridden cadence", async () => {
+    // The production cadence is 15 minutes, which no E2E can wait for, and the
+    // post-startup kick has long since fired by the time a spec runs. Making
+    // both injectable is what lets the E2E prove the sweep dispatches with no
+    // manual trigger — the one claim unit tests cannot make. Same convention as
+    // CHANNEL_HEALTH_INTERVAL_MS.
+    vi.useFakeTimers();
+    let calls = 0;
+    startInboxSweep(
+      async () => {
+        calls++;
+      },
+      { intervalMs: 1000, startupDelayMs: 100 }
+    );
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(calls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(calls).toBe(2);
+  });
 });

--- a/packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts
+++ b/packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts
@@ -1,103 +1,13 @@
 // audit-exempt: internal endpoint called by OpenClaw plugin, not a user-facing action
 import { NextRequest, NextResponse } from "next/server";
 import { validateGatewayToken } from "@/lib/gateway-auth";
-import { db } from "@/db";
-import { integrationConnections } from "@/db/schema";
-import { eq } from "drizzle-orm";
-import { decrypt, encrypt } from "@/lib/encryption";
-import { refreshAccessToken } from "@/lib/integrations/google-oauth";
-import { isTokenExpired, createRefreshDedup } from "@/lib/integrations/oauth-token";
-import { getOAuthSettings } from "@/lib/integrations/oauth-settings";
 import {
-  refreshMicrosoftCredentials,
+  resolveConnectionCredentials,
+  ConnectionNotFoundError,
+  ConnectionNotActiveError,
+  CredentialsDecryptError,
   OAuthSettingsMissingError,
-} from "@/lib/integrations/microsoft-refresh";
-
-interface GoogleCredentials {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt?: string;
-  [k: string]: unknown;
-}
-
-// Per-connectionId in-flight refresh tracker used by the Google refresh path
-// (see createRefreshDedup in oauth-token.ts for the full rationale / issue
-// #237). The Microsoft equivalent lives in @/lib/integrations/microsoft-refresh.
-const dedupeGoogleRefresh = createRefreshDedup<GoogleCredentials>();
-
-async function refreshGoogleCredentials(
-  connectionId: string,
-  current: GoogleCredentials
-): Promise<GoogleCredentials> {
-  return dedupeGoogleRefresh(connectionId, async () => {
-    try {
-      const oauthSettings = await getOAuthSettings("google");
-      if (!oauthSettings) {
-        console.error("Google OAuth token refresh failed: OAuth settings not configured");
-        throw new OAuthSettingsMissingError("Google");
-      }
-
-      const refreshed = await refreshAccessToken({
-        refreshToken: current.refreshToken,
-        clientId: oauthSettings.clientId,
-        clientSecret: oauthSettings.clientSecret,
-      });
-
-      const updated: GoogleCredentials = {
-        ...current,
-        accessToken: refreshed.accessToken,
-        expiresAt: refreshed.expiresAt,
-      };
-
-      await db
-        .update(integrationConnections)
-        .set({
-          credentials: encrypt(JSON.stringify(updated)),
-          updatedAt: new Date(),
-        })
-        .where(eq(integrationConnections.id, connectionId));
-
-      console.log("Refreshed Google OAuth token for connection", connectionId);
-      return updated;
-    } catch (err) {
-      if (err instanceof OAuthSettingsMissingError) {
-        // Re-throw: there is no safe stale fallback when settings are missing
-        // and a refresh is required (see class comment above).
-        throw err;
-      }
-      console.error("Google OAuth token refresh failed:", err);
-      return current;
-    }
-  });
-}
-
-// Shared minimal shape both GoogleCredentials and MicrosoftCredentials satisfy.
-// Used only for the dispatch lookup below; refreshGoogleCredentials and
-// refreshMicrosoftCredentials keep their own precise parameter/return types
-// internally. expiresAt is required here (rather than optional) because the
-// dispatch call site below only invokes refreshFn once credentials.expiresAt
-// has already been checked truthy, and MicrosoftCredentials.expiresAt is
-// itself required — a required field here keeps both refresh functions
-// structurally assignable to this table without widening either one.
-interface OAuthCredentials {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt: string;
-  [k: string]: unknown;
-}
-
-// Dispatch table keyed by connection.type. connection.type comes from the DB
-// column, not user input, but the lookup is still guarded by the `refreshFn &&`
-// truthiness check below (a plain object, no prototype pollution surface) —
-// a type outside this table (e.g. "odoo", "web-search") simply misses and no
-// refresh is attempted, matching the old per-provider `if` gates exactly.
-const REFRESH_BY_TYPE: Record<
-  string,
-  (connectionId: string, current: OAuthCredentials) => Promise<Record<string, unknown>>
-> = {
-  google: refreshGoogleCredentials,
-  microsoft: refreshMicrosoftCredentials,
-};
+} from "@/lib/integrations/resolve-credentials";
 
 export async function GET(
   request: NextRequest,
@@ -109,69 +19,44 @@ export async function GET(
 
   const { connectionId } = await params;
 
-  const rows = await db
-    .select()
-    .from(integrationConnections)
-    .where(eq(integrationConnections.id, connectionId))
-    .limit(1);
-
-  if (rows.length === 0) {
-    // The plugins surface this body.error into the agent's tool error, so a bare
-    // "Connection not found" reaches the user as an opaque "technical problem
-    // (error 404)". Make it actionable and provider-generic: the connection was
-    // removed or replaced (e.g. deleted + re-added, which mints a new id and
-    // orphans this reference), and an admin fixes it under Settings → Integrations.
-    return NextResponse.json(
-      {
-        error:
-          "This integration is no longer connected — it may have been removed or replaced. An admin can reconnect it under Settings → Integrations.",
-      },
-      { status: 404 }
-    );
-  }
-
-  const connection = rows[0];
-
-  if (connection.status === "pending") {
-    return NextResponse.json({ error: "Connection not active" }, { status: 403 });
-  }
-
-  let credentials;
+  // The credential-resolution logic (decrypt + OAuth auto-refresh + re-encrypt)
+  // is shared with the Inbox Agent's mailbox port via resolveConnectionCredentials;
+  // here we map its typed failures back to the HTTP contract the plugins expect.
   try {
-    credentials = JSON.parse(decrypt(connection.credentials));
-  } catch {
-    return NextResponse.json({ error: "Failed to decrypt credentials" }, { status: 500 });
-  }
-
-  // Auto-refresh expired OAuth tokens for whichever provider this connection
-  // is. The persist policy on a failed refresh differs per provider and lives
-  // in the respective refresh function: Google degrades gracefully to the
-  // current credentials (safe — Google does not rotate refresh tokens), while
-  // Microsoft retries the DB persist once and then throws rather than ever
-  // discarding a rotated refresh token (issue #237 — Microsoft DOES rotate,
-  // so losing that token bricks the mailbox). Missing OAuth settings fail
-  // loudly for either provider (see OAuthSettingsMissingError). Concurrent
-  // callers for the same connectionId share a single refresh via each
-  // provider's own in-flight dedup.
-  const refreshFn = REFRESH_BY_TYPE[connection.type];
-  if (refreshFn && credentials.expiresAt && isTokenExpired(credentials.expiresAt)) {
-    try {
-      credentials = await refreshFn(connectionId, credentials as OAuthCredentials);
-    } catch (err) {
-      if (err instanceof OAuthSettingsMissingError) {
-        // The access token is expired and there is no way to refresh it —
-        // fail loudly instead of returning a 200 with stale/expired tokens
-        // that the plugin would cache for another 5 minutes and fail on.
-        return NextResponse.json(
-          {
-            error: `${err.provider} OAuth settings missing — reconnect the mailbox or restore the OAuth app`,
-          },
-          { status: 503 }
-        );
-      }
-      throw err;
+    const resolved = await resolveConnectionCredentials(connectionId);
+    return NextResponse.json(resolved);
+  } catch (err) {
+    if (err instanceof ConnectionNotFoundError) {
+      // The plugins surface this body.error into the agent's tool error, so a bare
+      // "Connection not found" reaches the user as an opaque "technical problem
+      // (error 404)". Make it actionable and provider-generic: the connection was
+      // removed or replaced (e.g. deleted + re-added, which mints a new id and
+      // orphans this reference), and an admin fixes it under Settings → Integrations.
+      return NextResponse.json(
+        {
+          error:
+            "This integration is no longer connected — it may have been removed or replaced. An admin can reconnect it under Settings → Integrations.",
+        },
+        { status: 404 }
+      );
     }
+    if (err instanceof ConnectionNotActiveError) {
+      return NextResponse.json({ error: "Connection not active" }, { status: 403 });
+    }
+    if (err instanceof CredentialsDecryptError) {
+      return NextResponse.json({ error: "Failed to decrypt credentials" }, { status: 500 });
+    }
+    if (err instanceof OAuthSettingsMissingError) {
+      // The access token is expired and there is no way to refresh it — fail
+      // loudly instead of returning a 200 with stale/expired tokens that the
+      // plugin would cache for another 5 minutes and fail on.
+      return NextResponse.json(
+        {
+          error: `${err.provider} OAuth settings missing — reconnect the mailbox or restore the OAuth app`,
+        },
+        { status: 503 }
+      );
+    }
+    throw err;
   }
-
-  return NextResponse.json({ type: connection.type, credentials });
 }

--- a/packages/web/src/lib/email-workflows/lister.ts
+++ b/packages/web/src/lib/email-workflows/lister.ts
@@ -40,6 +40,14 @@ export interface EmailReadResult {
 export interface EmailPort {
   search(opts: { sinceDays?: number; folder?: string; limit?: number }): Promise<EmailListItem[]>;
   read(id: string): Promise<EmailReadResult>;
+  /**
+   * Release whatever the port holds open. Optional: stateless HTTP providers
+   * (Graph, Gmail) have nothing to release, while the IMAP adapter serves the
+   * lister's 1×search + N×read over ONE connection — a connection per message is
+   * not an option — and only the sweep can close it, since the port is created
+   * per (workflow × connection) there and discarded there.
+   */
+  close?(): Promise<void>;
 }
 
 /**

--- a/packages/web/src/lib/email-workflows/port.ts
+++ b/packages/web/src/lib/email-workflows/port.ts
@@ -1,5 +1,6 @@
 import { resolveConnectionCredentials } from "@/lib/integrations/resolve-credentials";
 import { createImapPort } from "@/lib/email-workflows/ports/imap";
+import { createGraphPort } from "@/lib/email-workflows/ports/graph";
 import type { EmailPort } from "@/lib/email-workflows/lister";
 
 /**
@@ -21,6 +22,8 @@ export async function createEmailPort(connectionId: string): Promise<EmailPort> 
   switch (type) {
     case "imap":
       return createImapPort(credentials);
+    case "microsoft":
+      return createGraphPort(credentials);
     default:
       // A workflow pointed at a non-mailbox connection (odoo, web-search) is a
       // configuration bug. Fail loudly rather than hand back a port that

--- a/packages/web/src/lib/email-workflows/port.ts
+++ b/packages/web/src/lib/email-workflows/port.ts
@@ -1,0 +1,32 @@
+import { resolveConnectionCredentials } from "@/lib/integrations/resolve-credentials";
+import { createImapPort } from "@/lib/email-workflows/ports/imap";
+import type { EmailPort } from "@/lib/email-workflows/lister";
+
+/**
+ * The sweep's production `createPort`: turn a connectionId into a live mailbox
+ * port.
+ *
+ * Credential resolution (decrypt + OAuth auto-refresh) is shared with the
+ * internal credentials route via {@link resolveConnectionCredentials}, so the
+ * sweep reaches a mailbox exactly the way the plugins do — from the same
+ * decrypted stored credentials, through one tested path.
+ *
+ * Failures propagate: the sweep catches them at unit level and surfaces them as
+ * the workflow's `error` status, which is the honest outcome for a mailbox that
+ * cannot be reached (see resolve-credentials' typed errors).
+ */
+export async function createEmailPort(connectionId: string): Promise<EmailPort> {
+  const { type, credentials } = await resolveConnectionCredentials(connectionId);
+
+  switch (type) {
+    case "imap":
+      return createImapPort(credentials);
+    default:
+      // A workflow pointed at a non-mailbox connection (odoo, web-search) is a
+      // configuration bug. Fail loudly rather than hand back a port that
+      // silently lists nothing forever.
+      throw new Error(
+        `createEmailPort: connection ${connectionId} is not a mailbox (type: ${type})`
+      );
+  }
+}

--- a/packages/web/src/lib/email-workflows/port.ts
+++ b/packages/web/src/lib/email-workflows/port.ts
@@ -1,6 +1,7 @@
 import { resolveConnectionCredentials } from "@/lib/integrations/resolve-credentials";
 import { createImapPort } from "@/lib/email-workflows/ports/imap";
 import { createGraphPort } from "@/lib/email-workflows/ports/graph";
+import { createGmailPort } from "@/lib/email-workflows/ports/gmail";
 import type { EmailPort } from "@/lib/email-workflows/lister";
 
 /**
@@ -24,6 +25,8 @@ export async function createEmailPort(connectionId: string): Promise<EmailPort> 
       return createImapPort(credentials);
     case "microsoft":
       return createGraphPort(credentials);
+    case "google":
+      return createGmailPort(credentials);
     default:
       // A workflow pointed at a non-mailbox connection (odoo, web-search) is a
       // configuration bug. Fail loudly rather than hand back a port that

--- a/packages/web/src/lib/email-workflows/ports/gmail.ts
+++ b/packages/web/src/lib/email-workflows/ports/gmail.ts
@@ -18,6 +18,29 @@ import type { EmailListItem, EmailPort, EmailReadResult } from "@/lib/email-work
 
 const DEFAULT_LABEL = "INBOX";
 
+/**
+ * Gmail's built-in labels, whose id IS their upper-cased name — which is the
+ * only reason upper-casing a folder ever worked as a labelId. A user-created
+ * label's id is an opaque `Label_17` instead, and its name is never a valid
+ * labelId, so anything outside this set has to be resolved over the wire.
+ */
+const SYSTEM_LABEL_IDS = new Set([
+  "INBOX",
+  "SENT",
+  "DRAFT",
+  "SPAM",
+  "TRASH",
+  "UNREAD",
+  "STARRED",
+  "IMPORTANT",
+  "CHAT",
+  "CATEGORY_PERSONAL",
+  "CATEGORY_SOCIAL",
+  "CATEGORY_PROMOTIONS",
+  "CATEGORY_UPDATES",
+  "CATEGORY_FORUMS",
+]);
+
 /** Same convention as the pinchy-email plugin's gmail adapter (E2E mock redirect). */
 function gmailBase(): string {
   return process.env.GMAIL_API_BASE_URL ?? "https://gmail.googleapis.com";
@@ -122,8 +145,47 @@ export function createGmailPort(credentials: unknown): EmailPort {
     return (await res.json()) as T;
   }
 
+  // What `search` last scoped to. `read` takes no folder argument, so without
+  // this the port would report the default for every message and a non-INBOX
+  // workflow's mail would all fail the filter's folder re-check — silently.
+  // The IMAP port gets this for free from its open mailbox; here it is explicit.
+  let searchedFolder: string | null = null;
+
+  // name (lower-cased) -> label id, fetched at most once per port. The port
+  // lives for one (workflow × connection) sweep unit, so this costs one extra
+  // round trip per unit that watches a user label, and none for system labels.
+  let labelIdsByName: Map<string, string> | null = null;
+
+  /** A folder name as Gmail's `labelIds` wants it: an id, not a name. */
+  async function resolveLabelId(folder: string): Promise<string> {
+    const upper = folder.toUpperCase();
+    if (SYSTEM_LABEL_IDS.has(upper)) return upper;
+
+    if (!labelIdsByName) {
+      const listed = await gmailGet<{ labels?: { id?: string; name?: string }[] }>(
+        "/users/me/labels"
+      );
+      labelIdsByName = new Map(
+        (listed.labels ?? [])
+          .filter((l): l is { id: string; name: string } => Boolean(l.id && l.name))
+          .map((l) => [l.name.toLowerCase(), l.id])
+      );
+    }
+
+    const id = labelIdsByName.get(folder.toLowerCase());
+    if (!id) {
+      // Never degrade to INBOX or to an unscoped search: a workflow watching a
+      // renamed or deleted label must surface as that workflow's `error` status,
+      // not quietly start acting on somebody else's mail.
+      throw new Error(`Gmail port: no label named "${folder}" in this mailbox`);
+    }
+    return id;
+  }
+
   return {
     async search(opts): Promise<EmailListItem[]> {
+      const folder = opts.folder ?? DEFAULT_LABEL;
+      searchedFolder = folder;
       const parts: string[] = [];
       // Scope the folder with labelIds, NEVER with `q`. Gmail's query language
       // only documents `in:trash`/`in:spam` for folder scoping; `label:INBOX`
@@ -132,7 +194,7 @@ export function createGmailPort(credentials: unknown): EmailPort {
       // SILENTLY EMPTY results, which for a sweep is the worst failure there is:
       // it reads as "nothing new" while the workflow looks perfectly healthy.
       // The pinchy-email plugin's adapter learned this the hard way.
-      parts.push(`labelIds=${encodeURIComponent((opts.folder ?? DEFAULT_LABEL).toUpperCase())}`);
+      parts.push(`labelIds=${encodeURIComponent(await resolveLabelId(folder))}`);
       if (opts.limit) parts.push(`maxResults=${encodeURIComponent(String(opts.limit))}`);
       if (opts.sinceDays) {
         // `q` carries only the time window — day granularity, a coarse
@@ -156,10 +218,10 @@ export function createGmailPort(credentials: unknown): EmailPort {
       const message = await gmailGet<GmailMessage>(
         `/users/me/messages/${encodeURIComponent(id)}?format=full`
       );
-      // Report the mailbox-level label rather than guessing from labelIds: the
-      // workflow's filter re-checks `folder` by name and the listing is scoped
-      // to it by construction.
-      return mapGmailMessage({ folder: DEFAULT_LABEL, message });
+      // The label this port searched, rather than guessing from the message's
+      // labelIds: the filter re-checks `folder` by name, and every id reaching
+      // `read` came from that scoped listing.
+      return mapGmailMessage({ folder: searchedFolder ?? DEFAULT_LABEL, message });
     },
   };
 }

--- a/packages/web/src/lib/email-workflows/ports/gmail.ts
+++ b/packages/web/src/lib/email-workflows/ports/gmail.ts
@@ -1,0 +1,165 @@
+import type { EmailListItem, EmailPort, EmailReadResult } from "@/lib/email-workflows/lister";
+
+/**
+ * The Gmail mailbox port for the reconciliation sweep.
+ *
+ * Runs Pinchy-side from decrypted stored credentials, with no agent session.
+ * Stateless HTTP, so it implements no `close()`.
+ *
+ * Spoken over plain `fetch`, deliberately NOT the `googleapis` SDK: the plugin
+ * carries that dependency, the web app does not, and two endpoints do not
+ * justify pulling an SDK into it (the web app's google-oauth.ts talks raw HTTP
+ * for the same reason).
+ *
+ * Unlike Graph, Gmail message ids are stable — Gmail has labels, not folders, so
+ * "moving" a mail is a relabel and the id never changes. No immutable-id dance
+ * is needed for the ledger's claim key here.
+ */
+
+const DEFAULT_LABEL = "INBOX";
+
+/** Same convention as the pinchy-email plugin's gmail adapter (E2E mock redirect). */
+function gmailBase(): string {
+  return process.env.GMAIL_API_BASE_URL ?? "https://gmail.googleapis.com";
+}
+
+interface GmailHeader {
+  name?: string;
+  value?: string;
+}
+
+export interface GmailPart {
+  mimeType?: string;
+  filename?: string;
+  headers?: GmailHeader[];
+  body?: { attachmentId?: string; size?: number };
+  parts?: GmailPart[];
+}
+
+export interface GmailMessage {
+  id: string;
+  /** ms since epoch, as a string. */
+  internalDate?: string;
+  labelIds?: string[];
+  payload?: GmailPart;
+}
+
+/** RFC 5322 header names are case-insensitive; Gmail echoes the sender's spelling. */
+function headerValue(headers: GmailHeader[] | undefined, name: string): string | undefined {
+  const wanted = name.toLowerCase();
+  return headers?.find((h) => h.name?.toLowerCase() === wanted)?.value;
+}
+
+/**
+ * Walk the MIME part tree and collect the parts a human would call an
+ * attachment: a named part that is not `Content-Disposition: inline`. An inline
+ * part is the HTML body's own embedded image, and counting it would fire every
+ * workflow's `hasAttachment` filter on ordinary newsletters — the same trap as
+ * IMAP's disposition and Graph's isInline.
+ */
+function collectGmailAttachments(part?: GmailPart): { mimeType: string; filename?: string }[] {
+  const found: { mimeType: string; filename?: string }[] = [];
+  const walk = (p?: GmailPart): void => {
+    if (!p) return;
+    if (p.filename && p.filename.length > 0) {
+      const disposition = headerValue(p.headers, "Content-Disposition") ?? "";
+      if (!/^\s*inline/i.test(disposition)) {
+        found.push({ mimeType: p.mimeType ?? "application/octet-stream", filename: p.filename });
+      }
+    }
+    for (const child of p.parts ?? []) walk(child);
+  };
+  walk(part);
+  return found;
+}
+
+/** Gmail's message shape → the lister's raw-shaped {@link EmailReadResult}. */
+export function mapGmailMessage(input: { folder: string; message: GmailMessage }): EmailReadResult {
+  const { folder, message } = input;
+  const headers = message.payload?.headers;
+  // Prefer the Date header; fall back to Gmail's internalDate (ms since epoch,
+  // as a string). Without the fallback a mail with no Date header would be
+  // rejected by the lister as unparseable and silently dropped by its
+  // poison-message isolation.
+  const dateHeader = headerValue(headers, "Date");
+  const internal = message.internalDate ? Number(message.internalDate) : NaN;
+  const date = dateHeader ?? (Number.isFinite(internal) ? new Date(internal).toISOString() : "");
+
+  return {
+    id: message.id,
+    // Raw header values pass straight through: the lister is what unwraps
+    // `Display Name <addr>` and splits recipient lists, and it already handles
+    // quoted names containing commas.
+    from: headerValue(headers, "From") ?? "",
+    to: headerValue(headers, "To") ?? "",
+    cc: headerValue(headers, "Cc") ?? "",
+    subject: headerValue(headers, "Subject") ?? "",
+    date,
+    folder,
+    messageIdHeader: headerValue(headers, "Message-ID"),
+    attachments: collectGmailAttachments(message.payload),
+  };
+}
+
+/** Build an {@link EmailPort} over the Gmail API from decrypted credentials. */
+export function createGmailPort(credentials: unknown): EmailPort {
+  const creds = credentials as { accessToken?: unknown };
+  if (typeof creds?.accessToken !== "string" || creds.accessToken.length === 0) {
+    throw new Error("Gmail port: stored credentials carry no access token");
+  }
+  const accessToken = creds.accessToken;
+
+  async function gmailGet<T>(path: string): Promise<T> {
+    const res = await fetch(`${gmailBase()}/gmail/v1${path}`, {
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: "application/json" },
+    });
+    if (!res.ok) {
+      // Never answer a failed call as an empty mailbox — that reads as "nothing
+      // new" and silently retires the workflow while its status stays `active`.
+      const body = await res.text().catch(() => "");
+      throw new Error(`Gmail port: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  return {
+    async search(opts): Promise<EmailListItem[]> {
+      const parts: string[] = [];
+      // Scope the folder with labelIds, NEVER with `q`. Gmail's query language
+      // only documents `in:trash`/`in:spam` for folder scoping; `label:INBOX`
+      // works only through the q parser's undocumented aliasing, and Gmail
+      // search excludes Trash/Spam by default — so scoping through `q` risks
+      // SILENTLY EMPTY results, which for a sweep is the worst failure there is:
+      // it reads as "nothing new" while the workflow looks perfectly healthy.
+      // The pinchy-email plugin's adapter learned this the hard way.
+      parts.push(`labelIds=${encodeURIComponent((opts.folder ?? DEFAULT_LABEL).toUpperCase())}`);
+      if (opts.limit) parts.push(`maxResults=${encodeURIComponent(String(opts.limit))}`);
+      if (opts.sinceDays) {
+        // `q` carries only the time window — day granularity, a coarse
+        // pre-filter. The sweep's own sinceTs watermark is what actually bounds
+        // the window.
+        parts.push(`q=${encodeURIComponent(`newer_than:${opts.sinceDays}d`)}`);
+      }
+      const listed = await gmailGet<{ messages?: { id: string }[] }>(
+        `/users/me/messages?${parts.join("&")}`
+      );
+      // Gmail omits `messages` entirely (rather than sending []) when nothing
+      // matches.
+      return (listed.messages ?? []).map((m) => ({ id: m.id }));
+    },
+
+    async read(id): Promise<EmailReadResult> {
+      // `format=full` is the only format that carries the MIME part tree, which
+      // is where attachment metadata lives. It also ships the text body's bytes,
+      // which we ignore — Gmail has no "structure without body" format, and
+      // attachment BYTES are not included either way (only their attachmentId).
+      const message = await gmailGet<GmailMessage>(
+        `/users/me/messages/${encodeURIComponent(id)}?format=full`
+      );
+      // Report the mailbox-level label rather than guessing from labelIds: the
+      // workflow's filter re-checks `folder` by name and the listing is scoped
+      // to it by construction.
+      return mapGmailMessage({ folder: DEFAULT_LABEL, message });
+    },
+  };
+}

--- a/packages/web/src/lib/email-workflows/ports/graph.ts
+++ b/packages/web/src/lib/email-workflows/ports/graph.ts
@@ -1,0 +1,156 @@
+import type { EmailListItem, EmailPort, EmailReadResult } from "@/lib/email-workflows/lister";
+
+/**
+ * The Microsoft Graph (Microsoft 365) mailbox port for the reconciliation sweep.
+ *
+ * Runs Pinchy-side from decrypted stored credentials, with no agent session —
+ * the sweep is deterministic orchestration, not an agent turn. Stateless HTTP,
+ * so it implements no `close()`.
+ */
+
+const DEFAULT_FOLDER = "inbox";
+
+/**
+ * Graph's DEFAULT message ids are NOT stable: they change when a message moves
+ * between folders. The ledger's claim key is
+ * `(workflowId, connectionId, providerMessageId)`, so an unstable id means a
+ * filed-away mail reappears under a new id, misses the ledger, and is processed
+ * twice. Asking for immutable ids is what makes the claim key durable.
+ *
+ * This must stay CONSISTENT for the lifetime of the ledger: ids minted in
+ * immutable mode are not interchangeable with default-mode ids, so removing this
+ * header would invalidate every id already stored at once and re-dispatch a
+ * whole window as "new". A test guards it for exactly that reason.
+ */
+const IMMUTABLE_ID_HEADER = { Prefer: 'IdType="ImmutableId"' } as const;
+
+/** Same convention as probe.ts and the pinchy-email plugin's graph adapter. */
+function graphBase(): string {
+  return process.env.GRAPH_API_BASE_URL ?? "https://graph.microsoft.com";
+}
+
+interface GraphAddress {
+  emailAddress?: { name?: string; address?: string };
+}
+
+interface GraphAttachment {
+  id?: string;
+  name?: string | null;
+  contentType?: string | null;
+  isInline?: boolean;
+}
+
+export interface GraphMessage {
+  id: string;
+  subject?: string | null;
+  receivedDateTime?: string | null;
+  internetMessageId?: string | null;
+  from?: GraphAddress;
+  toRecipients?: GraphAddress[];
+  ccRecipients?: GraphAddress[];
+  attachments?: GraphAttachment[];
+}
+
+/** Bare, comma-joined addresses — the shape the lister's address split expects. */
+function formatAddresses(list?: GraphAddress[]): string {
+  return (list ?? [])
+    .map((r) => r.emailAddress?.address?.trim() ?? "")
+    .filter((a) => a.length > 0)
+    .join(", ");
+}
+
+/** Graph's message shape → the lister's raw-shaped {@link EmailReadResult}. */
+export function mapGraphMessage(input: { folder: string; message: GraphMessage }): EmailReadResult {
+  const { folder, message } = input;
+  return {
+    id: message.id,
+    from: message.from?.emailAddress?.address?.trim() ?? "",
+    to: formatAddresses(message.toRecipients),
+    cc: formatAddresses(message.ccRecipients),
+    subject: message.subject ?? "",
+    date: message.receivedDateTime ?? "",
+    // The requested folder, not Graph's opaque parentFolderId: the workflow's
+    // filter re-checks `folder` by name, and the listing is scoped to this
+    // folder by construction.
+    folder,
+    messageIdHeader: message.internetMessageId ?? undefined,
+    attachments: (message.attachments ?? [])
+      // An inline part is the HTML body's own embedded image; counting it would
+      // fire every workflow's hasAttachment filter on ordinary newsletters.
+      .filter((a) => !a.isInline)
+      .map((a) => ({
+        mimeType: a.contentType ?? "application/octet-stream",
+        filename: a.name ?? undefined,
+      })),
+  };
+}
+
+/** Build an {@link EmailPort} over Microsoft Graph from decrypted credentials. */
+export function createGraphPort(credentials: unknown): EmailPort {
+  const creds = credentials as { accessToken?: unknown };
+  if (typeof creds?.accessToken !== "string" || creds.accessToken.length === 0) {
+    // Validate at the edge (mirroring probe.ts) so a mis-typed connection fails
+    // loudly here instead of as an opaque 401 later.
+    throw new Error("Graph port: stored credentials carry no access token");
+  }
+  const accessToken = creds.accessToken;
+
+  async function graphGet<T>(path: string): Promise<T> {
+    const res = await fetch(`${graphBase()}/v1.0${path}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+        ...IMMUTABLE_ID_HEADER,
+      },
+    });
+    if (!res.ok) {
+      // Never answer a failed call as an empty mailbox: that would read as
+      // "nothing new" and silently retire the workflow while its status stayed
+      // `active`. Let it reach the sweep's unit-level catch instead.
+      const body = await res.text().catch(() => "");
+      throw new Error(`Graph port: ${res.status} ${res.statusText} — ${body.slice(0, 200)}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  return {
+    async search(opts): Promise<EmailListItem[]> {
+      const folder = opts.folder ?? DEFAULT_FOLDER;
+      // Built with encodeURIComponent rather than URLSearchParams, mirroring the
+      // pinchy-email plugin's adapter: URLSearchParams encodes a space as `+`,
+      // and `%20` is the unambiguous form for OData expressions.
+      const parts = [
+        `$select=${encodeURIComponent("id")}`,
+        // Newest first, so a bounded page keeps the most recent mail.
+        `$orderby=${encodeURIComponent("receivedDateTime desc")}`,
+      ];
+      if (opts.limit) parts.push(`$top=${encodeURIComponent(String(opts.limit))}`);
+      if (opts.sinceDays) {
+        const since = new Date(Date.now() - opts.sinceDays * 24 * 60 * 60_000).toISOString();
+        // Graph requires the first $orderby property to lead the $filter, in the
+        // same order — the pinchy-email plugin's adapter hit this too. Ordering
+        // by receivedDateTime means the receivedDateTime predicate must come first.
+        parts.push(`$filter=${encodeURIComponent(`receivedDateTime ge ${since}`)}`);
+      }
+      const listed = await graphGet<{ value?: { id: string }[] }>(
+        `/me/mailFolders/${encodeURIComponent(folder)}/messages?${parts.join("&")}`
+      );
+      return (listed.value ?? []).map((m) => ({ id: m.id }));
+    },
+
+    async read(id): Promise<EmailReadResult> {
+      const parts = [
+        `$select=${encodeURIComponent(
+          "id,subject,receivedDateTime,internetMessageId,from,toRecipients,ccRecipients"
+        )}`,
+        // Expand attachments in the same round trip, but $select inside the
+        // expand so Graph does not ship every attachment's contentBytes with it.
+        `$expand=${encodeURIComponent("attachments($select=id,name,contentType,isInline)")}`,
+      ];
+      const message = await graphGet<GraphMessage>(
+        `/me/messages/${encodeURIComponent(id)}?${parts.join("&")}`
+      );
+      return mapGraphMessage({ folder: DEFAULT_FOLDER, message });
+    },
+  };
+}

--- a/packages/web/src/lib/email-workflows/ports/graph.ts
+++ b/packages/web/src/lib/email-workflows/ports/graph.ts
@@ -113,9 +113,16 @@ export function createGraphPort(credentials: unknown): EmailPort {
     return (await res.json()) as T;
   }
 
+  // What `search` last scoped to. `read` takes no folder argument, so without
+  // this the port would report the default for every message and a non-inbox
+  // workflow's mail would all fail the filter's folder re-check — silently.
+  // The IMAP port gets this for free from its open mailbox; here it is explicit.
+  let searchedFolder: string | null = null;
+
   return {
     async search(opts): Promise<EmailListItem[]> {
       const folder = opts.folder ?? DEFAULT_FOLDER;
+      searchedFolder = folder;
       // Built with encodeURIComponent rather than URLSearchParams, mirroring the
       // pinchy-email plugin's adapter: URLSearchParams encodes a space as `+`,
       // and `%20` is the unambiguous form for OData expressions.
@@ -150,7 +157,10 @@ export function createGraphPort(credentials: unknown): EmailPort {
       const message = await graphGet<GraphMessage>(
         `/me/messages/${encodeURIComponent(id)}?${parts.join("&")}`
       );
-      return mapGraphMessage({ folder: DEFAULT_FOLDER, message });
+      // The folder this port searched, not Graph's opaque parentFolderId: the
+      // filter re-checks `folder` by name, and every id reaching `read` came
+      // from that scoped listing.
+      return mapGraphMessage({ folder: searchedFolder ?? DEFAULT_FOLDER, message });
     },
   };
 }

--- a/packages/web/src/lib/email-workflows/ports/imap.ts
+++ b/packages/web/src/lib/email-workflows/ports/imap.ts
@@ -1,0 +1,182 @@
+import { ImapFlow } from "imapflow";
+import type { MessageAddressObject, MessageEnvelopeObject, MessageStructureObject } from "imapflow";
+
+import { tlsModeForPort } from "@/lib/integrations/imap-probe";
+import { imapTestSchema } from "@/lib/schemas/imap";
+import type { EmailListItem, EmailPort, EmailReadResult } from "@/lib/email-workflows/lister";
+
+/**
+ * The IMAP mailbox port for the Inbox Agent's reconciliation sweep.
+ *
+ * Unlike the `pinchy-email` plugin's adapters (which serve an agent's tools),
+ * this runs Pinchy-side with no agent session, from decrypted stored
+ * credentials — the sweep is deterministic orchestration, not an agent turn.
+ * The web app deliberately never imports the plugin's adapters (see lister.ts).
+ *
+ * Connection lifecycle: the lister does 1×search + N×read, so the port opens
+ * ONE connection lazily and serves everything over it, and the sweep closes it
+ * in a `finally`. A connection per message is not an option.
+ */
+
+const DEFAULT_FOLDER = "INBOX";
+
+/** Bound the sweep's IMAP I/O; a firewalled host must not stall the cadence. */
+const CONNECT_TIMEOUT_MS = 10_000;
+const SOCKET_TIMEOUT_MS = 30_000;
+
+/** Bare, comma-joined addresses — the shape the lister's address split expects.
+ *
+ * Display names are dropped on purpose: `normalizeAddress` discards them anyway,
+ * and re-emitting them would mean quoting every name containing a comma just to
+ * survive the round trip through the lister's splitter. */
+function formatAddressList(list?: MessageAddressObject[]): string {
+  return (list ?? [])
+    .map((a) => a.address?.trim() ?? "")
+    .filter((a) => a.length > 0)
+    .join(", ");
+}
+
+/**
+ * Walk a BODYSTRUCTURE tree and collect the parts a human would call an
+ * attachment. Only `disposition: "attachment"` counts — an `inline` part is the
+ * HTML body's own image, and treating it as an attachment would fire every
+ * workflow's `hasAttachment` filter on ordinary newsletters.
+ */
+export function collectAttachments(
+  node?: MessageStructureObject
+): { mimeType: string; filename?: string }[] {
+  const found: { mimeType: string; filename?: string }[] = [];
+  const walk = (n?: MessageStructureObject): void => {
+    if (!n) return;
+    if (n.disposition?.toLowerCase() === "attachment") {
+      found.push({
+        mimeType: n.type,
+        // Content-Disposition's filename is the RFC 6266 home; the Content-Type
+        // `name` parameter is the legacy fallback older senders still use.
+        filename: n.dispositionParameters?.filename ?? n.parameters?.name,
+      });
+    }
+    for (const child of n.childNodes ?? []) walk(child);
+  };
+  walk(node);
+  return found;
+}
+
+/** imapflow's parsed message → the lister's raw-shaped {@link EmailReadResult}. */
+export function mapImapMessage(input: {
+  uid: number;
+  folder: string;
+  envelope?: MessageEnvelopeObject;
+  bodyStructure?: MessageStructureObject;
+  internalDate?: Date;
+}): EmailReadResult {
+  const { uid, folder, envelope, bodyStructure, internalDate } = input;
+  // A message with no Date header still has an IMAP INTERNALDATE. Without this
+  // fallback the lister would reject it as unparseable and its poison-message
+  // isolation would silently drop a real email.
+  const date = envelope?.date ?? internalDate;
+  return {
+    id: String(uid),
+    from: formatAddressList(envelope?.from),
+    to: formatAddressList(envelope?.to),
+    cc: formatAddressList(envelope?.cc),
+    subject: envelope?.subject ?? "",
+    date: date ? date.toISOString() : "",
+    folder,
+    messageIdHeader: envelope?.messageId,
+    attachments: collectAttachments(bodyStructure),
+  };
+}
+
+/**
+ * Build an {@link EmailPort} over IMAP from a connection's decrypted credentials.
+ *
+ * Credentials are validated at this edge (mirroring probe.ts): a connection
+ * whose stored blob does not match the IMAP shape fails loudly here rather than
+ * as an opaque runtime error deep inside imapflow.
+ */
+export function createImapPort(credentials: unknown): EmailPort {
+  const parsed = imapTestSchema.safeParse(credentials);
+  if (!parsed.success) {
+    throw new Error("IMAP port: stored credentials do not match the IMAP shape");
+  }
+  const creds = parsed.data;
+
+  let client: ImapFlow | null = null;
+  let openFolder: string | null = null;
+
+  /** Connect once, then select the folder only when it actually changes. */
+  async function open(folder: string): Promise<ImapFlow> {
+    if (!client) {
+      client = new ImapFlow({
+        host: creds.imapHost,
+        port: creds.imapPort,
+        secure: tlsModeForPort(creds.imapPort, creds.security).secure,
+        auth: { user: creds.username, pass: creds.password },
+        logger: false,
+        connectionTimeout: CONNECT_TIMEOUT_MS,
+        greetingTimeout: CONNECT_TIMEOUT_MS,
+        socketTimeout: SOCKET_TIMEOUT_MS,
+      });
+      await client.connect();
+    }
+    if (openFolder !== folder) {
+      await client.mailboxOpen(folder);
+      openFolder = folder;
+    }
+    return client;
+  }
+
+  return {
+    async search(opts): Promise<EmailListItem[]> {
+      const folder = opts.folder ?? DEFAULT_FOLDER;
+      const imap = await open(folder);
+      // `since` is a date, not a timestamp: IMAP SINCE has day granularity, so
+      // this is a coarse pre-filter. The sweep's own `sinceTs` watermark is what
+      // actually bounds the window — this only keeps us from hydrating the
+      // entire mailbox.
+      const since = opts.sinceDays
+        ? new Date(Date.now() - opts.sinceDays * 24 * 60 * 60_000)
+        : undefined;
+      // imapflow answers `false` (not an empty array) when the server rejects
+      // the SEARCH — treat that as "nothing listed" rather than crashing on .map.
+      const uids = await imap.search({ since }, { uid: true });
+      const ids = (Array.isArray(uids) ? uids : []).map((uid) => ({ id: String(uid) }));
+      // Keep the NEWEST when a limit applies: UIDs ascend with arrival, so the
+      // tail is the most recent mail — the half a bounded pass should look at.
+      return opts.limit && ids.length > opts.limit ? ids.slice(-opts.limit) : ids;
+    },
+
+    async read(id): Promise<EmailReadResult> {
+      const folder = openFolder ?? DEFAULT_FOLDER;
+      const imap = await open(folder);
+      const message = await imap.fetchOne(
+        id,
+        { envelope: true, bodyStructure: true, internalDate: true },
+        { uid: true }
+      );
+      if (!message) {
+        // Deleted or expunged between search and read. The lister isolates this
+        // per message, so it costs exactly this mail.
+        throw new Error(`IMAP port: message ${id} not found in ${folder}`);
+      }
+      return mapImapMessage({
+        uid: Number(id),
+        folder,
+        envelope: message.envelope,
+        bodyStructure: message.bodyStructure,
+        // imapflow types internalDate as string | Date depending on the server's
+        // response shape; normalize before the mapper's toISOString().
+        internalDate: message.internalDate ? new Date(message.internalDate) : undefined,
+      });
+    },
+
+    async close(): Promise<void> {
+      if (!client) return;
+      const closing = client;
+      client = null;
+      openFolder = null;
+      await closing.logout();
+    },
+  };
+}

--- a/packages/web/src/lib/email-workflows/ports/imap.ts
+++ b/packages/web/src/lib/email-workflows/ports/imap.ts
@@ -108,7 +108,7 @@ export function createImapPort(credentials: unknown): EmailPort {
   /** Connect once, then select the folder only when it actually changes. */
   async function open(folder: string): Promise<ImapFlow> {
     if (!client) {
-      client = new ImapFlow({
+      const opening = new ImapFlow({
         host: creds.imapHost,
         port: creds.imapPort,
         secure: tlsModeForPort(creds.imapPort, creds.security).secure,
@@ -118,7 +118,12 @@ export function createImapPort(credentials: unknown): EmailPort {
         greetingTimeout: CONNECT_TIMEOUT_MS,
         socketTimeout: SOCKET_TIMEOUT_MS,
       });
-      await client.connect();
+      // Publish the client only once it is actually connected. A failed connect
+      // must leave the port exactly as it was: the sweep closes every port in a
+      // `finally`, and a cached half-open client would make that close log a
+      // bogus logout failure on top of the real error it already reported.
+      await opening.connect();
+      client = opening;
     }
     if (openFolder !== folder) {
       await client.mailboxOpen(folder);
@@ -135,12 +140,15 @@ export function createImapPort(credentials: unknown): EmailPort {
       // this is a coarse pre-filter. The sweep's own `sinceTs` watermark is what
       // actually bounds the window — this only keeps us from hydrating the
       // entire mailbox.
-      const since = opts.sinceDays
-        ? new Date(Date.now() - opts.sinceDays * 24 * 60 * 60_000)
-        : undefined;
+      // No window means every message, said explicitly: `{ since: undefined }`
+      // asks the search compiler to read an undefined-valued term as an absent
+      // one, which is a favour it does not owe us.
+      const query = opts.sinceDays
+        ? { since: new Date(Date.now() - opts.sinceDays * 24 * 60 * 60_000) }
+        : { all: true };
       // imapflow answers `false` (not an empty array) when the server rejects
       // the SEARCH — treat that as "nothing listed" rather than crashing on .map.
-      const uids = await imap.search({ since }, { uid: true });
+      const uids = await imap.search(query, { uid: true });
       const ids = (Array.isArray(uids) ? uids : []).map((uid) => ({ id: String(uid) }));
       // Keep the NEWEST when a limit applies: UIDs ascend with arrival, so the
       // tail is the most recent mail — the half a bounded pass should look at.

--- a/packages/web/src/lib/email-workflows/sweep.ts
+++ b/packages/web/src/lib/email-workflows/sweep.ts
@@ -10,6 +10,7 @@ import { resetStuckProcessingEmails } from "@/lib/email-workflows/ledger";
 import type { StuckClaimKey } from "@/lib/email-workflows/ledger";
 import { listDispatchableEmails } from "@/lib/email-workflows/lister";
 import { loadDispatchableWorkflows } from "@/lib/email-workflows/loader";
+import type { DispatchableWorkflow } from "@/lib/email-workflows/loader";
 import { DEFAULT_RUN_TIMEOUT_MS } from "@/lib/email-workflows/run-adapter";
 import type { EmailPort } from "@/lib/email-workflows/lister";
 import type { RunAgent } from "@/lib/email-workflows/dispatch";
@@ -74,35 +75,23 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
     seenWorkflowIds.add(unit.workflow.id);
     try {
       const port = await deps.createPort(unit.workflow.connectionId);
-      // `folder` only narrows the provider query — the filter re-checks it
-      // anyway, so this saves hydrating mail that is guaranteed to be dropped.
-      const { emails, candidateCount } = await listDispatchableEmails(port, {
-        sinceDays: unit.sweepWindowDays,
-        folder: unit.workflow.filter.folder,
-        limit: SWEEP_LIST_LIMIT,
-      });
-      // A full page means the window held at least as much mail as we are willing
-      // to hydrate, so this pass saw a truncated mailbox. Say so: the overflow is
-      // not merely deferred (see SWEEP_LIST_LIMIT), and a component whose whole
-      // job is "never lose an email" must not truncate in silence.
-      //
-      // Read the CANDIDATE count, not `emails.length`: the lister drops messages
-      // it cannot hydrate, so a full page with one poison mail yields LIMIT-1
-      // emails — and gating on the hydrated count would fall silent on exactly
-      // the pass that is both truncated and lossy.
-      if (candidateCount >= SWEEP_LIST_LIMIT) {
-        console.warn(
-          `reconciliation sweep: hit the listing limit of ${SWEEP_LIST_LIMIT} for workflow ${unit.workflow.id} on connection ${unit.workflow.connectionId} — mail beyond it was not seen this pass`
-        );
+      try {
+        await sweepUnit(unit, port, deps);
+      } finally {
+        // The port can hold a real connection (IMAP), and this is its only
+        // owner — so release it on every path, including the dead-mailbox throw
+        // below, which would otherwise strand a connection every cadence.
+        // A close failure must NOT fail a unit whose work already succeeded
+        // (ledger written, runs done): log it and move on.
+        try {
+          await port.close?.();
+        } catch (closeErr) {
+          console.error(
+            `reconciliation sweep: failed to close the port for connection ${unit.workflow.connectionId}`,
+            closeErr
+          );
+        }
       }
-      // The sweep re-lists a whole window, so it is the only place the per-
-      // (workflow × connection) watermark can be enforced: the lister speaks
-      // `sinceDays` and nothing downstream reads `receivedAt`. Without this gate
-      // a workflow attached to an old mailbox would retroactively act on the
-      // entire window (design §8, "New workflow on old mailbox"). Below the
-      // watermark is dropped before the claim, never claimed-and-skipped.
-      const fresh = emails.filter((email) => email.receivedAt >= unit.sinceTs);
-      await dispatchEmails({ workflow: unit.workflow, emails: fresh, runAgent: deps.runAgent });
     } catch (err) {
       // A unit-level failure is a broken *mailbox* (credentials, unreachable
       // host) — invisible in the ledger, because nothing was ever listed. It
@@ -122,6 +111,43 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
     // on `status`, so the workflow would keep running while displaying `error`.
     await setWorkflowStatus(workflowId, failedWorkflowIds.has(workflowId) ? "error" : "active");
   }
+}
+
+/** One (workflow × connection) pass over an already-open port. */
+async function sweepUnit(
+  unit: DispatchableWorkflow,
+  port: EmailPort,
+  deps: SweepDeps
+): Promise<void> {
+  // `folder` only narrows the provider query — the filter re-checks it
+  // anyway, so this saves hydrating mail that is guaranteed to be dropped.
+  const { emails, candidateCount } = await listDispatchableEmails(port, {
+    sinceDays: unit.sweepWindowDays,
+    folder: unit.workflow.filter.folder,
+    limit: SWEEP_LIST_LIMIT,
+  });
+  // A full page means the window held at least as much mail as we are willing
+  // to hydrate, so this pass saw a truncated mailbox. Say so: the overflow is
+  // not merely deferred (see SWEEP_LIST_LIMIT), and a component whose whole
+  // job is "never lose an email" must not truncate in silence.
+  //
+  // Read the CANDIDATE count, not `emails.length`: the lister drops messages
+  // it cannot hydrate, so a full page with one poison mail yields LIMIT-1
+  // emails — and gating on the hydrated count would fall silent on exactly
+  // the pass that is both truncated and lossy.
+  if (candidateCount >= SWEEP_LIST_LIMIT) {
+    console.warn(
+      `reconciliation sweep: hit the listing limit of ${SWEEP_LIST_LIMIT} for workflow ${unit.workflow.id} on connection ${unit.workflow.connectionId} — mail beyond it was not seen this pass`
+    );
+  }
+  // The sweep re-lists a whole window, so it is the only place the per-
+  // (workflow × connection) watermark can be enforced: the lister speaks
+  // `sinceDays` and nothing downstream reads `receivedAt`. Without this gate
+  // a workflow attached to an old mailbox would retroactively act on the
+  // entire window (design §8, "New workflow on old mailbox"). Below the
+  // watermark is dropped before the claim, never claimed-and-skipped.
+  const fresh = emails.filter((email) => email.receivedAt >= unit.sinceTs);
+  await dispatchEmails({ workflow: unit.workflow, emails: fresh, runAgent: deps.runAgent });
 }
 
 async function setWorkflowStatus(workflowId: string, status: EmailWorkflowStatus): Promise<void> {

--- a/packages/web/src/lib/integrations/resolve-credentials.ts
+++ b/packages/web/src/lib/integrations/resolve-credentials.ts
@@ -1,0 +1,165 @@
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { integrationConnections } from "@/db/schema";
+import { decrypt, encrypt } from "@/lib/encryption";
+import { refreshAccessToken } from "@/lib/integrations/google-oauth";
+import { isTokenExpired, createRefreshDedup } from "@/lib/integrations/oauth-token";
+import { getOAuthSettings } from "@/lib/integrations/oauth-settings";
+import {
+  refreshMicrosoftCredentials,
+  OAuthSettingsMissingError,
+} from "@/lib/integrations/microsoft-refresh";
+
+/**
+ * Resolve a connection's decrypted, refreshed credentials — the single seam both
+ * the internal credentials route (which maps failures to HTTP status codes) and
+ * the Inbox Agent's mailbox port (which lets them propagate to the sweep as the
+ * workflow's `error` status) share, so the tricky decrypt + OAuth-refresh +
+ * re-encrypt logic lives in exactly one place.
+ *
+ * Failures are *typed*, not HTTP responses: callers decide how to surface them.
+ * {@link OAuthSettingsMissingError} (re-exported from microsoft-refresh) is the
+ * fourth case — the token is expired and cannot be refreshed.
+ */
+export class ConnectionNotFoundError extends Error {
+  constructor(public readonly connectionId: string) {
+    super(`Integration connection ${connectionId} not found`);
+    this.name = "ConnectionNotFoundError";
+  }
+}
+
+export class ConnectionNotActiveError extends Error {
+  constructor(public readonly connectionId: string) {
+    super(`Integration connection ${connectionId} is not active`);
+    this.name = "ConnectionNotActiveError";
+  }
+}
+
+export class CredentialsDecryptError extends Error {
+  constructor(public readonly connectionId: string) {
+    super(`Failed to decrypt credentials for connection ${connectionId}`);
+    this.name = "CredentialsDecryptError";
+  }
+}
+
+export { OAuthSettingsMissingError };
+
+export interface ResolvedCredentials {
+  type: string;
+  credentials: Record<string, unknown>;
+}
+
+interface GoogleCredentials {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt?: string;
+  [k: string]: unknown;
+}
+
+// Per-connectionId in-flight refresh tracker for the Google path (see
+// createRefreshDedup / issue #237). The Microsoft equivalent lives in
+// microsoft-refresh.ts. Module-level so concurrent resolvers for the same
+// connection share one refresh.
+const dedupeGoogleRefresh = createRefreshDedup<GoogleCredentials>();
+
+async function refreshGoogleCredentials(
+  connectionId: string,
+  current: GoogleCredentials
+): Promise<GoogleCredentials> {
+  return dedupeGoogleRefresh(connectionId, async () => {
+    try {
+      const oauthSettings = await getOAuthSettings("google");
+      if (!oauthSettings) {
+        console.error("Google OAuth token refresh failed: OAuth settings not configured");
+        throw new OAuthSettingsMissingError("Google");
+      }
+
+      const refreshed = await refreshAccessToken({
+        refreshToken: current.refreshToken,
+        clientId: oauthSettings.clientId,
+        clientSecret: oauthSettings.clientSecret,
+      });
+
+      const updated: GoogleCredentials = {
+        ...current,
+        accessToken: refreshed.accessToken,
+        expiresAt: refreshed.expiresAt,
+      };
+
+      await db
+        .update(integrationConnections)
+        .set({ credentials: encrypt(JSON.stringify(updated)), updatedAt: new Date() })
+        .where(eq(integrationConnections.id, connectionId));
+
+      console.log("Refreshed Google OAuth token for connection", connectionId);
+      return updated;
+    } catch (err) {
+      if (err instanceof OAuthSettingsMissingError) {
+        // No safe stale fallback when settings are missing and a refresh is
+        // required — re-throw.
+        throw err;
+      }
+      console.error("Google OAuth token refresh failed:", err);
+      return current;
+    }
+  });
+}
+
+// Shared minimal shape both GoogleCredentials and MicrosoftCredentials satisfy;
+// expiresAt is required so both refresh functions stay structurally assignable
+// (the call site only invokes a refresh once expiresAt is truthy).
+interface OAuthCredentials {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  [k: string]: unknown;
+}
+
+// Dispatch keyed by connection.type (a DB column, not user input); a type
+// outside this table (imap, odoo, web-search) simply misses and no refresh is
+// attempted.
+const REFRESH_BY_TYPE: Record<
+  string,
+  (connectionId: string, current: OAuthCredentials) => Promise<Record<string, unknown>>
+> = {
+  google: refreshGoogleCredentials,
+  microsoft: refreshMicrosoftCredentials,
+};
+
+export async function resolveConnectionCredentials(
+  connectionId: string
+): Promise<ResolvedCredentials> {
+  const rows = await db
+    .select()
+    .from(integrationConnections)
+    .where(eq(integrationConnections.id, connectionId))
+    .limit(1);
+
+  if (rows.length === 0) {
+    throw new ConnectionNotFoundError(connectionId);
+  }
+
+  const connection = rows[0];
+  if (connection.status === "pending") {
+    throw new ConnectionNotActiveError(connectionId);
+  }
+
+  let credentials: Record<string, unknown>;
+  try {
+    credentials = JSON.parse(decrypt(connection.credentials));
+  } catch {
+    throw new CredentialsDecryptError(connectionId);
+  }
+
+  // Auto-refresh expired OAuth tokens. The per-provider persist policy on a
+  // failed refresh lives in each refresh function (Google degrades to current;
+  // Microsoft retries then throws rather than dropping a rotated token — #237).
+  // Missing OAuth settings throw OAuthSettingsMissingError for the caller to map.
+  const refreshFn = REFRESH_BY_TYPE[connection.type];
+  if (refreshFn && credentials.expiresAt && isTokenExpired(credentials.expiresAt as string)) {
+    credentials = await refreshFn(connectionId, credentials as unknown as OAuthCredentials);
+  }
+
+  return { type: connection.type, credentials };
+}

--- a/packages/web/src/server/inbox-sweep-deps.ts
+++ b/packages/web/src/server/inbox-sweep-deps.ts
@@ -1,0 +1,106 @@
+/**
+ * Production dependencies for the reconciliation sweep (#139).
+ *
+ * The sweep engine (`runReconciliationSweep`) and the run adapter
+ * (`createOpenClawRunAgent`) are both written against injected seams so they can
+ * be tested without a mailbox or a Gateway. This module is where those seams
+ * meet reality: real mailboxes via {@link createEmailPort}, real runs via the
+ * live OpenClaw client.
+ *
+ * It lives apart from the scheduler (`inbox-sweep.ts`) on purpose — the
+ * scheduler stays a pure cadence with no knowledge of DB or Gateway, which is
+ * what lets its tests run with no mocks at all.
+ */
+import { eq } from "drizzle-orm";
+import type { OpenClawClient } from "openclaw-node";
+
+import { db } from "@/db";
+import { agents } from "@/db/schema";
+import { createEmailPort } from "@/lib/email-workflows/port";
+import { createOpenClawRunAgent } from "@/lib/email-workflows/run-adapter";
+import type { SweepDeps } from "@/lib/email-workflows/sweep";
+import { waitForAgentInRuntime } from "@/server/agent-readiness";
+
+/** The slice of the gateway client the sweep's dependencies need. */
+export type SweepGatewayClient = Pick<
+  OpenClawClient,
+  "chat" | "chatAbort" | "hasMethod" | "agents" | "isConnected"
+>;
+
+/**
+ * How long to wait for an agent to land in OpenClaw's runtime before deferring
+ * the email.
+ *
+ * Deliberately well below the ~100 s worst-case `config.apply` lag the chat path
+ * budgets for: here a miss is cheap and lossless (the adapter defers, the row
+ * stays `processing`, the next sweep retries it), whereas waiting blocks the
+ * sweep for every email behind it. In steady state this costs one `agents.list`
+ * read and returns immediately.
+ */
+export const DEFAULT_READINESS_DEADLINE_MS = 30_000;
+
+/** The agent's `provider/model` ref, or null if the agent is gone. */
+export async function loadAgentModel(agentId: string): Promise<string | null> {
+  const agent = await db.query.agents.findFirst({
+    where: eq(agents.id, agentId),
+    columns: { model: true },
+  });
+  return agent?.model ?? null;
+}
+
+/**
+ * The run adapter's runtime-readiness gate, over three distinct Gateway states
+ * that the underlying primitives blur together.
+ *
+ * The adapter reads `false` as "defer this email", and `waitForAgentInRuntime`
+ * answers `false` for two very different situations:
+ *
+ *   1. The agent is not in the runtime yet — a real, transient miss. Deferring
+ *      is exactly right: the next sweep retries and nothing is lost.
+ *   2. The Gateway has no `agents.list` RPC, so readiness is *unobservable*.
+ *      Deferring on that would be catastrophic and completely silent — every
+ *      email claimed, deferred, reset, re-claimed, deferred again, forever,
+ *      while the workflow reports `active` and processes nothing.
+ *
+ * Unobservable is not "no", so case 2 proceeds and lets the run answer: a
+ * genuinely unknown agent id fails that one run loudly, which is strictly better
+ * than an invisible loop.
+ *
+ * But `hasMethod` cannot separate case 2 from a third state — a Gateway that is
+ * simply not connected. The client's advertised-method list is filled at the
+ * hello-ok handshake and is empty until then, so "too old" and "not connected
+ * yet" look identical through it. Proceeding while disconnected would claim the
+ * email, fail the chat, and (any run throw being terminal to the dispatcher)
+ * mark a never-examined mail `failed` and notify the user. `isConnected` is the
+ * distinguisher, checked first: no connection means defer, which costs one
+ * cadence and loses nothing.
+ */
+export function createAgentReadinessGate(
+  client: SweepGatewayClient,
+  opts: { deadlineMs?: number } = {}
+): (agentId: string) => Promise<boolean> {
+  return async (agentId) => {
+    if (!client.isConnected) return false;
+    if (!client.hasMethod("agents.list")) return true;
+    return waitForAgentInRuntime(
+      agentId,
+      {
+        hasAgentsListRpc: () => true,
+        listRuntimeAgentIds: async () => (await client.agents.list()).agents.map((a) => a.id),
+      },
+      { deadlineMs: opts.deadlineMs ?? DEFAULT_READINESS_DEADLINE_MS }
+    );
+  };
+}
+
+/** Everything {@link import("@/lib/email-workflows/sweep").runReconciliationSweep} needs to run for real. */
+export function buildSweepDeps(client: SweepGatewayClient): SweepDeps {
+  return {
+    createPort: createEmailPort,
+    runAgent: createOpenClawRunAgent({
+      client,
+      loadAgentModel,
+      waitForAgentReady: createAgentReadinessGate(client),
+    }),
+  };
+}

--- a/packages/web/src/server/inbox-sweep.ts
+++ b/packages/web/src/server/inbox-sweep.ts
@@ -60,17 +60,23 @@ let _startupTimeout: ReturnType<typeof setTimeout> | null = null;
 /**
  * Start the in-process sweep cadence: a post-startup kick plus a recurring
  * interval, both firing the same re-entrancy-guarded runner so a slow pass never
- * overlaps its own next tick. `runSweep` is injected (the production wiring —
- * `runReconciliationSweep` with a real mailbox port — is a later brick), keeping
- * the scheduler testable and decoupled from mailbox I/O.
+ * overlaps its own next tick. `runSweep` is injected (production composes it in
+ * `inbox-sweep-deps.ts`), keeping the scheduler decoupled from DB and gateway —
+ * which is what lets these tests run with no mocks at all.
+ *
+ * `opts` overrides the cadence. Production leaves it empty; the E2E stack shortens
+ * it via `INBOX_SWEEP_INTERVAL_MS`, since no test can wait 15 minutes for a tick.
  */
-export function startInboxSweep(runSweep: () => Promise<void>): void {
+export function startInboxSweep(
+  runSweep: () => Promise<void>,
+  opts: { intervalMs?: number; startupDelayMs?: number } = {}
+): void {
   const guarded = createGuardedSweepRunner(runSweep);
-  _interval = setInterval(() => void guarded(), SWEEP_INTERVAL_MS);
+  _interval = setInterval(() => void guarded(), opts.intervalMs ?? SWEEP_INTERVAL_MS);
   _startupTimeout = setTimeout(() => {
     _startupTimeout = null;
     void guarded();
-  }, SWEEP_STARTUP_DELAY_MS);
+  }, opts.startupDelayMs ?? SWEEP_STARTUP_DELAY_MS);
 }
 
 /** Stop the cadence, clearing both timers so a stopped scheduler never fires again. */

--- a/packages/web/src/server/inbox-sweep.ts
+++ b/packages/web/src/server/inbox-sweep.ts
@@ -1,0 +1,91 @@
+/**
+ * The Inbox Agent reconciliation-sweep scheduler (Brick E): the in-process
+ * cadence that drives {@link import("@/lib/email-workflows/sweep").runReconciliationSweep}
+ * autonomously, mirroring the established periodic-job pattern (`upload-gc.ts`,
+ * `audit-verify-job.ts`) — a `setInterval` plus a post-startup kick.
+ *
+ * The sweep is the correctness path, not the low-latency path: it re-lists a
+ * whole window every cadence, so it runs infrequently. The token-free
+ * steady-state poll is a later brick (an OpenClaw cron event-trigger), leaving
+ * this as the safety net that guarantees no email is ever lost.
+ */
+
+/**
+ * Wrap a sweep in a re-entrancy guard: a call made while a previous run is still
+ * in flight is *skipped*, never run concurrently.
+ *
+ * The ledger's atomic claim already makes overlapping sweeps *correct* (no email
+ * is claimed twice), but not *free* — each pass re-lists the whole window and
+ * hits provider rate limits. Without this guard a sweep slower than the cadence
+ * would stack redundant provider I/O on top of itself. In-flight state is
+ * encapsulated per runner (rather than a module-level flag) so it is directly
+ * testable and cannot leak between callers.
+ */
+export function createGuardedSweepRunner(runSweep: () => Promise<void>): () => Promise<void> {
+  let inFlight = false;
+  return async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await runSweep();
+    } catch (err) {
+      // A sweep failure is logged and swallowed, never rethrown: the interval
+      // fires this as `void run()`, so a rejection would be an unhandled
+      // process-level rejection. The `finally` still frees the guard, so one bad
+      // pass never wedges every future sweep.
+      console.error("[inbox-sweep] sweep failed:", err);
+    } finally {
+      inFlight = false;
+    }
+  };
+}
+
+/**
+ * Cadence for the reconciliation sweep. Deliberately infrequent: each pass
+ * re-lists a whole window (an O(window) provider read per connection), so this
+ * is the safety net, not the low-latency path. The token-free steady-state poll
+ * that will run near-real-time is a later brick (an OpenClaw cron event-trigger).
+ */
+export const SWEEP_INTERVAL_MS = 15 * 60_000;
+
+/**
+ * Delay before the first pass, so the OpenClaw gateway and config have settled
+ * after a restart before we dispatch (mirrors upload-gc/audit-verify-job).
+ */
+export const SWEEP_STARTUP_DELAY_MS = 30_000;
+
+let _interval: ReturnType<typeof setInterval> | null = null;
+let _startupTimeout: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Start the in-process sweep cadence: a post-startup kick plus a recurring
+ * interval, both firing the same re-entrancy-guarded runner so a slow pass never
+ * overlaps its own next tick. `runSweep` is injected (the production wiring —
+ * `runReconciliationSweep` with a real mailbox port — is a later brick), keeping
+ * the scheduler testable and decoupled from mailbox I/O.
+ */
+export function startInboxSweep(runSweep: () => Promise<void>): void {
+  const guarded = createGuardedSweepRunner(runSweep);
+  _interval = setInterval(() => void guarded(), SWEEP_INTERVAL_MS);
+  _startupTimeout = setTimeout(() => {
+    _startupTimeout = null;
+    void guarded();
+  }, SWEEP_STARTUP_DELAY_MS);
+}
+
+/** Stop the cadence, clearing both timers so a stopped scheduler never fires again. */
+export function stopInboxSweep(): void {
+  if (_interval !== null) {
+    clearInterval(_interval);
+    _interval = null;
+  }
+  if (_startupTimeout !== null) {
+    clearTimeout(_startupTimeout);
+    _startupTimeout = null;
+  }
+}
+
+/** Test-only helper (mirrors upload-gc / audit-verify-job pattern). */
+export function _isInboxSweepRunning(): boolean {
+  return _interval !== null;
+}

--- a/packages/web/src/server/inbox-sweep.ts
+++ b/packages/web/src/server/inbox-sweep.ts
@@ -66,11 +66,19 @@ let _startupTimeout: ReturnType<typeof setTimeout> | null = null;
  *
  * `opts` overrides the cadence. Production leaves it empty; the E2E stack shortens
  * it via `INBOX_SWEEP_INTERVAL_MS`, since no test can wait 15 minutes for a tick.
+ *
+ * Idempotent: the timer handles live in module state, so a second start without
+ * this would overwrite the first one's handles and orphan an interval that fires
+ * forever with nobody holding a reference to stop it — doubling every sweep's
+ * provider I/O. That leak is the reason this cadence is not hung off the
+ * gateway's `connected` event; making start itself safe removes the footgun
+ * instead of leaving it for every future caller to remember.
  */
 export function startInboxSweep(
   runSweep: () => Promise<void>,
   opts: { intervalMs?: number; startupDelayMs?: number } = {}
 ): void {
+  stopInboxSweep();
   const guarded = createGuardedSweepRunner(runSweep);
   _interval = setInterval(() => void guarded(), opts.intervalMs ?? SWEEP_INTERVAL_MS);
   _startupTimeout = setTimeout(() => {


### PR DESCRIPTION
Brick E of the Inbox Agent (#139), on top of the merged sweep engine (#750). After this, the feature runs on its own: mail lands in a mailbox and Pinchy acts on it with nobody asking.

## What's here

| | |
|---|---|
| **Scheduler** | `server/inbox-sweep.ts` — interval + post-startup kick, re-entrancy guard, `runSweep` injected |
| **Credential seam** | `lib/integrations/resolve-credentials.ts` — extracted, shared with the internal credentials route |
| **Port lifecycle** | `EmailPort.close?()` — only IMAP holds a connection; the sweep closes it in a `finally` |
| **Mailbox ports** | `ports/{imap,graph,gmail}.ts` + `createEmailPort` dispatch |
| **Boot wiring** | `buildSweepDeps` + `startInboxSweep` in `server.ts` |
| **E2E** | an unread mail dispatches with no manual trigger, against real GreenMail |

## The load-bearing decisions

**Two Gateway states the primitives blur together** (`inbox-sweep-deps.ts`, both mutation-verified). The run adapter reads `false` from the readiness gate as "defer this email":

1. `waitForAgentInRuntime` also answers `false` when the Gateway has no `agents.list` — readiness is *unobservable*, not *negative*. Wired naively, every email would loop forever (claim → defer → reset → re-claim) while the workflow reports `active` and processes nothing. Unobservable is not "no": proceed and let the run answer.
2. `hasMethod` cannot separate "too old" from "not connected" — the advertised-method list is filled at hello-ok and empty until then. Proceeding while disconnected would terminally fail mail nobody ever examined *and notify the user about it*. `isConnected` is checked first. The first sweep fires 30s after boot, so this is the ordinary path, not a corner case.

That gate is also what makes an eager start safe, which is why the cadence is **not** hung off the `connected` event — that refires on every reconnect and would leak a second interval.

**Gmail scopes folders with `labelIds`, never `q`.** Gmail's query language only documents `in:trash`/`in:spam` for folder scoping, and search excludes Trash/Spam by default — `q`-scoping risks *silently empty* results. For a sweep that is the worst failure there is: it reads as "nothing new" while the workflow looks healthy. (The pinchy-email plugin paid for this lesson already.)

## Why the E2E earns its keep

Every layer below it is covered against an injected seam, and they all share one blind spot: they are *called by the test*. So the spec never triggers a sweep — it seeds a workflow and a message and then only watches.

It paid for itself immediately: the first run went red because the sweep never claimed the mail, **silently** — the loader drops a workflow whose notification recipients don't resolve, with no log and no status change. That was a seeded-data bug (`created_by` NULL), not a product bug, but it is exactly the failure class this spec exists to surface.

The connection seeds `greenmail:3143` with `security: "none"` rather than riding the plugin's `IMAP_MOCK_HOST` redirect, so the real credential path runs and the sweep's port needs no test-only branch.

## Verification

- `pnpm test` — 8641 passed, **0 test failures**. Three files are red in my worktree only (`knowledge/embeddings*`, `pdf-extract`): `pdfjs-dist`/`node-llama-cpp` are declared but not linked here. Pre-existing, untouched by these commits, and CI installs them.
- `pnpm test:db` — 260 passed (throwaway pgvector Postgres)
- `pnpm typecheck`, lint, `format:check` — clean
- **IMAP E2E — 6/6 on a fresh stack**, the 5 existing plugin tests plus the new sweep test

## Not in scope

Brick F (the token-free OpenClaw cron condition-watcher poll for low latency) and the NL→workflow creation tool (#705). Workflows are still seeded directly — no product surface creates them yet.

Refs #139