### PR TITLE
docs(skills): refresh the model catalog before any eval sweep

### DIFF
--- a/.claude/skills/run-model-eval/SKILL.md
+++ b/.claude/skills/run-model-eval/SKILL.md
@@ -20,7 +20,21 @@ resumes from JSONL.**
 
 ## Iron rules (each one cost us real damage once)
 
-1. **PROBE FIRST.** Before any full sweep of a new model or scenario: run
+1. **REFRESH THE CATALOG FIRST.** Before ANY sweep, run `pnpm models:discover`
+   (see the `update-ollama-cloud-models` skill) and act on the delta. The model
+   set decays under you: on 2026-07-15 Ollama retired `deepseek-v3.2` and
+   `glm-4.7` mid-benchmark, and we only noticed two days later — by accident,
+   while researching prices. `models:discover` exits non-zero on `REMOVED`, so
+   this is a 30-second check that prevents two expensive failures: a sweep that
+   burns hours 404-ing on a model that no longer exists, and a published
+   benchmark whose model set the provider no longer serves. `ADDED` matters just
+   as much — a sweep that silently omits the newest models is stale the day it
+   ships. The skill's own trigger list said "before a release", never "before a
+   sweep"; that gap is exactly how this bit us.
+   Retired models are NOT deleted from the dataset: their last measured numbers
+   stay published and citable, marked as withdrawn from the serving path (see
+   `data/CHANGELOG.md`, and the legacy policy in `data/README.md`).
+2. **PROBE FIRST.** Before any full sweep of a new model or scenario: run
    N=3 × 3-4 capable models (`EVAL_N=3`, `EVAL_CANDIDATE_MODELS=...`), then
    **read the trajectories** (`results/<label>.trajectories.jsonl`) — check
    tool calls, final messages, and that failures are model behavior, not
@@ -29,34 +43,34 @@ resumes from JSONL.**
    inboxes, a mock that couldn't sum two-step line entries, a stack duplicate
    guard masking behavior. A full sweep on a broken grader wastes ~12h and
    contaminates the dataset.
-2. **ONE SWEEP PER STACK.** Never run a sweep manually while the watchdog is
+3. **ONE SWEEP PER STACK.** Never run a sweep manually while the watchdog is
    armed (`active-scenario` ≠ `none`), and never two sweeps concurrently —
    they share mock state + the agent's model pin and **corrupt each other's
    state-based grades**. Check `pgrep -f eval:models` first. Contaminated
    models show ≠12 runs per cell: delete their rows from BOTH
    `<label>.jsonl` and `<label>.trajectories.jsonl`, then re-run them.
-3. **odoo-mock is image-built** (`docker-compose.eval.yml` build context, no
+4. **odoo-mock is image-built** (`docker-compose.eval.yml` build context, no
    volume mount). Mock changes need
    `... up -d --build odoo-mock` — and never mid-sweep.
-4. **Stack env is exact:** `PINCHY_VERSION=latest DB_PASSWORD=eval_dev_pw
+5. **Stack env is exact:** `PINCHY_VERSION=latest DB_PASSWORD=eval_dev_pw
 docker compose -p pinchy-eval -f docker-compose.yml -f docker-compose.e2e.yml
 -f docker-compose.eval.yml up --build -d`. `DB_PASSWORD` must be non-default
    (Pinchy rotates `pinchy_dev` away). If openclaw won't stabilise with
    `SecretRefResolutionError`: stale config volume — surgically delete
    `/openclaw-config/openclaw.json*` in the pinchy container and restart
    pinchy+openclaw (never `down -v`).
-5. **Key is seeded once.** Pass `OLLAMA_CLOUD_API_KEY` via env on the first
+6. **Key is seeded once.** Pass `OLLAMA_CLOUD_API_KEY` via env on the first
    `eval:models` run (it lands in the eval DB); later runs and the watchdog
    resume **keyless**. Never write the key to disk.
-6. **Fresh worktree: seed `results/` from `data/`** before topping up, or the
+7. **Fresh worktree: seed `results/` from `data/`** before topping up, or the
    rebuilt scorecards will contain only the new model:
    `cp packages/web/eval/data/*.jsonl packages/web/eval/data/*.json packages/web/eval/results/`
-7. **Long sweeps run under the watchdog, not a session.** Session-spawned
+8. **Long sweeps run under the watchdog, not a session.** Session-spawned
    background sweeps die with the session. Install per the header of
    `watchdog.sh` (in this skill dir; launchd + `caffeinate`, checks every
    15 min, stall-kills after 30 min without progress). The Mac must stay
    awake and powered; keep `EXPECTED_RUNS` = models × N in sync.
-8. **Publishing is manual and per-scenario:** copy
+9. **Publishing is manual and per-scenario:** copy
    `results/<label>{.jsonl,.trajectories.jsonl,.json}` → `eval/data/`, update
    the manifest table in `data/README.md`, commit as
    `data(eval): <scenario> ... (N models, M runs)`.
@@ -65,17 +79,19 @@ docker compose -p pinchy-eval -f docker-compose.yml -f docker-compose.e2e.yml
 
 1. Add it to `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS` (use the
    `update-ollama-cloud-models` skill; verify tools via
-   `scripts/verify-ollama-cloud-tools.mjs --only=<id>`).
-2. Stack up (rule 4) → `pnpm -C packages/web eval:selftest` green.
-3. Seed `results/` (rule 6). **Probe** the new model, N=3, across the two
-   cheapest discriminators (happy + silent); inspect trajectories (rule 1).
+   `scripts/verify-ollama-cloud-tools.mjs --only=<id>`). Flags come from a live
+   probe, never from a library page — and a single green probe is a smoke test,
+   not proof: probe a NEW model several times before trusting it.
+2. Stack up (rule 5) → `pnpm -C packages/web eval:selftest` green.
+3. Seed `results/` (rule 7). **Probe** the new model, N=3, across the two
+   cheapest discriminators (happy + silent); inspect trajectories (rule 2).
 4. Add the id to `MODELS` + bump `EXPECTED_RUNS` in
    `~/.pinchy-eval-watchdog/watchdog.sh`, then per scenario label:
    `echo <label> > ~/.pinchy-eval-watchdog/active-scenario` and
    `launchctl kickstart gui/$(id -u)/com.pinchy.eval-watchdog`. Resume skips
    models already at N, so only the new model runs.
 5. When each label completes: `pnpm -C packages/web tsx eval/regrade.ts
-<label> --quotes` (sanity + evidence quotes), then publish (rule 8).
+<label> --quotes` (sanity + evidence quotes), then publish (rule 9).
 6. Set `active-scenario` to `none` when done.
 
 ## Recipe: add a scenario

--- a/.claude/skills/update-ollama-cloud-models/SKILL.md
+++ b/.claude/skills/update-ollama-cloud-models/SKILL.md
@@ -24,6 +24,13 @@ probe is the one mistake this skill is here to prevent.
 - An ollama-cloud email/announcement mentions a new model or version.
 - Preparing a Pinchy release (this is a pre-release checklist item — run it
   even for tiny releases).
+- **Before any Eval-v1 sweep** (iron rule 1 of the `run-model-eval` skill). The
+  benchmark's whole claim is that it measures what the provider actually serves
+  today, so a sweep against a drifted catalog is worse than no sweep: it burns
+  hours on models that 404, and publishes a model set the provider retired. This
+  is not hypothetical — Ollama retired `deepseek-v3.2` and `glm-4.7` on
+  2026-07-15 and the catalog still carried both two days later, because nothing
+  in either skill said to check before a sweep.
 - You suspect the catalog drifted (a model 404s, a tier pick feels stale).
 
 Do **not** add a model from its library page alone, ever. No key → no verified


### PR DESCRIPTION
## What happened

Ollama retired **`deepseek-v3.2`** and **`glm-4.7`** from Cloud on **2026-07-15**. We found out two days later — by accident, while researching pricing for the cost basis — and only just before committing to a ~12h re-sweep of a 14-model set, two of whose models no longer exist. Verified against Ollama's own cloud model list: neither is served any more.

## The gap was the trigger, not the tooling

`pnpm models:discover` already diffs our catalog against `ollama.com/v1/models` and **exits non-zero on `REMOVED`**. It would have caught this in 30 seconds. Nobody ran it, because neither skill said to:

> `update-ollama-cloud-models` → *when to use:* an announcement · preparing a release · you suspect drift

A sweep is none of those, and the last release predates the retirement. So the catalog quietly carried two dead models — which also means a **Pinchy user can currently pick a model that 404s**, since the catalog feeds the model picker and the OpenClaw config. (That production side is tracked separately.)

## The fix

- **New iron rule 1 in `run-model-eval`: REFRESH THE CATALOG FIRST** — ahead of PROBE FIRST, because it comes first in the workflow. Names the incident, per the section's "each one cost us real damage once" contract. Covers both directions: `REMOVED` burns hours 404-ing, `ADDED` ships a benchmark that's stale on day one.
- **`update-ollama-cloud-models` gains "before any Eval-v1 sweep"** as a trigger, with the reasoning: the benchmark's whole claim is that it measures what the provider actually serves *today*.
- The rule also pins what happens to a retired model's data: **it is not deleted.** Its last measured numbers stay published and citable, marked as withdrawn from the serving path — the legacy policy from #802.

## Note for the reviewer

This renumbers iron rules 2–8 → 3–9 and repoints the recipe's cross-references (rules 4/6/1/8 → 5/7/2/9). Those references are load-bearing — the recipe literally says "stack up (rule 4)" — so they had to move with the numbers.

Docs only; no code touched.