### PR TITLE
feat(kb): report unsearchable and failed files in reindex counts

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -81,7 +81,7 @@ The response reports what happened:
 | `skipped`      | Unchanged since the last run, left alone.                                                                                                     |
 | `removed`      | Gone from disk, dropped from the index.                                                                                                       |
 | `unsearchable` | Read without error, but the file holds no text to search — nearly always a scanned PDF (see [Scope in this release](#scope-in-this-release)). |
-| `failed`       | Couldn't be read or parsed at all. The file is left out and the run continues.                                                                |
+| `failed`       | Couldn't be read or parsed at all. The run continues; if an earlier version of the file was indexed, that version stays searchable.           |
 
 `indexed` counts documents the agent can actually reach, not documents we processed — that's why a scanned PDF lands under `unsearchable` instead. If either of the last two numbers is above zero, part of your corpus can't answer questions yet, and it's worth knowing which part before someone asks it something.
 

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -65,8 +65,25 @@ Indexing is idempotent — unchanged files are skipped on the next run, changed 
 The response reports what happened:
 
 ```json
-{ "indexed": 3, "skipped": 12, "removed": 1, "pathCount": 2 }
+{
+  "indexed": 3,
+  "skipped": 12,
+  "removed": 1,
+  "unsearchable": 2,
+  "failed": 0,
+  "pathCount": 2
+}
 ```
+
+| Field          | What it means                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `indexed`      | Added or updated, and searchable afterwards.                                                                                                  |
+| `skipped`      | Unchanged since the last run, left alone.                                                                                                     |
+| `removed`      | Gone from disk, dropped from the index.                                                                                                       |
+| `unsearchable` | Read without error, but the file holds no text to search — nearly always a scanned PDF (see [Scope in this release](#scope-in-this-release)). |
+| `failed`       | Couldn't be read or parsed at all. The file is left out and the run continues.                                                                |
+
+`indexed` counts documents the agent can actually reach, not documents we processed — that's why a scanned PDF lands under `unsearchable` instead. If either of the last two numbers is above zero, part of your corpus can't answer questions yet, and it's worth knowing which part before someone asks it something.
 
 ## 8. Chat with the agent
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -295,14 +295,14 @@ See [Create a Knowledge Base Agent](/guides/create-knowledge-base-agent/) for th
 }
 ```
 
-| Field          | Description                                                                                                                         |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                   |
-| `skipped`      | Unchanged content hash, chunks already present.                                                                                     |
-| `removed`      | Source file no longer on disk; the document and its chunks were deleted.                                                            |
-| `unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF). |
-| `failed`       | The file could not be read or parsed. It is left out and the run continues; one bad file never aborts the reindex.                  |
-| `pathCount`    | Number of granted folders reindexed.                                                                                                |
+| Field          | Description                                                                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                                                |
+| `skipped`      | Unchanged content hash, chunks already present.                                                                                                                  |
+| `removed`      | Source file no longer on disk; the document and its chunks were deleted.                                                                                         |
+| `unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF).                              |
+| `failed`       | The file could not be read or parsed. The run continues — one bad file never aborts the reindex — and a previously indexed version of the file stays searchable. |
+| `pathCount`    | Number of granted folders reindexed.                                                                                                                             |
 
 `unsearchable` and `failed` can be non-zero on a `200`: the reindex itself succeeded and these are its findings about the corpus. Both are also recorded in the `knowledge.reindex` audit entry.
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -285,8 +285,26 @@ See [Create a Knowledge Base Agent](/guides/create-knowledge-base-agent/) for th
 **Response:**
 
 ```json
-{ "indexed": 3, "skipped": 12, "removed": 1, "pathCount": 2 }
+{
+  "indexed": 3,
+  "skipped": 12,
+  "removed": 1,
+  "unsearchable": 2,
+  "failed": 0,
+  "pathCount": 2
+}
 ```
+
+| Field          | Description                                                                                                                         |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                   |
+| `skipped`      | Unchanged content hash, chunks already present.                                                                                     |
+| `removed`      | Source file no longer on disk; the document and its chunks were deleted.                                                            |
+| `unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF). |
+| `failed`       | The file could not be read or parsed. It is left out and the run continues; one bad file never aborts the reindex.                  |
+| `pathCount`    | Number of granted folders reindexed.                                                                                                |
+
+`unsearchable` and `failed` can be non-zero on a `200`: the reindex itself succeeded and these are its findings about the corpus. Both are also recorded in the `knowledge.reindex` audit entry.
 
 **Errors:**
 

--- a/packages/web/src/__tests__/api/knowledge-reindex.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-reindex.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
+import type { IngestResult } from "@/lib/knowledge/ingest";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
@@ -60,6 +61,16 @@ function makeRequest(body: Record<string, unknown> = {}) {
   });
 }
 
+/**
+ * An ingestDirectory result with every counter at zero, overridden by `counts`.
+ * Typed as IngestResult so a new counter added to ingest.ts fails to compile
+ * here until the route is taught to aggregate it, rather than silently
+ * dropping out of the response.
+ */
+function ingestResult(counts: Partial<IngestResult> = {}): IngestResult {
+  return { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0, ...counts };
+}
+
 const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
 
 const agentRow = {
@@ -76,7 +87,7 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
     mockGetSession.mockResolvedValue({ user: { id: "admin-1", role: "admin" } });
     mockLimit.mockResolvedValue([agentRow]);
     mockGetSetting.mockResolvedValue("http://ollama.local:11434");
-    mockIngestDirectory.mockResolvedValue({ indexed: 2, skipped: 1, removed: 0 });
+    mockIngestDirectory.mockResolvedValue(ingestResult({ indexed: 2, skipped: 1 }));
     POST = (await import("@/app/api/agents/[agentId]/knowledge/reindex/route")).POST;
   });
 
@@ -103,12 +114,15 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
 
   it("reindexes every granted folder and aggregates counts across paths", async () => {
     mockIngestDirectory
-      .mockResolvedValueOnce({ indexed: 2, skipped: 1, removed: 0 })
-      .mockResolvedValueOnce({ indexed: 3, skipped: 0, removed: 1 });
+      .mockResolvedValueOnce(ingestResult({ indexed: 2, skipped: 1 }))
+      .mockResolvedValueOnce(ingestResult({ indexed: 3, removed: 1 }));
 
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ indexed: 5, skipped: 1, removed: 1, pathCount: 2 });
+    expect(await res.json()).toEqual({
+      ...ingestResult({ indexed: 5, skipped: 1, removed: 1 }),
+      pathCount: 2,
+    });
 
     expect(mockIngestDirectory).toHaveBeenCalledTimes(2);
     // Each granted folder is ingested with the shared single-tenant org id.
@@ -134,7 +148,7 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
     mockLimit.mockResolvedValueOnce([{ id: "agent-1", name: "Smithers", pluginConfig: null }]);
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ indexed: 0, skipped: 0, removed: 0, pathCount: 0 });
+    expect(await res.json()).toEqual({ ...ingestResult(), pathCount: 0 });
     expect(mockIngestDirectory).not.toHaveBeenCalled();
 
     // A no-op reindex is still audited (success, zero counts).
@@ -171,8 +185,8 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
 
   it("writes a knowledge.reindex audit row with {id,name} agent ref, counts, and no raw filesystem path/PII", async () => {
     mockIngestDirectory
-      .mockResolvedValueOnce({ indexed: 2, skipped: 1, removed: 0 })
-      .mockResolvedValueOnce({ indexed: 3, skipped: 0, removed: 1 });
+      .mockResolvedValueOnce(ingestResult({ indexed: 2, skipped: 1 }))
+      .mockResolvedValueOnce(ingestResult({ indexed: 3, removed: 1 }));
 
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(200);
@@ -182,12 +196,40 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
     expect(entry.eventType).toBe("knowledge.reindex");
     expect(entry.outcome).toBe("success");
     expect(entry.detail.agent).toEqual({ id: "agent-1", name: "Smithers" });
-    expect(entry.detail).toMatchObject({ pathCount: 2, indexed: 5, skipped: 1, removed: 1 });
+    expect(entry.detail).toMatchObject({
+      pathCount: 2,
+      indexed: 5,
+      skipped: 1,
+      removed: 1,
+      unsearchable: 0,
+      failed: 0,
+    });
 
     // No full filesystem paths (which can embed usernames) in the audit detail.
     const serialized = JSON.stringify(entry);
     expect(serialized).not.toContain("/data/hr");
     expect(serialized).not.toContain("/data/legal");
     expect(serialized).not.toMatch(/[^\s@]+@[^\s@]+\.[^\s@]+/); // no email-shaped strings
+  });
+
+  // The counts are the ONLY thing an admin sees after a reindex, so the two
+  // that mean "this file will never answer a question" have to survive the
+  // trip from ingest to response and audit. Dropping them here would restore
+  // exactly the false "everything indexed" the ingest layer stopped telling.
+  it("reports unsearchable and failed files in both the response and the audit row", async () => {
+    mockIngestDirectory
+      .mockResolvedValueOnce(ingestResult({ indexed: 4, unsearchable: 2 }))
+      .mockResolvedValueOnce(ingestResult({ indexed: 1, skipped: 3, unsearchable: 1, failed: 2 }));
+
+    const res = await POST(makeRequest(), ctx as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ...ingestResult({ indexed: 5, skipped: 3, unsearchable: 3, failed: 2 }),
+      pathCount: 2,
+    });
+
+    const entry = mockDeferAuditLog.mock.calls[0][0];
+    expect(entry.outcome).toBe("success");
+    expect(entry.detail).toMatchObject({ indexed: 5, unsearchable: 3, failed: 2 });
   });
 });

--- a/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
@@ -357,9 +357,22 @@ it("keeps ingesting the rest of the corpus when one file's extraction throws", a
     return [{ page: 1, text: PAGE_1_TEXT }];
   });
 
-  const result = await ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf });
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const result = await ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf });
 
-  expect(result).toEqual(counts({ indexed: 1, failed: 1 }));
+    expect(result).toEqual(counts({ indexed: 1, failed: 1 }));
+
+    // `failed: 1` alone is a dead end — the admin-facing counts must not name
+    // paths (PII rule), so the server log is the only place that says WHICH
+    // file failed and why. One log line per failed file, path and cause.
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    const logged = consoleError.mock.calls[0].map(String).join(" ");
+    expect(logged).toContain(join(tmpRoot, "a-broken.pdf"));
+    expect(logged).toContain("Invalid PDF structure");
+  } finally {
+    consoleError.mockRestore();
+  }
   // The good file is indexed regardless of walk order; the broken one leaves
   // no half-written document row behind.
   const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
@@ -386,4 +399,40 @@ it("surfaces an embedding outage as a run failure instead of blaming every file"
   );
   // Bailed on the first file rather than walking the rest of the corpus.
   expect(embed).toHaveBeenCalledTimes(1);
+});
+
+// The replace path must not destroy before it can rebuild: a previously
+// indexed file that changes into something unparseable is a `failed` UPDATE,
+// not a license to drop the last good version. Deleting the old document
+// before extraction would leave the corpus silently poorer on every such
+// file — the run reports success with failed:1 while content that was
+// findable yesterday is gone today.
+it("keeps the last indexed version searchable when a file changes into one that fails to parse", async () => {
+  const pdfPath = join(tmpRoot, "policy.pdf");
+  writeFileSync(pdfPath, "good-bytes-v1");
+
+  const { deps } = fakeDeps([{ page: 1, text: PAGE_1_TEXT }]);
+  expect(await ingestDirectory(ORG_ID, tmpRoot, deps)).toEqual(counts({ indexed: 1 }));
+
+  const [docBefore] = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  const chunksBefore = await chunksFor(docBefore.id);
+  expect(chunksBefore).not.toHaveLength(0);
+
+  // The file changes on disk, but the new version is corrupt.
+  writeFileSync(pdfPath, "corrupt-bytes-v2");
+  const embed = vi.fn(async (texts: string[]) => texts.map(() => Array(1024).fill(0.1)));
+  const extractPdf = vi.fn(async () => {
+    throw new Error("Invalid PDF structure");
+  });
+
+  const result = await ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf });
+  expect(result).toEqual(counts({ failed: 1 }));
+
+  // The last good version is still there, chunks and all: same document row,
+  // old content hash, so the next run with a repaired file re-indexes it.
+  const docsAfter = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  expect(docsAfter).toHaveLength(1);
+  expect(docsAfter[0].id).toBe(docBefore.id);
+  expect(docsAfter[0].contentHash).toBe(docBefore.contentHash);
+  expect(await chunksFor(docBefore.id)).toHaveLength(chunksBefore.length);
 });

--- a/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
@@ -16,7 +16,7 @@ import { and, eq } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kbChunks, kbDocuments } from "@/db/schema";
-import { ingestDirectory, type IngestDeps } from "@/lib/knowledge/ingest";
+import { ingestDirectory, type IngestDeps, type IngestResult } from "@/lib/knowledge/ingest";
 
 const ORG_ID = "org-kb-ingest-test";
 
@@ -54,6 +54,16 @@ async function chunksFor(documentId: string) {
   return db.select().from(kbChunks).where(eq(kbChunks.documentId, documentId));
 }
 
+/**
+ * An IngestResult with every counter at zero, overridden by `expected`. Lets a
+ * test name only the counters it is about while still asserting via toEqual
+ * that every OTHER counter is zero — so a file quietly landing in the wrong
+ * bucket fails the test that owns the right one.
+ */
+function counts(expected: Partial<IngestResult> = {}): IngestResult {
+  return { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0, ...expected };
+}
+
 it("indexes a PDF into kb_documents + kb_chunks with real embeddings, then skips a re-run with unchanged content", async () => {
   const pdfPath = join(tmpRoot, "handbook.pdf");
   writeFileSync(pdfPath, "fake-pdf-bytes-v1");
@@ -66,7 +76,7 @@ it("indexes a PDF into kb_documents + kb_chunks with real embeddings, then skips
 
   const result = await ingestDirectory(ORG_ID, tmpRoot, deps);
 
-  expect(result).toEqual({ indexed: 1, skipped: 0, removed: 0 });
+  expect(result).toEqual(counts({ indexed: 1 }));
   expect(extractPdf).toHaveBeenCalledTimes(1);
   expect(extractPdf).toHaveBeenCalledWith(pdfPath);
 
@@ -91,7 +101,7 @@ it("indexes a PDF into kb_documents + kb_chunks with real embeddings, then skips
 
   // ── Second run, no changes on disk ──────────────────────────────────────
   const secondResult = await ingestDirectory(ORG_ID, tmpRoot, deps);
-  expect(secondResult).toEqual({ indexed: 0, skipped: 1, removed: 0 });
+  expect(secondResult).toEqual(counts({ skipped: 1 }));
   // No re-extraction, no re-embedding: real idempotency, not just a
   // row-count coincidence.
   expect(extractPdf).toHaveBeenCalledTimes(1);
@@ -121,7 +131,7 @@ it("replaces the document and its chunks when the file's content changes", async
   const { deps: updatedDeps } = fakeDeps([{ page: 1, text: "Updated policy text for 2026." }]);
 
   const result = await ingestDirectory(ORG_ID, tmpRoot, updatedDeps);
-  expect(result).toEqual({ indexed: 1, skipped: 0, removed: 0 });
+  expect(result).toEqual(counts({ indexed: 1 }));
 
   const docsAfter = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
   expect(docsAfter).toHaveLength(1);
@@ -155,7 +165,7 @@ it("indexes byte-identical files at different paths as separate documents (no un
   const { deps } = fakeDeps();
   const result = await ingestDirectory(ORG_ID, tmpRoot, deps);
 
-  expect(result).toEqual({ indexed: 2, skipped: 0, removed: 0 });
+  expect(result).toEqual(counts({ indexed: 2 }));
   const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
   expect(docs).toHaveLength(2);
   // Both share the same content hash but are distinct rows with distinct paths.
@@ -166,7 +176,7 @@ it("indexes byte-identical files at different paths as separate documents (no un
 
   // Idempotent re-run: both skip, no crash, no new rows.
   const secondResult = await ingestDirectory(ORG_ID, tmpRoot, deps);
-  expect(secondResult).toEqual({ indexed: 0, skipped: 2, removed: 0 });
+  expect(secondResult).toEqual(counts({ skipped: 2 }));
   const docsAfter = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
   expect(docsAfter).toHaveLength(2);
 });
@@ -184,7 +194,7 @@ it("removes the document and its chunks when the source file disappears from dis
   rmSync(pdfPath);
 
   const result = await ingestDirectory(ORG_ID, tmpRoot, deps);
-  expect(result).toEqual({ indexed: 0, skipped: 0, removed: 1 });
+  expect(result).toEqual(counts({ removed: 1 }));
 
   const docsAfter = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
   expect(docsAfter).toHaveLength(0);
@@ -207,7 +217,7 @@ it("does not touch documents indexed from a different root directory for the sam
 
     // Ingesting tmpRoot must not report the other root's untouched file as
     // removed, and must leave its document row alone.
-    expect(result).toEqual({ indexed: 1, skipped: 0, removed: 0 });
+    expect(result).toEqual(counts({ indexed: 1 }));
     const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
     expect(docs.map((d) => d.sourcePath).sort()).toEqual([otherPdfPath, pdfPath].sort());
   } finally {
@@ -264,7 +274,7 @@ it("accepts a single-file root path (not just a directory) and indexes that one 
   // Root IS the file, not its parent directory.
   const result = await ingestDirectory(ORG_ID, pdfPath, deps);
 
-  expect(result).toEqual({ indexed: 1, skipped: 0, removed: 0 });
+  expect(result).toEqual(counts({ indexed: 1 }));
   expect(extractPdf).toHaveBeenCalledWith(pdfPath);
 
   const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
@@ -273,7 +283,7 @@ it("accepts a single-file root path (not just a directory) and indexes that one 
 
   // Idempotent on a file root too: a second run skips, never re-removes.
   const second = await ingestDirectory(ORG_ID, pdfPath, deps);
-  expect(second).toEqual({ indexed: 0, skipped: 1, removed: 0 });
+  expect(second).toEqual(counts({ skipped: 1 }));
 });
 
 it("ignores a single-file root whose extension is not on the allowlist", async () => {
@@ -283,7 +293,7 @@ it("ignores a single-file root whose extension is not on the allowlist", async (
   const { deps, extractPdf } = fakeDeps();
   const result = await ingestDirectory(ORG_ID, txtPath, deps);
 
-  expect(result).toEqual({ indexed: 0, skipped: 0, removed: 0 });
+  expect(result).toEqual(counts());
   expect(extractPdf).not.toHaveBeenCalled();
   const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
   expect(docs).toHaveLength(0);
@@ -291,5 +301,89 @@ it("ignores a single-file root whose extension is not on the allowlist", async (
 
 it("returns a zero result for a root path that does not exist, without throwing", async () => {
   const result = await ingestDirectory(ORG_ID, join(tmpRoot, "does-not-exist"), fakeDeps().deps);
-  expect(result).toEqual({ indexed: 0, skipped: 0, removed: 0 });
+  expect(result).toEqual(counts());
+});
+
+// An image-only scan (~13% of the reference customer corpus, incl. every
+// certificate) parses fine and yields pages with no text layer, so chunking
+// produces nothing and the document is never retrievable. Counting that as
+// `indexed` tells an admin the corpus is complete while a slice of it can
+// never answer a question — the count exists to mean "findable", so a
+// zero-chunk document gets its own honest bucket instead.
+it("reports a text-less scan as unsearchable rather than indexed, on the first run and every run after", async () => {
+  const pdfPath = join(tmpRoot, "scan.pdf");
+  writeFileSync(pdfPath, "fake-scanned-pdf-bytes");
+
+  // What pdfjs returns for an image-only scan: pages exist, text layer empty.
+  const { deps, embed } = fakeDeps([
+    { page: 1, text: "" },
+    { page: 2, text: "   " },
+  ]);
+
+  const result = await ingestDirectory(ORG_ID, tmpRoot, deps);
+  expect(result).toEqual(counts({ unsearchable: 1 }));
+  // Nothing to embed — the scan must not burn an embedding call.
+  expect(embed).not.toHaveBeenCalled();
+
+  // The document row still exists: it IS a known corpus file, and the removal
+  // pass must not treat "no chunks" as "gone from disk".
+  const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  expect(docs).toHaveLength(1);
+  expect(docs[0].sourcePath).toBe(pdfPath);
+  expect(await chunksFor(docs[0].id)).toHaveLength(0);
+
+  // Every subsequent run reports the same honest number. The zero-chunk
+  // recovery branch re-extracts this file forever (its hash never changes and
+  // it never gains chunks), which is exactly why it must not re-report itself
+  // as freshly `indexed` each time.
+  const second = await ingestDirectory(ORG_ID, tmpRoot, deps);
+  expect(second).toEqual(counts({ unsearchable: 1 }));
+  const docsAfter = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  expect(docsAfter).toHaveLength(1);
+  expect(docsAfter[0].id).toBe(docs[0].id);
+});
+
+// A corpus is not a curated fixture: one corrupt or unreadable PDF is normal.
+// Without a per-file boundary it aborts the entire reindex, so a single bad
+// file costs every other file its update — and under a retrying job runner it
+// would fail the same way forever.
+it("keeps ingesting the rest of the corpus when one file's extraction throws", async () => {
+  writeFileSync(join(tmpRoot, "a-broken.pdf"), "corrupt-bytes");
+  writeFileSync(join(tmpRoot, "b-good.pdf"), "good-bytes");
+
+  const embed = vi.fn(async (texts: string[]) => texts.map(() => Array(1024).fill(0.1)));
+  const extractPdf = vi.fn(async (absPath: string) => {
+    if (absPath.endsWith("a-broken.pdf")) throw new Error("Invalid PDF structure");
+    return [{ page: 1, text: PAGE_1_TEXT }];
+  });
+
+  const result = await ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf });
+
+  expect(result).toEqual(counts({ indexed: 1, failed: 1 }));
+  // The good file is indexed regardless of walk order; the broken one leaves
+  // no half-written document row behind.
+  const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  expect(docs.map((d) => d.sourcePath)).toEqual([join(tmpRoot, "b-good.pdf")]);
+  expect(await chunksFor(docs[0].id)).not.toHaveLength(0);
+});
+
+// The counterpart to the test above, and the reason the per-file boundary is
+// scoped to extraction only: Ollama being unreachable is ONE outage, not N
+// corrupt files. Swallowing it per file would report "193 failed" for a
+// systemic problem, bury the actual cause, and pointlessly parse the whole
+// corpus on the way. Embedding and DB errors abort the run and surface.
+it("surfaces an embedding outage as a run failure instead of blaming every file", async () => {
+  writeFileSync(join(tmpRoot, "a.pdf"), "bytes-a");
+  writeFileSync(join(tmpRoot, "b.pdf"), "bytes-b");
+
+  const embed = vi.fn(async () => {
+    throw new Error("connect ECONNREFUSED 127.0.0.1:11434");
+  });
+  const extractPdf = vi.fn(async () => [{ page: 1, text: PAGE_1_TEXT }]);
+
+  await expect(ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf })).rejects.toThrow(
+    /ECONNREFUSED/
+  );
+  // Bailed on the first file rather than walking the rest of the corpus.
+  expect(embed).toHaveBeenCalledTimes(1);
 });

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
@@ -17,6 +17,15 @@ import { safeProviderError, type AuditLogEntry, type EntityRef } from "@/lib/aud
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
+/** The all-zero result: what a reindex with nothing to do reports. */
+const ZERO_COUNTS: IngestResult = {
+  indexed: 0,
+  skipped: 0,
+  removed: 0,
+  unsearchable: 0,
+  failed: 0,
+};
+
 /**
  * Sums the per-root ingest results into the totals the response and the audit
  * row report. Written out field by field on purpose: a counter added to
@@ -32,7 +41,7 @@ function totalCounts(results: IngestResult[]): IngestResult {
       unsearchable: total.unsearchable + result.unsearchable,
       failed: total.failed + result.failed,
     }),
-    { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0 }
+    ZERO_COUNTS
   );
 }
 
@@ -128,10 +137,10 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
         actorId,
         outcome: "success",
         pathCount: 0,
-        counts: totalCounts([]),
+        counts: ZERO_COUNTS,
       })
     );
-    return NextResponse.json({ ...totalCounts([]), pathCount: 0 });
+    return NextResponse.json({ ...ZERO_COUNTS, pathCount: 0 });
   }
 
   // The embedding model is fixed (bge-m3) but still needs a reachable Ollama
@@ -145,7 +154,7 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
         actorId,
         outcome: "failure",
         pathCount: targetPaths.length,
-        counts: totalCounts([]),
+        counts: ZERO_COUNTS,
         reason: "ollama_not_configured",
       })
     );

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
@@ -6,7 +6,7 @@ import { parseRequestBody } from "@/lib/api-validation";
 import { knowledgeReindexSchema } from "@/lib/schemas/knowledge-base";
 import { db } from "@/db";
 import { activeAgents, type AgentPluginConfig } from "@/db/schema";
-import { ingestDirectory, type IngestDeps } from "@/lib/knowledge/ingest";
+import { ingestDirectory, type IngestDeps, type IngestResult } from "@/lib/knowledge/ingest";
 import { embedTexts } from "@/lib/knowledge/embeddings";
 import { extractPdfPages } from "@/lib/knowledge/pdf-extract";
 import { DEFAULT_ORG_ID, EMBEDDING_MODEL, EMBEDDING_DIMENSIONS } from "@/lib/knowledge/constants";
@@ -16,6 +16,25 @@ import { deferAuditLog } from "@/lib/audit-deferred";
 import { safeProviderError, type AuditLogEntry, type EntityRef } from "@/lib/audit";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
+
+/**
+ * Sums the per-root ingest results into the totals the response and the audit
+ * row report. Written out field by field on purpose: a counter added to
+ * IngestResult then fails to compile here until it is summed, so a new counter
+ * cannot silently drop out of the only numbers an admin ever sees.
+ */
+function totalCounts(results: IngestResult[]): IngestResult {
+  return results.reduce<IngestResult>(
+    (total, result) => ({
+      indexed: total.indexed + result.indexed,
+      skipped: total.skipped + result.skipped,
+      removed: total.removed + result.removed,
+      unsearchable: total.unsearchable + result.unsearchable,
+      failed: total.failed + result.failed,
+    }),
+    { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0 }
+  );
+}
 
 // Builds (but does not send) the knowledge.reindex audit entry — a pure
 // function so every branch shares the same detail shape. Callers pass this
@@ -27,9 +46,7 @@ function reindexAuditEntry(args: {
   actorId: string;
   outcome: "success" | "failure";
   pathCount: number;
-  indexed: number;
-  skipped: number;
-  removed: number;
+  counts: IngestResult;
   reason?: string;
 }): AuditLogEntry {
   return {
@@ -40,10 +57,18 @@ function reindexAuditEntry(args: {
     outcome: args.outcome,
     detail: {
       agent: args.agent,
+      // Listed one by one rather than spread from `counts`: a spread would
+      // copy whatever IngestResult grows into straight onto an HMAC-signed
+      // row, and the obvious next counter to want is a list of the paths that
+      // failed — precisely the filesystem paths this detail must never carry
+      // (AGENTS.md PII rule; see `pathCount` above). Adding a counter here has
+      // to stay a decision, not a side effect.
       pathCount: args.pathCount,
-      indexed: args.indexed,
-      skipped: args.skipped,
-      removed: args.removed,
+      indexed: args.counts.indexed,
+      skipped: args.counts.skipped,
+      removed: args.counts.removed,
+      unsearchable: args.counts.unsearchable,
+      failed: args.counts.failed,
       ...(args.reason !== undefined ? { reason: args.reason } : {}),
     },
   };
@@ -66,6 +91,10 @@ function reindexAuditEntry(args: {
  * large-corpus reindex needs async execution + progress reporting — that's
  * Phase 2 (see the implementation plan); do NOT block a request on a
  * multi-minute ingest in production.
+ *
+ * The response and audit row report every ingest counter, `unsearchable` and
+ * `failed` included: these are the numbers an admin trusts the corpus by, so
+ * "indexed" must keep meaning "findable" rather than merely "processed".
  */
 export const POST = withAdmin<RouteContext>(async (request, { params }, session) => {
   const { agentId } = await params;
@@ -99,12 +128,10 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
         actorId,
         outcome: "success",
         pathCount: 0,
-        indexed: 0,
-        skipped: 0,
-        removed: 0,
+        counts: totalCounts([]),
       })
     );
-    return NextResponse.json({ indexed: 0, skipped: 0, removed: 0, pathCount: 0 });
+    return NextResponse.json({ ...totalCounts([]), pathCount: 0 });
   }
 
   // The embedding model is fixed (bge-m3) but still needs a reachable Ollama
@@ -118,9 +145,7 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
         actorId,
         outcome: "failure",
         pathCount: targetPaths.length,
-        indexed: 0,
-        skipped: 0,
-        removed: 0,
+        counts: totalCounts([]),
         reason: "ollama_not_configured",
       })
     );
@@ -140,15 +165,14 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
     extractPdf: extractPdfPages,
   };
 
-  let indexed = 0;
-  let skipped = 0;
-  let removed = 0;
+  // Collected per root so a throw partway through still audits the roots that
+  // did finish. Ingest handles a single unreadable file on its own (counting
+  // it as `failed`), so reaching this catch means something systemic — the
+  // embedding endpoint or the database — took the run down.
+  const results: IngestResult[] = [];
   try {
     for (const path of targetPaths) {
-      const result = await ingestDirectory(DEFAULT_ORG_ID, path, deps);
-      indexed += result.indexed;
-      skipped += result.skipped;
-      removed += result.removed;
+      results.push(await ingestDirectory(DEFAULT_ORG_ID, path, deps));
     }
   } catch (err) {
     // safeProviderError scrubs emails + caps length; the underlying error could
@@ -159,26 +183,26 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
         actorId,
         outcome: "failure",
         pathCount: targetPaths.length,
-        indexed,
-        skipped,
-        removed,
+        counts: totalCounts(results),
         reason: safeProviderError(err instanceof Error ? err.message : "reindex_failed"),
       })
     );
     return NextResponse.json({ error: "Knowledge base reindex failed" }, { status: 500 });
   }
 
+  // Success covers `unsearchable`/`failed` files too: the reindex itself did
+  // its job, and those counts are a finding about the corpus, not a failure of
+  // the action. Burying them would be the failure.
+  const counts = totalCounts(results);
   deferAuditLog(
     reindexAuditEntry({
       agent: agentRef,
       actorId,
       outcome: "success",
       pathCount: targetPaths.length,
-      indexed,
-      skipped,
-      removed,
+      counts,
     })
   );
 
-  return NextResponse.json({ indexed, skipped, removed, pathCount: targetPaths.length });
+  return NextResponse.json({ ...counts, pathCount: targetPaths.length });
 });

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -607,6 +607,13 @@ export type AuditLogEntry =
       // reindexed — NOT the folder paths themselves, which can embed a
       // username (AGENTS.md PII rule). `reason` is present on failure rows
       // only (embedding endpoint unconfigured, ingest error).
+      //
+      // The counters mirror IngestResult (lib/knowledge/ingest.ts) and are
+      // what an admin judges the corpus by, so they distinguish findable from
+      // merely processed: `unsearchable` files were indexed but produced no
+      // text to retrieve (image-only scans), and `failed` files could not be
+      // read or parsed at all. Both can be non-zero on a `success` row — the
+      // reindex worked, and these are its findings.
       eventType: "knowledge.reindex";
       detail: {
         agent: EntityRef;
@@ -614,6 +621,8 @@ export type AuditLogEntry =
         indexed: number;
         skipped: number;
         removed: number;
+        unsearchable: number;
+        failed: number;
         reason?: string;
       };
     })

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -254,6 +254,12 @@ async function ingestFile(orgId: string, absPath: string, deps: IngestDeps): Pro
     return written > 0 ? "indexed" : "unsearchable";
   }
 
+  // Extract BEFORE deleting the old version: a file that changed into
+  // something unparseable throws here and stays a `failed` update, with the
+  // last good document and its chunks still searchable. Deleting first would
+  // turn that same failure into silent data loss on a success response.
+  const pages = await fileStep(absPath, () => deps.extractPdf(absPath));
+
   if (existing) {
     // Content changed since the last ingest: replace wholesale. Deleting
     // the document row cascades to its (now stale) chunks via the
@@ -261,7 +267,6 @@ async function ingestFile(orgId: string, absPath: string, deps: IngestDeps): Pro
     await db.delete(kbDocuments).where(eq(kbDocuments.id, existing.id));
   }
 
-  const pages = await fileStep(absPath, () => deps.extractPdf(absPath));
   const wholeDocText = pages.map((p) => p.text).join("\n");
 
   const [doc] = await db
@@ -303,6 +308,9 @@ export async function ingestDirectory(
       // (embedding outage, DB gone) are NOT FileIngestErrors and still escape
       // — see ingestFile.
       if (!(err instanceof FileIngestError)) throw err;
+      // The admin-facing counts must not name paths (audit PII rule), so this
+      // server log is the only place that says WHICH file failed and why.
+      console.error(`[kb-ingest] ${err.message}`, err.cause);
       failed++;
     }
   }
@@ -312,6 +320,12 @@ export async function ingestDirectory(
   // via isUnderRoot (separator-bounded for a directory root, exact-match for
   // a file root) so ingesting one root never touches documents indexed from a
   // different root for the same org.
+  //
+  // A file that vanishes between the walk and the read is still in
+  // `discovered`, so this pass leaves its document row alone for one run (it
+  // counts as `failed` above); the next run no longer discovers it and
+  // removes it here. Erring toward keeping the row beats deleting on a
+  // transient read failure.
   const discoveredSet = new Set(discovered);
   const existingForOrg = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, orgId));
 

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -12,6 +12,12 @@
  *   - a previously-indexed file that's gone from disk -> delete its document
  *     row (cascades to its chunks).
  *
+ * The result counts what an operator needs to trust the corpus, so "processed"
+ * is never conflated with "findable": a file that parses but yields no text
+ * (image-only scan) counts as `unsearchable`, not `indexed`, and a file that
+ * cannot be read or parsed counts as `failed` without taking the rest of the
+ * run down with it.
+ *
  * The embedder and PDF extractor are dependency-injected: production wires
  * `embedTexts` (./embeddings.ts) and a pdfjs-based extractor
  * (./pdf-extract.ts); tests inject deterministic fakes so the integration
@@ -54,12 +60,22 @@ export interface IngestOptions {
 }
 
 export interface IngestResult {
-  /** Documents newly indexed, replaced due to a content change, or recovered from a zero-chunk state. */
+  /** Documents newly indexed, replaced due to a content change, or recovered from a zero-chunk state — and searchable afterwards (at least one chunk). */
   indexed: number;
   /** Documents left untouched: unchanged content hash, chunks already present. */
   skipped: number;
   /** Documents deleted because their source file is no longer on disk. */
   removed: number;
+  /**
+   * Files that parsed without error but yielded no chunks, so they are indexed
+   * yet can never be retrieved — an image-only scan with no text layer is the
+   * normal cause. Counted apart from `indexed` because the counts exist to
+   * answer "is the corpus findable?", and folding these into `indexed` reports
+   * a complete corpus while a slice of it silently answers nothing.
+   */
+  unsearchable: number;
+  /** Files skipped because reading or extracting THIS file threw (unreadable, corrupt). The run continues; see the per-file boundary in ingestDirectory. */
+  failed: number;
 }
 
 /** Applies the per-file eligibility rules (skip-hidden + A/B denylist + extension allowlist) to a basename. */
@@ -132,16 +148,22 @@ function isUnderRoot(sourcePath: string, rootDir: string): boolean {
   return sourcePath.startsWith(rootPrefix);
 }
 
-/** Chunks `pages`, embeds every chunk, and inserts the resulting kb_chunks rows for `documentId`. No-op if chunking yields nothing (e.g. an all-whitespace PDF). */
+/**
+ * Chunks `pages`, embeds every chunk, and inserts the resulting kb_chunks rows
+ * for `documentId`. Returns the number of chunks written — zero means the
+ * document is indexed but unsearchable (e.g. an image-only scan whose text
+ * layer is empty), which callers must report as such rather than as a
+ * successful index.
+ */
 async function writeChunks(
   documentId: string,
   orgId: string,
   sourcePath: string,
   pages: IngestPage[],
   deps: IngestDeps
-): Promise<void> {
+): Promise<number> {
   const chunks = chunkPages(pages);
-  if (chunks.length === 0) return;
+  if (chunks.length === 0) return 0;
 
   const vectors = await deps.embed(chunks.map((chunk) => chunk.text));
 
@@ -156,6 +178,106 @@ async function writeChunks(
       embedding: vectors[i],
     }))
   );
+
+  return chunks.length;
+}
+
+/**
+ * A file-level ingest failure: THIS file could not be read or parsed (corrupt
+ * PDF, permission denied, vanished between the walk and the read). Distinct
+ * from the errors ingestDirectory deliberately lets escape — embedding and DB
+ * failures are systemic, and reporting an Ollama outage as "193 corrupt files"
+ * would bury the one fact an operator needs.
+ */
+class FileIngestError extends Error {
+  constructor(
+    readonly sourcePath: string,
+    cause: unknown
+  ) {
+    super(`Ingest failed for ${sourcePath}`, { cause });
+    this.name = "FileIngestError";
+  }
+}
+
+/** Runs a file-scoped step, tagging anything it throws as a FileIngestError so the per-file boundary in ingestDirectory can catch exactly those. */
+async function fileStep<T>(sourcePath: string, step: () => Promise<T>): Promise<T> {
+  try {
+    return await step();
+  } catch (err) {
+    throw new FileIngestError(sourcePath, err);
+  }
+}
+
+/** How one file ended up, mapping 1:1 onto the IngestResult counters of the same name. */
+type FileOutcome = "indexed" | "skipped" | "unsearchable";
+
+/**
+ * Ingests one file: hash it, decide skip/recover/replace/insert, and write its
+ * chunks. Reading and PDF extraction are wrapped in fileStep() so a failure
+ * THIS file owns surfaces as a FileIngestError; embedding and DB calls are
+ * deliberately left bare so a systemic outage aborts the whole run.
+ */
+async function ingestFile(orgId: string, absPath: string, deps: IngestDeps): Promise<FileOutcome> {
+  const { buffer, fileStat } = await fileStep(absPath, async () => ({
+    buffer: await readFile(absPath),
+    fileStat: await stat(absPath),
+  }));
+  const contentHash = createHash("sha256").update(buffer).digest("hex");
+
+  const [existing] = await db
+    .select()
+    .from(kbDocuments)
+    .where(and(eq(kbDocuments.orgId, orgId), eq(kbDocuments.sourcePath, absPath)))
+    .limit(1);
+
+  if (existing && existing.contentHash === contentHash) {
+    const [{ value: chunkCount }] = await db
+      .select({ value: count() })
+      .from(kbChunks)
+      .where(eq(kbChunks.documentId, existing.id));
+
+    if (chunkCount > 0) return "skipped";
+
+    // Robustness case: a document row survives with zero chunks (e.g. a
+    // prior ingest crashed after the document insert but before chunk
+    // writes, or an operator hand-deleted kb_chunks rows). The content
+    // hash still matches the file on disk, so a naive "hash matches ->
+    // skip" would leave this document permanently unsearchable while
+    // silently reporting success. We recover instead: rebuild chunks for
+    // the existing document (same id, no duplicate row).
+    //
+    // A file with no text at all lands here too, on every run, and rebuilds
+    // to zero chunks again — the write result, not the branch, is what tells
+    // the two apart.
+    const pages = await fileStep(absPath, () => deps.extractPdf(absPath));
+    const written = await writeChunks(existing.id, orgId, absPath, pages, deps);
+    return written > 0 ? "indexed" : "unsearchable";
+  }
+
+  if (existing) {
+    // Content changed since the last ingest: replace wholesale. Deleting
+    // the document row cascades to its (now stale) chunks via the
+    // kb_chunks.document_id FK.
+    await db.delete(kbDocuments).where(eq(kbDocuments.id, existing.id));
+  }
+
+  const pages = await fileStep(absPath, () => deps.extractPdf(absPath));
+  const wholeDocText = pages.map((p) => p.text).join("\n");
+
+  const [doc] = await db
+    .insert(kbDocuments)
+    .values({
+      orgId,
+      contentHash,
+      sourcePath: absPath,
+      pageCount: pages.length,
+      mtime: fileStat.mtime,
+      lang: detectLang(wholeDocText),
+    })
+    .returning();
+
+  const written = await writeChunks(doc.id, orgId, absPath, pages, deps);
+  return written > 0 ? "indexed" : "unsearchable";
 }
 
 export async function ingestDirectory(
@@ -167,68 +289,22 @@ export async function ingestDirectory(
   const allowedExtensions = opts.allowedExtensions ?? DEFAULT_ALLOWED_EXTENSIONS;
   const discovered = await discoverFiles(rootDir, allowedExtensions);
 
-  let indexed = 0;
-  let skipped = 0;
+  const tally: Record<FileOutcome, number> = { indexed: 0, skipped: 0, unsearchable: 0 };
+  let failed = 0;
 
   for (const absPath of discovered) {
-    const buffer = await readFile(absPath);
-    const contentHash = createHash("sha256").update(buffer).digest("hex");
-    const fileStat = await stat(absPath);
-
-    const [existing] = await db
-      .select()
-      .from(kbDocuments)
-      .where(and(eq(kbDocuments.orgId, orgId), eq(kbDocuments.sourcePath, absPath)))
-      .limit(1);
-
-    if (existing && existing.contentHash === contentHash) {
-      const [{ value: chunkCount }] = await db
-        .select({ value: count() })
-        .from(kbChunks)
-        .where(eq(kbChunks.documentId, existing.id));
-
-      if (chunkCount > 0) {
-        skipped++;
-        continue;
-      }
-
-      // Robustness case: a document row survives with zero chunks (e.g. a
-      // prior ingest crashed after the document insert but before chunk
-      // writes, or an operator hand-deleted kb_chunks rows). The content
-      // hash still matches the file on disk, so a naive "hash matches ->
-      // skip" would leave this document permanently unsearchable while
-      // silently reporting success. We recover instead: rebuild chunks for
-      // the existing document (same id, no duplicate row).
-      const pages = await deps.extractPdf(absPath);
-      await writeChunks(existing.id, orgId, absPath, pages, deps);
-      indexed++;
-      continue;
+    try {
+      tally[await ingestFile(orgId, absPath, deps)]++;
+    } catch (err) {
+      // One unreadable or corrupt file is a normal property of a real corpus,
+      // so it costs itself and nothing else: without this boundary a single
+      // bad PDF aborts the reindex for every other file, and under a retrying
+      // job runner it would fail identically forever. Systemic errors
+      // (embedding outage, DB gone) are NOT FileIngestErrors and still escape
+      // — see ingestFile.
+      if (!(err instanceof FileIngestError)) throw err;
+      failed++;
     }
-
-    if (existing) {
-      // Content changed since the last ingest: replace wholesale. Deleting
-      // the document row cascades to its (now stale) chunks via the
-      // kb_chunks.document_id FK.
-      await db.delete(kbDocuments).where(eq(kbDocuments.id, existing.id));
-    }
-
-    const pages = await deps.extractPdf(absPath);
-    const wholeDocText = pages.map((p) => p.text).join("\n");
-
-    const [doc] = await db
-      .insert(kbDocuments)
-      .values({
-        orgId,
-        contentHash,
-        sourcePath: absPath,
-        pageCount: pages.length,
-        mtime: fileStat.mtime,
-        lang: detectLang(wholeDocText),
-      })
-      .returning();
-
-    await writeChunks(doc.id, orgId, absPath, pages, deps);
-    indexed++;
   }
 
   // Removal pass: any previously-indexed document under this root whose
@@ -247,5 +323,5 @@ export async function ingestDirectory(
     removed++;
   }
 
-  return { indexed, skipped, removed };
+  return { ...tally, removed, failed };
 }


### PR DESCRIPTION
## Why

The reindex counts are the only signal an admin has about the knowledge-base corpus, and they conflated **processed** with **findable**.

A PDF with no text layer — an image-only scan, ~13% of the reference customer corpus **including every certificate** — parses fine, produces zero chunks, and was still counted as `indexed`. So the corpus reported complete while a slice of it could never answer a question. `writeChunks` returned early on zero chunks and the caller incremented `indexed` regardless.

Separately, ingest had no per-file boundary: one corrupt PDF aborted the entire reindex, taking every other file's update with it.

Neither is caught by the eval harness by construction — it grades attribution against what *was* retrieved, never against what *should have been* retrievable.

## What changed

`IngestResult` gains two counters, carried through the route response and the `knowledge.reindex` audit entry:

- **`unsearchable`** — parsed, but yielded no chunks. Stable across runs: the zero-chunk recovery branch re-extracts these forever, so they must not re-report as freshly `indexed` each time. The write result, not the branch, is what tells a text-less scan apart from a crash-orphaned document — no new schema field needed.
- **`failed`** — the file could not be read or parsed. The run continues.

The per-file boundary is scoped to read + extract **only**. An embedding outage is one outage, not N corrupt files: swallowing it per file would report "193 failed" for an Ollama that's down, bury the cause, and pointlessly parse the whole corpus on the way. Embedding and DB errors still abort and surface — locked in by a test.

## Prep for #714

The async reindex has to answer what "processed" means for a zero-chunk document before it can report `processed/total`, and its retry loop would otherwise re-die on the same poison file forever. Building progress reporting on the old counts would have wired the false "everything indexed" in permanently.

## Note on the audit row

`reindexAuditEntry` lists its counters explicitly rather than spreading `IngestResult`. The obvious next counter to want is *which* paths failed — and a spread would copy those straight onto an HMAC-signed row, the exact filesystem paths that detail must never carry (AGENTS.md PII rule). Adding a counter there stays a decision, not a side effect.

`unsearchable`/`failed` above zero still audits as `outcome: "success"`: the reindex worked, and these are its findings about the corpus.

## Test plan

- [x] `ingest.integration.test.ts` — 3 new tests: text-less scan counts `unsearchable` on first **and** subsequent runs (embed never called, document row survives the removal pass); one throwing file leaves the rest of the corpus indexed with no half-written row; an embedding outage rejects instead of blaming every file.
- [x] `knowledge-reindex.test.ts` — both counters survive into the response and audit detail.
- [x] Full suites green: 8908 unit, 263 integration (`test:db` against ephemeral pgvector).
- [x] `typecheck` (incl. tests), `lint` (0 errors), `format:check`, docs build + anchor verified.
- [x] Docs updated: reindex guide + API reference now document all five counters.