### PR TITLE
feat(eval): capture per-run token cost, joined by session key (#798)

### DIFF
--- a/packages/web/eval/README.md
+++ b/packages/web/eval/README.md
@@ -344,7 +344,10 @@ whole task's cost, not one call's:
 "tokens": { "prompt": 9200, "completion": 640, "contextTokens": 41200 }
 ```
 
-- `prompt` / `completion` — summed input / output tokens across the run.
+- `prompt` / `completion` — summed prompt / output tokens across the run.
+  `prompt` counts all three prompt classes the model read (`input + cacheRead +
+cacheWrite`), which differ only in billing, so caching hosters aren't
+  under-reported.
 - `contextTokens` — the PEAK context-window pressure (max over turns, not sum).
   It is the read-side of the "Piper" false-success incident: a run whose context
   climbs without compaction firing is a PLATFORM risk factor, not a model score.

--- a/packages/web/eval/README.md
+++ b/packages/web/eval/README.md
@@ -312,7 +312,8 @@ OLLAMA_CLOUD_API_KEY=... pnpm -C packages/web eval:models
       "passCaretK": 0,
       "tagHistogram": { "false-success": 1 },
       "medianLatencyMs": 8421,
-      "medianTokens": 1203
+      "medianTokens": 1203,
+      "medianTokensPerCompletedTask": 1450
     }
   ]
 }
@@ -330,6 +331,35 @@ overlap. `tagHistogram` counts which `FailureTag`s fired across all failing
 runs for that model — this is usually more actionable than the raw pass
 rate (e.g. "always `id-malformed`" points at a very different fix than
 "always `task-incomplete`").
+
+### Token cost per run (pinchy#798)
+
+Each `RunResult` now carries a `tokens` object, joined from `usage_records` by
+the run's unique OpenClaw session key (`agent:<id>:direct:<userId>:<chatId>` —
+`dispatchAndScrape` mints a fresh `chatId` per run, so the join is exact, not a
+time window). It is summed over every turn of the run's tool loop, so it is the
+whole task's cost, not one call's:
+
+```json
+"tokens": { "prompt": 9200, "completion": 640, "contextTokens": 41200 }
+```
+
+- `prompt` / `completion` — summed input / output tokens across the run.
+- `contextTokens` — the PEAK context-window pressure (max over turns, not sum).
+  It is the read-side of the "Piper" false-success incident: a run whose context
+  climbs without compaction firing is a PLATFORM risk factor, not a model score.
+  Omitted when no turn recorded it.
+- `costUsd` — summed `estimated_cost_usd`, present only when a provider prices
+  per token. Absent for Ollama Cloud, which is subscription-billed (no per-token
+  price); the published `$` figure is a labeled multi-hoster range computed
+  offline from the token counts, never this column.
+
+The scorecard exposes two medians: `medianTokens` (over all runs) and
+**`medianTokensPerCompletedTask`** (over PASSING runs only). The latter is the
+published primary cost metric — a model that fails cheaply must not read as
+cheaper than one that actually completed the task. The capture is best-effort:
+the collector polls for recorder lag and yields no `tokens` (rather than
+aborting the run) on a miss, so a run with no usage row simply has no cost.
 
 ## The triage guard — a catastrophic cell has to be read
 

--- a/packages/web/eval/__tests__/token-usage.test.ts
+++ b/packages/web/eval/__tests__/token-usage.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { aggregateTokenUsage, collectRunTokens, type UsageRow } from "../token-usage";
+import { describe, expect, it, vi } from "vitest";
+import type { Sql } from "postgres";
+import {
+  aggregateTokenUsage,
+  collectRunTokens,
+  makeTokenCollector,
+  type UsageRow,
+} from "../token-usage";
 
 const row = (over: Partial<UsageRow> = {}): UsageRow => ({
   inputTokens: 0,
   outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
   contextTokens: null,
   estimatedCostUsd: null,
   ...over,
@@ -21,6 +29,16 @@ describe("aggregateTokenUsage", () => {
       row({ inputTokens: 30, outputTokens: 5 }),
     ]);
     expect(usage).toMatchObject({ prompt: 380, completion: 65 });
+  });
+
+  it("counts cacheRead/cacheWrite as prompt tokens (all three prompt classes the model read)", () => {
+    // input/cacheRead/cacheWrite are disjoint (see usage-from-trajectory.ts);
+    // all three are tokens the model read, differing only in billing. Dropping
+    // the cache classes under-reports prompt volume on caching hosters.
+    const usage = aggregateTokenUsage([
+      row({ inputTokens: 5, cacheReadTokens: 630, cacheWriteTokens: 320, outputTokens: 12 }),
+    ]);
+    expect(usage).toMatchObject({ prompt: 955, completion: 12 });
   });
 
   it("takes the PEAK context (max), not the sum — context is window pressure", () => {
@@ -135,5 +153,62 @@ describe("collectRunTokens", () => {
   it("never throws — a query error degrades to undefined, never aborts the sweep", async () => {
     const usage = await collectRunTokens(() => Promise.reject(new Error("db down")), clockOpts());
     expect(usage).toBeUndefined();
+  });
+
+  it("reports the query error via onQueryError so a systemic break is not fully silent", async () => {
+    const errors: unknown[] = [];
+    const usage = await collectRunTokens(() => Promise.reject(new Error("db down")), {
+      ...clockOpts(),
+      onQueryError: (e) => errors.push(e),
+    });
+    expect(usage).toBeUndefined();
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toContain("db down");
+  });
+});
+
+// A fake `Sql` tagged-template. `makeTokenCollector` interpolates `${agentId}`
+// then `${pattern}`, so the LIKE pattern is always the last interpolated value.
+function fakeSql(onCall: (pattern: string) => Promise<UsageRow[]>): Sql {
+  const tag = (_strings: TemplateStringsArray, ...values: unknown[]) =>
+    onCall(values[values.length - 1] as string);
+  return tag as unknown as Sql;
+}
+
+describe("makeTokenCollector", () => {
+  const clockOpts = () => {
+    const clock = fakeClock();
+    return { timeoutMs: 20_000, intervalMs: 500, now: clock.now, sleep: clock.sleep };
+  };
+
+  it("lowercases the session_key pattern to match the stored (lowercased) key", async () => {
+    // usage_records.session_key is written lowercased (see lib/usage*.ts), so a
+    // raw mixed-case agentId/chatId would silently never match. Verify the
+    // pattern is folded to lower case.
+    let seen: string | undefined;
+    const collect = makeTokenCollector(
+      fakeSql((pattern) => {
+        seen = pattern;
+        return Promise.resolve([]);
+      }),
+      clockOpts()
+    );
+    await collect("Agent-ABC", "Chat-DEF");
+    expect(seen).toBe("agent:agent-abc:direct:%:chat-def");
+  });
+
+  it("warns at most once per sweep even if every run's join query keeps failing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const collect = makeTokenCollector(
+        fakeSql(() => Promise.reject(new Error("boom"))),
+        clockOpts()
+      );
+      expect(await collect("a", "chat-1")).toBeUndefined();
+      expect(await collect("a", "chat-2")).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/web/eval/__tests__/token-usage.test.ts
+++ b/packages/web/eval/__tests__/token-usage.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { aggregateTokenUsage, collectRunTokens, type UsageRow } from "../token-usage";
+
+const row = (over: Partial<UsageRow> = {}): UsageRow => ({
+  inputTokens: 0,
+  outputTokens: 0,
+  contextTokens: null,
+  estimatedCostUsd: null,
+  ...over,
+});
+
+describe("aggregateTokenUsage", () => {
+  it("returns undefined for no rows (no usage recorded for this run)", () => {
+    expect(aggregateTokenUsage([])).toBeUndefined();
+  });
+
+  it("sums input/output across every turn of the run's tool loop", () => {
+    const usage = aggregateTokenUsage([
+      row({ inputTokens: 100, outputTokens: 20 }),
+      row({ inputTokens: 250, outputTokens: 40 }),
+      row({ inputTokens: 30, outputTokens: 5 }),
+    ]);
+    expect(usage).toMatchObject({ prompt: 380, completion: 65 });
+  });
+
+  it("takes the PEAK context (max), not the sum — context is window pressure", () => {
+    const usage = aggregateTokenUsage([
+      row({ contextTokens: 12_000 }),
+      row({ contextTokens: 47_000 }),
+      row({ contextTokens: 31_000 }),
+    ]);
+    expect(usage?.contextTokens).toBe(47_000);
+  });
+
+  it("ignores null context turns when taking the peak", () => {
+    const usage = aggregateTokenUsage([
+      row({ contextTokens: null }),
+      row({ contextTokens: 8_000 }),
+      row({ contextTokens: null }),
+    ]);
+    expect(usage?.contextTokens).toBe(8_000);
+  });
+
+  it("omits contextTokens entirely when every turn recorded it as null", () => {
+    const usage = aggregateTokenUsage([row({ inputTokens: 10 }), row({ inputTokens: 10 })]);
+    expect(usage).toBeDefined();
+    expect(usage).not.toHaveProperty("contextTokens");
+  });
+
+  it("sums estimated cost, parsing the postgres numeric string", () => {
+    const usage = aggregateTokenUsage([
+      row({ estimatedCostUsd: "0.001200" }),
+      row({ estimatedCostUsd: "0.000800" }),
+    ]);
+    expect(usage?.costUsd).toBeCloseTo(0.002, 6);
+  });
+
+  it("omits costUsd when no turn priced per token (Ollama Cloud subscription)", () => {
+    const usage = aggregateTokenUsage([
+      row({ inputTokens: 10, estimatedCostUsd: null }),
+      row({ inputTokens: 10, estimatedCostUsd: null }),
+    ]);
+    expect(usage).toBeDefined();
+    expect(usage).not.toHaveProperty("costUsd");
+  });
+});
+
+// A scripted clock + query so the polling loop is deterministic without a DB.
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: (ms: number) => {
+      t += ms;
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A query whose successive calls return the next scripted row-set. */
+function scriptedQuery(script: UsageRow[][]): () => Promise<UsageRow[]> {
+  let i = 0;
+  return () => Promise.resolve(script[Math.min(i++, script.length - 1)]);
+}
+
+describe("collectRunTokens", () => {
+  const clockOpts = () => {
+    const clock = fakeClock();
+    return { timeoutMs: 20_000, intervalMs: 500, now: clock.now, sleep: clock.sleep };
+  };
+
+  it("returns the aggregate once the row count is stable across two reads", async () => {
+    const usage = await collectRunTokens(
+      scriptedQuery([
+        [row({ inputTokens: 42, outputTokens: 17 })],
+        [row({ inputTokens: 42, outputTokens: 17 })],
+      ]),
+      clockOpts()
+    );
+    expect(usage).toMatchObject({ prompt: 42, completion: 17 });
+  });
+
+  it("keeps polling while the recorder is still writing turns, then settles", async () => {
+    // 1 row, then 3 (recorder catching up), then 3 stable → sum of the 3.
+    const three = [
+      row({ inputTokens: 100, outputTokens: 10 }),
+      row({ inputTokens: 100, outputTokens: 10 }),
+      row({ inputTokens: 100, outputTokens: 10 }),
+    ];
+    const usage = await collectRunTokens(
+      scriptedQuery([[row({ inputTokens: 100, outputTokens: 10 })], three, three]),
+      clockOpts()
+    );
+    expect(usage).toMatchObject({ prompt: 300, completion: 30 });
+  });
+
+  it("returns undefined when no usage row ever appears before the timeout", async () => {
+    const usage = await collectRunTokens(scriptedQuery([[]]), clockOpts());
+    expect(usage).toBeUndefined();
+  });
+
+  it("returns the best-effort aggregate if rows appear but never stabilize", async () => {
+    // Count grows every single poll and never plateaus → on timeout, return the
+    // last aggregate seen rather than throwing away a partial count.
+    let n = 0;
+    const everGrowing = () => {
+      n += 1;
+      return Promise.resolve(Array.from({ length: n }, () => row({ inputTokens: 10 })));
+    };
+    const usage = await collectRunTokens(everGrowing, clockOpts());
+    expect(usage).toBeDefined();
+    expect(usage!.prompt).toBeGreaterThan(0);
+  });
+
+  it("never throws — a query error degrades to undefined, never aborts the sweep", async () => {
+    const usage = await collectRunTokens(() => Promise.reject(new Error("db down")), clockOpts());
+    expect(usage).toBeUndefined();
+  });
+});

--- a/packages/web/eval/eval-models.spec.ts
+++ b/packages/web/eval/eval-models.spec.ts
@@ -334,9 +334,13 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
           scorecard
         );
       }
-
-      await pinchyDelete(`/api/agents/${agentId}`, cookie);
     } finally {
+      // Clean up the ephemeral sweep agent even when a run throws, then always
+      // close the token DB client. Each cleanup is isolated so one failing does
+      // not skip the other.
+      await pinchyDelete(`/api/agents/${agentId}`, cookie).catch((err: unknown) =>
+        console.warn(`[eval] agent cleanup failed: ${String(err)}`)
+      );
       await tokenSql.end();
     }
   });

--- a/packages/web/eval/eval-models.spec.ts
+++ b/packages/web/eval/eval-models.spec.ts
@@ -54,6 +54,7 @@ import {
   injectOdooCreateSilentSuccess,
 } from "./run-eval";
 import { captureRunFingerprint } from "./fingerprint";
+import { makeTokenCollector } from "./token-usage";
 import { setupHetznerAgent } from "./eval-shared";
 import type { RunResult } from "../src/lib/eval/types";
 
@@ -205,6 +206,13 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
 
     const { agentId } = await setupHetznerAgent(cookie);
 
+    // A sweep-lived DB client for the #798 token join. Separate from the seeding
+    // `sql` above (already ended) so its lifetime spans every run; closed in the
+    // finally below. The collector polls `usage_records` per run by the run's
+    // unique session key — best-effort, never fails a run.
+    const tokenSql = postgres(dbUrl);
+    const collectTokens = makeTokenCollector(tokenSql);
+
     // Each scenario in SWEEP_SCENARIOS gets its OWN run list + scorecard file
     // (label) so "vendor-bill-created" and "honest-failure" (failure-
     // injection) results never mix into one buildScorecard grouping — the
@@ -239,92 +247,97 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
       }
     };
 
-    for (const { label, scenario, extraSetup } of scenariosToRun) {
-      // Resume: seed the scorecard with runs already persisted to the JSONL
-      // (from a prior interrupted invocation) and skip models already at N.
-      const existingRuns = await readExistingRuns(label);
-      const scenarioRuns: RunResult[] = [...existingRuns];
+    try {
+      for (const { label, scenario, extraSetup } of scenariosToRun) {
+        // Resume: seed the scorecard with runs already persisted to the JSONL
+        // (from a prior interrupted invocation) and skip models already at N.
+        const existingRuns = await readExistingRuns(label);
+        const scenarioRuns: RunResult[] = [...existingRuns];
 
-      for (const model of candidates) {
-        const alreadyDone = existingRuns.filter((r) => r.model === model).length;
-        if (alreadyDone >= n) continue; // fully covered by a previous run
+        for (const model of candidates) {
+          const alreadyDone = existingRuns.filter((r) => r.model === model).length;
+          if (alreadyDone >= n) continue; // fully covered by a previous run
 
-        // Per-model setup (pin + stack readiness) with retry; if the stack
-        // stays unreachable, SKIP this model rather than aborting the sweep.
-        try {
-          await withRetry(async () => {
-            await pinAgentModel(cookie, agentId, model);
-            await waitForOpenClawStable(() => pinchyGet("/api/health/openclaw", cookie));
-            await waitForAgentDispatchable(
-              (id) => pinchyGet(`/api/health/openclaw?agentId=${id}`, cookie),
-              agentId
-            );
-          }, `setup ${model} / ${label}`);
-        } catch (err) {
-          console.warn(
-            `[eval] SKIPPING ${model} / ${label} — setup failed after retries: ${String(err)}`
-          );
-          continue;
-        }
-
-        for (let i = alreadyDone; i < n; i++) {
-          const runStart = Date.now();
+          // Per-model setup (pin + stack readiness) with retry; if the stack
+          // stays unreachable, SKIP this model rather than aborting the sweep.
           try {
-            await withRetry(
-              async () => {
-                await resetGraphMock();
-                await seedGraphMockMessages([
-                  scenario.graphSeedMessage,
-                  ...(scenario.extraGraphMessages ?? []),
-                ]);
-                await resetOdooMock();
-                await seedOdooBaseline(scenario.odooBaseline);
-                if (extraSetup) await extraSetup();
-                await loginViaUI(page, getAdminEmail(), getAdminPassword());
-              },
-              `run-setup ${model} #${String(i)}`
-            );
-            const result = await runOnce({
-              page,
-              cookie,
-              agentId,
-              model,
-              scenario,
-              scenarioLabel: label,
-            });
-            scenarioRuns.push(result);
-            await appendRunResult(label, result);
+            await withRetry(async () => {
+              await pinAgentModel(cookie, agentId, model);
+              await waitForOpenClawStable(() => pinchyGet("/api/health/openclaw", cookie));
+              await waitForAgentDispatchable(
+                (id) => pinchyGet(`/api/health/openclaw?agentId=${id}`, cookie),
+                agentId
+              );
+            }, `setup ${model} / ${label}`);
           } catch (err) {
-            // A hung/looping run (dispatch idle-timeout) or any per-run error
-            // must NOT abort the whole sweep or discard the scenario's data. A
-            // hang is itself a reliability signal (some models spiral when a
-            // tool result contradicts their plan), so record it as a graded
-            // run-timeout failure and keep going.
-            const latencyMs = Date.now() - runStart;
             console.warn(
-              `[eval] run ${String(i + 1)}/${String(n)} for ${model} / ${label} recorded as run-timeout: ${String(err)}`
+              `[eval] SKIPPING ${model} / ${label} — setup failed after retries: ${String(err)}`
             );
-            const timeoutResult: RunResult = {
-              model,
-              passed: false,
-              tags: ["run-timeout"],
-              notes: [String(err)],
-              latencyMs,
-              scenario: label,
-            };
-            scenarioRuns.push(timeoutResult);
-            await appendRunResult(label, timeoutResult);
+            continue;
+          }
+
+          for (let i = alreadyDone; i < n; i++) {
+            const runStart = Date.now();
+            try {
+              await withRetry(
+                async () => {
+                  await resetGraphMock();
+                  await seedGraphMockMessages([
+                    scenario.graphSeedMessage,
+                    ...(scenario.extraGraphMessages ?? []),
+                  ]);
+                  await resetOdooMock();
+                  await seedOdooBaseline(scenario.odooBaseline);
+                  if (extraSetup) await extraSetup();
+                  await loginViaUI(page, getAdminEmail(), getAdminPassword());
+                },
+                `run-setup ${model} #${String(i)}`
+              );
+              const result = await runOnce({
+                page,
+                cookie,
+                agentId,
+                model,
+                scenario,
+                scenarioLabel: label,
+                collectTokens,
+              });
+              scenarioRuns.push(result);
+              await appendRunResult(label, result);
+            } catch (err) {
+              // A hung/looping run (dispatch idle-timeout) or any per-run error
+              // must NOT abort the whole sweep or discard the scenario's data. A
+              // hang is itself a reliability signal (some models spiral when a
+              // tool result contradicts their plan), so record it as a graded
+              // run-timeout failure and keep going.
+              const latencyMs = Date.now() - runStart;
+              console.warn(
+                `[eval] run ${String(i + 1)}/${String(n)} for ${model} / ${label} recorded as run-timeout: ${String(err)}`
+              );
+              const timeoutResult: RunResult = {
+                model,
+                passed: false,
+                tags: ["run-timeout"],
+                notes: [String(err)],
+                latencyMs,
+                scenario: label,
+              };
+              scenarioRuns.push(timeoutResult);
+              await appendRunResult(label, timeoutResult);
+            }
           }
         }
+
+        const scorecard = await writeScorecard(label, scenarioRuns, fingerprint);
+        console.log(
+          `[eval] wrote scorecard "${label}" for ${String(scenarioRuns.length)} runs:`,
+          scorecard
+        );
       }
 
-      const scorecard = await writeScorecard(label, scenarioRuns, fingerprint);
-      console.log(
-        `[eval] wrote scorecard "${label}" for ${String(scenarioRuns.length)} runs:`,
-        scorecard
-      );
+      await pinchyDelete(`/api/agents/${agentId}`, cookie);
+    } finally {
+      await tokenSql.end();
     }
-
-    await pinchyDelete(`/api/agents/${agentId}`, cookie);
   });
 });

--- a/packages/web/eval/run-eval.ts
+++ b/packages/web/eval/run-eval.ts
@@ -25,6 +25,7 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { EVAL_CANARY_JSONL_LINE, parseEvalJsonl } from "./canary";
 import type { RunFingerprint } from "./fingerprint";
+import type { TokenCollector } from "./token-usage";
 import { buildTrajectory, type NormalizeAuditEntry } from "../src/lib/eval/normalize";
 import { gradeRunForScenario } from "../src/lib/eval/graders";
 import { buildScorecard, type ScorecardEntry } from "../src/lib/eval/scorecard";
@@ -291,6 +292,12 @@ async function scrapeFinalAssistantMessage(page: Page): Promise<string> {
 export interface DispatchResult {
   finalMessage: string;
   latencyMs: number;
+  /**
+   * The chatId this dispatch ran under. The run's OpenClaw session is
+   * `agent:<agentId>:direct:<userId>:<chatId>`, so this is the key the #798
+   * token join filters `usage_records` by (see token-usage.ts).
+   */
+  chatId: string;
 }
 
 /**
@@ -322,7 +329,7 @@ export async function dispatchAndScrape(
   const latencyMs = Date.now() - start;
 
   const finalMessage = await scrapeFinalAssistantMessage(page);
-  return { finalMessage, latencyMs };
+  return { finalMessage, latencyMs, chatId };
 }
 
 // ── Agent model pinning ──────────────────────────────────────────────────
@@ -369,6 +376,14 @@ export interface RunOnceParams {
    * (see `writeScorecard`). Purely a label — does not affect grading.
    */
   scenarioLabel?: string;
+  /**
+   * Joins this run to its `usage_records` tokens/cost by (agentId, chatId), for
+   * the #798 cost metric. Optional and injected (the DB coupling lives in the
+   * sweep spec, not here) — when omitted, `RunResult.tokens` stays undefined and
+   * the run is graded exactly as before. Never throws; a capture miss degrades
+   * to undefined rather than failing the run.
+   */
+  collectTokens?: TokenCollector;
 }
 
 /**
@@ -383,7 +398,7 @@ export async function runOnce(params: RunOnceParams): Promise<RunResult> {
   const scenario = params.scenario ?? hetznerInvoiceScenario;
   const since = new Date().toISOString();
 
-  const { finalMessage, latencyMs } = await dispatchAndScrape(
+  const { finalMessage, latencyMs, chatId } = await dispatchAndScrape(
     page,
     agentId,
     params.prompt ?? scenario.userPrompt
@@ -391,6 +406,9 @@ export async function runOnce(params: RunOnceParams): Promise<RunResult> {
 
   const auditEntries = await collectToolAuditEntries(cookie, agentId, since);
   const odooMoves = await getOdooRecords("account.move");
+  // Join this run's tokens/cost by its unique session (agentId, chatId). Polls
+  // for the recorder lag; best-effort — undefined on a miss, never throws.
+  const tokens = params.collectTokens ? await params.collectTokens(agentId, chatId) : undefined;
 
   const trajectory = buildTrajectory({
     model,
@@ -402,6 +420,7 @@ export async function runOnce(params: RunOnceParams): Promise<RunResult> {
     extraIssuedMessageHandles: scenario.extraIssuedMessageHandles,
     extraIssuedAttachmentHandles: scenario.extraIssuedAttachmentHandles,
     latencyMs,
+    tokens,
   });
 
   const result = gradeRunForScenario(trajectory, scenario);

--- a/packages/web/eval/token-usage.ts
+++ b/packages/web/eval/token-usage.ts
@@ -26,18 +26,25 @@ import type { RunTokenUsage } from "../src/lib/eval/types";
 /**
  * One `usage_records` row as read for the join. `estimated_cost_usd` is a
  * `numeric` column, so postgres.js hands it back as a string (or null); the
- * token columns are integers, `context_tokens` nullable.
+ * token columns are integers, `context_tokens` nullable. `input`, `cacheRead`
+ * and `cacheWrite` are the three DISJOINT prompt classes (see
+ * usage-from-trajectory.ts) — all tokens the model read, differing only in
+ * billing — so the run's prompt volume is their sum.
  */
 export interface UsageRow {
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
   contextTokens: number | null;
   estimatedCostUsd: string | null;
 }
 
 /**
  * Rolls up a run's `usage_records` rows into a {@link RunTokenUsage}. Pure.
- * - `prompt`/`completion`: summed over every turn (the task's total cost).
+ * - `prompt`: summed over every turn, counting all three prompt classes
+ *   (`input + cacheRead + cacheWrite`) so caching hosters aren't under-reported.
+ * - `completion`: summed output over every turn (the task's total cost).
  * - `contextTokens`: the PEAK (max) across turns, ignoring nulls — window
  *   pressure, not a total. Omitted when no turn recorded it.
  * - `costUsd`: summed parsed cost. Omitted when no turn priced per token.
@@ -54,7 +61,7 @@ export function aggregateTokenUsage(rows: UsageRow[]): RunTokenUsage | undefined
   let costUsd: number | undefined;
 
   for (const r of rows) {
-    prompt += r.inputTokens;
+    prompt += r.inputTokens + r.cacheReadTokens + r.cacheWriteTokens;
     completion += r.outputTokens;
     if (r.contextTokens !== null) {
       peakContext =
@@ -81,6 +88,15 @@ export interface CollectTokensOptions {
   now?: () => number;
   /** Injectable delay (tests). Default a real `setTimeout` sleep. */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Called when the join query throws. The result still degrades to
+   * `undefined` (a DB blip must never abort the sweep), but a THROWN query is a
+   * systemic break — a renamed column, a session-key convention drift — that
+   * would otherwise capture nothing for the whole sweep, indistinguishable from
+   * "this provider is subscription-billed". `makeTokenCollector` uses this to
+   * warn once so the break is visible in the logs rather than fully silent.
+   */
+  onQueryError?: (err: unknown) => void;
 }
 
 const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -88,7 +104,11 @@ const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r
 /**
  * Polls `query` until the row count is non-empty AND unchanged since the
  * previous read (the recorder has finished writing this run's turns), then
- * returns the aggregate. Best-effort on the edges:
+ * returns the aggregate. Count-stability is a sound "done" signal because the
+ * recorder writes a run's turns in ONE atomic batch insert (see
+ * `insertPerTurnUsage`) and the collector only runs after the run is idle, so
+ * the count steps 0 → N → N and never settles on a partial N. Best-effort on
+ * the edges:
  * - No rows before `timeoutMs` → `undefined` (run recorded no usage).
  * - Rows that never stabilize before `timeoutMs` → the last aggregate seen,
  *   rather than discarding a partial count.
@@ -111,7 +131,8 @@ export async function collectRunTokens(
     let rows: UsageRow[];
     try {
       rows = await query();
-    } catch {
+    } catch (err) {
+      opts.onQueryError?.(err);
       return undefined;
     }
 
@@ -140,15 +161,36 @@ export type TokenCollector = (
  *
  * The session_key filter anchors on both the agent prefix and the run's unique
  * chatId suffix (`agent:<agentId>:direct:%:<chatId>`), so the `%` only spans the
- * userId segment and the rows are exactly this run's.
+ * userId segment and the rows are exactly this run's. The pattern is
+ * lower-cased because `usage_records.session_key` is written lower-cased (see
+ * `lib/usage.ts` / `lib/usage-per-turn.ts`); matching the raw mixed-case id
+ * would silently return nothing.
+ *
+ * A thrown join query (renamed column, convention drift) degrades to no tokens
+ * — but is warned ONCE per sweep so a systemic break is visible in the logs
+ * rather than fully silent (a captured-nothing sweep looks identical to a
+ * subscription-billed one otherwise).
  */
 export function makeTokenCollector(sql: Sql, opts: CollectTokensOptions = {}): TokenCollector {
+  let warnedQueryError = false;
+  const onQueryError =
+    opts.onQueryError ??
+    ((err: unknown) => {
+      if (warnedQueryError) return;
+      warnedQueryError = true;
+      console.warn(
+        `[eval] token join query failed — capturing no per-run cost for this sweep: ${String(err)}`
+      );
+    });
+
   return (agentId, chatId) => {
-    const pattern = `agent:${agentId}:direct:%:${chatId}`;
+    const pattern = `agent:${agentId}:direct:%:${chatId}`.toLowerCase();
     const query = async (): Promise<UsageRow[]> => {
       const rows = await sql<UsageRow[]>`
         SELECT input_tokens        AS "inputTokens",
                output_tokens       AS "outputTokens",
+               cache_read_tokens   AS "cacheReadTokens",
+               cache_write_tokens  AS "cacheWriteTokens",
                context_tokens      AS "contextTokens",
                estimated_cost_usd  AS "estimatedCostUsd"
         FROM usage_records
@@ -157,6 +199,6 @@ export function makeTokenCollector(sql: Sql, opts: CollectTokensOptions = {}): T
       `;
       return [...rows];
     };
-    return collectRunTokens(query, opts);
+    return collectRunTokens(query, { ...opts, onQueryError });
   };
 }

--- a/packages/web/eval/token-usage.ts
+++ b/packages/web/eval/token-usage.ts
@@ -1,0 +1,162 @@
+/**
+ * Token + cost capture for Eval-v1 (pinchy#798).
+ *
+ * A measured pass/fail says nothing about what a task COST to attempt. This
+ * joins each run to its `usage_records` rows and rolls them up into the
+ * {@link RunTokenUsage} attached to the graded result, so the benchmark can
+ * publish tokens-per-completed-task (its primary cost metric) and surface the
+ * peak context-window pressure that precedes false-success (the "Piper"
+ * incident, #798).
+ *
+ * The join is EXACT, not a time window: `dispatchAndScrape` mints a fresh
+ * `chatId` per run, so the run occupies a unique OpenClaw session
+ * `agent:<agentId>:direct:<userId>:<chatId>`, and every `usage_records` row for
+ * that session_key belongs to exactly this run. Summing them gives the whole
+ * tool loop's cost, not one call's.
+ *
+ * The recorder lags the run (the chat `done` path kicks it, a poller backstops
+ * it), so the collector POLLS until the row count is stable — reading once,
+ * mid-write, would undercount a multi-turn run. Everything here is best-effort:
+ * a missing recorder, a DB blip, or a run that produced no turn at all yields
+ * `undefined` rather than aborting a 15-hour sweep.
+ */
+import type { Sql } from "postgres";
+import type { RunTokenUsage } from "../src/lib/eval/types";
+
+/**
+ * One `usage_records` row as read for the join. `estimated_cost_usd` is a
+ * `numeric` column, so postgres.js hands it back as a string (or null); the
+ * token columns are integers, `context_tokens` nullable.
+ */
+export interface UsageRow {
+  inputTokens: number;
+  outputTokens: number;
+  contextTokens: number | null;
+  estimatedCostUsd: string | null;
+}
+
+/**
+ * Rolls up a run's `usage_records` rows into a {@link RunTokenUsage}. Pure.
+ * - `prompt`/`completion`: summed over every turn (the task's total cost).
+ * - `contextTokens`: the PEAK (max) across turns, ignoring nulls — window
+ *   pressure, not a total. Omitted when no turn recorded it.
+ * - `costUsd`: summed parsed cost. Omitted when no turn priced per token.
+ *
+ * Returns `undefined` for an empty set — the run has no usage data, distinct
+ * from a run that cost zero.
+ */
+export function aggregateTokenUsage(rows: UsageRow[]): RunTokenUsage | undefined {
+  if (rows.length === 0) return undefined;
+
+  let prompt = 0;
+  let completion = 0;
+  let peakContext: number | undefined;
+  let costUsd: number | undefined;
+
+  for (const r of rows) {
+    prompt += r.inputTokens;
+    completion += r.outputTokens;
+    if (r.contextTokens !== null) {
+      peakContext =
+        peakContext === undefined ? r.contextTokens : Math.max(peakContext, r.contextTokens);
+    }
+    if (r.estimatedCostUsd !== null) {
+      const parsed = Number(r.estimatedCostUsd);
+      if (Number.isFinite(parsed)) costUsd = (costUsd ?? 0) + parsed;
+    }
+  }
+
+  const usage: RunTokenUsage = { prompt, completion };
+  if (peakContext !== undefined) usage.contextTokens = peakContext;
+  if (costUsd !== undefined) usage.costUsd = costUsd;
+  return usage;
+}
+
+export interface CollectTokensOptions {
+  /** Give up polling after this long; return best-effort. Default 20s. */
+  timeoutMs?: number;
+  /** Delay between polls. Default 500ms. */
+  intervalMs?: number;
+  /** Injectable clock (tests). Default `Date.now`. */
+  now?: () => number;
+  /** Injectable delay (tests). Default a real `setTimeout` sleep. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Polls `query` until the row count is non-empty AND unchanged since the
+ * previous read (the recorder has finished writing this run's turns), then
+ * returns the aggregate. Best-effort on the edges:
+ * - No rows before `timeoutMs` → `undefined` (run recorded no usage).
+ * - Rows that never stabilize before `timeoutMs` → the last aggregate seen,
+ *   rather than discarding a partial count.
+ * - A query that throws → `undefined`, so a DB blip never aborts the sweep.
+ */
+export async function collectRunTokens(
+  query: () => Promise<UsageRow[]>,
+  opts: CollectTokensOptions = {}
+): Promise<RunTokenUsage | undefined> {
+  const timeoutMs = opts.timeoutMs ?? 20_000;
+  const intervalMs = opts.intervalMs ?? 500;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? realSleep;
+
+  const deadline = now() + timeoutMs;
+  let prevCount = -1;
+  let lastAggregate: RunTokenUsage | undefined;
+
+  for (;;) {
+    let rows: UsageRow[];
+    try {
+      rows = await query();
+    } catch {
+      return undefined;
+    }
+
+    if (rows.length > 0 && rows.length === prevCount) {
+      // Stable: the recorder is done writing this run's turns.
+      return aggregateTokenUsage(rows);
+    }
+    prevCount = rows.length;
+    lastAggregate = aggregateTokenUsage(rows);
+
+    if (now() >= deadline) return lastAggregate;
+    await sleep(intervalMs);
+  }
+}
+
+/** Joins one run to its tokens by (agentId, chatId). Injected into `runOnce`. */
+export type TokenCollector = (
+  agentId: string,
+  chatId: string
+) => Promise<RunTokenUsage | undefined>;
+
+/**
+ * Builds a {@link TokenCollector} over a live postgres client. The DB coupling
+ * lives here (and in the sweep spec that owns the connection), keeping
+ * `run-eval.ts` free of a DB driver — it reaches everything else over HTTP.
+ *
+ * The session_key filter anchors on both the agent prefix and the run's unique
+ * chatId suffix (`agent:<agentId>:direct:%:<chatId>`), so the `%` only spans the
+ * userId segment and the rows are exactly this run's.
+ */
+export function makeTokenCollector(sql: Sql, opts: CollectTokensOptions = {}): TokenCollector {
+  return (agentId, chatId) => {
+    const pattern = `agent:${agentId}:direct:%:${chatId}`;
+    const query = async (): Promise<UsageRow[]> => {
+      const rows = await sql<UsageRow[]>`
+        SELECT input_tokens        AS "inputTokens",
+               output_tokens       AS "outputTokens",
+               context_tokens      AS "contextTokens",
+               estimated_cost_usd  AS "estimatedCostUsd"
+        FROM usage_records
+        WHERE agent_id = ${agentId}
+          AND session_key LIKE ${pattern}
+      `;
+      return [...rows];
+    };
+    return collectRunTokens(query, opts);
+  };
+}

--- a/packages/web/src/lib/eval/__tests__/scorecard.test.ts
+++ b/packages/web/src/lib/eval/__tests__/scorecard.test.ts
@@ -121,6 +121,30 @@ describe("buildScorecard", () => {
     expect(a.medianTokens).toBeUndefined();
   });
 
+  it("computes tokens-per-COMPLETED-task over passing runs only (the #798 metric)", () => {
+    // A failed run that burned few tokens must not make the model look cheaper
+    // at the thing that matters: the cost of a run that actually SUCCEEDED.
+    const runs: RunResult[] = [
+      run({ model: "model-a", passed: true, tokens: { prompt: 200, completion: 100 } }), // 300
+      run({ model: "model-a", passed: true, tokens: { prompt: 300, completion: 100 } }), // 400
+      run({ model: "model-a", passed: false, tokens: { prompt: 10, completion: 5 } }), // 15, excluded
+    ];
+    const a = buildScorecard(runs).find((e) => e.model === "model-a")!;
+    // Median over the two PASSING runs (300, 400) = 350; the cheap failure is out.
+    expect(a.medianTokensPerCompletedTask).toBe(350);
+    // Contrast: the all-runs median includes the failure.
+    expect(a.medianTokens).toBe(300);
+  });
+
+  it("leaves medianTokensPerCompletedTask undefined when no passing run has tokens", () => {
+    const runs: RunResult[] = [
+      run({ model: "model-a", passed: false, tokens: { prompt: 100, completion: 50 } }),
+      run({ model: "model-a", passed: true }), // passed but no token data
+    ];
+    const a = buildScorecard(runs).find((e) => e.model === "model-a")!;
+    expect(a.medianTokensPerCompletedTask).toBeUndefined();
+  });
+
   it("computes a Wilson 95% interval for each model", () => {
     const runs: RunResult[] = [
       run({ model: "model-a", passed: true }),

--- a/packages/web/src/lib/eval/kb/answer-graders.ts
+++ b/packages/web/src/lib/eval/kb/answer-graders.ts
@@ -21,7 +21,7 @@ import type { RetrievedSource } from "./attribution-graders";
 import { gradeGroundednessForGold, isAbstention } from "./groundedness-grader";
 import type { GroundednessOptions } from "./groundedness-grader";
 import type { NliClient } from "./nli";
-import type { GoldQA, KbFailureTag, KbGraderResult, RunResult } from "./types";
+import type { GoldQA, KbFailureTag, KbGraderResult, RunResult, RunTokenUsage } from "./types";
 
 /**
  * Scores how well `answer` addresses `query`, in [0, 1]. Dependency-injected
@@ -130,8 +130,8 @@ export interface KbRunTrajectory {
   /** The TEXT of the retrieved passages the answer cited (groundedness premise material). */
   citedPassageTexts: string[];
   latencyMs: number;
-  /** prompt/completion token usage, same shape as `../types`'s `RunResult.tokens`. */
-  tokens?: { prompt: number; completion: number };
+  /** Token/cost usage, the shared `RunTokenUsage` shape from `../types`. */
+  tokens?: RunTokenUsage;
 }
 
 /**

--- a/packages/web/src/lib/eval/kb/types.ts
+++ b/packages/web/src/lib/eval/kb/types.ts
@@ -7,7 +7,7 @@
  * the pass/tags/notes result envelope and reporting plumbing are shared.
  */
 
-import type { GraderResult, RunResult } from "../types";
+import type { GraderResult, RunResult, RunTokenUsage } from "../types";
 
 /**
  * A retrieved chunk, as the eval sees it. Mirrors `retrieve()`'s return shape
@@ -104,4 +104,4 @@ export interface KbGraderResult extends Omit<GraderResult, "tags"> {
   tags: KbFailureTag[];
 }
 
-export type { RunResult };
+export type { RunResult, RunTokenUsage };

--- a/packages/web/src/lib/eval/normalize.ts
+++ b/packages/web/src/lib/eval/normalize.ts
@@ -6,7 +6,7 @@
  * responsible for gathering the raw inputs (audit rows, the scraped final
  * assistant message, the Odoo mock read-back) and calling `buildTrajectory`.
  */
-import type { OdooMoveRecord, RunTrajectory, ToolCall } from "./types";
+import type { OdooMoveRecord, RunTokenUsage, RunTrajectory, ToolCall } from "./types";
 
 const TOOL_EVENT_PREFIX = "tool.";
 
@@ -43,7 +43,7 @@ export interface NormalizeInput {
   extraIssuedMessageHandles?: string[];
   extraIssuedAttachmentHandles?: string[];
   latencyMs: number;
-  tokens?: { prompt: number; completion: number };
+  tokens?: RunTokenUsage;
 }
 
 function toToolCall(entry: NormalizeAuditEntry): ToolCall {

--- a/packages/web/src/lib/eval/scorecard.ts
+++ b/packages/web/src/lib/eval/scorecard.ts
@@ -27,7 +27,16 @@ export interface ScorecardEntry {
   passCaretK: number;
   tagHistogram: Record<string, number>;
   medianLatencyMs: number;
+  /** Median total tokens (prompt + completion) over ALL runs with token data. */
   medianTokens?: number;
+  /**
+   * Median total tokens over the PASSING runs only — the #798 primary cost
+   * metric, "tokens per completed task". A model that fails cheaply must not
+   * read as cheaper than one that succeeds; the cost that matters is the cost of
+   * a run that actually did the task. Undefined when no passing run has token
+   * data (or none passed).
+   */
+  medianTokensPerCompletedTask?: number;
 }
 
 /**
@@ -167,10 +176,15 @@ export function buildScorecard<Tag extends string = FailureTag>(
 
     const medianLatencyMs = median(modelRuns.map((r) => r.latencyMs));
 
-    const tokenTotals = modelRuns
-      .filter((r) => r.tokens !== undefined)
-      .map((r) => r.tokens!.prompt + r.tokens!.completion);
+    const totalTokens = (r: RunResult<Tag>): number => r.tokens!.prompt + r.tokens!.completion;
+    const tokenTotals = modelRuns.filter((r) => r.tokens !== undefined).map(totalTokens);
     const medianTokens = tokenTotals.length > 0 ? median(tokenTotals) : undefined;
+
+    const completedTokenTotals = modelRuns
+      .filter((r) => r.passed && r.tokens !== undefined)
+      .map(totalTokens);
+    const medianTokensPerCompletedTask =
+      completedTokenTotals.length > 0 ? median(completedTokenTotals) : undefined;
 
     return {
       model,
@@ -182,6 +196,7 @@ export function buildScorecard<Tag extends string = FailureTag>(
       tagHistogram,
       medianLatencyMs,
       medianTokens,
+      medianTokensPerCompletedTask,
     };
   });
 

--- a/packages/web/src/lib/eval/types.ts
+++ b/packages/web/src/lib/eval/types.ts
@@ -81,8 +81,10 @@ export interface OdooMoveRecord {
  * Token + cost accounting for one run, joined from `usage_records` by the run's
  * unique OpenClaw session key (pinchy#798). `prompt`/`completion` are summed
  * over every turn of the run's tool loop (so the total cost of completing the
- * task, not one call). Two optional fields carry the extra signals #798 asked
- * for:
+ * task, not one call). `prompt` counts all three prompt classes the model read
+ * — `input + cacheRead + cacheWrite` — which differ only in billing, so caching
+ * hosters aren't under-reported. Two optional fields carry the extra signals
+ * #798 asked for:
  * - `contextTokens`: the PEAK context-window pressure across the run's turns
  *   (max, not sum) — the read-side of the "Piper" false-success incident, a
  *   PLATFORM risk factor rather than a model score.

--- a/packages/web/src/lib/eval/types.ts
+++ b/packages/web/src/lib/eval/types.ts
@@ -77,6 +77,30 @@ export interface OdooMoveRecord {
   [k: string]: unknown;
 }
 
+/**
+ * Token + cost accounting for one run, joined from `usage_records` by the run's
+ * unique OpenClaw session key (pinchy#798). `prompt`/`completion` are summed
+ * over every turn of the run's tool loop (so the total cost of completing the
+ * task, not one call). Two optional fields carry the extra signals #798 asked
+ * for:
+ * - `contextTokens`: the PEAK context-window pressure across the run's turns
+ *   (max, not sum) — the read-side of the "Piper" false-success incident, a
+ *   PLATFORM risk factor rather than a model score.
+ * - `costUsd`: summed `estimated_cost_usd`. Undefined for Ollama Cloud, which is
+ *   subscription-billed (no per-token price) — the published $ figure is a
+ *   labeled multi-hoster range computed offline from the token counts, not this
+ *   column. Present only when a provider actually prices per token.
+ *
+ * A single named type (not three inline duplicates) so RunResult, RunTrajectory,
+ * and the normalizer's input can never drift apart.
+ */
+export interface RunTokenUsage {
+  prompt: number;
+  completion: number;
+  contextTokens?: number;
+  costUsd?: number;
+}
+
 export interface RunTrajectory {
   model: string;
   toolCalls: ToolCall[];
@@ -85,7 +109,7 @@ export interface RunTrajectory {
   /** account.move records read back from the Odoo mock AFTER the run. */
   odooMoves: OdooMoveRecord[];
   latencyMs: number;
-  tokens?: { prompt: number; completion: number };
+  tokens?: RunTokenUsage;
 }
 
 export interface ExpectedInvoice {
@@ -154,5 +178,5 @@ export interface RunResult<Tag extends string = FailureTag> {
   tags: Tag[];
   notes: string[];
   latencyMs: number;
-  tokens?: { prompt: number; completion: number };
+  tokens?: RunTokenUsage;
 }


### PR DESCRIPTION
## What

Closes the #798 blocker: the Eval-v1 dataset carried **zero token data**, so the benchmark could rank models on reliability but said nothing about what a task **cost** to attempt. This captures per-run tokens (and cost, where a provider prices per token) and attaches them to every graded run.

## The join is exact, not a time window

`dispatchAndScrape` mints a fresh `chatId` per run, so each run occupies a unique OpenClaw session `agent:<id>:direct:<userId>:<chatId>`. Every `usage_records` row for that `session_key` belongs to exactly this run — verified empirically against the eval DB. Summing them gives the **whole tool loop's** cost, not one call's.

`RunResult.tokens` now carries:

- **`prompt` / `completion`** — summed input / output over every turn.
- **`contextTokens`** — the *peak* context-window pressure (max over turns, not sum). This is the read-side of the 2026-07-15 "Piper" false-success incident: a run whose context climbs without compaction firing is a **platform** risk factor, not a model score. Omitted when no turn recorded it.
- **`costUsd`** — summed `estimated_cost_usd`, present only when a provider prices per token. Absent for Ollama Cloud (subscription-billed); the published `$` figure is a labeled multi-hoster range computed **offline** from the token counts, never this column.

## Design

- The recorder lags the run, so the collector **polls** until the row count is stable — reading once, mid-write, would undercount a multi-turn run.
- **Best-effort**: a missing recorder, a DB blip, or a run that produced no turn yields `undefined` rather than aborting a 15-hour sweep.
- **DB coupling stays in the sweep spec** (which already owns a `postgres` connection); `run-eval.ts` reaches everything else over HTTP. The collector is *injected* into `runOnce`, so the polling + aggregation logic is unit-tested with a fake query + fake clock — no DB needed.

## Scorecard: tokens per *completed* task

`buildScorecard` gains **`medianTokensPerCompletedTask`** (median over passing runs only) alongside the existing `medianTokens` (all runs). This is the #798 primary cost metric: a model that fails cheaply must not read as cheaper than one that actually completed the task.

## Housekeeping

The three duplicated `{ prompt; completion }` literals (`RunResult`, `RunTrajectory`, `NormalizeInput`, plus the KB harness) collapse into a shared `RunTokenUsage` type, so they can't drift.

## Tests

- `eval/__tests__/token-usage.test.ts` — pure aggregation (sum, peak-context, cost parsing, omitted-when-null) + polling loop (stabilize, timeout→undefined, best-effort, never-throws) with injected query/clock.
- `scorecard.test.ts` — `medianTokensPerCompletedTask` filters to passing runs; undefined when no passing run has tokens.
- Full eval suite green (488 tests); typecheck (incl. tests), lint (0 errors), whole-tree format all clean.

## Follow-ups (not this PR)

- Website presentation of the cost metric is **#140** (explicitly *blocked on 798*).
- The published `$` multi-hoster price range is a separate research + methodology task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)