### PR TITLE
fix(kb): batch and time-bound Ollama embedding requests

### DIFF
--- a/packages/web/src/__tests__/lib/knowledge/embeddings.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/embeddings.test.ts
@@ -260,6 +260,48 @@ describe("embedTexts", () => {
     const [, init] = vi.mocked(fetch).mock.calls[0];
     expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
+
+  it("times out when the response body read stalls, not only the initial fetch", async () => {
+    // A connection can wedge *after* the response headers arrive — fetch()
+    // resolves, but response.json() then never settles. If the timeout only
+    // covered fetch(), that stall would hang the reindex forever. The abort
+    // must stay armed through the body read.
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const signal = init?.signal as AbortSignal;
+      return {
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted", "AbortError"));
+            });
+          }),
+      } as unknown as Response;
+    });
+
+    await expect(
+      embedTexts(["hallo"], { baseUrl: "http://ollama:11434", timeoutMs: 20 })
+    ).rejects.toThrow(/timed out/i);
+  });
+
+  it("rejects vector-width drift across batches even without expectedDim", async () => {
+    // Per-batch validation guarantees each request is internally consistent but
+    // not that batch 2's width matches batch 1's — e.g. Ollama reloading a
+    // different model mid-reindex. Without a cross-batch guard, mixed-width
+    // vectors would reach the kb_chunks embedding column and fail opaquely at
+    // insert instead of here.
+    let call = 0;
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      const width = call++ === 0 ? 3 : 2; // batch 1: 3-dim, batch 2: 2-dim
+      const embeddings = (body.input as string[]).map(() => Array<number>(width).fill(1));
+      return new Response(JSON.stringify({ embeddings }), { status: 200 });
+    });
+
+    await expect(
+      embedTexts(["a", "b", "c"], { baseUrl: "http://ollama:11434", batchSize: 2 })
+    ).rejects.toThrow(/dimension/i);
+  });
 });
 
 describe("embedTexts (provider: local, node-llama-cpp mocked)", () => {

--- a/packages/web/src/__tests__/lib/knowledge/embeddings.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/embeddings.test.ts
@@ -184,6 +184,82 @@ describe("embedTexts", () => {
       [1, 2, 3],
     ]);
   });
+
+  // Ingest embeds a whole document's chunks in ONE embedTexts() call
+  // (ingest.ts: `deps.embed(chunks.map(c => c.text))`). A large PDF produces
+  // hundreds of chunks; sending them all in a single unbounded POST is what
+  // took the reindex down at document 117 (a 342-page PDF) with `fetch failed`.
+  // embedTexts must split the input into bounded, sequential requests.
+  it("splits a large input into sequential batches of at most batchSize and concatenates in order", async () => {
+    // Echo each input's length as a length-1 vector so order is verifiable.
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      const embeddings = (body.input as string[]).map((t) => [t.length]);
+      return new Response(JSON.stringify({ embeddings }), { status: 200 });
+    });
+
+    const result = await embedTexts(["a", "bb", "ccc", "dddd", "eeeee"], {
+      baseUrl: "http://ollama:11434",
+      batchSize: 2,
+    });
+
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls).toHaveLength(3); // ceil(5 / 2)
+    const inputsPerCall = calls.map(
+      ([, init]) => JSON.parse((init?.body as string) ?? "{}").input as string[]
+    );
+    expect(inputsPerCall).toEqual([["a", "bb"], ["ccc", "dddd"], ["eeeee"]]);
+    expect(inputsPerCall.every((input) => input.length <= 2)).toBe(true);
+    // Concatenated in the original order, not per-batch-scrambled.
+    expect(result).toEqual([[1], [2], [3], [4], [5]]);
+  });
+
+  it("caps the batch size by default instead of sending one unbounded request", async () => {
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      const embeddings = (body.input as string[]).map(() => [1]);
+      return new Response(JSON.stringify({ embeddings }), { status: 200 });
+    });
+
+    const texts = Array.from({ length: 200 }, (_, i) => `chunk-${i}`);
+    const result = await embedTexts(texts, { baseUrl: "http://ollama:11434" });
+
+    const calls = vi.mocked(fetch).mock.calls;
+    // Pins the default (32): a change to it is a deliberate one-line edit here,
+    // not a silent widening. 200 inputs => ceil(200 / 32) = 7 requests.
+    expect(calls).toHaveLength(7);
+    for (const [, init] of calls) {
+      const input = JSON.parse((init?.body as string) ?? "{}").input as string[];
+      expect(input.length).toBeLessThanOrEqual(32);
+    }
+    expect(result).toHaveLength(200);
+  });
+
+  it("returns [] without calling fetch for an empty input", async () => {
+    await expect(embedTexts([], { baseUrl: "http://ollama:11434" })).resolves.toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("aborts a stalled request and throws a clear timeout error instead of hanging forever", async () => {
+    // A wedged Ollama connection otherwise stalls the whole reindex with no
+    // upper bound. embedTexts must pass an AbortSignal and surface the abort
+    // as a timeout error, not a silent hang.
+    vi.mocked(fetch).mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          (init?.signal as AbortSignal).addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          });
+        })
+    );
+
+    await expect(
+      embedTexts(["hallo"], { baseUrl: "http://ollama:11434", timeoutMs: 20 })
+    ).rejects.toThrow(/timed out/i);
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe("embedTexts (provider: local, node-llama-cpp mocked)", () => {

--- a/packages/web/src/lib/knowledge/embeddings.ts
+++ b/packages/web/src/lib/knowledge/embeddings.ts
@@ -43,9 +43,40 @@ export interface EmbeddingConfig {
    * reports the knowledge base as empty. Unused when provider === "local".
    */
   keepAlive?: number | string;
+  /**
+   * Max inputs per Ollama `/api/embed` request. Ingest embeds a whole
+   * document's chunks in ONE embedTexts() call, and a large PDF yields
+   * hundreds — a single unbounded POST is what took the reindex down at a
+   * 342-page document with `fetch failed`. Requests are issued sequentially
+   * and their vectors concatenated in the original order. Defaults to 32.
+   * Unused when provider === "local" (that path is already one input per call).
+   */
+  batchSize?: number;
+  /**
+   * Per-request abort timeout in ms for the Ollama path. A wedged embedding
+   * connection otherwise stalls the whole (multi-hour) reindex with no upper
+   * bound; aborting frees the job to fail cleanly and release its slot.
+   * Defaults to 180000. Unused when provider === "local".
+   */
+  timeoutMs?: number;
 }
 
 const DEFAULT_MODEL = "bge-m3";
+/**
+ * See EmbeddingConfig.batchSize. Bounded so one large document can't ship its
+ * whole chunk set in a single POST. bge-m3 latency measured linear in batch
+ * size (~1.3-1.5s/chunk on a loaded CPU), so a larger batch buys no throughput
+ * — only a bigger payload and a longer request. 32 keeps each POST small and
+ * fast while matching the batch size the pipeline ran at historically.
+ */
+const DEFAULT_BATCH_SIZE = 32;
+/**
+ * See EmbeddingConfig.timeoutMs. The worst 32-batch measured on a loaded CPU
+ * was ~42s; add a ~25s cold model load and 180s clears the realistic worst
+ * case with margin, while still bounding a genuinely dead connection (which
+ * hangs forever) rather than policing slow-but-progressing embedding.
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 180_000;
 
 interface OllamaEmbedResponse {
   embeddings?: unknown;
@@ -144,15 +175,71 @@ async function embedTextsLocal(texts: string[], cfg: EmbeddingConfig): Promise<n
 }
 
 /**
+ * POST one bounded batch to Ollama's `/api/embed`, aborting if it stalls past
+ * `timeoutMs`. Kept separate from embedTexts so the batching loop stays a
+ * plain slice-and-concat; this is the single HTTP boundary where a timeout
+ * and the non-2xx / shape checks belong.
+ */
+async function embedBatchViaOllama(
+  batch: string[],
+  url: string,
+  headers: Record<string, string>,
+  cfg: EmbeddingConfig,
+  timeoutMs: number
+): Promise<number[][]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: cfg.model ?? DEFAULT_MODEL,
+        input: batch,
+        keep_alive: cfg.keepAlive ?? -1,
+      }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    // Distinguish our own abort (a stall we cut off) from a genuine network
+    // failure ("fetch failed"), which stays as-is so a real connection error
+    // still reads as one.
+    if (controller.signal.aborted) {
+      throw new Error(`Ollama embeddings request timed out after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    const error = await response.text().catch(() => "unknown error");
+    throw new Error(`Ollama embeddings API error (${response.status}): ${error}`);
+  }
+
+  const data = (await response.json()) as OllamaEmbedResponse;
+  return assertEmbeddingShape(data.embeddings, batch.length, cfg, "Ollama embeddings API");
+}
+
+/**
  * Embed a batch of texts. Defaults to Ollama's `/api/embed` endpoint
  * (`{ model, input: string[] }` -> `{ embeddings: number[][] }`); when
  * `cfg.provider === "local"`, embeds in-process via node-llama-cpp instead
  * (see `embedTextsLocal`).
+ *
+ * The Ollama path splits `texts` into sequential requests of at most
+ * `cfg.batchSize` (default 64) and concatenates their vectors in the original
+ * order — ingest hands a whole document's chunks in one call, so an unbounded
+ * POST here is what a large PDF used to break the reindex on.
  */
 export async function embedTexts(texts: string[], cfg: EmbeddingConfig): Promise<number[][]> {
   if (cfg.provider === "local") {
     return embedTextsLocal(texts, cfg);
   }
+
+  if (texts.length === 0) return [];
 
   const url = `${cfg.baseUrl.replace(/\/$/, "")}/api/embed`;
 
@@ -161,21 +248,14 @@ export async function embedTexts(texts: string[], cfg: EmbeddingConfig): Promise
     headers.Authorization = `Bearer ${cfg.apiKey}`;
   }
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      model: cfg.model ?? DEFAULT_MODEL,
-      input: texts,
-      keep_alive: cfg.keepAlive ?? -1,
-    }),
-  });
+  const batchSize = cfg.batchSize ?? DEFAULT_BATCH_SIZE;
+  const timeoutMs = cfg.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
-  if (!response.ok) {
-    const error = await response.text().catch(() => "unknown error");
-    throw new Error(`Ollama embeddings API error (${response.status}): ${error}`);
+  const all: number[][] = [];
+  for (let start = 0; start < texts.length; start += batchSize) {
+    const batch = texts.slice(start, start + batchSize);
+    const vectors = await embedBatchViaOllama(batch, url, headers, cfg, timeoutMs);
+    for (const vector of vectors) all.push(vector);
   }
-
-  const data = (await response.json()) as OllamaEmbedResponse;
-  return assertEmbeddingShape(data.embeddings, texts.length, cfg, "Ollama embeddings API");
+  return all;
 }

--- a/packages/web/src/lib/knowledge/embeddings.ts
+++ b/packages/web/src/lib/knowledge/embeddings.ts
@@ -176,9 +176,11 @@ async function embedTextsLocal(texts: string[], cfg: EmbeddingConfig): Promise<n
 
 /**
  * POST one bounded batch to Ollama's `/api/embed`, aborting if it stalls past
- * `timeoutMs`. Kept separate from embedTexts so the batching loop stays a
- * plain slice-and-concat; this is the single HTTP boundary where a timeout
- * and the non-2xx / shape checks belong.
+ * `timeoutMs` — whether the stall is at connect, waiting for headers, or
+ * reading the body (fetch() resolves once headers arrive, so the body read
+ * needs the same bound). Kept separate from embedTexts so the batching loop
+ * stays a plain slice-and-concat; this is the single HTTP boundary where a
+ * timeout and the non-2xx / shape checks belong.
  */
 async function embedBatchViaOllama(
   batch: string[],
@@ -190,9 +192,8 @@ async function embedBatchViaOllama(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  let response: Response;
   try {
-    response = await fetch(url, {
+    const response = await fetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify({
@@ -202,10 +203,19 @@ async function embedBatchViaOllama(
       }),
       signal: controller.signal,
     });
+
+    if (!response.ok) {
+      const error = await response.text().catch(() => "unknown error");
+      throw new Error(`Ollama embeddings API error (${response.status}): ${error}`);
+    }
+
+    const data = (await response.json()) as OllamaEmbedResponse;
+    return assertEmbeddingShape(data.embeddings, batch.length, cfg, "Ollama embeddings API");
   } catch (err) {
-    // Distinguish our own abort (a stall we cut off) from a genuine network
-    // failure ("fetch failed"), which stays as-is so a real connection error
-    // still reads as one.
+    // The timeout aborts the request whether it stalls mid-fetch or mid
+    // body-read; both surface here as an AbortError. Convert either to a clear
+    // timeout, distinct from a genuine network failure ("fetch failed") — which
+    // stays as-is so a real connection error still reads as one.
     if (controller.signal.aborted) {
       throw new Error(`Ollama embeddings request timed out after ${timeoutMs}ms`);
     }
@@ -213,14 +223,6 @@ async function embedBatchViaOllama(
   } finally {
     clearTimeout(timer);
   }
-
-  if (!response.ok) {
-    const error = await response.text().catch(() => "unknown error");
-    throw new Error(`Ollama embeddings API error (${response.status}): ${error}`);
-  }
-
-  const data = (await response.json()) as OllamaEmbedResponse;
-  return assertEmbeddingShape(data.embeddings, batch.length, cfg, "Ollama embeddings API");
 }
 
 /**
@@ -230,7 +232,7 @@ async function embedBatchViaOllama(
  * (see `embedTextsLocal`).
  *
  * The Ollama path splits `texts` into sequential requests of at most
- * `cfg.batchSize` (default 64) and concatenates their vectors in the original
+ * `cfg.batchSize` (default 32) and concatenates their vectors in the original
  * order — ingest hands a whole document's chunks in one call, so an unbounded
  * POST here is what a large PDF used to break the reindex on.
  */
@@ -257,5 +259,10 @@ export async function embedTexts(texts: string[], cfg: EmbeddingConfig): Promise
     const vectors = await embedBatchViaOllama(batch, url, headers, cfg, timeoutMs);
     for (const vector of vectors) all.push(vector);
   }
-  return all;
+
+  // Each batch is validated internally, but not against the others: a model
+  // swap mid-reindex could hand batch 2 a different width than batch 1. Revalidate
+  // the concatenation once so mixed-width vectors fail here, not opaquely at the
+  // kb_chunks embedding insert.
+  return assertEmbeddingShape(all, texts.length, cfg, "Ollama embeddings API");
 }


### PR DESCRIPTION
## Why

The reindex against the real reference corpus reliably died partway through — a 342-page PDF took the whole run down with `fetch failed`, and because every retry hit the same file, no document past it was ever indexed. A progress bar over a run that can't finish is half the value.

Root cause, `ingest.ts`:

```js
const vectors = await deps.embed(chunks.map((chunk) => chunk.text));
```

Ingest embeds a **whole document's chunks in one `embedTexts()` call**. A large PDF yields hundreds of chunks, all shipped in a single unbounded POST to Ollama's `/api/embed`. That is the request that fails. This bug predates the async-job work (#714) and is independent of it — it lives in the shared embedding client, so it also affects the synchronous reindex on `main`.

## What

`embedTexts` (the Ollama path only) now:

- **Batches** the input into sequential requests of at most `batchSize` and concatenates their vectors in the original order.
- **Time-bounds** each request with an `AbortSignal`, failing it as a clear timeout instead of letting a wedged connection stall a multi-hour reindex forever.

The `provider: "local"` node-llama-cpp path is untouched — it already embeds one input per call, so this failure class can't occur there.

## Defaults are measurement-based, not guessed

Measured bge-m3 latency on a loaded local CPU (the one empirical unknown a unit test can't cover):

| batch | latency | per-chunk |
|------:|--------:|----------:|
| 16 | 22.3s | 1.39s |
| 32 | 41.6s | 1.30s |
| 64 | 94.9s | 1.48s |

Latency is **linear in batch size** — a bigger batch buys no throughput, only a larger payload and a longer request that sits closer to the timeout. So:

- **`batchSize` = 32** — small, fast POST; the size the pipeline historically ran at. A 64-batch was verified to succeed against real Ollama (1024-dim, 64 vectors), so 32 is comfortably safe on the payload axis.
- **`timeoutMs` = 180000** — clears the worst measured 32-batch (~42s) plus a ~25s cold model load with margin, while still bounding a genuinely dead connection (which hangs forever) rather than policing slow-but-progressing embedding.

Both are overridable via `EmbeddingConfig`.

## Tests

New unit tests in `embeddings.test.ts`: large input splits into ordered batches; the default caps at 32 (pinned — a change is a deliberate edit); empty input makes no request; a stalled request aborts with a timeout error and an `AbortSignal` is passed. Full existing embeddings suite stays green (19/19).

## Not in scope

The strategic move to the native `provider: "local"` embedder (embeddinggemma, which is sequential and immune to this class) is #715 — a 768-dim column migration + admin setting + GGUF bundling + mandatory full reindex. This fix is the correct, small hardening for the Ollama path every current deployment runs on until then.
