### PR TITLE
feat(kb): run the reindex as a background job with progress (#714 part 1)

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -97,6 +97,8 @@ curl -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/knowledg
 
 `total` is every document we found across the granted folders, counted before the first one is read — so it doesn't move once the run starts. `counts` fills in as the run goes, so you don't have to wait until the end to see how it's going:
 
+`processed` counts whole documents, so a long one holds the number still while we work through it — a 300-page PDF can sit there for minutes. That's the run being slow, not stuck.
+
 | Field          | What it means                                                                                                                                 |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `indexed`      | Added or updated, and searchable afterwards.                                                                                                  |

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -74,7 +74,7 @@ The request comes back immediately with a job to watch:
 
 Indexing itself runs in the background. It has to: every page has to be read, split, and turned into a vector, and on a few thousand documents that's hours of work on a CPU. Nothing about that fits inside an HTTP request, so the request queues the run and hands you its id.
 
-One index run happens at a time. Trigger a second while one is going and you get a `409` carrying the running job's id — so you can watch the run that's already happening rather than start a duplicate.
+One index run happens at a time, across your whole Pinchy — the index is shared, and embedding is CPU-hungry enough that two runs would only slow each other down. Trigger a second while one is going and you get a `409` naming the run that's in your way, including which agent it belongs to. That may not be the agent you asked about; watch that one instead of retrying.
 
 ## 8. Watch the run
 

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -95,7 +95,7 @@ curl -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/knowledg
 }
 ```
 
-`total` is every document we found across the granted folders, counted before the first one is read — so it doesn't move once the run starts. When the run finishes, `counts` tells you what it found:
+`total` is every document we found across the granted folders, counted before the first one is read — so it doesn't move once the run starts. `counts` fills in as the run goes, so you don't have to wait until the end to see how it's going:
 
 | Field          | What it means                                                                                                                                 |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -62,18 +62,40 @@ This reads the agent's granted folders, extracts text from each PDF, splits it i
 
 Indexing is idempotent — unchanged files are skipped on the next run, changed files are re-indexed, and files removed from disk are dropped from the index. **Re-run reindex whenever documents change** — new files, edits, or deletions. There's no automatic file-watcher yet; a scheduled sweep is planned for a later phase.
 
-The response reports what happened:
+The request comes back immediately with a job to watch:
 
 ```json
 {
-  "indexed": 3,
-  "skipped": 12,
-  "removed": 1,
-  "unsearchable": 2,
-  "failed": 0,
+  "jobId": "6f1c2b64-6c3e-4a2f-9c19-5c1d3a1f2e77",
+  "status": "pending",
   "pathCount": 2
 }
 ```
+
+Indexing itself runs in the background. It has to: every page has to be read, split, and turned into a vector, and on a few thousand documents that's hours of work on a CPU. Nothing about that fits inside an HTTP request, so the request queues the run and hands you its id.
+
+One index run happens at a time. Trigger a second while one is going and you get a `409` carrying the running job's id — so you can watch the run that's already happening rather than start a duplicate.
+
+## 8. Watch the run
+
+Ask the same endpoint how it's going:
+
+```bash
+curl -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/knowledge/reindex"
+```
+
+```json
+{
+  "job": {
+    "status": "running",
+    "processed": 340,
+    "total": 1893,
+    "counts": null
+  }
+}
+```
+
+`total` is every document we found across the granted folders, counted before the first one is read — so it doesn't move once the run starts. When the run finishes, `counts` tells you what it found:
 
 | Field          | What it means                                                                                                                                 |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -85,7 +107,11 @@ The response reports what happened:
 
 `indexed` counts documents the agent can actually reach, not documents we processed — that's why a scanned PDF lands under `unsearchable` instead. If either of the last two numbers is above zero, part of your corpus can't answer questions yet, and it's worth knowing which part before someone asks it something.
 
-## 8. Chat with the agent
+A `status` of `failed` is a different thing from a `failed` file: it means something systemic stopped the whole run — the embedding endpoint went away, or the database did — and `error` says what. A broken file never gets that far; it's counted and stepped over.
+
+If Pinchy restarts mid-run, the run resumes on the next start. Nothing is lost and nothing is done twice: everything already indexed is skipped on the way back through.
+
+## 9. Chat with the agent
 
 Go back to the agent's chat and start asking questions. The agent calls `knowledge_search` behind the scenes, which runs a hybrid search — semantic (vector) and full-text — over the passages you indexed, then answers using only what it found.
 
@@ -124,9 +150,9 @@ Phase 1 of the knowledge base is deliberately narrow:
 
 - Only **text-based PDFs** are indexed and searchable via `knowledge_search`. Scanned/image-only PDFs and Office documents (`.docx`, etc.) are on the roadmap, not indexed today.
 - There's no clickable link from a citation into the PDF viewer yet — citations are text (document path + page), not a jump-to-passage link.
-- Indexing is a manual, synchronous admin action (step 7). A scheduled sweep and progress UI are planned for a later phase.
+- Indexing is a manual admin action (step 7). It runs in the background and reports progress, but you still have to ask for it — a scheduled sweep and a progress UI in the app are planned for a later phase.
 
-Every retrieval and every reindex is recorded in the [audit trail](/concepts/audit-trail/) — reindex as `knowledge.reindex`, and each `knowledge_search` call as `retrieval.query` with the documents it drew on. The search query text itself is never stored in plaintext, only a one-way hash.
+Every retrieval and every reindex is recorded in the [audit trail](/concepts/audit-trail/) — each `knowledge_search` call as `retrieval.query` with the documents it drew on, and every reindex as two `knowledge.reindex` entries sharing a `jobId`: who asked for it, and how it turned out. Both are needed, because the run finishes long after the request that started it. The search query text itself is never stored in plaintext, only a one-way hash.
 
 ## Customizing the agent
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -336,17 +336,17 @@ The agent's most recent index run — in flight or last finished. **Admin only.*
 }
 ```
 
-| Field                 | Description                                                                                                                         |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `status`              | `pending`, `running`, `succeeded`, or `failed`.                                                                                     |
-| `processed` / `total` | Documents done, and documents found. `total` is `null` until discovery has walked every folder; it never changes after that.        |
-| `counts`              | The run's findings **so far**, updated as it goes. `null` before the first document.                                                |
-| `counts.indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                   |
-| `counts.skipped`      | Unchanged content hash, chunks already present.                                                                                     |
-| `counts.removed`      | Source file no longer on disk; the document and its chunks were deleted. Stays `0` until the run's final pass.                      |
-| `counts.unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF). |
-| `counts.failed`       | The file could not be read or parsed. The run continues — one bad file never aborts the reindex — and a previously indexed version of the file stays searchable. |
-| `error`               | Why the run failed. `null` unless `status` is `failed`.                                                                             |
+| Field                 | Description                                                                                                                                                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `status`              | `pending`, `running`, `succeeded`, or `failed`.                                                                                                                                                                    |
+| `processed` / `total` | Documents done, and documents found. `total` is `null` until discovery has walked every folder; it never changes after that. `processed` advances per whole document, so a long one can hold it still for minutes. |
+| `counts`              | The run's findings **so far**, updated as it goes. `null` before the first document.                                                                                                                               |
+| `counts.indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                                                                                                  |
+| `counts.skipped`      | Unchanged content hash, chunks already present.                                                                                                                                                                    |
+| `counts.removed`      | Source file no longer on disk; the document and its chunks were deleted. Stays `0` until the run's final pass.                                                                                                     |
+| `counts.unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF).                                                                                |
+| `counts.failed`       | The file could not be read or parsed. The run continues — one bad file never aborts the reindex — and a previously indexed version of the file stays searchable.                                                   |
+| `error`               | Why the run failed. `null` unless `status` is `failed`.                                                                                                                                                            |
 
 `unsearchable` and `failed` can be non-zero on a `succeeded` run: the reindex itself worked, and these are its findings about the corpus.
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -305,7 +305,7 @@ The request returns as soon as the job is queued — indexing runs in the backgr
 - `401` — not authenticated
 - `403` — not an admin
 - `404` — agent not found
-- `409` — a reindex is already running. One index job runs at a time. The response carries the running job's `jobId` and `status`, so you can watch that run instead of retrying.
+- `409` — a reindex is already running. One index job runs at a time across the whole instance, so the run in your way may belong to a **different** agent. The response carries the running job's `jobId`, `status`, and `agent` — `GET` that agent's reindex endpoint to watch it, rather than retrying.
 - `503` — the local Ollama embedding endpoint isn't configured (see [Set Up Local Ollama](/guides/ollama-setup/))
 
 ### `GET /api/agents/:agentId/knowledge/reindex`

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -340,10 +340,10 @@ The agent's most recent index run — in flight or last finished. **Admin only.*
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `status`              | `pending`, `running`, `succeeded`, or `failed`.                                                                                     |
 | `processed` / `total` | Documents done, and documents found. `total` is `null` until discovery has walked every folder; it never changes after that.        |
-| `counts`              | The run's findings. `null` until the run finishes.                                                                                  |
+| `counts`              | The run's findings **so far**, updated as it goes. `null` before the first document.                                                |
 | `counts.indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                   |
 | `counts.skipped`      | Unchanged content hash, chunks already present.                                                                                     |
-| `counts.removed`      | Source file no longer on disk; the document and its chunks were deleted.                                                            |
+| `counts.removed`      | Source file no longer on disk; the document and its chunks were deleted. Stays `0` until the run's final pass.                      |
 | `counts.unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF). |
 | `counts.failed`       | The file could not be read or parsed. The run continues — one bad file never aborts the reindex — and a previously indexed version of the file stays searchable. |
 | `error`               | Why the run failed. `null` unless `status` is `failed`.                                                                             |

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -274,7 +274,9 @@ See [Create a Knowledge Base Agent](/guides/create-knowledge-base-agent/) for th
 
 ### `POST /api/agents/:agentId/knowledge/reindex`
 
-(Re)index the agent's granted knowledge-base folders. **Admin only.** Reads the agent's `pinchy-files` `allowed_paths`, extracts text from each PDF, chunks and embeds it with the fixed `bge-m3` model, and stores the result in Pinchy's Postgres knowledge-base index. Idempotent: unchanged files are skipped, changed files are replaced, and files removed from disk are dropped from the index.
+Queue a (re)index of the agent's granted knowledge-base folders. **Admin only.** Reads the agent's `pinchy-files` `allowed_paths`, extracts text from each PDF, chunks and embeds it with the fixed `bge-m3` model, and stores the result in Pinchy's Postgres knowledge-base index. Idempotent: unchanged files are skipped, changed files are replaced, and files removed from disk are dropped from the index.
+
+The request returns as soon as the job is queued — indexing runs in the background, because a real corpus takes hours to embed. Poll [`GET`](#get-apiagentsagentidknowledgereindex) on the same path for progress and results.
 
 **Request body:**
 
@@ -282,36 +284,83 @@ See [Create a Knowledge Base Agent](/guides/create-knowledge-base-agent/) for th
 | ------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `paths` | string[] | No       | Subset of the agent's granted folders to reindex. Can only narrow the granted set — any path not already granted is ignored. Omit to reindex every granted folder. |
 
-**Response:**
+**Response — `202 Accepted`:**
 
 ```json
 {
-  "indexed": 3,
-  "skipped": 12,
-  "removed": 1,
-  "unsearchable": 2,
-  "failed": 0,
+  "jobId": "6f1c2b64-6c3e-4a2f-9c19-5c1d3a1f2e77",
+  "status": "pending",
   "pathCount": 2
 }
 ```
 
-| Field          | Description                                                                                                                                                      |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                                                |
-| `skipped`      | Unchanged content hash, chunks already present.                                                                                                                  |
-| `removed`      | Source file no longer on disk; the document and its chunks were deleted.                                                                                         |
-| `unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF).                              |
-| `failed`       | The file could not be read or parsed. The run continues — one bad file never aborts the reindex — and a previously indexed version of the file stays searchable. |
-| `pathCount`    | Number of granted folders reindexed.                                                                                                                             |
-
-`unsearchable` and `failed` can be non-zero on a `200`: the reindex itself succeeded and these are its findings about the corpus. Both are also recorded in the `knowledge.reindex` audit entry.
+| Field       | Description                                                                                            |
+| ----------- | ------------------------------------------------------------------------------------------------------ |
+| `jobId`     | The queued job. Pass nothing — `GET` on the same path reports this agent's most recent job.            |
+| `status`    | `pending` (queued) — or `noop` when the agent has no granted folders, in which case `jobId` is `null`. |
+| `pathCount` | Number of granted folders the job will reindex.                                                        |
 
 **Errors:**
 
 - `401` — not authenticated
 - `403` — not an admin
 - `404` — agent not found
+- `409` — a reindex is already running. One index job runs at a time. The response carries the running job's `jobId` and `status`, so you can watch that run instead of retrying.
 - `503` — the local Ollama embedding endpoint isn't configured (see [Set Up Local Ollama](/guides/ollama-setup/))
+
+### `GET /api/agents/:agentId/knowledge/reindex`
+
+The agent's most recent index run — in flight or last finished. **Admin only.** Returns `{ "job": null }` if the agent has never been reindexed.
+
+**Response:**
+
+```json
+{
+  "job": {
+    "id": "6f1c2b64-6c3e-4a2f-9c19-5c1d3a1f2e77",
+    "status": "succeeded",
+    "processed": 18,
+    "total": 18,
+    "counts": {
+      "indexed": 3,
+      "skipped": 12,
+      "removed": 1,
+      "unsearchable": 2,
+      "failed": 0
+    },
+    "error": null,
+    "createdAt": "2026-07-17T10:00:00.000Z",
+    "startedAt": "2026-07-17T10:00:05.000Z",
+    "finishedAt": "2026-07-17T10:04:11.000Z"
+  }
+}
+```
+
+| Field                 | Description                                                                                                                         |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `status`              | `pending`, `running`, `succeeded`, or `failed`.                                                                                     |
+| `processed` / `total` | Documents done, and documents found. `total` is `null` until discovery has walked every folder; it never changes after that.        |
+| `counts`              | The run's findings. `null` until the run finishes.                                                                                  |
+| `counts.indexed`      | Documents added, updated, or rebuilt — and searchable afterwards.                                                                   |
+| `counts.skipped`      | Unchanged content hash, chunks already present.                                                                                     |
+| `counts.removed`      | Source file no longer on disk; the document and its chunks were deleted.                                                            |
+| `counts.unsearchable` | Parsed without error but yielded no text, so the document exists in the index yet can never be retrieved (typically a scanned PDF). |
+| `counts.failed`       | The file could not be read or parsed. The run continues — one bad file never aborts the reindex — and a previously indexed version of the file stays searchable. |
+| `error`               | Why the run failed. `null` unless `status` is `failed`.                                                                             |
+
+`unsearchable` and `failed` can be non-zero on a `succeeded` run: the reindex itself worked, and these are its findings about the corpus.
+
+`status: "failed"` means something systemic stopped the run — the embedding endpoint or the database — not that a file was broken. A broken file is a `counts.failed`, and the run keeps going. Failed runs keep the counts they reached before dying.
+
+A run interrupted by a restart is picked up again automatically: indexing is idempotent, so the resumed run skips everything already done.
+
+Every run writes two `knowledge.reindex` audit entries, correlated by `jobId`: the admin's request, and the outcome (recorded by the background worker, with the counts).
+
+**Errors:**
+
+- `401` — not authenticated
+- `403` — not an admin
+- `404` — agent not found
 
 ### `POST /api/internal/knowledge/search`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -93,7 +93,7 @@ Configure the first LLM provider as part of the setup flow.
 | ---------- | ------ | -------- | --------------------------------------------------------------- |
 | `provider` | string | Yes      | `anthropic`, `openai`, `google`, `ollama-cloud`, `ollama-local` |
 | `apiKey`   | string | Cond.    | Required for cloud providers                                    |
-| `baseUrl`  | string | Cond.    | Required for `ollama-local`                                     |
+| `url`      | string | Cond.    | Required for `ollama-local`                                     |
 
 **Response:** `{ "success": true }`
 

--- a/packages/web/drizzle/0055_odd_microbe.sql
+++ b/packages/web/drizzle/0055_odd_microbe.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "kb_index_jobs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" text NOT NULL,
+	"agent_id" text NOT NULL,
+	"agent_name" text NOT NULL,
+	"requested_by" text NOT NULL,
+	"paths" jsonb NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"total" integer,
+	"processed" integer DEFAULT 0 NOT NULL,
+	"counts" jsonb,
+	"error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"started_at" timestamp,
+	"finished_at" timestamp,
+	CONSTRAINT "kb_index_jobs_status_check" CHECK ("kb_index_jobs"."status" IN ('pending', 'running', 'succeeded', 'failed'))
+);
+--> statement-breakpoint
+ALTER TABLE "kb_index_jobs" ADD CONSTRAINT "kb_index_jobs_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_kb_index_jobs_active" ON "kb_index_jobs" USING btree ("org_id") WHERE "kb_index_jobs"."status" IN ('pending', 'running');--> statement-breakpoint
+CREATE INDEX "idx_kb_index_jobs_status_created" ON "kb_index_jobs" USING btree ("status","created_at");--> statement-breakpoint
+CREATE INDEX "idx_kb_index_jobs_agent_created" ON "kb_index_jobs" USING btree ("agent_id","created_at");

--- a/packages/web/drizzle/meta/0055_snapshot.json
+++ b/packages/web/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,3418 @@
+{
+  "id": "d8667e03-5b6d-4d87-b03c-c30c76d962de",
+  "prevId": "8b8bd43d-6f7e-481d-8bc7-c33643a58d09",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_groups_group_id_idx": {
+          "name": "agent_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_visibility_check": {
+          "name": "agents_visibility_check",
+          "value": "\"agents\".\"visibility\" IN ('restricted', 'all')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_timestamp": {
+          "name": "idx_audit_resource_timestamp",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_verify_state": {
+      "name": "audit_verify_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified_id": {
+          "name": "last_verified_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_verified_hmac": {
+          "name": "last_verified_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_connection_cursors": {
+      "name": "email_connection_cursors",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_connection_cursors_connection_id_integration_connections_id_fk": {
+          "name": "email_connection_cursors_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_connection_cursors",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflow_connections": {
+      "name": "email_workflow_connections",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since_ts": {
+          "name": "since_ts",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_workflow_connections_workflow_id_email_workflows_id_fk": {
+          "name": "email_workflow_connections_workflow_id_email_workflows_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflow_connections_connection_id_integration_connections_id_fk": {
+          "name": "email_workflow_connections_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_workflow_connections_workflow_id_connection_id_pk": {
+          "name": "email_workflow_connections_workflow_id_connection_id_pk",
+          "columns": ["workflow_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflows": {
+      "name": "email_workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_every": {
+          "name": "poll_every",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'5m'"
+        },
+        "sweep_window_days": {
+          "name": "sweep_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "openclaw_job_id": {
+          "name": "openclaw_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_workflows_agent_idx": {
+          "name": "email_workflows_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_workflows_enabled_idx": {
+          "name": "email_workflows_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_workflows\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_workflows_agent_id_agents_id_fk": {
+          "name": "email_workflows_agent_id_agents_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflows_created_by_user_id_fk": {
+          "name": "email_workflows_created_by_user_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_workflows_status_check": {
+          "name": "email_workflows_status_check",
+          "value": "\"email_workflows\".\"status\" IN ('pending', 'active', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_type_check": {
+          "name": "integration_connections_type_check",
+          "value": "\"integration_connections\".\"type\" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')"
+        },
+        "integration_connections_status_check": {
+          "name": "integration_connections_status_check",
+          "value": "\"integration_connections\".\"status\" IN ('active', 'pending', 'auth_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_claimed_by_user_id_idx": {
+          "name": "invites_claimed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_email_expires_at_idx": {
+          "name": "invites_email_expires_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_role_check": {
+          "name": "invites_role_check",
+          "value": "\"invites\".\"role\" IN ('admin', 'member')"
+        },
+        "invites_type_check": {
+          "name": "invites_type_check",
+          "value": "\"invites\".\"type\" IN ('invite', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kb_chunks": {
+      "name": "kb_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kb_chunks_doc": {
+          "name": "idx_kb_chunks_doc",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_chunks_org_path": {
+          "name": "idx_kb_chunks_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_chunks_document_id_kb_documents_id_fk": {
+          "name": "kb_chunks_document_id_kb_documents_id_fk",
+          "tableFrom": "kb_chunks",
+          "tableTo": "kb_documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_documents": {
+      "name": "kb_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_kb_doc_org_path": {
+          "name": "uq_kb_doc_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_doc_org_hash": {
+          "name": "idx_kb_doc_org_hash",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_index_jobs": {
+      "name": "kb_index_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paths": {
+          "name": "paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_kb_index_jobs_active": {
+          "name": "uq_kb_index_jobs_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kb_index_jobs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_status_created": {
+          "name": "idx_kb_index_jobs_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_agent_created": {
+          "name": "idx_kb_index_jobs_agent_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_index_jobs_agent_id_agents_id_fk": {
+          "name": "kb_index_jobs_agent_id_agents_id_fk",
+          "tableFrom": "kb_index_jobs",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kb_index_jobs_status_check": {
+          "name": "kb_index_jobs_status_check",
+          "value": "\"kb_index_jobs\".\"status\" IN ('pending', 'running', 'succeeded', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipients": {
+      "name": "notification_recipients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_recipients_user_unread_idx": {
+          "name": "notification_recipients_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipients_user_id_user_id_fk": {
+          "name": "notification_recipients_user_id_user_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_recipients_notification_id_notifications_id_fk": {
+          "name": "notification_recipients_notification_id_notifications_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notification_recipients_user_id_notification_id_pk": {
+          "name": "notification_recipients_user_id_notification_id_pk",
+          "columns": ["user_id", "notification_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_agent_created_idx": {
+          "name": "notifications_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_agent_id_agents_id_fk": {
+          "name": "notifications_agent_id_agents_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_status_check": {
+          "name": "notifications_status_check",
+          "value": "\"notifications\".\"status\" IN ('success', 'failure')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.processed_emails": {
+      "name": "processed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id_header": {
+          "name": "message_id_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "processed_emails_claim_uniq": {
+          "name": "processed_emails_claim_uniq",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "processed_emails_status_idx": {
+          "name": "processed_emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "processed_emails_workflow_id_email_workflows_id_fk": {
+          "name": "processed_emails_workflow_id_email_workflows_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "processed_emails_status_check": {
+          "name": "processed_emails_status_check",
+          "value": "\"processed_emails\".\"status\" IN ('processing', 'done', 'no_action', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user_timestamp": {
+          "name": "idx_usage_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent_timestamp": {
+          "name": "idx_usage_agent_timestamp",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_groups_group_id_idx": {
+          "name": "user_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_pseudonym": {
+          "name": "audit_pseudonym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_audit_pseudonym_unique": {
+          "name": "user_audit_pseudonym_unique",
+          "nullsNotDistinct": false,
+          "columns": ["audit_pseudonym"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"user\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"starter_prompts\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1784188851340,
       "tag": "0054_safe_vision",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1784286855381,
+      "tag": "0055_odd_microbe",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -354,6 +354,14 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   const { startAuditVerifyJob, stopAuditVerifyJob } = await import("./src/server/audit-verify-job");
   startAuditVerifyJob();
 
+  // Run queued knowledge-base reindexes in the background. A real corpus is
+  // hours of CPU-only embedding, which can't happen inside the admin's HTTP
+  // request. The post-boot kick also requeues any job left `running` by a
+  // crashed predecessor — this process is the only worker, so nothing else
+  // could still hold one.
+  const { startKbIndexWorker, stopKbIndexWorker } = await import("./src/server/kb-index-worker");
+  startKbIndexWorker();
+
   // Graceful shutdown: stop the upload GC + usage poller intervals, close the
   // memory-audit watcher, disconnect from OpenClaw, drain browser WebSockets,
   // then close the HTTP server and DB pool. Without this, a SIGTERM (e.g.
@@ -373,6 +381,7 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       stopUploadGc: () => stopUploadGc(),
       stopChatErrorGc: () => stopChatErrorGc(),
       stopAuditVerifyJob: () => stopAuditVerifyJob(),
+      stopKbIndexWorker: () => stopKbIndexWorker(),
       stopUsagePoller: () => stopUsagePoller(),
       stopMemoryAuditWatcher: () =>
         stopMemoryAuditWatcher ? stopMemoryAuditWatcher() : Promise.resolve(),

--- a/packages/web/src/__tests__/api/knowledge-reindex.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-reindex.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
-import type { IngestResult } from "@/lib/knowledge/ingest";
+import type { KbIndexJob } from "@/lib/knowledge/index-jobs";
+import type { IngestResult } from "@/lib/knowledge/types";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
@@ -31,19 +32,11 @@ vi.mock("@/lib/settings", () => ({
   getSetting: (...args: unknown[]) => mockGetSetting(...args),
 }));
 
-const mockIngestDirectory = vi.fn();
-vi.mock("@/lib/knowledge/ingest", () => ({
-  ingestDirectory: (...args: unknown[]) => mockIngestDirectory(...args),
-}));
-
-const mockEmbedTexts = vi.fn();
-vi.mock("@/lib/knowledge/embeddings", () => ({
-  embedTexts: (...args: unknown[]) => mockEmbedTexts(...args),
-}));
-
-const mockExtractPdfPages = vi.fn();
-vi.mock("@/lib/knowledge/pdf-extract", () => ({
-  extractPdfPages: (...args: unknown[]) => mockExtractPdfPages(...args),
+const mockEnqueueIndexJob = vi.fn();
+const mockGetLatestIndexJobForAgent = vi.fn();
+vi.mock("@/lib/knowledge/index-jobs", () => ({
+  enqueueIndexJob: (...args: unknown[]) => mockEnqueueIndexJob(...args),
+  getLatestIndexJobForAgent: (...args: unknown[]) => mockGetLatestIndexJobForAgent(...args),
 }));
 
 const mockDeferAuditLog = vi.fn();
@@ -61,14 +54,33 @@ function makeRequest(body: Record<string, unknown> = {}) {
   });
 }
 
-/**
- * An ingestDirectory result with every counter at zero, overridden by `counts`.
- * Typed as IngestResult so a new counter added to ingest.ts fails to compile
- * here until the route is taught to aggregate it, rather than silently
- * dropping out of the response.
- */
+function makeGetRequest() {
+  return new NextRequest("http://localhost/api/agents/agent-1/knowledge/reindex");
+}
+
+/** An IngestResult with every counter at zero, overridden by `counts`. Typed so a counter added to ingest fails to compile here rather than silently vanishing from what an admin sees. */
 function ingestResult(counts: Partial<IngestResult> = {}): IngestResult {
   return { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0, ...counts };
+}
+
+function makeJob(overrides: Partial<KbIndexJob> = {}): KbIndexJob {
+  return {
+    id: "job-1",
+    orgId: DEFAULT_ORG_ID,
+    agentId: "agent-1",
+    agentName: "Smithers",
+    requestedBy: "admin-1",
+    paths: ["/data/hr", "/data/legal"],
+    status: "pending",
+    total: null,
+    processed: 0,
+    counts: null,
+    error: null,
+    createdAt: new Date("2026-07-17T10:00:00Z"),
+    startedAt: null,
+    finishedAt: null,
+    ...overrides,
+  };
 }
 
 const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
@@ -87,83 +99,109 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
     mockGetSession.mockResolvedValue({ user: { id: "admin-1", role: "admin" } });
     mockLimit.mockResolvedValue([agentRow]);
     mockGetSetting.mockResolvedValue("http://ollama.local:11434");
-    mockIngestDirectory.mockResolvedValue(ingestResult({ indexed: 2, skipped: 1 }));
+    mockEnqueueIndexJob.mockResolvedValue({ status: "queued", job: makeJob() });
     POST = (await import("@/app/api/agents/[agentId]/knowledge/reindex/route")).POST;
   });
 
-  it("returns 401 when unauthenticated and never ingests", async () => {
+  it("returns 401 when unauthenticated and never enqueues", async () => {
     mockGetSession.mockResolvedValueOnce(null);
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(401);
-    expect(mockIngestDirectory).not.toHaveBeenCalled();
+    expect(mockEnqueueIndexJob).not.toHaveBeenCalled();
   });
 
-  it("returns 403 for an authenticated non-admin and never ingests", async () => {
+  it("returns 403 for an authenticated non-admin and never enqueues", async () => {
     mockGetSession.mockResolvedValueOnce({ user: { id: "user-1", role: "member" } });
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(403);
-    expect(mockIngestDirectory).not.toHaveBeenCalled();
+    expect(mockEnqueueIndexJob).not.toHaveBeenCalled();
   });
 
-  it("returns 404 when the agent does not exist (or is deleted) and never ingests", async () => {
+  it("returns 404 when the agent does not exist (or is deleted) and never enqueues", async () => {
     mockLimit.mockResolvedValueOnce([]);
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(404);
-    expect(mockIngestDirectory).not.toHaveBeenCalled();
+    expect(mockEnqueueIndexJob).not.toHaveBeenCalled();
   });
 
-  it("reindexes every granted folder and aggregates counts across paths", async () => {
-    mockIngestDirectory
-      .mockResolvedValueOnce(ingestResult({ indexed: 2, skipped: 1 }))
-      .mockResolvedValueOnce(ingestResult({ indexed: 3, removed: 1 }));
-
+  // The whole point of #714: a real corpus is hours of embedding, so the
+  // request hands back a job to watch instead of blocking until it is done.
+  it("queues a job for every granted folder and answers 202 with the job to poll", async () => {
     const res = await POST(makeRequest(), ctx as never);
-    expect(res.status).toBe(200);
+
+    expect(res.status).toBe(202);
     expect(await res.json()).toEqual({
-      ...ingestResult({ indexed: 5, skipped: 1, removed: 1 }),
+      jobId: "job-1",
+      status: "pending",
       pathCount: 2,
     });
 
-    expect(mockIngestDirectory).toHaveBeenCalledTimes(2);
-    // Each granted folder is ingested with the shared single-tenant org id.
-    expect(mockIngestDirectory.mock.calls[0][0]).toBe(DEFAULT_ORG_ID);
-    expect(mockIngestDirectory.mock.calls[0][1]).toBe("/data/hr");
-    expect(mockIngestDirectory.mock.calls[1][0]).toBe(DEFAULT_ORG_ID);
-    expect(mockIngestDirectory.mock.calls[1][1]).toBe("/data/legal");
-    // The production deps (embed + extractPdf) are passed as the third arg.
-    const deps = mockIngestDirectory.mock.calls[0][2];
-    expect(typeof deps.embed).toBe("function");
-    expect(typeof deps.extractPdf).toBe("function");
+    expect(mockEnqueueIndexJob).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueIndexJob.mock.calls[0][0]).toMatchObject({
+      orgId: DEFAULT_ORG_ID,
+      agentId: "agent-1",
+      // Snapshotted onto the job so the outcome row can still name the agent
+      // hours later, and so the worker indexes what was authorized when asked.
+      agentName: "Smithers",
+      requestedBy: "admin-1",
+      paths: ["/data/hr", "/data/legal"],
+    });
   });
 
   it("narrows to the requested subset but never past the agent's granted folders", async () => {
-    // /data/legal is granted; /etc/passwd is NOT — it must be dropped, not ingested.
+    // /data/legal is granted; /etc/passwd is NOT — it must be dropped, not queued.
     const res = await POST(makeRequest({ paths: ["/data/legal", "/etc/passwd"] }), ctx as never);
-    expect(res.status).toBe(200);
-    expect(mockIngestDirectory).toHaveBeenCalledTimes(1);
-    expect(mockIngestDirectory.mock.calls[0][1]).toBe("/data/legal");
+    expect(res.status).toBe(202);
+    expect(mockEnqueueIndexJob.mock.calls[0][0].paths).toEqual(["/data/legal"]);
   });
 
-  it("returns 200 with zero counts and never ingests when the agent has no granted folders", async () => {
+  // Serialized per org by the job store. Rejecting with the blocking job's id
+  // is what lets the admin watch the run that is actually happening instead of
+  // clicking again into a queue that will never grow.
+  it("returns 409 with the in-flight job when the org is already reindexing", async () => {
+    mockEnqueueIndexJob.mockResolvedValueOnce({
+      status: "busy",
+      job: makeJob({ id: "job-running", status: "running", processed: 30, total: 42 }),
+    });
+
+    const res = await POST(makeRequest(), ctx as never);
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining("already"),
+      jobId: "job-running",
+      status: "running",
+    });
+
+    const entry = mockDeferAuditLog.mock.calls[0][0];
+    expect(entry.outcome).toBe("failure");
+    expect(entry.detail.jobId).toBe("job-running");
+    expect(entry.detail.reason).toBe("index_job_already_running");
+  });
+
+  it("returns 200 and never enqueues when the agent has no granted folders", async () => {
     mockLimit.mockResolvedValueOnce([{ id: "agent-1", name: "Smithers", pluginConfig: null }]);
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ...ingestResult(), pathCount: 0 });
-    expect(mockIngestDirectory).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual({ jobId: null, status: "noop", pathCount: 0 });
+    expect(mockEnqueueIndexJob).not.toHaveBeenCalled();
 
-    // A no-op reindex is still audited (success, zero counts).
+    // A no-op reindex is still audited (success, no job).
     expect(mockDeferAuditLog).toHaveBeenCalledTimes(1);
     const entry = mockDeferAuditLog.mock.calls[0][0];
     expect(entry.eventType).toBe("knowledge.reindex");
     expect(entry.outcome).toBe("success");
     expect(entry.detail.pathCount).toBe(0);
+    expect(entry.detail.jobId).toBeUndefined();
   });
 
+  // Fast feedback beats a job that queues, waits, and fails hours later with
+  // the same information.
   it("returns 503 and audits a failure when the embedding endpoint is not configured", async () => {
     mockGetSetting.mockResolvedValueOnce(null);
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(503);
-    expect(mockIngestDirectory).not.toHaveBeenCalled();
+    expect(mockEnqueueIndexJob).not.toHaveBeenCalled();
 
     expect(mockDeferAuditLog).toHaveBeenCalledTimes(1);
     const entry = mockDeferAuditLog.mock.calls[0][0];
@@ -172,8 +210,8 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
     expect(entry.detail.reason).toBe("ollama_not_configured");
   });
 
-  it("returns 500 and audits a failure when ingest throws", async () => {
-    mockIngestDirectory.mockRejectedValueOnce(new Error("disk exploded"));
+  it("returns 500 and audits a failure when enqueueing throws", async () => {
+    mockEnqueueIndexJob.mockRejectedValueOnce(new Error("db exploded"));
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(500);
 
@@ -183,27 +221,23 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
     expect(entry.outcome).toBe("failure");
   });
 
-  it("writes a knowledge.reindex audit row with {id,name} agent ref, counts, and no raw filesystem path/PII", async () => {
-    mockIngestDirectory
-      .mockResolvedValueOnce(ingestResult({ indexed: 2, skipped: 1 }))
-      .mockResolvedValueOnce(ingestResult({ indexed: 3, removed: 1 }));
-
+  it("audits the request with an {id,name} agent ref, the jobId, and no raw filesystem path/PII", async () => {
     const res = await POST(makeRequest(), ctx as never);
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(202);
 
     expect(mockDeferAuditLog).toHaveBeenCalledTimes(1);
     const entry = mockDeferAuditLog.mock.calls[0][0];
     expect(entry.eventType).toBe("knowledge.reindex");
+    expect(entry.actorType).toBe("user");
+    expect(entry.actorId).toBe("admin-1");
     expect(entry.outcome).toBe("success");
     expect(entry.detail.agent).toEqual({ id: "agent-1", name: "Smithers" });
-    expect(entry.detail).toMatchObject({
-      pathCount: 2,
-      indexed: 5,
-      skipped: 1,
-      removed: 1,
-      unsearchable: 0,
-      failed: 0,
-    });
+    expect(entry.detail).toMatchObject({ pathCount: 2, jobId: "job-1" });
+
+    // Counters are absent, not zero: nothing has been counted yet, and zeros
+    // here would record an empty corpus for every reindex ever started.
+    expect(entry.detail.indexed).toBeUndefined();
+    expect(entry.detail.failed).toBeUndefined();
 
     // No full filesystem paths (which can embed usernames) in the audit detail.
     const serialized = JSON.stringify(entry);
@@ -211,25 +245,113 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
     expect(serialized).not.toContain("/data/legal");
     expect(serialized).not.toMatch(/[^\s@]+@[^\s@]+\.[^\s@]+/); // no email-shaped strings
   });
+});
 
-  // The counts are the ONLY thing an admin sees after a reindex, so the two
-  // that mean "this file will never answer a question" have to survive the
-  // trip from ingest to response and audit. Dropping them here would restore
-  // exactly the false "everything indexed" the ingest layer stopped telling.
-  it("reports unsearchable and failed files in both the response and the audit row", async () => {
-    mockIngestDirectory
-      .mockResolvedValueOnce(ingestResult({ indexed: 4, unsearchable: 2 }))
-      .mockResolvedValueOnce(ingestResult({ indexed: 1, skipped: 3, unsearchable: 1, failed: 2 }));
+describe("GET /api/agents/[agentId]/knowledge/reindex", () => {
+  let GET: typeof import("@/app/api/agents/[agentId]/knowledge/reindex/route").GET;
 
-    const res = await POST(makeRequest(), ctx as never);
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ user: { id: "admin-1", role: "admin" } });
+    mockLimit.mockResolvedValue([agentRow]);
+    GET = (await import("@/app/api/agents/[agentId]/knowledge/reindex/route")).GET;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    expect((await GET(makeGetRequest(), ctx as never)).status).toBe(401);
+  });
+
+  it("returns 403 for an authenticated non-admin — index state is admin-only, like the reindex itself", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "user-1", role: "member" } });
+    expect((await GET(makeGetRequest(), ctx as never)).status).toBe(403);
+  });
+
+  it("returns 404 when the agent does not exist", async () => {
+    mockLimit.mockResolvedValueOnce([]);
+    expect((await GET(makeGetRequest(), ctx as never)).status).toBe(404);
+  });
+
+  it("reports no job for an agent that has never been reindexed", async () => {
+    mockGetLatestIndexJobForAgent.mockResolvedValueOnce(null);
+    const res = await GET(makeGetRequest(), ctx as never);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
-      ...ingestResult({ indexed: 5, skipped: 3, unsearchable: 3, failed: 2 }),
-      pathCount: 2,
-    });
+    expect(await res.json()).toEqual({ job: null });
+  });
 
-    const entry = mockDeferAuditLog.mock.calls[0][0];
-    expect(entry.outcome).toBe("success");
-    expect(entry.detail).toMatchObject({ indexed: 5, unsearchable: 3, failed: 2 });
+  it("reports progress while a run is in flight", async () => {
+    mockGetLatestIndexJobForAgent.mockResolvedValueOnce(
+      makeJob({
+        status: "running",
+        processed: 30,
+        total: 42,
+        startedAt: new Date("2026-07-17T10:00:05Z"),
+      })
+    );
+
+    const res = await GET(makeGetRequest(), ctx as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      job: { id: "job-1", status: "running", processed: 30, total: 42, counts: null },
+    });
+  });
+
+  // This endpoint is now the only place an admin sees the counts, so the two
+  // that mean "this file will never answer a question" have to survive the trip
+  // from the worker to here. Dropping them would restore exactly the false
+  // "everything indexed" the ingest counters exist to prevent.
+  it("reports unsearchable and failed files on a finished run", async () => {
+    mockGetLatestIndexJobForAgent.mockResolvedValueOnce(
+      makeJob({
+        status: "succeeded",
+        processed: 9,
+        total: 9,
+        counts: ingestResult({ indexed: 5, skipped: 1, unsearchable: 2, failed: 1 }),
+        finishedAt: new Date("2026-07-17T11:00:00Z"),
+      })
+    );
+
+    const res = await GET(makeGetRequest(), ctx as never);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.job.status).toBe("succeeded");
+    expect(body.job.counts).toEqual(
+      ingestResult({ indexed: 5, skipped: 1, unsearchable: 2, failed: 1 })
+    );
+  });
+
+  it("reports why a failed run failed", async () => {
+    mockGetLatestIndexJobForAgent.mockResolvedValueOnce(
+      makeJob({
+        status: "failed",
+        processed: 3,
+        total: 42,
+        counts: ingestResult({ indexed: 3 }),
+        error: "connect ECONNREFUSED",
+        finishedAt: new Date("2026-07-17T11:00:00Z"),
+      })
+    );
+
+    const res = await GET(makeGetRequest(), ctx as never);
+
+    const body = await res.json();
+    expect(body.job).toMatchObject({ status: "failed", error: "connect ECONNREFUSED" });
+  });
+
+  // Not a PII boundary — the admin granted these folders and can see them in
+  // the permissions UI. The response is a projection of the run's STATE, and
+  // paths are its input; shipping the job row wholesale would also mean
+  // shipping the enqueue-time snapshot, which can disagree with the grants the
+  // admin is looking at right now. Report what the run is doing, nothing else.
+  it("reports the run's state without echoing the job's path snapshot", async () => {
+    mockGetLatestIndexJobForAgent.mockResolvedValueOnce(makeJob({ status: "running" }));
+
+    const res = await GET(makeGetRequest(), ctx as never);
+
+    const serialized = JSON.stringify(await res.json());
+    expect(serialized).not.toContain("/data/hr");
+    expect(serialized).not.toContain("/data/legal");
   });
 });

--- a/packages/web/src/__tests__/api/knowledge-reindex.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-reindex.test.ts
@@ -158,10 +158,22 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
   // Serialized per org by the job store. Rejecting with the blocking job's id
   // is what lets the admin watch the run that is actually happening instead of
   // clicking again into a queue that will never grow.
-  it("returns 409 with the in-flight job when the org is already reindexing", async () => {
+  //
+  // The blocking run can belong to a DIFFERENT agent — one index job per org,
+  // not per agent — and status is only readable per agent. So the 409 has to
+  // name that agent too, or the jobId it hands back points at a run the caller
+  // has no endpoint to look up.
+  it("returns 409 naming the in-flight job AND the agent it belongs to", async () => {
     mockEnqueueIndexJob.mockResolvedValueOnce({
       status: "busy",
-      job: makeJob({ id: "job-running", status: "running", processed: 30, total: 42 }),
+      job: makeJob({
+        id: "job-running",
+        status: "running",
+        processed: 30,
+        total: 42,
+        agentId: "agent-other",
+        agentName: "Legal KB",
+      }),
     });
 
     const res = await POST(makeRequest(), ctx as never);
@@ -171,6 +183,8 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
       error: expect.stringContaining("already"),
       jobId: "job-running",
       status: "running",
+      // Where to go and watch it.
+      agent: { id: "agent-other", name: "Legal KB" },
     });
 
     const entry = mockDeferAuditLog.mock.calls[0][0];

--- a/packages/web/src/__tests__/lib/knowledge/index-jobs.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/index-jobs.integration.test.ts
@@ -140,16 +140,25 @@ describe("kb index job store", () => {
     expect(await claimNextIndexJob()).toBeNull();
   });
 
-  it("records discovery total and per-file progress", async () => {
+  // Progress and findings land in ONE write, because they answer two questions
+  // an operator asks at the same moment: how far along is it, and is it going
+  // well? A run at 7/42 that has already found 5 unsearchable files is a corpus
+  // problem worth seeing now, not after the remaining 35.
+  it("records discovery total, per-file progress, and the findings so far", async () => {
     const agent = await makeAgent();
     await enqueueIndexJob(enqueueArgs(agent.id));
     const job = await claimNextIndexJob();
 
-    await recordIndexJobProgress(job!.id, { processed: 0, total: 42 });
-    await recordIndexJobProgress(job!.id, { processed: 7, total: 42 });
+    await recordIndexJobProgress(job!.id, { processed: 0, total: 42, counts: zeroCounts() });
+    await recordIndexJobProgress(job!.id, {
+      processed: 7,
+      total: 42,
+      counts: { ...zeroCounts(), indexed: 2, unsearchable: 5 },
+    });
 
     const latest = await getLatestIndexJobForAgent(agent.id);
     expect(latest).toMatchObject({ processed: 7, total: 42, status: "running" });
+    expect(latest?.counts).toEqual({ ...zeroCounts(), indexed: 2, unsearchable: 5 });
   });
 
   it("records the findings and the terminal status when a job succeeds", async () => {
@@ -196,17 +205,23 @@ describe("kb index job store", () => {
     const agent = await makeAgent();
     await enqueueIndexJob(enqueueArgs(agent.id));
     const job = await claimNextIndexJob();
-    await recordIndexJobProgress(job!.id, { processed: 30, total: 42 });
+    await recordIndexJobProgress(job!.id, {
+      processed: 30,
+      total: 42,
+      counts: { ...zeroCounts(), indexed: 30 },
+    });
 
     const requeued = await requeueOrphanedIndexJobs();
 
     expect(requeued).toBe(1);
     const latest = await getLatestIndexJobForAgent(agent.id);
     expect(latest?.status).toBe("pending");
-    // Progress resets because discovery re-runs from the top; reporting 30/42
-    // for a run that restarted at zero would be the same "processed ≠ real"
-    // lie the counters exist to prevent.
+    // Progress AND findings reset, because discovery re-runs from the top.
+    // Reporting 30/42 for a run that restarted at zero would be the same
+    // "processed ≠ real" lie the counters exist to prevent — and leaving
+    // `indexed: 30` next to `processed: 0` would be a row contradicting itself.
     expect(latest).toMatchObject({ processed: 0, total: null, startedAt: null });
+    expect(latest?.counts).toBeNull();
     expect(await claimNextIndexJob()).not.toBeNull();
   });
 

--- a/packages/web/src/__tests__/lib/knowledge/index-jobs.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/index-jobs.integration.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The kb_index_jobs store: the queue behind the async reindex (#714).
+ *
+ * Exercised against a real Postgres because the two properties that matter are
+ * enforced by the database, not by application code: only one index job per org
+ * may be active at a time (partial unique index), and a claim is an atomic
+ * conditional UPDATE. Both are invisible to a mocked test.
+ */
+import { beforeEach, describe, it, expect } from "vitest";
+import { db } from "@/db";
+import { agents, kbIndexJobs } from "@/db/schema";
+import {
+  claimNextIndexJob,
+  enqueueIndexJob,
+  finishIndexJob,
+  getLatestIndexJobForAgent,
+  recordIndexJobProgress,
+  requeueOrphanedIndexJobs,
+} from "@/lib/knowledge/index-jobs";
+
+const ORG_ID = "org-index-jobs-test";
+
+async function makeAgent(name = "Smithers") {
+  const [agent] = await db
+    .insert(agents)
+    .values({ name, model: "test-model", greetingMessage: "Hi" })
+    .returning();
+  return agent;
+}
+
+function enqueueArgs(
+  agentId: string,
+  overrides: Partial<Parameters<typeof enqueueIndexJob>[0]> = {}
+) {
+  return {
+    orgId: ORG_ID,
+    agentId,
+    agentName: "Smithers",
+    paths: ["/data/hr"],
+    requestedBy: "admin-1",
+    ...overrides,
+  };
+}
+
+describe("kb index job store", () => {
+  beforeEach(async () => {
+    await db.delete(kbIndexJobs);
+  });
+
+  it("enqueues a pending job carrying the scope the worker needs to run it", async () => {
+    const agent = await makeAgent();
+
+    const result = await enqueueIndexJob(
+      enqueueArgs(agent.id, { paths: ["/data/hr", "/data/legal"] })
+    );
+
+    expect(result.status).toBe("queued");
+    expect(result.job.status).toBe("pending");
+    // The worker never re-derives scope from the agent: paths are resolved (and
+    // permission-narrowed) at enqueue time, so a grant revoked mid-queue can't
+    // widen what a job already in flight indexes.
+    expect(result.job.paths).toEqual(["/data/hr", "/data/legal"]);
+    expect(result.job.requestedBy).toBe("admin-1");
+    expect(result.job.processed).toBe(0);
+    expect(result.job.total).toBeNull();
+    expect(result.job.startedAt).toBeNull();
+  });
+
+  // The index is corpus-wide and embedding is CPU-bound on a 1.5-core
+  // container: two concurrent runs would race on the same (org, content_hash)
+  // rows and thrash the CPU for no gain. Serializing per org is the point of
+  // the partial unique index, and a second enqueue must say so rather than
+  // silently dropping the request or queueing a duplicate.
+  it("refuses a second active job for the org and hands back the one already in flight", async () => {
+    const agentA = await makeAgent("Agent A");
+    const agentB = await makeAgent("Agent B");
+
+    const first = await enqueueIndexJob(enqueueArgs(agentA.id));
+    const second = await enqueueIndexJob(enqueueArgs(agentB.id, { agentName: "Agent B" }));
+
+    expect(second.status).toBe("busy");
+    // The caller gets the blocking job, not a bare rejection — it is the job
+    // they have to wait on, so it is the job they must be able to poll.
+    expect(second.job.id).toBe(first.job.id);
+    expect(second.job.agentId).toBe(agentA.id);
+
+    expect(await db.select().from(kbIndexJobs)).toHaveLength(1);
+  });
+
+  it("blocks a second enqueue while the first is running, not merely while it is pending", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob(enqueueArgs(agent.id));
+    await claimNextIndexJob();
+
+    const second = await enqueueIndexJob(enqueueArgs(agent.id));
+
+    expect(second.status).toBe("busy");
+    expect(second.job.status).toBe("running");
+  });
+
+  it("lets the next job through once the previous one has finished", async () => {
+    const agent = await makeAgent();
+    const first = await enqueueIndexJob(enqueueArgs(agent.id));
+    const claimed = await claimNextIndexJob();
+    await finishIndexJob(claimed!.id, { outcome: "succeeded", counts: zeroCounts() });
+
+    const second = await enqueueIndexJob(enqueueArgs(agent.id));
+
+    expect(second.status).toBe("queued");
+    expect(second.job.id).not.toBe(first.job.id);
+  });
+
+  it("claims a pending job exactly once", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob(enqueueArgs(agent.id));
+
+    const claimed = await claimNextIndexJob();
+    expect(claimed?.status).toBe("running");
+    expect(claimed?.startedAt).toBeInstanceOf(Date);
+
+    // Claimed jobs are not re-claimable: the conditional UPDATE is what stops
+    // an overlapping worker tick from running the same corpus twice.
+    expect(await claimNextIndexJob()).toBeNull();
+  });
+
+  it("claims the oldest pending job first", async () => {
+    const agent = await makeAgent();
+    const first = await enqueueIndexJob(enqueueArgs(agent.id));
+    const claimed = await claimNextIndexJob();
+    await finishIndexJob(claimed!.id, { outcome: "succeeded", counts: zeroCounts() });
+    const second = await enqueueIndexJob(enqueueArgs(agent.id));
+    const finished = await claimNextIndexJob();
+    await finishIndexJob(finished!.id, { outcome: "succeeded", counts: zeroCounts() });
+
+    expect(claimed!.id).toBe(first.job.id);
+    expect(finished!.id).toBe(second.job.id);
+  });
+
+  it("returns null when there is nothing to claim", async () => {
+    expect(await claimNextIndexJob()).toBeNull();
+  });
+
+  it("records discovery total and per-file progress", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob(enqueueArgs(agent.id));
+    const job = await claimNextIndexJob();
+
+    await recordIndexJobProgress(job!.id, { processed: 0, total: 42 });
+    await recordIndexJobProgress(job!.id, { processed: 7, total: 42 });
+
+    const latest = await getLatestIndexJobForAgent(agent.id);
+    expect(latest).toMatchObject({ processed: 7, total: 42, status: "running" });
+  });
+
+  it("records the findings and the terminal status when a job succeeds", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob(enqueueArgs(agent.id));
+    const job = await claimNextIndexJob();
+
+    const counts = { indexed: 4, skipped: 2, removed: 1, unsearchable: 3, failed: 1 };
+    await finishIndexJob(job!.id, { outcome: "succeeded", counts });
+
+    const latest = await getLatestIndexJobForAgent(agent.id);
+    expect(latest?.status).toBe("succeeded");
+    expect(latest?.counts).toEqual(counts);
+    expect(latest?.error).toBeNull();
+    expect(latest?.finishedAt).toBeInstanceOf(Date);
+  });
+
+  // A systemic failure (embedding endpoint down) still processed some files
+  // before it died. Those counts are the operator's only evidence of how far
+  // the run got, so a failure must not throw them away.
+  it("keeps the partial findings when a job fails", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob(enqueueArgs(agent.id));
+    const job = await claimNextIndexJob();
+
+    await finishIndexJob(job!.id, {
+      outcome: "failed",
+      counts: { indexed: 2, skipped: 0, removed: 0, unsearchable: 0, failed: 0 },
+      error: "connect ECONNREFUSED ollama.local:11434",
+    });
+
+    const latest = await getLatestIndexJobForAgent(agent.id);
+    expect(latest?.status).toBe("failed");
+    expect(latest?.counts).toMatchObject({ indexed: 2 });
+    expect(latest?.error).toContain("ECONNREFUSED");
+    expect(latest?.finishedAt).toBeInstanceOf(Date);
+  });
+
+  // Exactly one web container runs the worker, so any job still marked
+  // `running` at boot belongs to a process that no longer exists — nothing
+  // else could be holding it. Ingest is content-hash idempotent, so requeueing
+  // costs a re-discovery and nothing more.
+  it("requeues jobs orphaned by a crash so a restart resumes them", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob(enqueueArgs(agent.id));
+    const job = await claimNextIndexJob();
+    await recordIndexJobProgress(job!.id, { processed: 30, total: 42 });
+
+    const requeued = await requeueOrphanedIndexJobs();
+
+    expect(requeued).toBe(1);
+    const latest = await getLatestIndexJobForAgent(agent.id);
+    expect(latest?.status).toBe("pending");
+    // Progress resets because discovery re-runs from the top; reporting 30/42
+    // for a run that restarted at zero would be the same "processed ≠ real"
+    // lie the counters exist to prevent.
+    expect(latest).toMatchObject({ processed: 0, total: null, startedAt: null });
+    expect(await claimNextIndexJob()).not.toBeNull();
+  });
+
+  it("leaves finished jobs alone when requeueing orphans", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob(enqueueArgs(agent.id));
+    const job = await claimNextIndexJob();
+    await finishIndexJob(job!.id, { outcome: "succeeded", counts: zeroCounts() });
+
+    expect(await requeueOrphanedIndexJobs()).toBe(0);
+    expect((await getLatestIndexJobForAgent(agent.id))?.status).toBe("succeeded");
+  });
+
+  it("reports the most recent job for the agent, and nothing for an agent that never ran one", async () => {
+    const agent = await makeAgent();
+    const other = await makeAgent("Other");
+
+    await enqueueIndexJob(enqueueArgs(agent.id));
+    const first = await claimNextIndexJob();
+    await finishIndexJob(first!.id, { outcome: "succeeded", counts: zeroCounts() });
+    const second = await enqueueIndexJob(enqueueArgs(agent.id));
+
+    expect((await getLatestIndexJobForAgent(agent.id))?.id).toBe(second.job.id);
+    expect(await getLatestIndexJobForAgent(other.id)).toBeNull();
+  });
+});
+
+function zeroCounts() {
+  return { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0 };
+}

--- a/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
@@ -20,6 +20,7 @@ import {
   ingestDirectory,
   ingestPaths,
   type IngestDeps,
+  type IngestProgress,
   type IngestResult,
 } from "@/lib/knowledge/ingest";
 
@@ -447,9 +448,14 @@ it("keeps the last indexed version searchable when a file changes into one that 
 /** Records every onProgress call so a test can assert the SEQUENCE, not just the final number — a bar that jumps 0 → done is not progress. */
 function progressRecorder() {
   const seen: Array<{ processed: number; total: number }> = [];
+  const counts: IngestResult[] = [];
   return {
     seen,
-    onProgress: (p: { processed: number; total: number }) => void seen.push({ ...p }),
+    counts,
+    onProgress: (p: IngestProgress) => {
+      seen.push({ processed: p.processed, total: p.total });
+      counts.push({ ...p.counts });
+    },
   };
 }
 
@@ -536,6 +542,46 @@ it("keeps a shared document when re-ingesting overlapping roots", async () => {
   expect(await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID))).toHaveLength(1);
 });
 
+// A granted folder is usually a bind mount. If it is not ready yet — and the
+// index worker now starts seconds after boot, so that is a live race — stat
+// throws and discovery finds nothing. Treating "I could not look" as "there is
+// nothing there" hands the removal pass an empty set, and scoping it to the
+// root then selects the ENTIRE corpus under that root for deletion. The run
+// reports success, `removed: N`, and the next reindex re-embeds everything.
+it("never removes a root's documents when the root itself could not be read", async () => {
+  const mount = join(tmpRoot, "mount");
+  writePdf(mount, "handbook.pdf");
+  const { deps } = fakeDeps();
+
+  await ingestPaths(ORG_ID, [mount], deps);
+  expect(await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID))).toHaveLength(1);
+
+  // The mount goes away (unmounted, or simply not attached yet).
+  rmSync(mount, { recursive: true, force: true });
+
+  const result = await ingestPaths(ORG_ID, [mount], deps);
+
+  expect(result).toEqual(counts());
+  expect(await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID))).toHaveLength(1);
+});
+
+// The other side of the same coin: a root we CAN read, that is genuinely empty,
+// must still drop what is no longer there. Otherwise deleting a document would
+// never take it out of the index.
+it("removes a root's documents when the root is readable and its files are gone", async () => {
+  const dir = join(tmpRoot, "dir");
+  writePdf(dir, "handbook.pdf");
+  const { deps } = fakeDeps();
+
+  await ingestPaths(ORG_ID, [dir], deps);
+  rmSync(join(dir, "handbook.pdf"));
+
+  const result = await ingestPaths(ORG_ID, [dir], deps);
+
+  expect(result).toEqual(counts({ removed: 1 }));
+  expect(await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID))).toHaveLength(0);
+});
+
 it("still reports a total of zero for roots with nothing to ingest", async () => {
   const { deps } = fakeDeps();
   const { seen, onProgress } = progressRecorder();
@@ -546,6 +592,41 @@ it("still reports a total of zero for roots with nothing to ingest", async () =>
   // Still one report: "0 of 0" is a finished run, and a caller that never hears
   // anything cannot tell that apart from a run that never started.
   expect(seen).toEqual([{ processed: 0, total: 0 }]);
+});
+
+// The tally travels WITH the progress report, because the return value is
+// exactly what a systemic failure destroys. A caller that only reads the return
+// learns nothing about a run that died two thirds of the way through.
+it("reports the running tally alongside progress, so a caller keeps it when the run throws", async () => {
+  writePdf(tmpRoot, "a-good.pdf", "a");
+  writePdf(tmpRoot, "b-good.pdf", "b");
+  writePdf(tmpRoot, "c-outage.pdf", "c");
+  const { deps } = fakeDeps();
+  let embedCalls = 0;
+  (deps.embed as ReturnType<typeof vi.fn>).mockImplementation(async (texts: string[]) => {
+    if (++embedCalls > 2) throw new Error("connect ECONNREFUSED");
+    return texts.map(() => Array(1024).fill(0.01));
+  });
+  const recorder = progressRecorder();
+
+  await expect(
+    ingestPaths(ORG_ID, [tmpRoot], deps, { onProgress: recorder.onProgress })
+  ).rejects.toThrow(/ECONNREFUSED/);
+
+  // The last report before the outage is the honest record: two indexed.
+  expect(recorder.counts.at(-1)).toEqual(counts({ indexed: 2 }));
+  expect(recorder.seen.at(-1)).toEqual({ processed: 2, total: 3 });
+});
+
+it("carries a zeroed tally on the very first report, before anything is counted", async () => {
+  writePdf(tmpRoot, "a.pdf", "a");
+  const { deps } = fakeDeps();
+  const recorder = progressRecorder();
+
+  await ingestPaths(ORG_ID, [tmpRoot], deps, { onProgress: recorder.onProgress });
+
+  expect(recorder.counts[0]).toEqual(counts());
+  expect(recorder.counts.at(-1)).toEqual(counts({ indexed: 1 }));
 });
 
 // A file the run could not read still moved the run forward — progress measures

--- a/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
@@ -16,7 +16,12 @@ import { and, eq } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kbChunks, kbDocuments } from "@/db/schema";
-import { ingestDirectory, type IngestDeps, type IngestResult } from "@/lib/knowledge/ingest";
+import {
+  ingestDirectory,
+  ingestPaths,
+  type IngestDeps,
+  type IngestResult,
+} from "@/lib/knowledge/ingest";
 
 const ORG_ID = "org-kb-ingest-test";
 
@@ -435,4 +440,128 @@ it("keeps the last indexed version searchable when a file changes into one that 
   expect(docsAfter[0].id).toBe(docBefore.id);
   expect(docsAfter[0].contentHash).toBe(docBefore.contentHash);
   expect(await chunksFor(docBefore.id)).toHaveLength(chunksBefore.length);
+});
+
+// ── ingestPaths: many roots, one honest progress total ───────────────────
+
+/** Records every onProgress call so a test can assert the SEQUENCE, not just the final number — a bar that jumps 0 → done is not progress. */
+function progressRecorder() {
+  const seen: Array<{ processed: number; total: number }> = [];
+  return {
+    seen,
+    onProgress: (p: { processed: number; total: number }) => void seen.push({ ...p }),
+  };
+}
+
+function writePdf(dir: string, name: string, bytes = "fake-pdf-bytes") {
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, name);
+  writeFileSync(p, bytes);
+  return p;
+}
+
+it("publishes the discovery total before any file is processed, then counts up to it", async () => {
+  writePdf(tmpRoot, "a.pdf", "a");
+  writePdf(tmpRoot, "b.pdf", "b");
+  const { deps } = fakeDeps();
+  const { seen, onProgress } = progressRecorder();
+
+  const result = await ingestPaths(ORG_ID, [tmpRoot], deps, { onProgress });
+
+  expect(result).toEqual(counts({ indexed: 2 }));
+  // The total is known upfront (discovery walked every root before the first
+  // extract), so the first report already carries it. A total that grew as the
+  // run went would make the bar run backwards.
+  expect(seen).toEqual([
+    { processed: 0, total: 2 },
+    { processed: 1, total: 2 },
+    { processed: 2, total: 2 },
+  ]);
+});
+
+it("counts progress across all roots against one total instead of restarting per root", async () => {
+  const hr = join(tmpRoot, "hr");
+  const legal = join(tmpRoot, "legal");
+  writePdf(hr, "a.pdf", "a");
+  writePdf(legal, "b.pdf", "b");
+  writePdf(legal, "c.pdf", "c");
+  const { deps } = fakeDeps();
+  const { seen, onProgress } = progressRecorder();
+
+  const result = await ingestPaths(ORG_ID, [hr, legal], deps, { onProgress });
+
+  expect(result).toEqual(counts({ indexed: 3 }));
+  expect(seen).toEqual([
+    { processed: 0, total: 3 },
+    { processed: 1, total: 3 },
+    { processed: 2, total: 3 },
+    { processed: 3, total: 3 },
+  ]);
+});
+
+// An admin can grant both a parent and its child (/data and /data/hr) — the
+// permissions UI has no reason to forbid it. Discovery would then find the same
+// file under both roots: counted twice in the total, the bar would stop at 3/4,
+// and the file would be ingested twice (indexed, then skipped) inflating the
+// counts. One file on disk is one unit of work.
+it("counts a file reachable from two overlapping roots exactly once", async () => {
+  const hr = join(tmpRoot, "hr");
+  writePdf(hr, "shared.pdf", "shared");
+  const { deps, extractPdf } = fakeDeps();
+  const { seen, onProgress } = progressRecorder();
+
+  const result = await ingestPaths(ORG_ID, [tmpRoot, hr], deps, { onProgress });
+
+  expect(result).toEqual(counts({ indexed: 1 }));
+  expect(extractPdf).toHaveBeenCalledTimes(1);
+  expect(seen).toEqual([
+    { processed: 0, total: 1 },
+    { processed: 1, total: 1 },
+  ]);
+  expect(await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID))).toHaveLength(1);
+});
+
+// Overlap must not make one root's removal pass delete the other's documents:
+// the passes stay per-root, so a document is only removed when it is gone from
+// the root it lives under.
+it("keeps a shared document when re-ingesting overlapping roots", async () => {
+  const hr = join(tmpRoot, "hr");
+  writePdf(hr, "shared.pdf", "shared");
+  const { deps } = fakeDeps();
+
+  await ingestPaths(ORG_ID, [tmpRoot, hr], deps);
+  const second = await ingestPaths(ORG_ID, [tmpRoot, hr], deps);
+
+  expect(second).toEqual(counts({ skipped: 1 }));
+  expect(await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID))).toHaveLength(1);
+});
+
+it("still reports a total of zero for roots with nothing to ingest", async () => {
+  const { deps } = fakeDeps();
+  const { seen, onProgress } = progressRecorder();
+
+  const result = await ingestPaths(ORG_ID, [join(tmpRoot, "nope")], deps, { onProgress });
+
+  expect(result).toEqual(counts());
+  // Still one report: "0 of 0" is a finished run, and a caller that never hears
+  // anything cannot tell that apart from a run that never started.
+  expect(seen).toEqual([{ processed: 0, total: 0 }]);
+});
+
+// A file the run could not read still moved the run forward — progress measures
+// how much of the corpus is behind us, not how much of it succeeded.
+it("advances progress past a file that failed to extract", async () => {
+  writePdf(tmpRoot, "a-broken.pdf", "broken");
+  writePdf(tmpRoot, "b-good.pdf", "good");
+  const { deps } = fakeDeps();
+  (deps.extractPdf as ReturnType<typeof vi.fn>).mockImplementation(async (p: string) => {
+    if (p.endsWith("a-broken.pdf")) throw new Error("Invalid PDF structure");
+    return [{ page: 1, text: PAGE_1_TEXT }];
+  });
+  const { seen, onProgress } = progressRecorder();
+
+  const result = await ingestPaths(ORG_ID, [tmpRoot], deps, { onProgress });
+
+  expect(result).toEqual(counts({ indexed: 1, failed: 1 }));
+  expect(seen.at(-1)).toEqual({ processed: 2, total: 2 });
 });

--- a/packages/web/src/__tests__/server/kb-index-worker.integration.test.ts
+++ b/packages/web/src/__tests__/server/kb-index-worker.integration.test.ts
@@ -16,7 +16,11 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { agents, auditLog, kbDocuments, kbIndexJobs } from "@/db/schema";
 import { enqueueIndexJob, getLatestIndexJobForAgent } from "@/lib/knowledge/index-jobs";
-import { runNextIndexJob } from "@/server/kb-index-worker";
+import {
+  runNextIndexJob,
+  runKbIndexWorkerTick,
+  _resetKbIndexWorkerForTest,
+} from "@/server/kb-index-worker";
 import type { IngestDeps } from "@/lib/knowledge/ingest";
 
 const ORG_ID = "org-kb-worker-test";
@@ -26,6 +30,7 @@ let tmpRoot: string;
 beforeEach(async () => {
   tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-kb-worker-test-"));
   await db.delete(kbIndexJobs);
+  _resetKbIndexWorkerForTest();
 });
 
 afterEach(() => {
@@ -207,10 +212,10 @@ describe("kb index worker", () => {
     expect(row.outcome).toBe("success");
   });
 
-  // A systemic outage is the job's failure. It must land as one, keep the
-  // partial counts, and — critically — release the org's active-job slot, or
-  // one Ollama blip would wedge the queue until a restart.
-  it("fails the job on a systemic outage, keeps partial counts, and frees the slot", async () => {
+  // A systemic outage is the job's failure. It must land as one and —
+  // critically — release the org's active-job slot, or one Ollama blip would
+  // wedge the queue until a restart.
+  it("fails the job on a systemic outage and frees the slot", async () => {
     const agent = await makeAgent();
     writePdf(tmpRoot, "a.pdf", "a");
     await enqueueIndexJob({
@@ -232,13 +237,6 @@ describe("kb index worker", () => {
     const job = await getLatestIndexJobForAgent(agent.id);
     expect(job?.status).toBe("failed");
     expect(job?.error).toContain("ECONNREFUSED");
-    expect(job?.counts).toEqual({
-      indexed: 0,
-      skipped: 0,
-      removed: 0,
-      unsearchable: 0,
-      failed: 0,
-    });
 
     const [row] = await reindexAuditRows();
     expect(row.outcome).toBe("failure");
@@ -273,6 +271,46 @@ describe("kb index worker", () => {
     expect(job).toMatchObject({ status: "succeeded", processed: 0, total: 0 });
   });
 
+  // The whole reason a failed run keeps counts: a 2000-PDF run that dies at
+  // file 1501 indexed 1500 documents, and "indexed: 0" would be a false report
+  // of an empty corpus on an HMAC-signed audit row. The counts have to come
+  // from what the run actually did before it died, not from the initial value
+  // of a variable the throw skipped past.
+  it("records what a failed run had already indexed, not zeros", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "a-good.pdf", "a");
+    writePdf(tmpRoot, "b-good.pdf", "b");
+    writePdf(tmpRoot, "c-outage.pdf", "c");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    // Two files embed fine; the endpoint dies on the third.
+    const deps = fakeDeps();
+    let embedCalls = 0;
+    deps.embed = async (texts: string[]) => {
+      if (++embedCalls > 2) throw new Error("connect ECONNREFUSED ollama.local:11434");
+      return texts.map(() => Array(1024).fill(0.01));
+    };
+
+    await runNextIndexJob({ deps });
+
+    const job = await getLatestIndexJobForAgent(agent.id);
+    expect(job?.status).toBe("failed");
+    expect(job?.counts).toMatchObject({ indexed: 2 });
+    expect(job?.processed).toBe(2);
+
+    // And the audit row carries the same truth — it is the record that outlives
+    // the job row.
+    const [row] = await reindexAuditRows();
+    expect(row.outcome).toBe("failure");
+    expect(row.detail).toMatchObject({ indexed: 2 });
+  });
+
   // The route's 503 only covers the moment of the request. Between enqueue and
   // run — hours, on a real corpus — the Ollama setting can be cleared, so the
   // worker resolves it itself and fails the job honestly instead of throwing an
@@ -300,5 +338,59 @@ describe("kb index worker", () => {
     const [row] = await reindexAuditRows();
     expect(row.outcome).toBe("failure");
     expect((row.detail as { reason?: string }).reason).toContain("ollama_not_configured");
+  });
+});
+
+describe("kb index worker tick", () => {
+  it("requeues jobs orphaned by a crash before it claims anything", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "handbook.pdf");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+    // A job left `running` by the process that died — nothing else can be
+    // holding it, so this tick has to free it and then run it.
+    await db.update(kbIndexJobs).set({ status: "running", startedAt: new Date() });
+
+    await runKbIndexWorkerTick({ deps: fakeDeps() });
+
+    expect(await getLatestIndexJobForAgent(agent.id)).toMatchObject({ status: "succeeded" });
+  });
+
+  // Requeueing is a BOOT act: it is only sound because a `running` job at
+  // startup belongs to a process that no longer exists. Repeat it on a later
+  // tick and that premise is false — the `running` job it finds is the one this
+  // process is working on right now, and resetting it flips a live run to
+  // `pending`, blanks its total, and makes every status read lie for hours.
+  it("never requeues again once it is running, so it cannot reset a live job", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "handbook.pdf");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    await runKbIndexWorkerTick({ deps: fakeDeps() });
+
+    // Stand in for a job this process has claimed and is embedding right now.
+    const startedAt = new Date();
+    await db
+      .update(kbIndexJobs)
+      .set({ status: "running", startedAt, processed: 30, total: 42, finishedAt: null });
+
+    await runKbIndexWorkerTick({ deps: fakeDeps() });
+
+    const job = await getLatestIndexJobForAgent(agent.id);
+    expect(job?.status).toBe("running");
+    expect(job?.processed).toBe(30);
+    expect(job?.total).toBe(42);
+    expect(job?.startedAt).toEqual(startedAt);
   });
 });

--- a/packages/web/src/__tests__/server/kb-index-worker.integration.test.ts
+++ b/packages/web/src/__tests__/server/kb-index-worker.integration.test.ts
@@ -1,0 +1,304 @@
+/**
+ * The knowledge-base index worker: claims a kb_index_jobs row, runs the ingest
+ * against the job's snapshotted paths, and records what happened (#714).
+ *
+ * Against a real Postgres, because everything worth asserting here is a
+ * transition of a real row — claimed, progressed, finished — plus the audit
+ * entry that outlives the run. Ingest itself is dependency-injected (fake
+ * embedder + extractor), so no Ollama and no real PDFs.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { agents, auditLog, kbDocuments, kbIndexJobs } from "@/db/schema";
+import { enqueueIndexJob, getLatestIndexJobForAgent } from "@/lib/knowledge/index-jobs";
+import { runNextIndexJob } from "@/server/kb-index-worker";
+import type { IngestDeps } from "@/lib/knowledge/ingest";
+
+const ORG_ID = "org-kb-worker-test";
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-kb-worker-test-"));
+  await db.delete(kbIndexJobs);
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function fakeDeps(): IngestDeps {
+  return {
+    embed: vi.fn(async (texts: string[]) => texts.map(() => Array(1024).fill(0.01))),
+    extractPdf: vi.fn(async () => [
+      { page: 1, text: "Onboarding starts on day one and every hire receives a laptop." },
+    ]),
+  };
+}
+
+async function makeAgent(name = "Smithers") {
+  const [agent] = await db
+    .insert(agents)
+    .values({ name, model: "test-model", greetingMessage: "Hi" })
+    .returning();
+  return agent;
+}
+
+function writePdf(dir: string, name: string, bytes = "fake-pdf-bytes") {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), bytes);
+}
+
+async function reindexAuditRows() {
+  return db.select().from(auditLog).where(eq(auditLog.eventType, "knowledge.reindex"));
+}
+
+describe("kb index worker", () => {
+  it("does nothing and reports nothing when the queue is empty", async () => {
+    expect(await runNextIndexJob({ deps: fakeDeps() })).toBeNull();
+    expect(await reindexAuditRows()).toHaveLength(0);
+  });
+
+  it("runs a queued job against its snapshotted paths and records the findings", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "handbook.pdf");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    const ran = await runNextIndexJob({ deps: fakeDeps() });
+
+    expect(ran?.status).toBe("succeeded");
+    const job = await getLatestIndexJobForAgent(agent.id);
+    expect(job).toMatchObject({ status: "succeeded", processed: 1, total: 1 });
+    expect(job?.counts).toEqual({
+      indexed: 1,
+      skipped: 0,
+      removed: 0,
+      unsearchable: 0,
+      failed: 0,
+    });
+    expect(job?.finishedAt).toBeInstanceOf(Date);
+
+    const docs = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+    expect(docs).toHaveLength(1);
+  });
+
+  // The run lands hours after the request, in a context with no request behind
+  // it, so it has to audit itself. Correlated to the admin's row by jobId — the
+  // same reason GC sweeps carry a sweepId.
+  it("audits the outcome as the system, correlated to the job", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "handbook.pdf");
+    const { job } = await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    await runNextIndexJob({ deps: fakeDeps() });
+
+    const rows = await reindexAuditRows();
+    expect(rows).toHaveLength(1);
+    const [row] = rows;
+    expect(row.actorType).toBe("system");
+    expect(row.outcome).toBe("success");
+    expect(row.resource).toBe(`agent:${agent.id}`);
+    const detail = row.detail as Record<string, unknown>;
+    expect(detail.jobId).toBe(job.id);
+    expect(detail.agent).toEqual({ id: agent.id, name: "Smithers" });
+    expect(detail).toMatchObject({ indexed: 1, unsearchable: 0, failed: 0, pathCount: 1 });
+
+    // The granted folder is a real filesystem path and can embed a username.
+    expect(JSON.stringify(row.detail)).not.toContain(tmpRoot);
+  });
+
+  // A renamed or deleted agent must not cost us the name on the audit row: the
+  // job snapshotted it at enqueue precisely so the outcome row can still say
+  // who it was for.
+  it("audits under the agent name as it was when the reindex was requested", async () => {
+    const agent = await makeAgent("Old Name");
+    writePdf(tmpRoot, "handbook.pdf");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: "Old Name",
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+    await db.update(agents).set({ name: "New Name" }).where(eq(agents.id, agent.id));
+
+    await runNextIndexJob({ deps: fakeDeps() });
+
+    const [row] = await reindexAuditRows();
+    expect((row.detail as { agent: unknown }).agent).toEqual({ id: agent.id, name: "Old Name" });
+  });
+
+  it("publishes progress as it goes, not only at the end", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "a.pdf", "a");
+    writePdf(tmpRoot, "b.pdf", "b");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    // Observed mid-run: a progress column only written at the end is a
+    // completion flag with extra steps, and the whole point of the job is that
+    // an admin can watch a multi-hour run advance.
+    const seen: Array<{ processed: number; total: number | null }> = [];
+    const deps = fakeDeps();
+    const realExtract = deps.extractPdf;
+    deps.extractPdf = async (p: string) => {
+      const [row] = await db.select().from(kbIndexJobs).limit(1);
+      seen.push({ processed: row.processed, total: row.total });
+      return realExtract(p);
+    };
+
+    await runNextIndexJob({ deps });
+
+    expect(seen).toEqual([
+      { processed: 0, total: 2 },
+      { processed: 1, total: 2 },
+    ]);
+    expect(await getLatestIndexJobForAgent(agent.id)).toMatchObject({ processed: 2, total: 2 });
+  });
+
+  // A corrupt file is the job's finding, not the job's failure: the run did
+  // what it was asked to and the rest of the corpus is indexed.
+  it("succeeds with a failed-file count when only individual files are broken", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "a-broken.pdf", "broken");
+    writePdf(tmpRoot, "b-good.pdf", "good");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    const deps = fakeDeps();
+    deps.extractPdf = async (p: string) => {
+      if (p.endsWith("a-broken.pdf")) throw new Error("Invalid PDF structure");
+      return [{ page: 1, text: "Onboarding starts on day one for every new hire." }];
+    };
+
+    await runNextIndexJob({ deps });
+
+    const job = await getLatestIndexJobForAgent(agent.id);
+    expect(job?.status).toBe("succeeded");
+    expect(job?.counts).toMatchObject({ indexed: 1, failed: 1 });
+    const [row] = await reindexAuditRows();
+    expect(row.outcome).toBe("success");
+  });
+
+  // A systemic outage is the job's failure. It must land as one, keep the
+  // partial counts, and — critically — release the org's active-job slot, or
+  // one Ollama blip would wedge the queue until a restart.
+  it("fails the job on a systemic outage, keeps partial counts, and frees the slot", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "a.pdf", "a");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    const deps = fakeDeps();
+    deps.embed = async () => {
+      throw new Error("connect ECONNREFUSED ollama.local:11434");
+    };
+
+    const ran = await runNextIndexJob({ deps });
+
+    expect(ran?.status).toBe("failed");
+    const job = await getLatestIndexJobForAgent(agent.id);
+    expect(job?.status).toBe("failed");
+    expect(job?.error).toContain("ECONNREFUSED");
+    expect(job?.counts).toEqual({
+      indexed: 0,
+      skipped: 0,
+      removed: 0,
+      unsearchable: 0,
+      failed: 0,
+    });
+
+    const [row] = await reindexAuditRows();
+    expect(row.outcome).toBe("failure");
+    expect((row.detail as { reason?: string }).reason).toBeTruthy();
+
+    // The slot is free: the next enqueue is accepted rather than told "busy".
+    const next = await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+    expect(next.status).toBe("queued");
+  });
+
+  // A granted folder can be empty, or gone by the time the job runs. That is a
+  // finished job reporting 0/0, not a stuck one.
+  it("finishes a job whose folders hold nothing to index", async () => {
+    const agent = await makeAgent();
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [join(tmpRoot, "empty")],
+    });
+
+    await runNextIndexJob({ deps: fakeDeps() });
+
+    const job = await getLatestIndexJobForAgent(agent.id);
+    expect(job).toMatchObject({ status: "succeeded", processed: 0, total: 0 });
+  });
+
+  // The route's 503 only covers the moment of the request. Between enqueue and
+  // run — hours, on a real corpus — the Ollama setting can be cleared, so the
+  // worker resolves it itself and fails the job honestly instead of throwing an
+  // opaque error into the interval.
+  it("fails the job when the embedding endpoint is not configured at run time", async () => {
+    const agent = await makeAgent();
+    writePdf(tmpRoot, "handbook.pdf");
+    await enqueueIndexJob({
+      orgId: ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: "admin-1",
+      paths: [tmpRoot],
+    });
+
+    // No deps injected and no Ollama setting seeded: the production resolution
+    // path runs and finds nothing.
+    const ran = await runNextIndexJob();
+
+    expect(ran?.status).toBe("failed");
+    const job = await getLatestIndexJobForAgent(agent.id);
+    expect(job?.status).toBe("failed");
+    expect(job?.error).toContain("ollama_not_configured");
+
+    const [row] = await reindexAuditRows();
+    expect(row.outcome).toBe("failure");
+    expect((row.detail as { reason?: string }).reason).toContain("ollama_not_configured");
+  });
+});

--- a/packages/web/src/__tests__/server/shutdown-steps.test.ts
+++ b/packages/web/src/__tests__/server/shutdown-steps.test.ts
@@ -11,6 +11,16 @@ function makeFakeClient(readyState: number) {
   return { readyState, close: vi.fn() };
 }
 
+// 0-based positions in the array buildShutdownSteps returns. The steps before
+// these are the stop*() calls, which the order test below covers by name;
+// these four have no `calls` entry of their own, so they are driven by index.
+// Named here so inserting a step is one edit rather than a hunt for magic
+// numbers.
+const STEP_OPENCLAW_DISCONNECT = 6;
+const STEP_WS_DRAIN = 7;
+const STEP_CLOSE_HTTP_SERVER = 8;
+const STEP_CLOSE_DB = 9;
+
 function makeDeps(overrides: Partial<ShutdownDeps> = {}, calls: string[] = []): ShutdownDeps {
   const wssClose = vi.fn((cb: () => void) => cb());
   return {
@@ -22,6 +32,9 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}, calls: string[] = []): 
     }),
     stopAuditVerifyJob: vi.fn(async () => {
       calls.push("stopAuditVerifyJob");
+    }),
+    stopKbIndexWorker: vi.fn(async () => {
+      calls.push("stopKbIndexWorker");
     }),
     stopUsagePoller: vi.fn(async () => {
       calls.push("stopUsagePoller");
@@ -45,12 +58,12 @@ function makeDeps(overrides: Partial<ShutdownDeps> = {}, calls: string[] = []): 
 }
 
 describe("buildShutdownSteps (#263)", () => {
-  it("returns exactly 9 steps in the documented order", async () => {
+  it("returns exactly 10 steps in the documented order", async () => {
     const calls: string[] = [];
     const deps = makeDeps({}, calls);
     const steps = buildShutdownSteps(deps);
 
-    expect(steps).toHaveLength(9);
+    expect(steps).toHaveLength(10);
 
     for (const step of steps) {
       await step();
@@ -60,6 +73,7 @@ describe("buildShutdownSteps (#263)", () => {
       "stopUploadGc",
       "stopChatErrorGc",
       "stopAuditVerifyJob",
+      "stopKbIndexWorker",
       "stopUsagePoller",
       "stopMemoryAuditWatcher",
       // disconnect + WS drain + closeHttpServer produce no `calls` entry by
@@ -107,8 +121,7 @@ describe("buildShutdownSteps (#263)", () => {
       const deps = makeDeps({ getOpenclawClient: vi.fn(() => client) });
       const steps = buildShutdownSteps(deps);
 
-      // Step index 5 (0-based) is the OpenClaw disconnect step.
-      await steps[5]();
+      await steps[STEP_OPENCLAW_DISCONNECT]();
 
       expect(client.disconnect).toHaveBeenCalledTimes(1);
     });
@@ -117,7 +130,7 @@ describe("buildShutdownSteps (#263)", () => {
       const deps = makeDeps({ getOpenclawClient: vi.fn(() => null) });
       const steps = buildShutdownSteps(deps);
 
-      await expect(steps[5]()).resolves.toBeUndefined();
+      await expect(steps[STEP_OPENCLAW_DISCONNECT]()).resolves.toBeUndefined();
     });
   });
 
@@ -136,8 +149,7 @@ describe("buildShutdownSteps (#263)", () => {
       });
       const steps = buildShutdownSteps(deps);
 
-      // Step index 6 (0-based) is the WS-drain step.
-      await steps[6]();
+      await steps[STEP_WS_DRAIN]();
 
       expect(openClient.close).toHaveBeenCalledWith(1001, "server shutting down");
       expect(closedClient.close).not.toHaveBeenCalled();
@@ -153,7 +165,7 @@ describe("buildShutdownSteps (#263)", () => {
         setTimeout(() => reject(new Error("WS drain step hung")), 500)
       );
 
-      await expect(Promise.race([steps[6](), timeout])).resolves.toBeUndefined();
+      await expect(Promise.race([steps[STEP_WS_DRAIN](), timeout])).resolves.toBeUndefined();
     });
   });
 
@@ -162,8 +174,7 @@ describe("buildShutdownSteps (#263)", () => {
       const deps = makeDeps();
       const steps = buildShutdownSteps(deps);
 
-      // Step index 7 (0-based) closes the HTTP server.
-      await steps[7]();
+      await steps[STEP_CLOSE_HTTP_SERVER]();
 
       expect(deps.closeHttpServer).toHaveBeenCalledTimes(1);
     });
@@ -172,8 +183,7 @@ describe("buildShutdownSteps (#263)", () => {
       const deps = makeDeps();
       const steps = buildShutdownSteps(deps);
 
-      // Step index 8 (0-based) closes the DB pool.
-      await steps[8]();
+      await steps[STEP_CLOSE_DB]();
 
       expect(deps.closeDb).toHaveBeenCalledTimes(1);
     });

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
@@ -6,104 +6,52 @@ import { parseRequestBody } from "@/lib/api-validation";
 import { knowledgeReindexSchema } from "@/lib/schemas/knowledge-base";
 import { db } from "@/db";
 import { activeAgents, type AgentPluginConfig } from "@/db/schema";
-import { ingestDirectory, type IngestDeps, type IngestResult } from "@/lib/knowledge/ingest";
-import { embedTexts } from "@/lib/knowledge/embeddings";
-import { extractPdfPages } from "@/lib/knowledge/pdf-extract";
-import { DEFAULT_ORG_ID, EMBEDDING_MODEL, EMBEDDING_DIMENSIONS } from "@/lib/knowledge/constants";
+import { enqueueIndexJob, getLatestIndexJobForAgent } from "@/lib/knowledge/index-jobs";
+import { reindexAuditEntry } from "@/lib/knowledge/reindex-audit";
+import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
 import { getSetting } from "@/lib/settings";
 import { PROVIDERS } from "@/lib/providers";
 import { deferAuditLog } from "@/lib/audit-deferred";
-import { safeProviderError, type AuditLogEntry, type EntityRef } from "@/lib/audit";
+import { safeProviderError, type EntityRef } from "@/lib/audit";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
-/** The all-zero result: what a reindex with nothing to do reports. */
-const ZERO_COUNTS: IngestResult = {
-  indexed: 0,
-  skipped: 0,
-  removed: 0,
-  unsearchable: 0,
-  failed: 0,
-};
+/** The agent, or null if it does not exist / is deleted. */
+async function findAgent(agentId: string) {
+  const [agent] = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId)).limit(1);
+  return agent ?? null;
+}
 
 /**
- * Sums the per-root ingest results into the totals the response and the audit
- * row report. Written out field by field on purpose: a counter added to
- * IngestResult then fails to compile here until it is summed, so a new counter
- * cannot silently drop out of the only numbers an admin ever sees.
+ * The agent's granted knowledge-base folders, optionally narrowed to a
+ * requested subset. A requested path outside the allowlist is dropped, so the
+ * body can only ever narrow the granted set — never widen it to index an
+ * arbitrary host directory.
  */
-function totalCounts(results: IngestResult[]): IngestResult {
-  return results.reduce<IngestResult>(
-    (total, result) => ({
-      indexed: total.indexed + result.indexed,
-      skipped: total.skipped + result.skipped,
-      removed: total.removed + result.removed,
-      unsearchable: total.unsearchable + result.unsearchable,
-      failed: total.failed + result.failed,
-    }),
-    ZERO_COUNTS
-  );
-}
-
-// Builds (but does not send) the knowledge.reindex audit entry — a pure
-// function so every branch shares the same detail shape. Callers pass this
-// straight to deferAuditLog(); the eslint pinchy/require-audit-log rule checks
-// the handler body's source text for a literal deferAuditLog(...) call, so the
-// send stays inline at each call site rather than behind a second indirection.
-function reindexAuditEntry(args: {
-  agent: EntityRef;
-  actorId: string;
-  outcome: "success" | "failure";
-  pathCount: number;
-  counts: IngestResult;
-  reason?: string;
-}): AuditLogEntry {
-  return {
-    actorType: "user",
-    actorId: args.actorId,
-    eventType: "knowledge.reindex",
-    resource: `agent:${args.agent.id}`,
-    outcome: args.outcome,
-    detail: {
-      agent: args.agent,
-      // Listed one by one rather than spread from `counts`: a spread would
-      // copy whatever IngestResult grows into straight onto an HMAC-signed
-      // row, and the obvious next counter to want is a list of the paths that
-      // failed — precisely the filesystem paths this detail must never carry
-      // (AGENTS.md PII rule; see `pathCount` above). Adding a counter here has
-      // to stay a decision, not a side effect.
-      pathCount: args.pathCount,
-      indexed: args.counts.indexed,
-      skipped: args.counts.skipped,
-      removed: args.counts.removed,
-      unsearchable: args.counts.unsearchable,
-      failed: args.counts.failed,
-      ...(args.reason !== undefined ? { reason: args.reason } : {}),
-    },
-  };
+function resolveTargetPaths(agent: { pluginConfig: unknown }, requested?: string[]): string[] {
+  const granted =
+    (agent.pluginConfig as AgentPluginConfig | null)?.["pinchy-files"]?.allowed_paths ?? [];
+  return requested ? requested.filter((p) => granted.includes(p)) : granted;
 }
 
 /**
- * POST /api/agents/[agentId]/knowledge/reindex — admin-only manual trigger to
+ * POST /api/agents/[agentId]/knowledge/reindex — admin-only trigger to
  * (re)ingest an agent's granted knowledge-base folders into the corpus-wide
- * index. This is the minimal manual trigger (MVP); a scheduled sweep + progress
- * UI is Phase 2.
+ * index.
+ *
+ * Enqueues; it does not index. A realistic corpus (~2k PDFs) is 1.5-7h of
+ * CPU-only embedding, so the work belongs to the background worker
+ * (src/server/kb-index-worker.ts) and this route hands back a job id to poll
+ * via GET on the same path (#714).
  *
  * Access boundary: admin-only (`withAdmin`) — index management is an admin
- * action. The set of folders reindexed is resolved from the SAME source the
- * search route scopes retrieval by: the agent's admin-configured `pinchy-files`
- * `allowed_paths`. An optional `paths` body can narrow to a subset but can
- * NEVER widen past the granted set (any path not granted is dropped), so the
- * body can't be used to index arbitrary host directories.
+ * action. The folders reindexed are resolved from the SAME source the search
+ * route scopes retrieval by: the agent's admin-configured `pinchy-files`
+ * `allowed_paths`.
  *
- * Sync execution is fine for the MVP (the sample corpus is small). A
- * large-corpus reindex needs async execution + progress reporting — that's
- * Phase 2 (see the implementation plan); do NOT block a request on a
- * multi-minute ingest in production.
- *
- * The response and audit row report every ingest counter, `unsearchable` and
- * `failed` included: these are the numbers an admin trusts the corpus by, so
- * "indexed" must keep meaning "findable" rather than merely "processed".
+ * Both the resolved paths and the agent's name are snapshotted onto the job:
+ * the worker must index what was authorized at the moment of the request, and
+ * must be able to name the agent on its outcome row hours later.
  */
 export const POST = withAdmin<RouteContext>(async (request, { params }, session) => {
   const { agentId } = await params;
@@ -111,50 +59,46 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
 
   const parsed = await parseRequestBody(knowledgeReindexSchema, request);
   if ("error" in parsed) return parsed.error;
-  const requestedPaths = parsed.data.paths;
 
-  const [agent] = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId)).limit(1);
+  const agent = await findAgent(agentId);
   if (!agent) {
     return NextResponse.json({ error: "Agent not found" }, { status: 404 });
   }
 
   const agentRef: EntityRef = { id: agent.id, name: agent.name };
-  const grantedPaths =
-    (agent.pluginConfig as AgentPluginConfig | null)?.["pinchy-files"]?.allowed_paths ?? [];
-
-  // A requested subset can only ever narrow the granted set — never widen it.
-  // Any requested path outside the agent's allowlist is silently dropped.
-  const targetPaths = requestedPaths
-    ? requestedPaths.filter((p) => grantedPaths.includes(p))
-    : grantedPaths;
+  const targetPaths = resolveTargetPaths(agent, parsed.data.paths);
 
   // Nothing granted (or nothing left after narrowing) — an honest no-op, not an
-  // error. Still audited so the action is on the record.
+  // error and not a job: there is no work to watch. Still audited so the action
+  // is on the record.
   if (targetPaths.length === 0) {
     deferAuditLog(
       reindexAuditEntry({
-        agent: agentRef,
+        actorType: "user",
         actorId,
+        agent: agentRef,
         outcome: "success",
         pathCount: 0,
-        counts: ZERO_COUNTS,
       })
     );
-    return NextResponse.json({ ...ZERO_COUNTS, pathCount: 0 });
+    return NextResponse.json({ jobId: null, status: "noop", pathCount: 0 });
   }
 
   // The embedding model is fixed (bge-m3) but still needs a reachable Ollama
   // base URL — the same admin-configured "Ollama (Local)" provider setting the
-  // search route and the chat/vision path already resolve.
+  // search route and the chat/vision path already resolve. Checked here as well
+  // as in the worker: queueing a job that can only fail, and saying so hours
+  // later, is worse than saying it now. The worker re-checks because the
+  // setting can change while a job waits.
   const ollamaBaseUrl = await getSetting(PROVIDERS["ollama-local"].settingsKey);
   if (!ollamaBaseUrl) {
     deferAuditLog(
       reindexAuditEntry({
-        agent: agentRef,
+        actorType: "user",
         actorId,
+        agent: agentRef,
         outcome: "failure",
         pathCount: targetPaths.length,
-        counts: ZERO_COUNTS,
         reason: "ollama_not_configured",
       })
     );
@@ -164,54 +108,116 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
     );
   }
 
-  const deps: IngestDeps = {
-    embed: (texts) =>
-      embedTexts(texts, {
-        baseUrl: ollamaBaseUrl,
-        model: EMBEDDING_MODEL,
-        expectedDim: EMBEDDING_DIMENSIONS,
-      }),
-    extractPdf: extractPdfPages,
-  };
-
-  // Collected per root so a throw partway through still audits the roots that
-  // did finish. Ingest handles a single unreadable file on its own (counting
-  // it as `failed`), so reaching this catch means something systemic — the
-  // embedding endpoint or the database — took the run down.
-  const results: IngestResult[] = [];
+  let enqueued;
   try {
-    for (const path of targetPaths) {
-      results.push(await ingestDirectory(DEFAULT_ORG_ID, path, deps));
-    }
+    enqueued = await enqueueIndexJob({
+      orgId: DEFAULT_ORG_ID,
+      agentId: agent.id,
+      agentName: agent.name,
+      requestedBy: actorId,
+      paths: targetPaths,
+    });
   } catch (err) {
     // safeProviderError scrubs emails + caps length; the underlying error could
     // echo a filesystem path, which this HMAC-signed audit row must not carry.
     deferAuditLog(
       reindexAuditEntry({
-        agent: agentRef,
+        actorType: "user",
         actorId,
+        agent: agentRef,
         outcome: "failure",
         pathCount: targetPaths.length,
-        counts: totalCounts(results),
-        reason: safeProviderError(err instanceof Error ? err.message : "reindex_failed"),
+        reason: safeProviderError(err instanceof Error ? err.message : "enqueue_failed"),
       })
     );
-    return NextResponse.json({ error: "Knowledge base reindex failed" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Knowledge base reindex could not be queued" },
+      { status: 500 }
+    );
   }
 
-  // Success covers `unsearchable`/`failed` files too: the reindex itself did
-  // its job, and those counts are a finding about the corpus, not a failure of
-  // the action. Burying them would be the failure.
-  const counts = totalCounts(results);
+  // One index run per org at a time (the index is corpus-wide and embedding is
+  // CPU-bound). Answering 409 WITH the blocking job's id — rather than a bare
+  // rejection — is what lets the admin watch the run that is actually
+  // happening instead of clicking again into a queue that will never grow.
+  if (enqueued.status === "busy") {
+    deferAuditLog(
+      reindexAuditEntry({
+        actorType: "user",
+        actorId,
+        agent: agentRef,
+        outcome: "failure",
+        pathCount: targetPaths.length,
+        jobId: enqueued.job.id,
+        reason: "index_job_already_running",
+      })
+    );
+    return NextResponse.json(
+      {
+        error: "A knowledge base reindex is already running",
+        jobId: enqueued.job.id,
+        status: enqueued.job.status,
+      },
+      { status: 409 }
+    );
+  }
+
   deferAuditLog(
     reindexAuditEntry({
-      agent: agentRef,
+      actorType: "user",
       actorId,
+      agent: agentRef,
       outcome: "success",
       pathCount: targetPaths.length,
-      counts,
+      jobId: enqueued.job.id,
     })
   );
 
-  return NextResponse.json({ ...counts, pathCount: targetPaths.length });
+  // 202, not 200: the reindex has been accepted, not performed. The outcome —
+  // and the counts — arrive via GET (and a `knowledge.reindex` audit row from
+  // the worker).
+  return NextResponse.json(
+    { jobId: enqueued.job.id, status: enqueued.job.status, pathCount: targetPaths.length },
+    { status: 202 }
+  );
+});
+
+/**
+ * GET /api/agents/[agentId]/knowledge/reindex — the agent's most recent index
+ * run: in flight or last finished.
+ *
+ * A projection of the job's state, not the job row: the enqueue-time `paths`
+ * snapshot is the run's input, which the admin already owns in the permissions
+ * UI and which can disagree with the grants they are looking at now.
+ *
+ * Admin-only, like the reindex it reports on.
+ */
+// audit-exempt: read-only status projection, no state change.
+export const GET = withAdmin<RouteContext>(async (_request, { params }) => {
+  const { agentId } = await params;
+
+  const agent = await findAgent(agentId);
+  if (!agent) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  const job = await getLatestIndexJobForAgent(agentId);
+  if (!job) return NextResponse.json({ job: null });
+
+  return NextResponse.json({
+    job: {
+      id: job.id,
+      status: job.status,
+      /** Documents behind the run, and how many discovery found. `total` is null until discovery has walked every root. */
+      processed: job.processed,
+      total: job.total,
+      /** The run's findings; null until it finishes. `unsearchable` and `failed` are the counters that say a document will never answer a question. */
+      counts: job.counts,
+      /** Scrubbed failure summary; null unless the run failed systemically. */
+      error: job.error,
+      createdAt: job.createdAt,
+      startedAt: job.startedAt,
+      finishedAt: job.finishedAt,
+    },
+  });
 });

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
@@ -137,10 +137,16 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
   }
 
   // One index run per org at a time (the index is corpus-wide and embedding is
-  // CPU-bound). Answering 409 WITH the blocking job's id — rather than a bare
+  // CPU-bound). Answering 409 WITH the blocking job — rather than a bare
   // rejection — is what lets the admin watch the run that is actually
   // happening instead of clicking again into a queue that will never grow.
+  //
+  // That run may belong to a DIFFERENT agent, since the limit is per org while
+  // status is only readable per agent. So the response names the blocking
+  // agent as well: a jobId whose status endpoint the caller can't find is not
+  // an answer, it's a riddle.
   if (enqueued.status === "busy") {
+    const blocking: EntityRef = { id: enqueued.job.agentId, name: enqueued.job.agentName };
     deferAuditLog(
       reindexAuditEntry({
         actorType: "user",
@@ -157,6 +163,7 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
         error: "A knowledge base reindex is already running",
         jobId: enqueued.job.id,
         status: enqueued.job.status,
+        agent: blocking,
       },
       { status: 409 }
     );

--- a/packages/web/src/db/enums.ts
+++ b/packages/web/src/db/enums.ts
@@ -62,3 +62,15 @@ export type ProcessedEmailStatus = (typeof PROCESSED_EMAIL_STATUSES)[number];
 // callers can't write an out-of-domain status.
 export const NOTIFICATION_STATUSES = ["success", "failure"] as const;
 export type NotificationStatus = (typeof NOTIFICATION_STATUSES)[number];
+
+// Knowledge-base async reindex (#714). Lifecycle of one kb_index_jobs row.
+// `pending` and `running` are the ACTIVE states: the partial unique index in
+// schema.ts is defined over exactly this pair, so adding a state here without
+// deciding whether it blocks a new enqueue would silently change how many
+// index runs an org can have in flight. Enforced at the DB with a CHECK
+// constraint so the worker and the route can't write an out-of-domain status.
+export const KB_INDEX_JOB_STATUSES = ["pending", "running", "succeeded", "failed"] as const;
+export type KbIndexJobStatus = (typeof KB_INDEX_JOB_STATUSES)[number];
+
+/** The states in which a job still owns the org's index — see the partial unique index `uq_kb_index_jobs_active`. */
+export const KB_INDEX_JOB_ACTIVE_STATUSES = ["pending", "running"] as const;

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -36,8 +36,12 @@ import {
   type ProcessedEmailStatus,
   NOTIFICATION_STATUSES,
   type NotificationStatus,
+  KB_INDEX_JOB_STATUSES,
+  KB_INDEX_JOB_ACTIVE_STATUSES,
+  type KbIndexJobStatus,
 } from "./enums";
 import type { EmailWorkflowFilter, ProcessedEmailOutcome } from "@/lib/email-workflows/types";
+import type { IngestResult } from "@/lib/knowledge/ingest";
 import { vector } from "./vector";
 
 // Render `IN ('a', 'b')` from an enum const (db/enums.ts) so a CHECK constraint
@@ -921,5 +925,62 @@ export const kbChunks = pgTable(
   (t) => [
     index("idx_kb_chunks_doc").on(t.documentId),
     index("idx_kb_chunks_org_path").on(t.orgId, t.sourcePath),
+  ]
+);
+
+// kb_index_jobs is the queue behind the async reindex (#714): the admin route
+// enqueues a row, an in-process worker (src/server/kb-index-worker.ts) claims
+// and runs it. Deliberately a plain table, not a queue engine — ingest is
+// content-hash idempotent, so a crashed run recovers by re-running, which is
+// the only guarantee a queue would have bought us.
+//
+// `paths` is a SNAPSHOT of the agent's granted folders resolved at enqueue
+// time, not a pointer to them: the worker must index what was authorized when
+// the admin asked, and re-reading the grants at run time would let a permission
+// change silently widen a job already in flight.
+export const kbIndexJobs = pgTable(
+  "kb_index_jobs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: text("org_id").notNull(),
+    agentId: text("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    // Snapshotted beside the id so the completion audit row can carry the
+    // {id, name} pair (AGENTS.md) without re-querying an agent that may have
+    // been renamed or deleted while the job ran.
+    agentName: text("agent_name").notNull(),
+    requestedBy: text("requested_by").notNull(),
+    paths: jsonb("paths").$type<string[]>().notNull(),
+    status: text("status").$type<KbIndexJobStatus>().notNull().default("pending"),
+    // Progress, in documents. `total` stays null until discovery has walked
+    // every root — a total that grew as we went would make the progress bar
+    // run backwards, so it is written once, upfront.
+    total: integer("total"),
+    processed: integer("processed").notNull().default(0),
+    // The ingest's findings (IngestResult), written when the job reaches a
+    // terminal state — on failure too, since partial counts are the operator's
+    // only evidence of how far the run got.
+    counts: jsonb("counts").$type<IngestResult>(),
+    error: text("error"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    startedAt: timestamp("started_at"),
+    finishedAt: timestamp("finished_at"),
+  },
+  (t) => [
+    // At most one active index job per org. The index is corpus-wide and
+    // embedding is CPU-bound on a 1.5-core container, so two concurrent runs
+    // would race on the same (org_id, source_path) documents and thrash the
+    // CPU for no throughput. This is the constraint the enqueue path relies on
+    // to answer "busy" instead of queueing a duplicate — application code alone
+    // could not make that atomic.
+    uniqueIndex("uq_kb_index_jobs_active")
+      .on(t.orgId)
+      .where(sql`${t.status} ${inEnum(KB_INDEX_JOB_ACTIVE_STATUSES)}`),
+    // Serves both the worker's claim ("oldest pending") and the status route's
+    // "latest job for this agent".
+    index("idx_kb_index_jobs_status_created").on(t.status, t.createdAt),
+    index("idx_kb_index_jobs_agent_created").on(t.agentId, t.createdAt),
+    check("kb_index_jobs_status_check", sql`${t.status} ${inEnum(KB_INDEX_JOB_STATUSES)}`),
   ]
 );

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -601,28 +601,51 @@ export type AuditLogEntry =
       };
     })
   | (AuditLogBase & {
-      // POST /api/agents/[agentId]/knowledge/reindex: an admin manually
-      // (re)ingests the agent's granted knowledge-base folders. Audited as an
-      // index-management action. `pathCount` is the number of granted folders
-      // reindexed — NOT the folder paths themselves, which can embed a
-      // username (AGENTS.md PII rule). `reason` is present on failure rows
-      // only (embedding endpoint unconfigured, ingest error).
+      // Knowledge-base index management. Since #714 a reindex is asynchronous,
+      // so ONE run produces TWO rows, correlated by `jobId` (the same
+      // correlation pattern as `sweepId` for GC sweeps):
       //
-      // The counters mirror IngestResult (lib/knowledge/ingest.ts) and are
-      // what an admin judges the corpus by, so they distinguish findable from
-      // merely processed: `unsearchable` files were indexed but produced no
-      // text to retrieve (image-only scans), and `failed` files could not be
-      // read or parsed at all. Both can be non-zero on a `success` row — the
-      // reindex worked, and these are its findings.
+      //   1. the admin's request        — actorType "user",   POST .../knowledge/reindex
+      //   2. the run's outcome          — actorType "system", written by the index worker
+      //
+      // Both are needed: the request is a user action and must be attributable
+      // even if the run never happens, and the outcome lands hours later in a
+      // context that has no request behind it.
+      //
+      // `pathCount` is the number of granted folders reindexed — NOT the folder
+      // paths themselves, which can embed a username (AGENTS.md PII rule).
+      // `reason` is present on failure rows only (embedding endpoint
+      // unconfigured, a job already running, ingest error).
+      //
+      // `jobId` is absent only where no job exists: nothing granted, or the
+      // request was rejected before it could enqueue.
+      //
+      // The counters mirror IngestResult (lib/knowledge/types.ts) and are what
+      // an admin judges the corpus by, so they distinguish findable from merely
+      // processed: `unsearchable` files were indexed but produced no text to
+      // retrieve (image-only scans), and `failed` files could not be read or
+      // parsed at all. Both can be non-zero on a `success` row — the reindex
+      // worked, and these are its findings. They are absent on the request row,
+      // which has not counted anything yet; writing zeros there would report an
+      // empty corpus for every reindex ever started. Kept flat rather than
+      // nested under a `counts` object so `detail->>'indexed'` keeps answering
+      // across rows written before this change — an append-only log should not
+      // need a shape-version branch to query.
+      //
+      // Spelled out field by field rather than typed as IngestResult on
+      // purpose: the obvious next counter to want is a list of the paths that
+      // failed, which is precisely what this HMAC-signed row must never carry.
+      // Adding a counter here has to stay a decision, not a side effect.
       eventType: "knowledge.reindex";
       detail: {
         agent: EntityRef;
         pathCount: number;
-        indexed: number;
-        skipped: number;
-        removed: number;
-        unsearchable: number;
-        failed: number;
+        jobId?: string;
+        indexed?: number;
+        skipped?: number;
+        removed?: number;
+        unsearchable?: number;
+        failed?: number;
         reason?: string;
       };
     })

--- a/packages/web/src/lib/knowledge/index-jobs.ts
+++ b/packages/web/src/lib/knowledge/index-jobs.ts
@@ -121,14 +121,23 @@ export async function claimNextIndexJob(): Promise<KbIndexJob | null> {
   return claimed ?? null;
 }
 
-/** Publishes discovery's document total and how many of them are done. Called often; deliberately the only write on the hot path. */
+/**
+ * Publishes how far the run has got and what it has found so far. Called once
+ * per document; deliberately the only write on the hot path.
+ *
+ * Findings ride along with progress rather than waiting for the finish, for
+ * two reasons. They answer the question an operator asks at the same moment as
+ * "how far along?" — namely "is it going well?", and a run that is 200 files in
+ * with 190 of them unsearchable is worth knowing about before the other 1800.
+ * And it costs nothing: the UPDATE was already happening.
+ */
 export async function recordIndexJobProgress(
   jobId: string,
-  progress: { processed: number; total: number }
+  progress: { processed: number; total: number; counts: IngestResult }
 ): Promise<void> {
   await db
     .update(kbIndexJobs)
-    .set({ processed: progress.processed, total: progress.total })
+    .set({ processed: progress.processed, total: progress.total, counts: progress.counts })
     .where(eq(kbIndexJobs.id, jobId));
 }
 
@@ -162,14 +171,16 @@ export async function finishIndexJob(jobId: string, args: FinishIndexJobArgs): P
  * idempotent, so resuming costs a re-discovery (almost everything skips) and
  * nothing more.
  *
- * Progress is reset with the status: discovery re-runs from the top, and
- * leaving 30/42 on a run that restarted at zero would be the same
- * processed-isn't-real lie the counters exist to prevent.
+ * Progress and findings are reset with the status: discovery re-runs from the
+ * top, so leaving 30/42 on a run that restarted at zero would be the same
+ * processed-isn't-real lie the counters exist to prevent — and leaving the dead
+ * run's `indexed: 30` beside `processed: 0` would be a row contradicting
+ * itself.
  */
 export async function requeueOrphanedIndexJobs(): Promise<number> {
   const requeued = await db
     .update(kbIndexJobs)
-    .set({ status: "pending", processed: 0, total: null, startedAt: null })
+    .set({ status: "pending", processed: 0, total: null, counts: null, startedAt: null })
     .where(eq(kbIndexJobs.status, "running"))
     .returning({ id: kbIndexJobs.id });
   return requeued.length;

--- a/packages/web/src/lib/knowledge/index-jobs.ts
+++ b/packages/web/src/lib/knowledge/index-jobs.ts
@@ -1,0 +1,187 @@
+/**
+ * The kb_index_jobs store: enqueue, claim, progress, finish (#714).
+ *
+ * The reindex route enqueues; the in-process worker
+ * (src/server/kb-index-worker.ts) claims and runs. Two invariants live in the
+ * database rather than here, because application checks cannot make them
+ * atomic:
+ *
+ *   - At most one ACTIVE (pending|running) job per org, via the partial unique
+ *     index `uq_kb_index_jobs_active`. enqueueIndexJob turns the resulting
+ *     unique violation into an honest "busy" answer.
+ *   - A job is claimed at most once, via a conditional UPDATE that pins
+ *     `status = 'pending'` — the same claim shape as the email ledger
+ *     (lib/email-workflows/ledger.ts), which this codebase already uses in
+ *     place of row locks.
+ */
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
+
+import { db } from "@/db";
+import { kbIndexJobs } from "@/db/schema";
+import { KB_INDEX_JOB_ACTIVE_STATUSES } from "@/db/enums";
+
+import type { IngestResult } from "./types";
+
+export type KbIndexJob = typeof kbIndexJobs.$inferSelect;
+
+export interface EnqueueIndexJobArgs {
+  orgId: string;
+  agentId: string;
+  /** Snapshotted onto the job so the completion audit row can name the agent even if it is renamed or deleted mid-run. */
+  agentName: string;
+  /** The actor id of the admin who asked. Carried onto the completion audit row so a background run is still attributable. */
+  requestedBy: string;
+  /** The agent's granted folders, already permission-narrowed by the caller. Snapshotted, never re-derived at run time. */
+  paths: string[];
+}
+
+export type EnqueueIndexJobResult =
+  /** The job was accepted and is waiting for the worker. */
+  | { status: "queued"; job: KbIndexJob }
+  /** The org already has a job in flight; `job` is that job, so the caller can point the admin at it instead of guessing. */
+  | { status: "busy"; job: KbIndexJob };
+
+/**
+ * Enqueues an index run for one agent's granted folders, unless the org
+ * already has one in flight.
+ *
+ * The busy check is the unique index, not a preceding SELECT: a check-then-
+ * insert would let two admins clicking at once both pass the check and both
+ * insert. Instead the insert itself is the check — `onConflictDoNothing`
+ * returns a row only to the winner, the same claim shape claimEmail() uses —
+ * and we look up the blocking job only once Postgres has told us we lost.
+ */
+export async function enqueueIndexJob(args: EnqueueIndexJobArgs): Promise<EnqueueIndexJobResult> {
+  // Two attempts, not a retry loop: the second covers the one narrow race
+  // where the blocking job finished between our rejected insert and the read
+  // that looks for it. Repeating that race would need jobs to complete within
+  // microseconds of each other, and a job takes minutes.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const [job] = await db
+      .insert(kbIndexJobs)
+      .values({
+        orgId: args.orgId,
+        agentId: args.agentId,
+        agentName: args.agentName,
+        requestedBy: args.requestedBy,
+        paths: args.paths,
+      })
+      .onConflictDoNothing()
+      .returning();
+    if (job) return { status: "queued", job };
+
+    const active = await findActiveIndexJob(args.orgId);
+    if (active) return { status: "busy", job: active };
+    // The slot freed up between our rejected insert and this read — take it.
+  }
+
+  throw new Error(
+    "Could not enqueue a knowledge-base index job: the org's active-job slot kept changing hands"
+  );
+}
+
+/** The org's in-flight job, if any. */
+export async function findActiveIndexJob(orgId: string): Promise<KbIndexJob | null> {
+  const [job] = await db
+    .select()
+    .from(kbIndexJobs)
+    .where(
+      and(
+        eq(kbIndexJobs.orgId, orgId),
+        inArray(kbIndexJobs.status, [...KB_INDEX_JOB_ACTIVE_STATUSES])
+      )
+    )
+    .limit(1);
+  return job ?? null;
+}
+
+/**
+ * Claims the oldest pending job for this worker, or returns null if there is
+ * nothing to do.
+ *
+ * The `status = 'pending'` predicate in the UPDATE is what makes the claim
+ * exclusive: an overlapping tick that reads the same id updates zero rows and
+ * gets null, rather than running the same corpus twice.
+ */
+export async function claimNextIndexJob(): Promise<KbIndexJob | null> {
+  const [next] = await db
+    .select({ id: kbIndexJobs.id })
+    .from(kbIndexJobs)
+    .where(eq(kbIndexJobs.status, "pending"))
+    .orderBy(asc(kbIndexJobs.createdAt))
+    .limit(1);
+  if (!next) return null;
+
+  const [claimed] = await db
+    .update(kbIndexJobs)
+    .set({ status: "running", startedAt: new Date() })
+    .where(and(eq(kbIndexJobs.id, next.id), eq(kbIndexJobs.status, "pending")))
+    .returning();
+
+  return claimed ?? null;
+}
+
+/** Publishes discovery's document total and how many of them are done. Called often; deliberately the only write on the hot path. */
+export async function recordIndexJobProgress(
+  jobId: string,
+  progress: { processed: number; total: number }
+): Promise<void> {
+  await db
+    .update(kbIndexJobs)
+    .set({ processed: progress.processed, total: progress.total })
+    .where(eq(kbIndexJobs.id, jobId));
+}
+
+export interface FinishIndexJobArgs {
+  outcome: "succeeded" | "failed";
+  /** The ingest's findings so far. Recorded on failure too — partial counts are the operator's only evidence of how far the run got. */
+  counts: IngestResult;
+  /** Scrubbed failure summary (safeProviderError). Omitted on success. */
+  error?: string;
+}
+
+/** Moves a job to its terminal state, recording what it found. Releases the org's active-job slot. */
+export async function finishIndexJob(jobId: string, args: FinishIndexJobArgs): Promise<void> {
+  await db
+    .update(kbIndexJobs)
+    .set({
+      status: args.outcome,
+      counts: args.counts,
+      error: args.error ?? null,
+      finishedAt: new Date(),
+    })
+    .where(eq(kbIndexJobs.id, jobId));
+}
+
+/**
+ * Returns `running` jobs to `pending` and returns how many were requeued.
+ *
+ * Called once at boot. Exactly one web container runs the worker, so a job
+ * still marked `running` when the process starts belongs to a process that no
+ * longer exists — nothing else could be holding it. Ingest is content-hash
+ * idempotent, so resuming costs a re-discovery (almost everything skips) and
+ * nothing more.
+ *
+ * Progress is reset with the status: discovery re-runs from the top, and
+ * leaving 30/42 on a run that restarted at zero would be the same
+ * processed-isn't-real lie the counters exist to prevent.
+ */
+export async function requeueOrphanedIndexJobs(): Promise<number> {
+  const requeued = await db
+    .update(kbIndexJobs)
+    .set({ status: "pending", processed: 0, total: null, startedAt: null })
+    .where(eq(kbIndexJobs.status, "running"))
+    .returning({ id: kbIndexJobs.id });
+  return requeued.length;
+}
+
+/** The agent's most recent index job — running or last finished. Backs the status route. */
+export async function getLatestIndexJobForAgent(agentId: string): Promise<KbIndexJob | null> {
+  const [job] = await db
+    .select()
+    .from(kbIndexJobs)
+    .where(eq(kbIndexJobs.agentId, agentId))
+    .orderBy(desc(kbIndexJobs.createdAt))
+    .limit(1);
+  return job ?? null;
+}

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -81,6 +81,16 @@ export interface IngestProgress {
   processed: number;
   /** Files discovered across every root, deduplicated. Known before the first file, so a bar built on it never runs backwards. */
   total: number;
+  /**
+   * The tally so far.
+   *
+   * Reported alongside progress rather than only returned, because the return
+   * value is exactly what a systemic failure destroys: a run that dies on file
+   * 1501 of 2000 really did index 1500 documents, and the only way a caller can
+   * know that is if the tally reached it before the throw. `removed` stays 0
+   * until the removal pass runs at the very end.
+   */
+  counts: IngestResult;
 }
 
 /** Applies the per-file eligibility rules (skip-hidden + A/B denylist + extension allowlist) to a basename. */
@@ -112,32 +122,46 @@ async function walkDir(dir: string, allowedExtensions: readonly string[]): Promi
 
 /**
  * Lists ingest-eligible files for a root that may be a directory OR a single
- * file. An `allowed_paths` grant (pinchy-files) can point at either; a naive
+ * file, or returns null if the root could not be read at all.
+ *
+ * An `allowed_paths` grant (pinchy-files) can point at either shape; a naive
  * `readdir(root)` throws ENOTDIR on a file root (surfacing as an opaque 500
  * from the reindex route), so we stat the root first: a directory is walked
- * recursively, a file is treated as a one-file corpus (subject to the same
- * eligibility rules), and a missing/other root yields nothing rather than
- * throwing.
+ * recursively, and a file is treated as a one-file corpus subject to the same
+ * eligibility rules.
+ *
+ * null and [] are DIFFERENT answers and the removal pass depends on it. []
+ * means "I looked, there is nothing" — documents under this root are genuinely
+ * gone and should be dropped. null means "I could not look", which is what an
+ * unmounted volume looks like, and is indistinguishable from an emptied folder
+ * from the outside. Collapsing the two would let a bind mount that is not
+ * ready yet — a live race, since the index worker starts seconds after boot —
+ * delete an entire corpus and report success.
  */
 async function discoverFiles(
   rootDir: string,
   allowedExtensions: readonly string[]
-): Promise<string[]> {
+): Promise<string[] | null> {
   let rootStat;
   try {
     rootStat = await stat(rootDir);
   } catch {
-    // Missing or unreadable root: nothing to ingest (and nothing to remove —
-    // see the removal pass, which is scoped to this same root).
-    return [];
+    return null;
   }
 
   if (rootStat.isFile()) {
     return isEligibleFile(basename(rootDir), allowedExtensions) ? [rootDir] : [];
   }
+  // A socket, device, or dangling symlink: readable, and holds no documents.
   if (!rootStat.isDirectory()) return [];
 
-  return walkDir(rootDir, allowedExtensions);
+  try {
+    return await walkDir(rootDir, allowedExtensions);
+  } catch {
+    // The root vanished or turned unreadable mid-walk. Same reasoning as
+    // above: a partial listing must not be mistaken for the whole truth.
+    return null;
+  }
 }
 
 /**
@@ -344,9 +368,15 @@ export async function ingestPaths(
 ): Promise<IngestResult> {
   const allowedExtensions = opts.allowedExtensions ?? DEFAULT_ALLOWED_EXTENSIONS;
 
+  // A root we could not read is dropped from the run entirely: it contributes
+  // no files to ingest AND no removal pass, because we have no evidence about
+  // what is under it. See discoverFiles for why that distinction is not
+  // pedantry.
   const perRoot: Array<{ rootDir: string; discovered: Set<string> }> = [];
   for (const rootDir of rootDirs) {
-    perRoot.push({ rootDir, discovered: new Set(await discoverFiles(rootDir, allowedExtensions)) });
+    const discovered = await discoverFiles(rootDir, allowedExtensions);
+    if (discovered === null) continue;
+    perRoot.push({ rootDir, discovered: new Set(discovered) });
   }
 
   // Deduplicated across roots, but ordered so each file is ingested while its
@@ -365,12 +395,14 @@ export async function ingestPaths(
   const tally: Record<FileOutcome, number> = { indexed: 0, skipped: 0, unsearchable: 0 };
   let failed = 0;
   let processed = 0;
+  let removed = 0;
   const total = queue.length;
+  const snapshot = (): IngestResult => ({ ...tally, removed, failed });
 
   // Reported before any work: "0 of N" is what tells a caller the run started
   // and how big it is. A caller that hears nothing until the first file lands
   // cannot tell a slow run from a dead one.
-  await opts.onProgress?.({ processed, total });
+  await opts.onProgress?.({ processed, total, counts: snapshot() });
 
   for (const absPath of queue) {
     try {
@@ -381,7 +413,8 @@ export async function ingestPaths(
       // bad PDF aborts the reindex for every other file, and under a retrying
       // job runner it would fail identically forever. Systemic errors
       // (embedding outage, DB gone) are NOT FileIngestErrors and still escape
-      // — see ingestFile.
+      // — see ingestFile. The tally reported so far is the caller's last
+      // honest word on what the run achieved before that happened.
       if (!(err instanceof FileIngestError)) throw err;
       // The admin-facing counts must not name paths (audit PII rule), so this
       // server log is the only place that says WHICH file failed and why.
@@ -389,15 +422,14 @@ export async function ingestPaths(
       failed++;
     }
     processed++;
-    await opts.onProgress?.({ processed, total });
+    await opts.onProgress?.({ processed, total, counts: snapshot() });
   }
 
-  let removed = 0;
   for (const { rootDir, discovered } of perRoot) {
     removed += await removeVanishedDocuments(orgId, rootDir, discovered);
   }
 
-  return { ...tally, removed, failed };
+  return snapshot();
 }
 
 /** Ingests a single root. Thin wrapper over ingestPaths — kept because most callers and tests deal in one directory at a time. */

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -18,6 +18,11 @@
  * cannot be read or parsed counts as `failed` without taking the rest of the
  * run down with it.
  *
+ * ingestPaths() runs many roots as ONE job: discovery walks every root before
+ * the first extract, so the document total is known upfront and a file
+ * reachable from two overlapping roots counts once. ingestDirectory() is the
+ * single-root wrapper over it.
+ *
  * The embedder and PDF extractor are dependency-injected: production wires
  * `embedTexts` (./embeddings.ts) and a pdfjs-based extractor
  * (./pdf-extract.ts); tests inject deterministic fakes so the integration
@@ -41,11 +46,13 @@ import {
 } from "./exclude-globs";
 import { chunkPages } from "./chunk";
 import { detectLang } from "./lid";
+import type { IngestPage, IngestResult } from "./types";
 
-export interface IngestPage {
-  page: number;
-  text: string;
-}
+// IngestPage/IngestResult live in ./types (a runtime-free module) because
+// db/schema.ts persists IngestResult as a jsonb column and cannot import from
+// this file — it is what this file imports. Re-exported here so callers can
+// keep treating the ingest module as the contract's home.
+export type { IngestPage, IngestResult } from "./types";
 
 export interface IngestDeps {
   /** Batch-embeds chunk texts into dense vectors (bge-m3, 1024-dim). Prod: `(t) => embedTexts(t, embedCfg)`. */
@@ -57,25 +64,23 @@ export interface IngestDeps {
 export interface IngestOptions {
   /** Overrides the default extension allowlist (`[".pdf"]` for the MVP). */
   allowedExtensions?: readonly string[];
+  /**
+   * Called once with the discovery total before the first file is touched, then
+   * after every file. `total` never changes during a run.
+   *
+   * Deliberately called per file rather than on a timer: ingest reports what
+   * happened, and a caller that wants fewer writes (the index worker persists
+   * each report to Postgres) throttles in its own callback, where the cost of a
+   * write is known.
+   */
+  onProgress?: (progress: IngestProgress) => void | Promise<void>;
 }
 
-export interface IngestResult {
-  /** Documents newly indexed, replaced due to a content change, or recovered from a zero-chunk state — and searchable afterwards (at least one chunk). */
-  indexed: number;
-  /** Documents left untouched: unchanged content hash, chunks already present. */
-  skipped: number;
-  /** Documents deleted because their source file is no longer on disk. */
-  removed: number;
-  /**
-   * Files that parsed without error but yielded no chunks, so they are indexed
-   * yet can never be retrieved — an image-only scan with no text layer is the
-   * normal cause. Counted apart from `indexed` because the counts exist to
-   * answer "is the corpus findable?", and folding these into `indexed` reports
-   * a complete corpus while a slice of it silently answers nothing.
-   */
-  unsearchable: number;
-  /** Files skipped because reading or extracting THIS file threw (unreadable, corrupt). The run continues; see the per-file boundary in ingestDirectory. */
-  failed: number;
+export interface IngestProgress {
+  /** Files whose ingest is behind us — including the ones that failed. Progress measures how much of the corpus is done, not how much of it succeeded. */
+  processed: number;
+  /** Files discovered across every root, deduplicated. Known before the first file, so a bar built on it never runs backwards. */
+  total: number;
 }
 
 /** Applies the per-file eligibility rules (skip-hidden + A/B denylist + extension allowlist) to a basename. */
@@ -285,19 +290,89 @@ async function ingestFile(orgId: string, absPath: string, deps: IngestDeps): Pro
   return written > 0 ? "indexed" : "unsearchable";
 }
 
-export async function ingestDirectory(
+/**
+ * Deletes the documents previously indexed under `rootDir` whose source file is
+ * no longer on disk, and returns how many. Scoped to rootDir via isUnderRoot
+ * (separator-bounded for a directory root, exact-match for a file root) so
+ * ingesting one root never touches documents indexed from a different root for
+ * the same org.
+ *
+ * `discovered` is that root's OWN listing, not the run's deduplicated queue: two
+ * overlapping roots (an admin may grant both /data and /data/hr) each see the
+ * shared file in their own set, so neither pass deletes what the other covers.
+ *
+ * A file that vanishes between the walk and the read is still in `discovered`,
+ * so this pass leaves its document row alone for one run (it counts as `failed`
+ * instead); the next run no longer discovers it and removes it here. Erring
+ * toward keeping the row beats deleting on a transient read failure.
+ */
+async function removeVanishedDocuments(
   orgId: string,
   rootDir: string,
+  discovered: ReadonlySet<string>
+): Promise<number> {
+  const existingForOrg = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, orgId));
+
+  let removed = 0;
+  for (const doc of existingForOrg) {
+    if (!isUnderRoot(doc.sourcePath, rootDir)) continue;
+    if (discovered.has(doc.sourcePath)) continue;
+    await db.delete(kbDocuments).where(eq(kbDocuments.id, doc.id));
+    removed++;
+  }
+  return removed;
+}
+
+/**
+ * Ingests every root in one run, reporting progress against a single total.
+ *
+ * Discovery walks all roots FIRST, for two reasons: the total has to be known
+ * before the first file so a progress bar can't run backwards, and a file
+ * reachable from two overlapping roots (an admin may grant both `/data` and
+ * `/data/hr`) is one unit of work — ingesting it twice would inflate `skipped`
+ * and stall the bar one short of its total.
+ *
+ * The removal pass stays per-root and keeps that root's OWN discovered set, so
+ * overlap never lets one root's pass delete a document the other root still
+ * covers.
+ */
+export async function ingestPaths(
+  orgId: string,
+  rootDirs: readonly string[],
   deps: IngestDeps,
   opts: IngestOptions = {}
 ): Promise<IngestResult> {
   const allowedExtensions = opts.allowedExtensions ?? DEFAULT_ALLOWED_EXTENSIONS;
-  const discovered = await discoverFiles(rootDir, allowedExtensions);
+
+  const perRoot: Array<{ rootDir: string; discovered: Set<string> }> = [];
+  for (const rootDir of rootDirs) {
+    perRoot.push({ rootDir, discovered: new Set(await discoverFiles(rootDir, allowedExtensions)) });
+  }
+
+  // Deduplicated across roots, but ordered so each file is ingested while its
+  // first root is being processed — the order only matters for readability of
+  // the progress stream, not for correctness.
+  const queue: string[] = [];
+  const seen = new Set<string>();
+  for (const { discovered } of perRoot) {
+    for (const absPath of discovered) {
+      if (seen.has(absPath)) continue;
+      seen.add(absPath);
+      queue.push(absPath);
+    }
+  }
 
   const tally: Record<FileOutcome, number> = { indexed: 0, skipped: 0, unsearchable: 0 };
   let failed = 0;
+  let processed = 0;
+  const total = queue.length;
 
-  for (const absPath of discovered) {
+  // Reported before any work: "0 of N" is what tells a caller the run started
+  // and how big it is. A caller that hears nothing until the first file lands
+  // cannot tell a slow run from a dead one.
+  await opts.onProgress?.({ processed, total });
+
+  for (const absPath of queue) {
     try {
       tally[await ingestFile(orgId, absPath, deps)]++;
     } catch (err) {
@@ -313,29 +388,24 @@ export async function ingestDirectory(
       console.error(`[kb-ingest] ${err.message}`, err.cause);
       failed++;
     }
+    processed++;
+    await opts.onProgress?.({ processed, total });
   }
 
-  // Removal pass: any previously-indexed document under this root whose
-  // source file is no longer among the discovered files. Scoped to rootDir
-  // via isUnderRoot (separator-bounded for a directory root, exact-match for
-  // a file root) so ingesting one root never touches documents indexed from a
-  // different root for the same org.
-  //
-  // A file that vanishes between the walk and the read is still in
-  // `discovered`, so this pass leaves its document row alone for one run (it
-  // counts as `failed` above); the next run no longer discovers it and
-  // removes it here. Erring toward keeping the row beats deleting on a
-  // transient read failure.
-  const discoveredSet = new Set(discovered);
-  const existingForOrg = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, orgId));
-
   let removed = 0;
-  for (const doc of existingForOrg) {
-    if (!isUnderRoot(doc.sourcePath, rootDir)) continue;
-    if (discoveredSet.has(doc.sourcePath)) continue;
-    await db.delete(kbDocuments).where(eq(kbDocuments.id, doc.id));
-    removed++;
+  for (const { rootDir, discovered } of perRoot) {
+    removed += await removeVanishedDocuments(orgId, rootDir, discovered);
   }
 
   return { ...tally, removed, failed };
+}
+
+/** Ingests a single root. Thin wrapper over ingestPaths — kept because most callers and tests deal in one directory at a time. */
+export async function ingestDirectory(
+  orgId: string,
+  rootDir: string,
+  deps: IngestDeps,
+  opts: IngestOptions = {}
+): Promise<IngestResult> {
+  return ingestPaths(orgId, [rootDir], deps, opts);
 }

--- a/packages/web/src/lib/knowledge/reindex-audit.ts
+++ b/packages/web/src/lib/knowledge/reindex-audit.ts
@@ -1,0 +1,62 @@
+/**
+ * Builds (but never sends) `knowledge.reindex` audit entries.
+ *
+ * Shared by the two halves of an async reindex — the route that takes the
+ * request and the worker that runs it hours later — so both halves cannot drift
+ * into describing the same run differently. Callers pass the result straight to
+ * deferAuditLog/appendAuditLog; the eslint pinchy/require-audit-log rule scans a
+ * handler's source text for a literal call, so the send stays inline at each
+ * call site rather than hiding behind a second indirection.
+ */
+import type { AuditLogEntry, EntityRef } from "@/lib/audit";
+
+import type { IngestResult } from "./types";
+
+/** The audit actorId the index worker signs its completion rows with (house pattern: actorType "system" + the job's name, cf. upload-gc). */
+export const KB_INDEX_WORKER_ACTOR = "kb-index-worker";
+
+export interface ReindexAuditArgs {
+  /** "user" for the admin's request, "system" for the worker's outcome row. */
+  actorType: "user" | "system";
+  /** The admin's id on a request row; KB_INDEX_WORKER_ACTOR on an outcome row — the requesting admin is reachable from the request row via jobId. */
+  actorId: string;
+  agent: EntityRef;
+  outcome: "success" | "failure";
+  pathCount: number;
+  /** Correlates the request row with the outcome row. Omitted where no job exists: nothing granted, or rejected before enqueue. */
+  jobId?: string;
+  /** The run's findings. Omitted on a request row — it has counted nothing yet, and zeros would report an empty corpus for every reindex ever started. */
+  counts?: IngestResult;
+  /** Scrubbed failure summary. Failure rows only. */
+  reason?: string;
+}
+
+export function reindexAuditEntry(args: ReindexAuditArgs): AuditLogEntry {
+  return {
+    actorType: args.actorType,
+    actorId: args.actorId,
+    eventType: "knowledge.reindex",
+    resource: `agent:${args.agent.id}`,
+    outcome: args.outcome,
+    detail: {
+      agent: args.agent,
+      pathCount: args.pathCount,
+      ...(args.jobId !== undefined ? { jobId: args.jobId } : {}),
+      // Copied field by field rather than spread from `counts`: a spread would
+      // put whatever IngestResult grows into onto an HMAC-signed row, and the
+      // obvious next counter to want is a list of the paths that failed —
+      // precisely the filesystem paths this detail must never carry (AGENTS.md
+      // PII rule; see `pathCount`). Adding a counter here stays a decision.
+      ...(args.counts !== undefined
+        ? {
+            indexed: args.counts.indexed,
+            skipped: args.counts.skipped,
+            removed: args.counts.removed,
+            unsearchable: args.counts.unsearchable,
+            failed: args.counts.failed,
+          }
+        : {}),
+      ...(args.reason !== undefined ? { reason: args.reason } : {}),
+    },
+  };
+}

--- a/packages/web/src/lib/knowledge/types.ts
+++ b/packages/web/src/lib/knowledge/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Knowledge-base contracts shared across layers.
+ *
+ * A types-only module (no imports, no runtime): `IngestResult` is written by
+ * ingest.ts, persisted as a jsonb column by db/schema.ts, and read back by the
+ * job store and the reindex routes. ingest.ts imports db/schema, so the schema
+ * cannot import IngestResult from ingest.ts without a cycle — the same reason
+ * email-workflows/types exists.
+ */
+
+export interface IngestPage {
+  page: number;
+  text: string;
+}
+
+export interface IngestResult {
+  /** Documents newly indexed, replaced due to a content change, or recovered from a zero-chunk state — and searchable afterwards (at least one chunk). */
+  indexed: number;
+  /** Documents left untouched: unchanged content hash, chunks already present. */
+  skipped: number;
+  /** Documents deleted because their source file is no longer on disk. */
+  removed: number;
+  /**
+   * Files that parsed without error but yielded no chunks, so they are indexed
+   * yet can never be retrieved — an image-only scan with no text layer is the
+   * normal cause. Counted apart from `indexed` because the counts exist to
+   * answer "is the corpus findable?", and folding these into `indexed` reports
+   * a complete corpus while a slice of it silently answers nothing.
+   */
+  unsearchable: number;
+  /** Files skipped because reading or extracting THIS file threw (unreadable, corrupt). The run continues; see the per-file boundary in ingestDirectory. */
+  failed: number;
+}
+
+/** A fresh IngestResult with every counter at zero — the identity for summing per-root results. A function, not a shared const, so no caller can mutate the zero. */
+export function zeroIngestResult(): IngestResult {
+  return { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0 };
+}
+
+/**
+ * Sums ingest results. Written out field by field on purpose: a counter added
+ * to IngestResult fails to compile here until it is summed, so a new counter
+ * cannot silently drop out of the numbers an admin sees.
+ */
+export function totalCounts(results: readonly IngestResult[]): IngestResult {
+  return results.reduce<IngestResult>(
+    (total, result) => ({
+      indexed: total.indexed + result.indexed,
+      skipped: total.skipped + result.skipped,
+      removed: total.removed + result.removed,
+      unsearchable: total.unsearchable + result.unsearchable,
+      failed: total.failed + result.failed,
+    }),
+    zeroIngestResult()
+  );
+}

--- a/packages/web/src/server/kb-index-worker.ts
+++ b/packages/web/src/server/kb-index-worker.ts
@@ -66,9 +66,10 @@ export async function runNextIndexJob(opts: RunIndexJobOptions = {}): Promise<Kb
   if (!job) return null;
 
   const agent = { id: job.agentId, name: job.agentName };
-  // `counts` is tracked outside the try so a systemic throw still reports how
-  // far the run got. ingestPaths only returns on success, so a failure would
-  // otherwise land with nothing to say.
+  // Updated from every progress report, NOT from ingestPaths' return value: a
+  // systemic throw skips the return, and a run that died on file 1501 of 2000
+  // still indexed 1500 documents. Reading the tally off the last report is the
+  // only way that survives the throw.
   let counts: IngestResult = zeroIngestResult();
 
   try {
@@ -79,7 +80,10 @@ export async function runNextIndexJob(opts: RunIndexJobOptions = {}): Promise<Kb
     if (!deps) throw new Error("ollama_not_configured");
 
     counts = await ingestPaths(job.orgId, job.paths, deps, {
-      onProgress: (progress) => recordIndexJobProgress(job.id, progress),
+      onProgress: (progress) => {
+        counts = progress.counts;
+        return recordIndexJobProgress(job.id, progress);
+      },
     });
   } catch (err) {
     // Ingest already absorbs a single unreadable file (counting it `failed`),
@@ -87,6 +91,13 @@ export async function runNextIndexJob(opts: RunIndexJobOptions = {}): Promise<Kb
     // database — took the run down. Finishing the job (rather than leaving it
     // `running`) is what frees the org's active-job slot: without it, one
     // Ollama blip would wedge the queue until the next restart.
+    //
+    // The one case this cannot rescue is the database itself being the outage:
+    // then finishIndexJob's own write fails too, the row stays `running`, and
+    // the slot is held until the next boot requeues it. Recovering from that
+    // without a restart would need a liveness signal (heartbeat + staleness
+    // sweep) that the single-container design does not otherwise need — and a
+    // database outage is already an operator's problem, not a queue's.
     const reason = safeProviderError(err instanceof Error ? err.message : "reindex_failed");
     await finishIndexJob(job.id, { outcome: "failed", counts, error: reason });
     await auditOutcome({ job, agent, outcome: "failure", counts, reason });
@@ -140,20 +151,48 @@ async function auditOutcome(args: {
 const POLL_INTERVAL_MS = 10_000;
 
 let _pollInterval: ReturnType<typeof setInterval> | null = null;
-let _startupTimeout: ReturnType<typeof setTimeout> | null = null;
 // Re-entrancy guard: a multi-hour run must not be started a second time by an
 // overlapping tick. The DB claim would refuse the double-run anyway; this keeps
 // us from hammering it every 10s for hours to find that out.
 let _runInFlight = false;
+// Whether this process has already cleaned up after its predecessor. See the
+// requeue in runKbIndexWorkerTick for why doing it exactly once is not an
+// optimization but a correctness condition.
+let _orphansRequeued = false;
 
-async function runGuarded(): Promise<void> {
+/**
+ * One turn of the worker: adopt any jobs the previous process left behind, then
+ * drain the queue.
+ *
+ * Exported for tests. The interval calls it; the re-entrancy guard means a tick
+ * that lands during a multi-hour run returns immediately.
+ */
+export async function runKbIndexWorkerTick(opts: RunIndexJobOptions = {}): Promise<void> {
   if (_runInFlight) return;
   _runInFlight = true;
   try {
-    // Drain: a queue that only moves one job per tick would take 10s per job to
-    // work through a backlog, and each loop stops as soon as claim finds
-    // nothing.
-    while (await runNextIndexJob()) {
+    // Requeueing is only sound as a BOOT act: a `running` job is safe to reset
+    // precisely because this process is the only worker and has not started
+    // one yet, so whatever holds it is gone. Once we begin claiming, that
+    // premise dies — the next `running` job we would find is OUR OWN, and
+    // resetting it flips a live run to `pending`, blanks its total, and makes
+    // every status read lie for the hours it keeps running. Hence: strictly
+    // before the first claim, and exactly once.
+    if (!_orphansRequeued) {
+      _orphansRequeued = true;
+      const requeued = await requeueOrphanedIndexJobs();
+      if (requeued > 0) {
+        console.log(`[kb-index-worker] requeued ${requeued} job(s) orphaned by a restart`);
+      }
+    }
+
+    // Drains the queue rather than running one job per tick. Today that loop
+    // body runs at most once: Pinchy is single-tenant (DEFAULT_ORG_ID) and the
+    // active-job index is per org, so there is never a second job to find. It
+    // is a `while` because "keep going while there is work" is the rule the
+    // worker should follow — an `if` would quietly become wrong the day a
+    // second org exists, and costs exactly as much to write.
+    while (await runNextIndexJob(opts)) {
       /* keep going while there is work */
     }
   } catch (err) {
@@ -163,25 +202,18 @@ async function runGuarded(): Promise<void> {
   }
 }
 
+/**
+ * Starts polling for queued index jobs.
+ *
+ * No post-boot kick, unlike the hourly sweeps (upload-gc, chat-error-gc): the
+ * poll is already 10s, so the first tick IS the kick. Arming a second, earlier
+ * path to the same work is what let an orphan-requeue race a claim the interval
+ * had already made.
+ */
 export function startKbIndexWorker(): void {
   _pollInterval = setInterval(() => {
-    void runGuarded();
+    void runKbIndexWorkerTick();
   }, POLL_INTERVAL_MS);
-
-  _startupTimeout = setTimeout(() => {
-    _startupTimeout = null;
-    // Jobs left `running` by a crashed predecessor are requeued before the
-    // first claim: this process is the only worker, so nothing else could still
-    // be holding them.
-    void requeueOrphanedIndexJobs()
-      .then((requeued) => {
-        if (requeued > 0) {
-          console.log(`[kb-index-worker] requeued ${requeued} job(s) orphaned by a restart`);
-        }
-      })
-      .catch((err) => console.error("[kb-index-worker] requeue of orphaned jobs failed:", err))
-      .then(() => runGuarded());
-  }, 30_000);
 }
 
 export function stopKbIndexWorker(): void {
@@ -189,13 +221,15 @@ export function stopKbIndexWorker(): void {
     clearInterval(_pollInterval);
     _pollInterval = null;
   }
-  if (_startupTimeout !== null) {
-    clearTimeout(_startupTimeout);
-    _startupTimeout = null;
-  }
 }
 
 // Test-only helper (mirrors upload-gc / chat-error-gc / audit-verify-job).
 export function _isKbIndexWorkerRunning(): boolean {
   return _pollInterval !== null;
+}
+
+/** Test-only: returns the module to its just-booted state, so a test can exercise the once-per-process orphan requeue. */
+export function _resetKbIndexWorkerForTest(): void {
+  _orphansRequeued = false;
+  _runInFlight = false;
 }

--- a/packages/web/src/server/kb-index-worker.ts
+++ b/packages/web/src/server/kb-index-worker.ts
@@ -1,0 +1,201 @@
+/**
+ * The knowledge-base index worker (#714).
+ *
+ * Claims a kb_index_jobs row, runs the ingest against the paths the job
+ * snapshotted at enqueue, publishes progress as it goes, and records the
+ * outcome — on the job row and in the audit trail.
+ *
+ * Lives in the web process on a setInterval, like every other background job
+ * here (upload-gc, chat-error-gc, audit-verify-job): one container, one worker,
+ * stopped through buildShutdownSteps so SIGTERM doesn't hang. That single-
+ * container assumption is also what makes requeueOrphanedIndexJobs() safe at
+ * boot — see its doc comment.
+ *
+ * A run can take hours (a ~2k-PDF corpus is 1.5-7h of CPU-only embedding), so
+ * the interval is a poll for NEW work, not a run cadence: the re-entrancy guard
+ * keeps overlapping ticks from starting a second run.
+ */
+import { appendAuditLog } from "@/lib/audit";
+import { safeProviderError } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
+import { embedTexts } from "@/lib/knowledge/embeddings";
+import { EMBEDDING_DIMENSIONS, EMBEDDING_MODEL } from "@/lib/knowledge/constants";
+import { extractPdfPages } from "@/lib/knowledge/pdf-extract";
+import { ingestPaths, type IngestDeps } from "@/lib/knowledge/ingest";
+import {
+  claimNextIndexJob,
+  finishIndexJob,
+  recordIndexJobProgress,
+  requeueOrphanedIndexJobs,
+  type KbIndexJob,
+} from "@/lib/knowledge/index-jobs";
+import { KB_INDEX_WORKER_ACTOR, reindexAuditEntry } from "@/lib/knowledge/reindex-audit";
+import { zeroIngestResult, type IngestResult } from "@/lib/knowledge/types";
+import { PROVIDERS } from "@/lib/providers";
+import { getSetting } from "@/lib/settings";
+
+/** Resolves the production embedder + extractor, or null if the KB's embedding endpoint is not configured. */
+async function resolveIngestDeps(): Promise<IngestDeps | null> {
+  const ollamaBaseUrl = await getSetting(PROVIDERS["ollama-local"].settingsKey);
+  if (!ollamaBaseUrl) return null;
+
+  return {
+    embed: (texts) =>
+      embedTexts(texts, {
+        baseUrl: ollamaBaseUrl,
+        model: EMBEDDING_MODEL,
+        expectedDim: EMBEDDING_DIMENSIONS,
+      }),
+    extractPdf: extractPdfPages,
+  };
+}
+
+export interface RunIndexJobOptions {
+  /** Test seam: injects a deterministic embedder/extractor. Production resolves them from the admin-configured Ollama endpoint. */
+  deps?: IngestDeps;
+}
+
+/**
+ * Runs the next queued job to completion, or returns null if there is none.
+ *
+ * Exported for tests and for the boot kick; the interval calls it through the
+ * re-entrancy guard below.
+ */
+export async function runNextIndexJob(opts: RunIndexJobOptions = {}): Promise<KbIndexJob | null> {
+  const job = await claimNextIndexJob();
+  if (!job) return null;
+
+  const agent = { id: job.agentId, name: job.agentName };
+  // `counts` is tracked outside the try so a systemic throw still reports how
+  // far the run got. ingestPaths only returns on success, so a failure would
+  // otherwise land with nothing to say.
+  let counts: IngestResult = zeroIngestResult();
+
+  try {
+    // Resolved per run, not per process: an admin can configure Ollama after a
+    // job is already queued, and the route's 503 only covers the moment of the
+    // request.
+    const deps = opts.deps ?? (await resolveIngestDeps());
+    if (!deps) throw new Error("ollama_not_configured");
+
+    counts = await ingestPaths(job.orgId, job.paths, deps, {
+      onProgress: (progress) => recordIndexJobProgress(job.id, progress),
+    });
+  } catch (err) {
+    // Ingest already absorbs a single unreadable file (counting it `failed`),
+    // so reaching here means something systemic — the embedding endpoint or the
+    // database — took the run down. Finishing the job (rather than leaving it
+    // `running`) is what frees the org's active-job slot: without it, one
+    // Ollama blip would wedge the queue until the next restart.
+    const reason = safeProviderError(err instanceof Error ? err.message : "reindex_failed");
+    await finishIndexJob(job.id, { outcome: "failed", counts, error: reason });
+    await auditOutcome({ job, agent, outcome: "failure", counts, reason });
+    return { ...job, status: "failed", counts, error: reason };
+  }
+
+  // `unsearchable` and `failed` files do not make this a failed run: the
+  // reindex did its job, and those counts are findings about the corpus.
+  // Burying them would be the failure.
+  await finishIndexJob(job.id, { outcome: "succeeded", counts });
+  await auditOutcome({ job, agent, outcome: "success", counts });
+  return { ...job, status: "succeeded", counts };
+}
+
+/**
+ * Writes the run's audit row.
+ *
+ * No request context here, so this follows the AGENTS.md non-request pattern:
+ * await the append, and hand a failure to recordAuditFailure rather than
+ * letting a broken audit sink take down a reindex that actually happened.
+ */
+async function auditOutcome(args: {
+  job: KbIndexJob;
+  agent: { id: string; name: string };
+  outcome: "success" | "failure";
+  counts: IngestResult;
+  reason?: string;
+}): Promise<void> {
+  const entry = reindexAuditEntry({
+    actorType: "system",
+    actorId: KB_INDEX_WORKER_ACTOR,
+    agent: args.agent,
+    outcome: args.outcome,
+    pathCount: args.job.paths.length,
+    jobId: args.job.id,
+    counts: args.counts,
+    reason: args.reason,
+  });
+  try {
+    await appendAuditLog(entry);
+  } catch (err) {
+    recordAuditFailure(err, entry);
+  }
+}
+
+/**
+ * How often to look for new work. Short because it is a poll for a QUEUED job,
+ * not a run cadence — a claimed run holds the guard below for as long as it
+ * takes, however many ticks pass underneath it.
+ */
+const POLL_INTERVAL_MS = 10_000;
+
+let _pollInterval: ReturnType<typeof setInterval> | null = null;
+let _startupTimeout: ReturnType<typeof setTimeout> | null = null;
+// Re-entrancy guard: a multi-hour run must not be started a second time by an
+// overlapping tick. The DB claim would refuse the double-run anyway; this keeps
+// us from hammering it every 10s for hours to find that out.
+let _runInFlight = false;
+
+async function runGuarded(): Promise<void> {
+  if (_runInFlight) return;
+  _runInFlight = true;
+  try {
+    // Drain: a queue that only moves one job per tick would take 10s per job to
+    // work through a backlog, and each loop stops as soon as claim finds
+    // nothing.
+    while (await runNextIndexJob()) {
+      /* keep going while there is work */
+    }
+  } catch (err) {
+    console.error("[kb-index-worker] job run failed:", err);
+  } finally {
+    _runInFlight = false;
+  }
+}
+
+export function startKbIndexWorker(): void {
+  _pollInterval = setInterval(() => {
+    void runGuarded();
+  }, POLL_INTERVAL_MS);
+
+  _startupTimeout = setTimeout(() => {
+    _startupTimeout = null;
+    // Jobs left `running` by a crashed predecessor are requeued before the
+    // first claim: this process is the only worker, so nothing else could still
+    // be holding them.
+    void requeueOrphanedIndexJobs()
+      .then((requeued) => {
+        if (requeued > 0) {
+          console.log(`[kb-index-worker] requeued ${requeued} job(s) orphaned by a restart`);
+        }
+      })
+      .catch((err) => console.error("[kb-index-worker] requeue of orphaned jobs failed:", err))
+      .then(() => runGuarded());
+  }, 30_000);
+}
+
+export function stopKbIndexWorker(): void {
+  if (_pollInterval !== null) {
+    clearInterval(_pollInterval);
+    _pollInterval = null;
+  }
+  if (_startupTimeout !== null) {
+    clearTimeout(_startupTimeout);
+    _startupTimeout = null;
+  }
+}
+
+// Test-only helper (mirrors upload-gc / chat-error-gc / audit-verify-job).
+export function _isKbIndexWorkerRunning(): boolean {
+  return _pollInterval !== null;
+}

--- a/packages/web/src/server/shutdown-steps.ts
+++ b/packages/web/src/server/shutdown-steps.ts
@@ -17,6 +17,7 @@ export interface ShutdownDeps {
   stopUploadGc: ShutdownStopFn;
   stopChatErrorGc: ShutdownStopFn;
   stopAuditVerifyJob: ShutdownStopFn;
+  stopKbIndexWorker: ShutdownStopFn;
   stopUsagePoller: ShutdownStopFn;
   stopMemoryAuditWatcher: ShutdownStopFn;
   getOpenclawClient: () => { disconnect: () => void | Promise<void> } | null;
@@ -36,6 +37,13 @@ export function buildShutdownSteps(deps: ShutdownDeps): ShutdownStopFn[] {
     () => deps.stopUploadGc(),
     () => deps.stopChatErrorGc(),
     () => deps.stopAuditVerifyJob(),
+    // Stops the poll for NEW index jobs. A run already in flight is not
+    // awaited: it can have hours left, which is far past any container's
+    // kill-grace period. It dies with the process and its job row stays
+    // `running`, which is exactly what the next boot requeues — see
+    // requeueOrphanedIndexJobs. Ingest is content-hash idempotent, so the
+    // resumed run re-discovers and skips everything already done.
+    () => deps.stopKbIndexWorker(),
     () => deps.stopUsagePoller(),
     () => deps.stopMemoryAuditWatcher(),
     // Disconnect from the OpenClaw Gateway cleanly so the WS + its in-flight

--- a/packages/web/src/test-helpers/integration/setup.ts
+++ b/packages/web/src/test-helpers/integration/setup.ts
@@ -44,6 +44,7 @@ const APPLICATION_TABLES = [
   "audit_verify_state",
   "kb_documents",
   "kb_chunks",
+  "kb_index_jobs",
 ] as const;
 
 // Drift guard: a new pgTable in db/schema.ts that isn't added to the truncate


### PR DESCRIPTION
Closes part 1 of #714 (the go-live gate). Parts 2 (one-click activation) and 3 (its docs) stay open — Part 2 is also waiting on #715, which changes its deployment story.

## Why

The reindex ran inside the admin's HTTP request. On the sample corpus that was fine; on a real one it is 1.5–7h of CPU-only embedding, which no HTTP client survives. This moves the work to a background job and gives the admin something to watch.

## What

- **`kb_index_jobs`** — a plain table, not a queue engine. Ingest is content-hash idempotent, so a crashed run recovers by re-running; that is the only guarantee pg-boss would have bought us (the 2026-07-12 plan guessed otherwise, before the ingest was idempotent).
- **An in-process worker** following the house pattern exactly (upload-gc, chat-error-gc, audit-verify-job): `setInterval` in `server.ts`, re-entrancy guard, `stop*()` in `buildShutdownSteps`. No new dependency, no second process.
- **`POST` → `202 {jobId}`**, **`GET` → progress + findings** on the same path.
- **Docs** rewritten: the guide and the API reference both still promised a synchronous call returning counts.

## Design decisions worth reviewing

- **One active job per org**, enforced by a partial unique index over `(pending|running)`. The index is corpus-wide and embedding is CPU-bound on a 1.5-core container, so two runs would race on the same documents and thrash the CPU for no throughput. A second `POST` gets **409 carrying the blocking job and its agent** — that run may belong to a *different* agent, and a jobId whose status endpoint the caller can't find is a riddle, not an answer.
- **Claims are `INSERT … ON CONFLICT DO NOTHING` + a conditional `UPDATE`** pinning `status='pending'` — the shape `claimEmail()` already uses here, rather than introducing row locks.
- **Crash recovery is a boot act.** One container ⇒ any `running` job at startup has no owner. The requeue happens inside the guarded tick, strictly before the first claim and exactly once, so it cannot reset a job this process is working on.
- **`paths` and `agentName` are snapshotted at enqueue.** The worker must index what was authorized when the admin asked; re-reading grants at run time would let a permission change widen a job already in flight.
- **Two audit rows per run**, correlated by `jobId` (the `sweepId` pattern): the request (`user`) and the outcome (`system`, hours later). Counters are *absent* on the request row rather than zero — zeros would record an empty corpus for every reindex ever started.
- **Failure is split along the line an operator cares about**: a corrupt file is the job's *finding* (`succeeded`, `failed:1`); a systemic outage is the job's *failure*, and finishing the row is what frees the org's slot.

## Verified live, not just in tests

Against the real 193-PDF reference corpus in a Docker stack (this is the class of bug the unit tests can't see — `server.ts` is never booted by them):

- `202` in **1.4s** with `total: 193` — discovery's count matches the corpus exactly.
- Killed the container mid-run: the orphan was requeued, and the 6 already-indexed documents replayed in ~8s instead of ~22s each. Idempotency demonstrated, not asserted.
- Second `POST` → `409` with the running jobId; no duplicate row.
- Audit trail: `user/success` → `user/failure/index_job_already_running` → `system/failure`, all correlated.

## Bugs an adversarial review found in my own code

All three shipped with a comment or a test claiming the opposite:

1. **A failed run reported `indexed: 0` regardless of what it achieved** — `counts` was hoisted out of the `try`, but `ingestPaths` only surfaces its tally through the return value, which a throw skips. The test that should have caught it asserted the bug as correct. The tally now travels with each progress report.
2. **The orphan requeue could reset a job this process had just claimed** (interval armed at 10s, requeue at 30s).
3. **The 409's jobId pointed at a run with no reachable status endpoint.**

Plus one older than this branch, and made far more reachable by it: **an unreadable root deleted its entire corpus.** `discoverFiles` swallowed a `stat` failure and returned `[]`; the removal pass then scoped itself to that root with an empty set and deleted everything under it, reporting success with `removed: N`. An unmounted volume is indistinguishable from an emptied folder from the outside — and the worker now starts seconds after boot, when a bind mount may not be attached yet. `discoverFiles` now answers `null` for "could not look" vs `[]` for "looked, nothing there". Both directions tested.

## Known limitation, deliberately not fixed here

If the **database** is the outage, `finishIndexJob`'s own write fails too, the row stays `running`, and the slot is held until the next boot requeues it. Recovering without a restart would need a heartbeat + staleness sweep that the single-container design does not otherwise need — and a database outage is already an operator's problem. Documented in the code.

## Gates

typecheck (incl. tests) · lint · prettier (web + docs) · 8935 unit · 298 integration · 348 script · 9 plugin packages · docs build (66 pages, new anchor verified in the built HTML) · test-deletion guard.
