### PR TITLE
fix(release): safe v0.9.0 upgrade path for the pgvector image swap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
   db:
     # pgvector/pgvector:pg17-trixie bundles the pgvector extension's shared
     # library on top of postgres:17 so `CREATE EXTENSION vector` (see
-    # packages/web/drizzle/0049_enable_pgvector.sql) succeeds. Powers the
+    # packages/web/drizzle/0054_safe_vision.sql) succeeds. Powers the
     # knowledge-base RAG index (kb_documents/kb_chunks, vector(1024) columns).
     #
     # Pinned to the `-trixie` variant, NOT the bare `pg17` tag: the plain

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -158,6 +158,90 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
+## Upgrading from v0.8.0 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+#### Re-fetch `docker-compose.yml` — the database image changed
+
+This release adds Knowledge Base agents, whose search index is built on the [`pgvector`](https://github.com/pgvector/pgvector) Postgres extension. The database migrations enable that extension on startup, and the stock `postgres:17` image doesn't ship it — so the `db` service now uses `pgvector/pgvector:pg17-trixie` instead.
+
+<Aside type="danger">
+  If you keep your old `docker-compose.yml`, the migration fails with `extension
+  "vector" is not available` and Pinchy restart-loops without serving anything —
+  migrations run on boot, so a failed one takes the whole app down, not just the
+  Knowledge Base. Nothing is lost when this happens: fetch the new compose file
+  and start again, and the migration picks up where it left off.
+</Aside>
+
+Re-fetch the compose file **before** pulling images:
+
+```bash
+cd /opt/pinchy
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
+sed -i 's/PINCHY_VERSION=v0.8.0/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+docker compose pull && docker compose up -d && docker image prune -f
+```
+
+Your data is safe across the image swap: it's the same PostgreSQL 17 on the same Debian base, reading the same `pgdata` volume in place — only the pgvector library is added. Both images are larger this release (the agent runtime now bundles an offline embedding model), so expect a bigger pull; the `docker image prune -f` from the standard flow keeps disk in check.
+
+<Aside type="caution">
+  **If you edited `docker-compose.yml` to [mount data
+  directories](/guides/mount-data-directories/)**, re-apply those `volumes:`
+  lines after re-fetching — the download overwrites them. Keeping custom mounts
+  in a `docker-compose.override.yml` instead makes future upgrades hands-off.
+</Aside>
+
+<Aside type="note">
+  **If you run your own PostgreSQL** instead of the bundled `db` service,
+  install the [pgvector](https://github.com/pgvector/pgvector) extension on that
+  server before upgrading — the migration runs `CREATE EXTENSION IF NOT EXISTS
+  vector` and needs both the extension files and a role allowed to create it.
+</Aside>
+
+### Upgrade notes
+
+#### First boot may take longer on installations with a lot of history
+
+The migrations build new indexes over your audit log and usage records. On an instance with months of history this can take a few minutes, during which Pinchy reports "unhealthy". If `docker compose up -d` gives up waiting and the `openclaw` service doesn't start ("dependency failed to start"), wait for `docker compose logs pinchy` to show the server starting, then run `docker compose up -d` once more.
+
+#### Container resource limits are now set by default
+
+The compose file now caps each service (pinchy 1 GB, openclaw 2 GB, db 1 GB memory, plus CPU limits) so one runaway container can't take down the host. Deployments that routinely needed more will see the container restarted by the kernel instead. Every limit is overridable in `.env` — see [Customizing your deployment](/guides/customizing-deployment/). After upgrading, `docker inspect --format '{{.State.OOMKilled}}' pinchy-openclaw-1` (and the other containers) tells you whether a limit is too tight for your workload.
+
+#### Knowledge Base agents (new, opt-in)
+
+Agents can now answer from your own documents with cited sources, backed by a search index in Pinchy's Postgres. Nothing is indexed until you set it up: mount document directories, pull the embedding model on your local Ollama (`ollama pull bge-m3`), create an agent from the new Knowledge Base template, and trigger indexing. See [Create a Knowledge Base agent](/guides/create-knowledge-base-agent/). If you don't use it, nothing changes for you.
+
+#### Agent memory recall now works offline
+
+The agent runtime image bundles a local embedding model, so agents' memory search works on every install — including fully offline ones — with no API key. Installs where memory recall silently returned nothing will notice agents actually remembering things. The memory index rebuilds automatically in the background after the upgrade; brief extra CPU on the openclaw container in the first minutes is expected.
+
+#### Shared agents no longer bring private memory into group chats
+
+A shared agent's `MEMORY.md` — what it learned in one-to-one conversations — is no longer injected into Telegram group sessions, so notes from private chats can't surface in front of a group. Shared agents may appear to "know less" in groups; that's the privacy fix working.
+
+#### Old channel attachments are cleaned up after 48 hours
+
+Inbound channel media (Telegram photos, documents) is now copied into the agent workspace on arrival, and the runtime's internal media cache is swept after 48 hours instead of growing forever. Attachments received **before** this upgrade were never copied, so ones older than 48 hours are removed by the first sweep and may no longer open from old conversations. Export anything you still need from pre-upgrade chats before upgrading.
+
+#### Workspace terminals stay disabled
+
+The OpenClaw runtime this release ships (2026.7.1) adds an interactive terminal into agent workspaces. Pinchy pins it off: a shell would bypass agent permission allow-lists and the audit trail. It will return as an RBAC-scoped, audited feature.
+
+### Database migrations
+
+Eleven additive migrations (`0044`–`0054`) run automatically on startup — no manual steps. No data is dropped or destructively rewritten; existing rows already satisfy every new constraint.
+
+- `0044` — schema hardening: four timestamp columns to `NOT NULL`, foreign-key and hot-path composite indexes, `CHECK` constraints on the enum-like text columns (roles, agent visibility, invite/connection types and statuses), and the `invites.claimed_by_user_id` foreign key switched to `ON DELETE SET NULL`.
+- `0045` — per-agent starter prompts (`agents.starter_prompts`, defaults to empty).
+- `0046`, `0048` — GDPR crypto-erasure groundwork: a pseudonymized actor ID on `user` (backfilled, then defaulted and made `UNIQUE`/`NOT NULL`) plus the `audit_verify_state` table backing periodic incremental chain verification.
+- `0047` — audit-log `TRUNCATE` guard (statement-level trigger) closing the row-trigger gap.
+- `0049`–`0051` — tables and constraints for email inbox workflows (foundation; no runtime surface in this release).
+- `0052` — notifications / activity-feed tables (foundation; no runtime surface in this release).
+- `0053` — per-turn context-window usage tracking (`usage_records.context_tokens`).
+- `0054` — Knowledge Base tables (`kb_documents`, `kb_chunks`) with the pgvector index; enables the `vector` extension (see the breaking change above).
+
 ## Upgrading from v0.7.0 to v0.8.0
 
 ### Breaking changes

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -179,7 +179,7 @@ Re-fetch the compose file **before** pulling images:
 ```bash
 cd /opt/pinchy
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
-sed -i 's/PINCHY_VERSION=v0.8.0/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+sed -i 's/^PINCHY_VERSION=.*/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -38,11 +38,11 @@ docker compose pull && docker compose up -d
 
 The `docker-compose.yml` defines three services:
 
-| Service    | Image            | Port             | Purpose                       |
-| ---------- | ---------------- | ---------------- | ----------------------------- |
-| `pinchy`   | Custom (Next.js) | 7777 (exposed)   | Web UI, API, WebSocket bridge |
-| `openclaw` | Custom (Node.js) | 18789 (internal) | AI agent runtime              |
-| `db`       | `postgres:17`    | 5432 (internal)  | Database                      |
+| Service    | Image                           | Port             | Purpose                             |
+| ---------- | ------------------------------- | ---------------- | ----------------------------------- |
+| `pinchy`   | Custom (Next.js)                | 7777 (exposed)   | Web UI, API, WebSocket bridge       |
+| `openclaw` | Custom (Node.js)                | 18789 (internal) | AI agent runtime                    |
+| `db`       | `pgvector/pgvector:pg17-trixie` | 5432 (internal)  | Database (PostgreSQL 17 + pgvector) |
 
 Only port **7777** is exposed to the host. OpenClaw and PostgreSQL are only reachable within the Docker network.
 

--- a/marketplace/caprover/pinchy.yml
+++ b/marketplace/caprover/pinchy.yml
@@ -10,7 +10,12 @@ captainVersion: 4
 
 services:
   $$cap_appname-db:
-    image: postgres:17
+    # Must match docker-compose.yml's db image. pgvector/pgvector:pg17-trixie is
+    # a drop-in postgres:17 replacement that bundles the pgvector extension so
+    # `CREATE EXTENSION vector` (migration 0054) succeeds — required at boot, so a
+    # stock postgres:17 here crash-loops on the first migration. A drift guard in
+    # scripts/lib/marketplace-lint.test.mjs keeps this pinned to the compose image.
+    image: pgvector/pgvector:pg17-trixie
     restart: unless-stopped
     volumes:
       - $$cap_appname-pgdata:/var/lib/postgresql/data

--- a/scripts/lib/marketplace-lint.mjs
+++ b/scripts/lib/marketplace-lint.mjs
@@ -94,6 +94,48 @@ export function assertValidPackerTemplate(content) {
 }
 
 /**
+ * Extracts the `image:` value of a single service block from compose-style YAML
+ * text (no YAML lib available). Finds the `<serviceKey>:` line, then the first
+ * `image:` at deeper indentation before the block ends — comment lines (`#`) and
+ * blank lines are skipped, so the prose in docker-compose.yml's db comment can't
+ * be mistaken for the image.
+ * @param {string} content - raw compose/one-click YAML
+ * @param {string} serviceKey - e.g. "db" or "$$cap_appname-db"
+ * @returns {string} the image reference (e.g. "pgvector/pgvector:pg17-trixie")
+ * @throws {Error} if the service or its image can't be found
+ */
+export function extractServiceImage(content, serviceKey) {
+  const lines = content.split("\n");
+  const esc = serviceKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const keyRe = new RegExp(`^(\\s*)${esc}:\\s*$`);
+  let found = false;
+  // The same key can appear more than once (e.g. `db:` both as a service and
+  // under another service's `depends_on:`). Try each occurrence and return the
+  // first block that actually declares an image; the depends_on block has none.
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(keyRe);
+    if (!m) continue;
+    found = true;
+    const indent = m[1].length;
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      const trimmed = line.trim();
+      if (trimmed === "" || trimmed.startsWith("#")) continue;
+      const curIndent = line.length - line.trimStart().length;
+      if (curIndent <= indent) break; // left this block
+      const im = trimmed.match(/^image:\s*(\S+)$/);
+      if (im) return im[1];
+    }
+  }
+  if (!found) {
+    throw new Error(`marketplace-lint: service "${serviceKey}" not found`);
+  }
+  throw new Error(
+    `marketplace-lint: no image declared for service "${serviceKey}"`,
+  );
+}
+
+/**
  * Validates the CapRover one-click template's critical invariants. Text-based
  * (no YAML lib); each invariant is a regression we have already hit or that
  * would silently break a real deploy.

--- a/scripts/lib/marketplace-lint.mjs
+++ b/scripts/lib/marketplace-lint.mjs
@@ -123,7 +123,9 @@ export function extractServiceImage(content, serviceKey) {
       if (trimmed === "" || trimmed.startsWith("#")) continue;
       const curIndent = line.length - line.trimStart().length;
       if (curIndent <= indent) break; // left this block
-      const im = trimmed.match(/^image:\s*(\S+)$/);
+      // `\S+` (not `.*$`) stops at the first whitespace, so a trailing inline
+      // comment (`image: foo:bar # pinned`) yields the bare image reference.
+      const im = trimmed.match(/^image:\s*(\S+)/);
       if (im) return im[1];
     }
   }

--- a/scripts/lib/marketplace-lint.test.mjs
+++ b/scripts/lib/marketplace-lint.test.mjs
@@ -8,12 +8,14 @@ import {
   checkShellSyntax,
   assertValidPackerTemplate,
   assertValidCaproverTemplate,
+  extractServiceImage,
 } from "./marketplace-lint.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const MARKETPLACE = resolve(ROOT, "marketplace");
 const TEMPLATE_PATH = resolve(MARKETPLACE, "digitalocean/template.json");
 const CAPROVER_PATH = resolve(MARKETPLACE, "caprover/pinchy.yml");
+const COMPOSE_PATH = resolve(ROOT, "docker-compose.yml");
 
 // ─── Packer template structure ────────────────────────────────────────────────
 
@@ -106,7 +108,66 @@ test("assertValidCaproverTemplate rejects a missing version pin", () => {
   assert.throws(() => assertValidCaproverTemplate(bad), /version defaultValue/);
 });
 
+// ─── Service image extraction ─────────────────────────────────────────────────
+
+test("extractServiceImage reads the image past a comment block", () => {
+  const yaml = `services:
+  db:
+    # a comment mentioning the word image in prose should be ignored
+    image: pgvector/pgvector:pg17-trixie
+    restart: unless-stopped
+  web:
+    image: ghcr.io/example/web:latest
+`;
+  assert.equal(
+    extractServiceImage(yaml, "db"),
+    "pgvector/pgvector:pg17-trixie",
+  );
+  assert.equal(extractServiceImage(yaml, "web"), "ghcr.io/example/web:latest");
+});
+
+test("extractServiceImage handles a CapRover $$-prefixed service key", () => {
+  const yaml = `services:
+  $$cap_appname-db:
+    image: postgres:17
+    restart: unless-stopped
+`;
+  assert.equal(extractServiceImage(yaml, "$$cap_appname-db"), "postgres:17");
+});
+
+test("extractServiceImage throws when the service or image is absent", () => {
+  assert.throws(
+    () => extractServiceImage("services:\n  db:\n    restart: always\n", "db"),
+    /no image declared/,
+  );
+  assert.throws(
+    () => extractServiceImage("services:\n  web:\n    image: x\n", "db"),
+    /not found/,
+  );
+});
+
 // ─── Real-file guards ─────────────────────────────────────────────────────────
+
+test("the CapRover db image matches docker-compose.yml's db image", () => {
+  // Drift guard (pinchy#820): the pgvector extension is required at boot
+  // (migration 0054 runs CREATE EXTENSION vector), so a CapRover template still
+  // pinning stock postgres:17 produces a dead-on-arrival install that crash-loops
+  // on first migration. Keep the one-click db image in lockstep with the
+  // canonical compose db image.
+  const composeDbImage = extractServiceImage(
+    readFileSync(COMPOSE_PATH, "utf8"),
+    "db",
+  );
+  const caproverDbImage = extractServiceImage(
+    readFileSync(CAPROVER_PATH, "utf8"),
+    "$$cap_appname-db",
+  );
+  assert.equal(
+    caproverDbImage,
+    composeDbImage,
+    `CapRover db image (${caproverDbImage}) must match docker-compose.yml db image (${composeDbImage}).`,
+  );
+});
 
 test("the committed DigitalOcean template.json is structurally valid", () => {
   assert.doesNotThrow(() =>

--- a/scripts/lib/marketplace-lint.test.mjs
+++ b/scripts/lib/marketplace-lint.test.mjs
@@ -126,6 +126,17 @@ test("extractServiceImage reads the image past a comment block", () => {
   assert.equal(extractServiceImage(yaml, "web"), "ghcr.io/example/web:latest");
 });
 
+test("extractServiceImage tolerates a trailing inline comment on the image line", () => {
+  const yaml = `services:
+  db:
+    image: pgvector/pgvector:pg17-trixie # pinned; see docker-compose.yml
+`;
+  assert.equal(
+    extractServiceImage(yaml, "db"),
+    "pgvector/pgvector:pg17-trixie",
+  );
+});
+
 test("extractServiceImage handles a CapRover $$-prefixed service key", () => {
   const yaml = `services:
   $$cap_appname-db:


### PR DESCRIPTION
Closes #819, closes #820.

This release swaps the db image to `pgvector/pgvector:pg17-trixie` because migration `0054` runs `CREATE EXTENSION vector` at boot. Migrations run under `set -e` on startup, so any path still on stock `postgres:17` doesn't just lose the Knowledge Base — **the whole app crash-loops**. This PR chases that change everywhere it matters.

### What's here

**`docs(upgrading)` — the v0.8.0 → next section (unblocks `pnpm release`)**
- `pnpm release` hard-aborts without a `## Upgrading from v0.8.0 to %%PINCHY_VERSION%%` section; this adds it.
- Breaking change #1, placed first: re-fetch `docker-compose.yml` before pulling, with the exact commands. Caveats for external/managed Postgres (install pgvector + `CREATE EXTENSION` privilege) and for operators who added custom data mounts by editing compose (re-apply after re-fetch — durable fix tracked in #835).
- Behaviour notes for the release: longer first boot on large audit tables, new default resource limits (#263) + OOM check, KB opt-in, offline memory recall, shared-agent memory no longer in group chats (#369), 48h media sweep, workspace terminals pinned off.
- Migration list `0044`–`0054`, attributed from the actual SQL.

**`fix(marketplace)` — CapRover was dead-on-arrival**
- `marketplace/caprover/pinchy.yml` still pinned `postgres:17` → every next-release CapRover one-click deploy would crash-loop on migration `0054`. Pinned to the compose image.
- Added a cross-file **drift guard** (`extractServiceImage` + a real-file test) asserting the CapRover db image equals `docker-compose.yml`'s, so this can't silently diverge again. TDD: the guard fails on the old `postgres:17`, passes after the fix.

**Trivia in the same sweep**
- `docs(installation)`: db image corrected in the services table.
- `docker-compose.yml`: db comment pointed at the real migration file (`0054_safe_vision.sql`; the pre-rebase `0049` name was stale and would misdirect anyone debugging the crash-loop).

### Verification
- `node --test scripts/lib/marketplace-lint.test.mjs` — 16/16 (drift guard red→green demonstrated).
- `node --test scripts/lib/upgrading-mdx-freshness.test.mjs` — green (placeholder section valid, `from v0.8.0` matches `package.json#version`).
- `pnpm test:scripts` — all green except `format-gate.test.mjs`, which fails only locally because `prettier` isn't installed in this worktree (declared root devDep, present in CI); all changed files are `prettier --check`-clean.

### Not in scope (deliberately)
The v0.7→v0.8 section lists migration `0044`, which was never in the v0.8.0 tag (it landed after; tag ends at `0043`) — a pre-existing mis-attribution in historical notes. Left alone here; flagged to the maintainer separately rather than rewriting shipped release notes.