### PR TITLE
fix(models): retire the 14 models Ollama dropped, repoint the dead tier slots

### DIFF
--- a/.claude/skills/update-ollama-cloud-models/SKILL.md
+++ b/.claude/skills/update-ollama-cloud-models/SKILL.md
@@ -119,6 +119,9 @@ these derived sites in the SAME change:
      per-model `contextWindow`, and the `reasoning`/`input` lists.
    - `__tests__/lib/model-vision.integration.test.ts` — `isModelVisionCapable`
      assertions (DB-backed; only `pnpm test:db` runs it, not `pnpm test`).
+   - `__tests__/lib/model-capabilities/seed.integration.test.ts` — DB-backed too,
+     and it asserts a FLOOR on the built-in model count (`>= 30` until the
+     2026-07-15 wave cut the catalog to 18). A retirement trips it.
    - `__tests__/lib/ollama-cloud-image-preference-drift.test.ts` — guards the
      image-preference list.
    - `__tests__/lib/vision-model-chain.test.ts` — its fixture simulates the LIVE

--- a/.claude/skills/update-ollama-cloud-models/SKILL.md
+++ b/.claude/skills/update-ollama-cloud-models/SKILL.md
@@ -121,6 +121,14 @@ these derived sites in the SAME change:
      assertions (DB-backed; only `pnpm test:db` runs it, not `pnpm test`).
    - `__tests__/lib/ollama-cloud-image-preference-drift.test.ts` — guards the
      image-preference list.
+   - `__tests__/lib/vision-model-chain.test.ts` — its fixture simulates the LIVE
+     cloud catalog, so a retired vision model must be swapped there too.
+   - `src/lib/model-resolver/__tests__/ollama-cloud.test.ts` — NOTE the path:
+     there is a second `ollama-cloud.test.ts` under `src/__tests__/lib/`, and
+     running only that one passes while this one fails.
+   - `scripts/lib/ollama-cloud-source.test.mjs` — run by `pnpm test:scripts`,
+     NOT by `pnpm test`. It pins one model's fields as a parser fixture and
+     asserts a catalog-size floor; both break on a retirement.
 
 8. **Run the gates** — the FULL suites, not just the one drift test. A removed
    model drifts unit AND DB-backed snapshots; `pnpm test` alone misses the

--- a/packages/web/src/__tests__/lib/model-capabilities/seed.integration.test.ts
+++ b/packages/web/src/__tests__/lib/model-capabilities/seed.integration.test.ts
@@ -11,8 +11,13 @@ beforeEach(async () => {
 it("inserts a row for every built-in model on first run", async () => {
   await seedBuiltinModels();
   const rows = await db.select().from(models);
-  // Anthropic (3) + OpenAI (3) + Google (3) + ollama-cloud (~33) = ~42
-  expect(rows.length).toBeGreaterThanOrEqual(30);
+  // Anthropic (3) + OpenAI (3) + Google (3) + ollama-cloud (18) = 27.
+  // The floor was 30 when ollama-cloud carried ~33 models; the 2026-07-15
+  // retirement wave cut that to 18. A floor near the real total is just a
+  // snapshot that breaks on every retirement — this guards "the seed inserted
+  // every provider's models, not only the first provider's", so it only has to
+  // sit above any single provider's count.
+  expect(rows.length).toBeGreaterThanOrEqual(20);
   expect(rows.every((r) => r.source === "builtin")).toBe(true);
 });
 

--- a/packages/web/src/__tests__/lib/model-vision.integration.test.ts
+++ b/packages/web/src/__tests__/lib/model-vision.integration.test.ts
@@ -44,10 +44,6 @@ describe("Ollama cloud vision models (from DB seed)", () => {
     expect(isModelVisionCapable("ollama-cloud/kimi-k2.5")).toBe(true);
   });
 
-  it("returns true for gemini-3-flash-preview", () => {
-    expect(isModelVisionCapable("ollama-cloud/gemini-3-flash-preview")).toBe(true);
-  });
-
   it("returns true for mistral-large-3:675b", () => {
     expect(isModelVisionCapable("ollama-cloud/mistral-large-3:675b")).toBe(true);
   });
@@ -71,12 +67,6 @@ describe("Ollama cloud vision models (from DB seed)", () => {
     // 2026-06-25, 2 rounds). Flagged vision:false so it's never picked for
     // images — its value is reliable tools, not vision.
     expect(isModelVisionCapable("ollama-cloud/kimi-k2.7-code")).toBe(false);
-  });
-
-  it("returns true for every ministral-3 variant", () => {
-    expect(isModelVisionCapable("ollama-cloud/ministral-3:3b")).toBe(true);
-    expect(isModelVisionCapable("ollama-cloud/ministral-3:8b")).toBe(true);
-    expect(isModelVisionCapable("ollama-cloud/ministral-3:14b")).toBe(true);
   });
 
   it("returns true for kimi-k2.6", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -139,7 +139,7 @@ vi.mock("@/lib/provider-models", () => {
     anthropic: "anthropic/claude-haiku-4-5-20251001",
     openai: "openai/gpt-5.4-mini",
     google: "google/gemini-2.5-flash",
-    "ollama-cloud": "ollama-cloud/gemini-3-flash-preview",
+    "ollama-cloud": "ollama-cloud/minimax-m3",
     "ollama-local": "",
   };
   // Default "live" catalog: all three ollama-cloud image-preference models are
@@ -150,7 +150,7 @@ vi.mock("@/lib/provider-models", () => {
       id: "ollama-cloud",
       name: "Ollama Cloud",
       models: [
-        { id: "ollama-cloud/gemini-3-flash-preview", name: "gemini-3-flash-preview" },
+        { id: "ollama-cloud/minimax-m3", name: "minimax-m3" },
         { id: "ollama-cloud/minimax-m3", name: "minimax-m3" },
         { id: "ollama-cloud/gemma4:31b", name: "gemma4:31b" },
       ],
@@ -1616,7 +1616,7 @@ describe("regenerateOpenClawConfig", () => {
         {
           id: "kb-agent-id",
           name: "Invoice Reader",
-          model: "ollama-cloud/glm-4.7", // text-only chat model
+          model: "ollama-cloud/glm-5.2", // text-only chat model
           templateId: "knowledge-base",
           pluginConfig: { "pinchy-files": { allowed_paths: ["/data/invoices/"] } },
           allowedTools: [],
@@ -1640,7 +1640,7 @@ describe("regenerateOpenClawConfig", () => {
       })
       .find((c) => c && c.plugins);
     expect(config.plugins.entries["pinchy-files"].config.visionModel).toBe(
-      "ollama-cloud/gemini-3-flash-preview"
+      "ollama-cloud/minimax-m3"
     );
   });
 
@@ -2114,16 +2114,9 @@ describe("regenerateOpenClawConfig", () => {
 
     expect(modelIds.sort()).toEqual(
       [
-        "deepseek-v3.1:671b",
-        "deepseek-v3.2",
         "deepseek-v4-flash",
         "deepseek-v4-pro",
-        "devstral-2:123b",
-        "devstral-small-2:24b",
-        "gemini-3-flash-preview",
         "gemma4:31b",
-        "glm-4.7",
-        "glm-5",
         "glm-5.1",
         "glm-5.2",
         "gpt-oss:120b",
@@ -2131,21 +2124,14 @@ describe("regenerateOpenClawConfig", () => {
         "kimi-k2.5",
         "kimi-k2.6",
         "kimi-k2.7-code",
-        "minimax-m2.1",
         "minimax-m2.5",
         "minimax-m2.7",
         "minimax-m3",
-        "ministral-3:14b",
-        "ministral-3:3b",
-        "ministral-3:8b",
         "mistral-large-3:675b",
         "nemotron-3-nano:30b",
         "nemotron-3-super",
         "nemotron-3-ultra",
-        "qwen3-coder-next",
-        "qwen3-coder:480b",
         "qwen3.5:397b",
-        "rnj-1:8b",
       ].sort()
     );
   });
@@ -2171,40 +2157,27 @@ describe("regenerateOpenClawConfig", () => {
     const ctx = Object.fromEntries(models.map((m) => [m.id, m.contextWindow]));
 
     // 32K — smallest in the list, was previously over-reported as 128K
-    expect(ctx["rnj-1:8b"]).toBe(32768);
     // 128K
     expect(ctx["gpt-oss:20b"]).toBe(131072);
     expect(ctx["gpt-oss:120b"]).toBe(131072);
     // 160K
-    expect(ctx["deepseek-v3.1:671b"]).toBe(163840);
-    expect(ctx["deepseek-v3.2"]).toBe(163840);
     // 198K (GLM 4.x/5.x family, minimax-m2.5)
-    expect(ctx["glm-4.7"]).toBe(202752);
-    expect(ctx["glm-5"]).toBe(202752);
     expect(ctx["glm-5.1"]).toBe(202752);
     expect(ctx["minimax-m2.5"]).toBe(202752);
     // 976K (GLM-5.2 — "NK" = N×1024 → 999424)
     expect(ctx["glm-5.2"]).toBe(999424);
     // 200K (other minimax variants)
-    expect(ctx["minimax-m2.1"]).toBe(204800);
     expect(ctx["minimax-m2.7"]).toBe(204800);
     // 256K — the most common class
-    expect(ctx["devstral-2:123b"]).toBe(262144);
     expect(ctx["gemma4:31b"]).toBe(262144);
     expect(ctx["kimi-k2.5"]).toBe(262144);
     expect(ctx["kimi-k2.6"]).toBe(262144);
     expect(ctx["kimi-k2.7-code"]).toBe(262144);
-    expect(ctx["ministral-3:3b"]).toBe(262144);
-    expect(ctx["ministral-3:8b"]).toBe(262144);
-    expect(ctx["ministral-3:14b"]).toBe(262144);
     expect(ctx["mistral-large-3:675b"]).toBe(262144);
     expect(ctx["nemotron-3-super"]).toBe(262144);
     expect(ctx["nemotron-3-ultra"]).toBe(262144);
-    expect(ctx["qwen3-coder-next"]).toBe(262144);
-    expect(ctx["qwen3-coder:480b"]).toBe(262144);
     expect(ctx["qwen3.5:397b"]).toBe(262144);
     // 384K
-    expect(ctx["devstral-small-2:24b"]).toBe(393216);
     // 512K — deepseek-v4-pro belongs here, not with flash below, despite its
     // library page claiming 1M (see ollama-cloud-models.ts)
     expect(ctx["deepseek-v4-pro"]).toBe(524288);
@@ -2212,7 +2185,6 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["minimax-m3"]).toBe(524288);
     // 1M
     expect(ctx["deepseek-v4-flash"]).toBe(1048576);
-    expect(ctx["gemini-3-flash-preview"]).toBe(1048576);
     expect(ctx["nemotron-3-nano:30b"]).toBe(1048576);
   });
 
@@ -2276,14 +2248,10 @@ describe("regenerateOpenClawConfig", () => {
     // devstral-small-2:24b is explicitly excluded — its library page claims
     // "Text, Image" but the runtime API rejects images with HTTP 400.
     const visionModels = [
-      "gemini-3-flash-preview",
       "gemma4:31b",
       "kimi-k2.5",
       "kimi-k2.6",
       "minimax-m3",
-      "ministral-3:3b",
-      "ministral-3:8b",
-      "ministral-3:14b",
       "mistral-large-3:675b",
     ];
     for (const id of visionModels) {
@@ -2294,10 +2262,6 @@ describe("regenerateOpenClawConfig", () => {
     // small-2:24b joined this list after the #416 smoke test demoted it.
     // qwen3.5:397b joined it too: its library page claims image input but the
     // live endpoint hallucinates image contents, so it is flagged text-only.
-    expect(byId["rnj-1:8b"].input).toEqual(["text"]);
-    expect(byId["qwen3-coder:480b"].input).toEqual(["text"]);
-    expect(byId["deepseek-v3.2"].input).toEqual(["text"]);
-    expect(byId["devstral-small-2:24b"].input).toEqual(["text"]);
     expect(byId["qwen3.5:397b"].input).toEqual(["text"]);
     // kimi-k2.7-code: library page claims image input (MoonViT), but the live
     // /v1/chat/completions returns HTTP 500 on image_url payloads (probed
@@ -2312,14 +2276,9 @@ describe("regenerateOpenClawConfig", () => {
 
     // Reasoning-capable cloud models per ollama.com/search?c=thinking&c=cloud
     const reasoningModels = [
-      "deepseek-v3.1:671b",
-      "deepseek-v3.2",
       "deepseek-v4-flash",
       "deepseek-v4-pro",
-      "gemini-3-flash-preview",
       "gemma4:31b",
-      "glm-4.7",
-      "glm-5",
       "glm-5.1",
       "glm-5.2",
       "gpt-oss:20b",
@@ -2341,18 +2300,7 @@ describe("regenerateOpenClawConfig", () => {
     // Non-reasoning — qwen3-coder-next explicitly "Non-thinking mode only",
     // ministral-3 / mistral-large-3 / devstral-* and rnj-1 not tagged,
     // minimax-m2.1 absent from Ollama's thinking tag list.
-    const nonReasoningModels = [
-      "devstral-2:123b",
-      "devstral-small-2:24b",
-      "minimax-m2.1",
-      "ministral-3:3b",
-      "ministral-3:8b",
-      "ministral-3:14b",
-      "mistral-large-3:675b",
-      "qwen3-coder-next",
-      "qwen3-coder:480b",
-      "rnj-1:8b",
-    ];
+    const nonReasoningModels = ["mistral-large-3:675b"];
     for (const id of nonReasoningModels) {
       expect(byId[id].reasoning).toBe(false);
     }
@@ -7589,7 +7537,7 @@ describe("regenerateOpenClawConfig size-drop guard (#311)", () => {
 
     const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
     expect(config.agents.defaults.pdfModel).toBeDefined();
-    expect(config.agents.defaults.pdfModel.primary).toBe("ollama-cloud/gemini-3-flash-preview");
+    expect(config.agents.defaults.pdfModel.primary).toBe("ollama-cloud/minimax-m3");
   });
 
   it("does not set agents.defaults.pdfModel when no provider is configured", async () => {
@@ -7738,7 +7686,7 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     await regenerateOpenClawConfig();
 
     const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
-    expect(config.agents.defaults.imageModel.primary).toBe("ollama-cloud/gemini-3-flash-preview");
+    expect(config.agents.defaults.imageModel.primary).toBe("ollama-cloud/minimax-m3");
   });
 
   it("native vision providers (anthropic, google) beat ollama-cloud for imageModel", async () => {
@@ -7821,7 +7769,7 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
     const expected = {
       primary: "openai/gpt-5.4-mini",
-      fallbacks: ["ollama-cloud/gemini-3-flash-preview"],
+      fallbacks: ["ollama-cloud/minimax-m3"],
     };
     expect(config.agents.defaults.pdfModel).toEqual(expected);
     expect(config.agents.defaults.imageModel).toEqual(expected);

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -151,7 +151,7 @@ vi.mock("@/lib/provider-models", () => {
       name: "Ollama Cloud",
       models: [
         { id: "ollama-cloud/minimax-m3", name: "minimax-m3" },
-        { id: "ollama-cloud/minimax-m3", name: "minimax-m3" },
+        { id: "ollama-cloud/kimi-k2.6", name: "kimi-k2.6" },
         { id: "ollama-cloud/gemma4:31b", name: "gemma4:31b" },
       ],
     },

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -278,16 +278,9 @@ describe("fetchProviderModels", () => {
         JSON.stringify({
           data: [
             // Tool-capable — should appear
-            { id: "deepseek-v3.1:671b" },
-            { id: "deepseek-v3.2" },
             { id: "deepseek-v4-flash" },
             { id: "deepseek-v4-pro" },
-            { id: "devstral-2:123b" },
-            { id: "devstral-small-2:24b" },
-            { id: "gemini-3-flash-preview" },
             { id: "gemma4:31b" },
-            { id: "glm-4.7" },
-            { id: "glm-5" },
             { id: "glm-5.1" },
             { id: "glm-5.2" },
             { id: "gpt-oss:20b" },
@@ -297,22 +290,15 @@ describe("fetchProviderModels", () => {
             { id: "kimi-k2.5" },
             { id: "kimi-k2.6" },
             { id: "kimi-k2.7-code" },
-            { id: "minimax-m2.1" },
             { id: "minimax-m2.5" },
             { id: "minimax-m2.7" },
             { id: "minimax-m3" },
-            { id: "ministral-3:3b" },
-            { id: "ministral-3:8b" },
-            { id: "ministral-3:14b" },
             { id: "mistral-large-3:675b" },
             { id: "nemotron-3-nano:30b" },
             { id: "nemotron-3-super" },
             { id: "nemotron-3-ultra" },
-            { id: "qwen3-coder-next" },
-            { id: "qwen3-coder:480b" },
             { id: "qwen3-next:80b" },
             { id: "qwen3.5:397b" },
-            { id: "rnj-1:8b" },
             // Tool-broken on the live chat/completions endpoint — must be filtered out
             { id: "cogito-2.1:671b" },
             { id: "gemma3:27b" },
@@ -332,16 +318,9 @@ describe("fetchProviderModels", () => {
     // Every tool-capable model surfaces
     expect(ids).toEqual(
       expect.arrayContaining([
-        "ollama-cloud/deepseek-v3.1:671b",
-        "ollama-cloud/deepseek-v3.2",
         "ollama-cloud/deepseek-v4-flash",
         "ollama-cloud/deepseek-v4-pro",
-        "ollama-cloud/devstral-2:123b",
-        "ollama-cloud/devstral-small-2:24b",
-        "ollama-cloud/gemini-3-flash-preview",
         "ollama-cloud/gemma4:31b",
-        "ollama-cloud/glm-4.7",
-        "ollama-cloud/glm-5",
         "ollama-cloud/glm-5.1",
         "ollama-cloud/glm-5.2",
         "ollama-cloud/gpt-oss:20b",
@@ -349,21 +328,14 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
         "ollama-cloud/kimi-k2.7-code",
-        "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",
         "ollama-cloud/minimax-m3",
-        "ollama-cloud/ministral-3:3b",
-        "ollama-cloud/ministral-3:8b",
-        "ollama-cloud/ministral-3:14b",
         "ollama-cloud/mistral-large-3:675b",
         "ollama-cloud/nemotron-3-nano:30b",
         "ollama-cloud/nemotron-3-super",
         "ollama-cloud/nemotron-3-ultra",
-        "ollama-cloud/qwen3-coder-next",
-        "ollama-cloud/qwen3-coder:480b",
         "ollama-cloud/qwen3.5:397b",
-        "ollama-cloud/rnj-1:8b",
       ])
     );
     // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
@@ -374,7 +346,7 @@ describe("fetchProviderModels", () => {
     expect(ids).not.toContain("ollama-cloud/qwen3-next:80b");
     // minimax-m3 was added to the allowlist (vision + tools confirmed live).
     expect(ids).toContain("ollama-cloud/minimax-m3");
-    expect(ids).toHaveLength(32);
+    expect(ids).toHaveLength(18);
 
     // Tool-broken models are filtered out (probed 2026-06-12: gemma3:4b leaks
     // pseudo tool calls as text, gemma3:12b serves HTTP 500, gemma3:27b
@@ -423,19 +395,12 @@ describe("fetchProviderModels", () => {
     const ids = ollama!.models.map((m) => m.id);
     // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
     expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
-    expect(ids).toHaveLength(32);
+    expect(ids).toHaveLength(18);
     expect(ids).toEqual(
       expect.arrayContaining([
-        "ollama-cloud/deepseek-v3.1:671b",
-        "ollama-cloud/deepseek-v3.2",
         "ollama-cloud/deepseek-v4-flash",
         "ollama-cloud/deepseek-v4-pro",
-        "ollama-cloud/devstral-2:123b",
-        "ollama-cloud/devstral-small-2:24b",
-        "ollama-cloud/gemini-3-flash-preview",
         "ollama-cloud/gemma4:31b",
-        "ollama-cloud/glm-4.7",
-        "ollama-cloud/glm-5",
         "ollama-cloud/glm-5.1",
         "ollama-cloud/glm-5.2",
         "ollama-cloud/gpt-oss:20b",
@@ -443,21 +408,14 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
         "ollama-cloud/kimi-k2.7-code",
-        "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",
         "ollama-cloud/minimax-m3",
-        "ollama-cloud/ministral-3:3b",
-        "ollama-cloud/ministral-3:8b",
-        "ollama-cloud/ministral-3:14b",
         "ollama-cloud/mistral-large-3:675b",
         "ollama-cloud/nemotron-3-nano:30b",
         "ollama-cloud/nemotron-3-super",
         "ollama-cloud/nemotron-3-ultra",
-        "ollama-cloud/qwen3-coder-next",
-        "ollama-cloud/qwen3-coder:480b",
         "ollama-cloud/qwen3.5:397b",
-        "ollama-cloud/rnj-1:8b",
       ])
     );
   });

--- a/packages/web/src/__tests__/lib/vision-model-chain.test.ts
+++ b/packages/web/src/__tests__/lib/vision-model-chain.test.ts
@@ -36,7 +36,7 @@ function stubStagingProviders() {
   );
   // Live ollama-cloud catalog includes the curated vision model.
   fetchProviderModels.mockResolvedValue([
-    { id: "ollama-cloud", models: [{ id: "ollama-cloud/gemini-3-flash-preview" }] },
+    { id: "ollama-cloud", models: [{ id: "ollama-cloud/minimax-m3" }] },
   ]);
   // Chat default kimi-k2.6 is NOT vision-capable; gpt-5.5 is.
   isModelVisionCapable.mockImplementation((m: string) => m === "openai/gpt-5.5");
@@ -54,7 +54,7 @@ describe("resolveDefaultVisionModelChain", () => {
     // fallback when the openai call fails (e.g. an invalid/expired key — the
     // staging symptom). This is the whole point of #2: a single pdfModel had no
     // fallback, so an unreachable primary silently killed PDF/vision.
-    expect(chain).toEqual(["openai/gpt-5.5", "ollama-cloud/gemini-3-flash-preview"]);
+    expect(chain).toEqual(["openai/gpt-5.5", "ollama-cloud/minimax-m3"]);
   });
 
   it("resolves ollama-cloud to its curated VISION model, not the chat default", async () => {
@@ -66,11 +66,11 @@ describe("resolveDefaultVisionModelChain", () => {
     );
     getDefaultModel.mockResolvedValue("ollama-cloud/kimi-k2.6");
     fetchProviderModels.mockResolvedValue([
-      { id: "ollama-cloud", models: [{ id: "ollama-cloud/gemini-3-flash-preview" }] },
+      { id: "ollama-cloud", models: [{ id: "ollama-cloud/minimax-m3" }] },
     ]);
     isModelVisionCapable.mockReturnValue(false);
     const chain = await resolveDefaultVisionModelChain();
-    expect(chain).toEqual(["ollama-cloud/gemini-3-flash-preview"]);
+    expect(chain).toEqual(["ollama-cloud/minimax-m3"]);
   });
 
   it("returns an empty chain on a text-only stack", async () => {
@@ -89,7 +89,7 @@ describe("resolveDefaultVisionModelChain", () => {
     stubStagingProviders();
     fetchProviderModels.mockClear();
     const chain = await resolveDefaultVisionModelChain();
-    expect(chain).toEqual(["openai/gpt-5.5", "ollama-cloud/gemini-3-flash-preview"]);
+    expect(chain).toEqual(["openai/gpt-5.5", "ollama-cloud/minimax-m3"]);
     expect(fetchProviderModels).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
@@ -21,7 +21,13 @@ describe("resolveOllamaCloud", () => {
 
   it("prefers a coder model when taskType=coder", () => {
     const r = resolveOllamaCloud({ tier: "balanced", taskType: "coder" });
-    expect(r.model).toMatch(/coder/i);
+    // Pinned to the id, not /coder/i. That regex was a proxy for "is the
+    // coder-specialised model" and it silently died with the qwen3-coder family
+    // (retired from Ollama Cloud 2026-07-15): the only coder model left is
+    // kimi-k2.7-code, which is a coder model whose name never says "coder".
+    // A name pattern cannot express this; the pick itself can.
+    expect(r.model).toBe("ollama-cloud/kimi-k2.7-code");
+    expect(r.fallbackUsed).toBe(false);
   });
 
   it("falls back to general when taskType has no dedicated map entry", () => {

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -23,9 +23,35 @@ const BY_TIER_FAMILY: Record<
 > = {
   fast: {
     general: "ollama-cloud/deepseek-v4-flash",
-    coder: "ollama-cloud/qwen3-coder-next",
-    // Smallest practical vision model: 8B, vision+tools, 256K context.
-    vision: "ollama-cloud/ministral-3:8b",
+    // qwen3-coder-next was retired from Ollama Cloud (2026-07-15), along with
+    // the whole qwen3-coder family. kimi-k2.7-code is the only coder-specialised
+    // model left on the platform, so this is a forced pick, not a ranking.
+    coder: "ollama-cloud/kimi-k2.7-code",
+    // ministral-3:8b ("smallest practical vision model: 8B, vision+tools") was
+    // retired 2026-07-15 with the entire ministral family. There is no small
+    // vision model left: the live vision set is gemma4:31b, kimi-k2.5/2.6,
+    // minimax-m3 (tools-blocked) and mistral-large-3:675b. So this tier's
+    // vision slot cannot be fast AND reliable, and reliability wins — the same
+    // trade-off the reasoning tier already made below, for the same reason: a
+    // corrupted invoice ref fails the turn outright, which is what the speed
+    // was meant to serve.
+    //
+    // Why kimi-k2.6 and not gemma4:31b, the one small-ish candidate:
+    //   - gemma4:31b is 0/12 on duplicate-guard and 0/12 on silent-failure in
+    //     the 2026-07-11 sweep — it never verifies before writing, and never
+    //     notices a create that did not persist. Both differences from kimi are
+    //     statistically significant (diff 0.42, CI [0.09, 0.68]; and 0.33, CI
+    //     [0.02, 0.61]); on the easy scenarios the two are tied. The aggregate
+    //     read is a TIE (diff -0.107, CI [-0.294, 0.08]) — which is exactly why
+    //     the aggregate is the wrong lens: it averages a tie on cheap scenarios
+    //     with a significant loss on the two that cost money.
+    //   - the id-corruption incident (see the balanced tier) is a long-identifier
+    //     failure the invoice scenarios do not probe at all, so the eval's tie
+    //     does not clear gemma4 of it — it is an unmeasured risk on top.
+    //   - rejecting gemma4 for balanced and reasoning but accepting it here
+    //     would be incoherent: carrying refs through a multi-turn tool loop is
+    //     this slot's job in every tier.
+    vision: "ollama-cloud/kimi-k2.6",
   },
   balanced: {
     // glm-4.7 (general) and gemma4:31b (vision) were replaced 2026-07-07
@@ -37,7 +63,9 @@ const BY_TIER_FAMILY: Record<
     // strongest non-thinking-preferred tool-driver: vision:true, 256K
     // context, already in the curated catalog (issue #669).
     general: "ollama-cloud/kimi-k2.6",
-    coder: "ollama-cloud/qwen3-coder:480b",
+    // qwen3-coder:480b retired 2026-07-15 with the rest of the qwen3-coder
+    // family; kimi-k2.7-code is the only coder-specialised model still served.
+    coder: "ollama-cloud/kimi-k2.7-code",
     vision: "ollama-cloud/kimi-k2.6",
   },
   reasoning: {

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -71,20 +71,6 @@ const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
 // the `OllamaCloudModel` shape.
 export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
   {
-    id: "deepseek-v3.1:671b",
-    contextWindow: 163840,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
-  },
-  {
-    id: "deepseek-v3.2",
-    contextWindow: 163840,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
-  },
-  {
     // The 1M here is real, unlike deepseek-v4-pro below: `ollama show
     // deepseek-v4-flash:cloud` reports 1048576, matching its library page
     // (checked 2026-07-16). Same family and same claimed size as pro, so it
@@ -124,58 +110,11 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
-    id: "devstral-2:123b",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: false,
-  },
-  {
-    // ollama.com/library/devstral-small-2 lists "Text, Image" in the input
-    // types, but the live `/v1/chat/completions` endpoint returns HTTP 400
-    // "Image input is not enabled for this model" on image_url payloads —
-    // confirmed by the empirical API smoke test in #416. Devstral is
-    // Mistral's coding series, not a vision model; the library page is
-    // misleading. Flagged `vision: false` so it isn't picked as an image
-    // model fallback.
-    id: "devstral-small-2:24b",
-    contextWindow: 393216,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: false,
-  },
-  {
-    // Capable vision/long-context model for chat-only agents, but it leaks
-    // tool calls as plain text ("default_api" signature) in agentic sessions —
-    // observed in production 2026-06-11. The resolver blocklist (-preview +
-    // tools) keeps it out of every tool slot; do not hand-pick it for agents
-    // that use tools.
-    id: "gemini-3-flash-preview",
-    contextWindow: 1048576,
-    maxTokens: 65536,
-    reasoning: true,
-    vision: true,
-  },
-  {
     id: "gemma4:31b",
     contextWindow: 262144,
     maxTokens: 8192,
     reasoning: true,
     vision: true,
-  },
-  {
-    id: "glm-4.7",
-    contextWindow: 202752,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
-  },
-  {
-    id: "glm-5",
-    contextWindow: 202752,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
   },
   {
     id: "glm-5.1",
@@ -239,13 +178,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
-    id: "minimax-m2.1",
-    contextWindow: 204800,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: false,
-  },
-  {
     id: "minimax-m2.5",
     contextWindow: 202752,
     maxTokens: 8192,
@@ -271,27 +203,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     contextWindow: 524288,
     maxTokens: 8192,
     reasoning: true,
-    vision: true,
-  },
-  {
-    id: "ministral-3:3b",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: true,
-  },
-  {
-    id: "ministral-3:8b",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: true,
-  },
-  {
-    id: "ministral-3:14b",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: false,
     vision: true,
   },
   {
@@ -326,20 +237,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
-    id: "qwen3-coder-next",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: false,
-  },
-  {
-    id: "qwen3-coder:480b",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: false,
-  },
-  {
     // The ollama.com/library/qwen3.5 page lists image input, but the live
     // /v1/chat/completions endpoint hallucinates image contents (wrong number
     // AND wrong color across distinct test images) rather than rejecting them
@@ -350,13 +247,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     contextWindow: 262144,
     maxTokens: 8192,
     reasoning: true,
-    vision: false,
-  },
-  {
-    id: "rnj-1:8b",
-    contextWindow: 32768,
-    maxTokens: 8192,
-    reasoning: false,
     vision: false,
   },
 ] as const satisfies readonly OllamaCloudModel[];

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -192,7 +192,13 @@ export const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
   // Ordering matters, not just membership: kimi-k2.6 must stay ahead of
   // gemma4:31b, or a tool-using image turn degrades to gemma4 again. Pinned by
   // the ordering guard in ollama-cloud-image-preference-drift.test.ts.
-  "gemini-3-flash-preview",
+  // gemini-3-flash-preview led this list until Ollama retired it from the cloud
+  // catalog (2026-07-15), so minimax-m3 inherits the head — and with it the
+  // default `imageModel` that consumer (2) hands out. That stays sound for the
+  // same reason it was sound for the preview model: minimax-m3's block is about
+  // mangling nested TOOL arguments, and this slot describes images rather than
+  // driving tools. Consumer (1) still applies `isBlocked`, so a tool-using turn
+  // keeps skipping it down to kimi-k2.6.
   "minimax-m3",
   "kimi-k2.6",
   "gemma4:31b",

--- a/scripts/lib/ollama-cloud-source.test.mjs
+++ b/scripts/lib/ollama-cloud-source.test.mjs
@@ -86,14 +86,20 @@ test("MODEL_ID_PATTERN accepts real ollama ids and rejects unsafe ones", () => {
 
 test("parses the real curated source and finds a known model with correct fields", () => {
   const models = parseOllamaCloudModels(readFileSync(REAL_SOURCE, "utf8"));
-  const glm = models.find((m) => m.id === "glm-4.7");
-  assert.ok(glm, "glm-4.7 should be present in the real catalog");
-  assert.equal(glm.contextWindow, 202752);
+  // glm-4.7 was this fixture until Ollama retired it (2026-07-15). Any live
+  // catalog entry serves the purpose — this test is about the PARSER, not about
+  // which models exist.
+  const glm = models.find((m) => m.id === "glm-5.2");
+  assert.ok(glm, "glm-5.2 should be present in the real catalog");
+  assert.equal(glm.contextWindow, 999424);
   assert.equal(glm.reasoning, true);
   assert.equal(glm.vision, false);
-  // Catch a parser that silently matches only the first entry.
+  // Catch a parser that silently matches only the first entry. The floor was 25
+  // when the catalog held 32; the 2026-07-15 retirement wave cut it to 18, so a
+  // floor near the catalog size would just be a snapshot that breaks on every
+  // retirement. 15 still catches the failure this guards (a parser returning 1).
   assert.ok(
-    models.length >= 25,
+    models.length >= 15,
     `expected the full catalog, parsed ${models.length}`,
   );
 });


### PR DESCRIPTION
## What `pnpm models:discover` says

**14 of our 32 curated models are no longer served** (Ollama's 2026-07-15 retirement wave), and **`ADDED` is 0**. The catalog was too big, not too small — every model worth having is already in it. Live count: 18. Our catalog now: 18, exactly matching.

**This is a live bug, not eval hygiene.** The catalog feeds the model picker and the OpenClaw config, so a user could pick a model that 404s.

## ⚠️ R6: three tier slots moved — this PR is the proposal, you ratify

Per the methodology, *"a resolver tier-map change hits every self-hosted deployment. Propose-only, human-ratified. No auto-apply, ever."*

| Slot | was | now | why |
|---|---|---|---|
| `fast.coder` | `qwen3-coder-next` | `kimi-k2.7-code` | whole qwen3-coder family retired; only coder model left. **Forced, not a ranking.** |
| `balanced.coder` | `qwen3-coder:480b` | `kimi-k2.7-code` | same |
| `fast.vision` | `ministral-3:8b` | `kimi-k2.6` | see below |

### `fast.vision` — the one real judgement call

The old pick was *"smallest practical vision model: 8B"*. **There is no small vision model left.** Live vision set: `gemma4:31b`, `kimi-k2.5/2.6`, `minimax-m3` (tools-blocked — a vision slot always resolves alongside tools), `mistral-large-3:675b` (0/12 on happy-path — it cannot do the task). So this slot can no longer be both fast and reliable.

`gemma4:31b` is the only small-ish candidate. Our own data rejects it:

| scenario | kimi-k2.6 | gemma4:31b | verdict |
|---|---|---|---|
| duplicate-guard | 5/12 | **0/12** | diff 0.42, CI [0.09, 0.68] — **significant** |
| silent-failure | 4/12 | **0/12** | diff 0.33, CI [0.02, 0.61] — **significant** |
| happy-path / line-items | 10/12 | 11/12 | tied |
| **aggregate** | | | **tie** (-0.107, CI [-0.294, 0.08]) |

The aggregate tie is real and it is the **wrong lens**: it averages a tie on the cheap scenarios with a significant loss on the two that cost money — never verifying before writing (double-pay), never noticing a create that didn't persist. And gemma4's id-corruption incident is a failure class the invoice scenarios never probe, so the tie doesn't clear it of that either.

Reliability beats the tier's nominal property — the same trade-off the `reasoning` tier already made, for the same reason.

## Also

`gemini-3-flash-preview` retired → `minimax-m3` inherits the head of `OLLAMA_CLOUD_IMAGE_PREFERENCE` and the default `imageModel`. Still sound: its block is about nested **tool** arguments; that slot only describes images.

## Test fallout worth reading

- **`/coder/i` was a proxy that died silently.** The resolver test asserted the coder pick's *name* matches `/coder/i`. The only coder model left is `kimi-k2.7-code` — a coder model whose name never says "coder". Pinned to the id instead.
- **`scripts/lib/ollama-cloud-source.test.mjs`** (run by `pnpm test:scripts`, **not** `pnpm test`) pinned glm-4.7's fields and asserted a catalog floor of ≥25. Both broke.
- **The skill's own list of snapshot sites was incomplete** — it named 5, there are 8, including two the unit suite never runs and a *second* `ollama-cloud.test.ts` at a different path that passes while the real one fails. Fixed in the skill.

## Gates

`pnpm test` 657 files / 8910 tests green · `pnpm test:scripts` exit 0 · typecheck clean · lint 0 errors.
`pnpm test:db` not run — no Postgres on 5433 locally; `model-vision.integration.test.ts` is DB-backed and CI covers it.

Refs #669