### PR TITLE
docs(eval): state the funding and vendor relationships outright (#802)

### DIFF
--- a/packages/web/eval/model-selection-methodology.md
+++ b/packages/web/eval/model-selection-methodology.md
@@ -174,4 +174,18 @@ them. For this benchmark:
   and data are open for exactly this reason — anyone can audit what we ran.
 - **Models are tested as-is** on their public Ollama Cloud `/v1` serving as of
   the run date; we do not use privileged endpoints or vendor-tuned settings.
-- **Funding:** the runs are executed on Pinchy's own Ollama Cloud account.
+- **Funding and vendor relationships.** The runs are paid for by Pinchy, on an
+  ordinary paid Ollama Cloud subscription at list price. **No model provider or
+  serving vendor funds, sponsors, or discounts this benchmark** — no credits, no
+  sponsorship, no partnership, no preview or privileged access. No vendor whose
+  model appears in the ranking has any commercial relationship with Pinchy, in
+  either direction: none is a customer, investor, or partner. If any of that ever
+  changes, it will be disclosed here before the next dataset release, not after
+  someone finds it.
+
+Why this section is specific rather than a generic "we're independent": our own
+R2 says the **serving layer is the dominant variable**, and every run in this
+dataset goes through one serving vendor. That puts Ollama in a position no
+ranked model occupies — so "who pays for the serving" is exactly the question a
+skeptical reader should ask, and it deserves a direct answer rather than
+silence.

--- a/packages/web/eval/model-selection-methodology.md
+++ b/packages/web/eval/model-selection-methodology.md
@@ -183,9 +183,9 @@ them. For this benchmark:
   changes, it will be disclosed here before the next dataset release, not after
   someone finds it.
 
-Why this section is specific rather than a generic "we're independent": our own
-R2 says the **serving layer is the dominant variable**, and every run in this
-dataset goes through one serving vendor. That puts Ollama in a position no
-ranked model occupies — so "who pays for the serving" is exactly the question a
-skeptical reader should ask, and it deserves a direct answer rather than
-silence.
+  Why this section is specific rather than a generic "we're independent": our
+  own R2 says the **serving layer is the dominant variable**, and every run in
+  this dataset goes through one serving vendor. That puts Ollama in a position
+  no ranked model occupies — so "who pays for the serving" is exactly the
+  question a skeptical reader should ask, and it deserves a direct answer rather
+  than silence.


### PR DESCRIPTION
## Why

The Disclosures section (#807) shipped with the claims verifiable from the repo, and deliberately **without** the one that wasn't: whether any vendor funds or sponsors this benchmark. I wouldn't assert "no sponsorship" without confirming it. Confirmed with the maintainer — so it can now be stated.

## What it now says

- The runs are paid for by Pinchy, on an **ordinary paid Ollama Cloud subscription at list price**.
- **No model provider or serving vendor funds, sponsors, or discounts this benchmark** — no credits, no sponsorship, no partnership, no preview/privileged access.
- No vendor in the ranking has a commercial relationship with Pinchy in either direction: none is a customer, investor, or partner.
- If that changes, it gets disclosed here **before** the next dataset release.

Plus a short paragraph on why this section is specific rather than generic independence boilerplate: our own **R2 says the serving layer is the dominant variable**, and every run in the dataset goes through one serving vendor. That puts Ollama in a position no ranked model occupies, so "who pays for the serving" is exactly the question a skeptical reader should ask. It deserves a direct answer, not silence.

Timing is the point: late disclosure is what damaged FrontierMath — not the funding. This lands before the Hugging Face mirror (marketing#39) and the launch (marketing#40), not after.

## Test plan

Docs only; no run/grade logic touched, no published number moves. `pnpm -C packages/web test` eval suite green (445).

Refs #802, #669