### PR TITLE
fix(eval): stamp PINCHY_BUILD_SHA into the eval stack so the fingerprint is comparable (#799)

### DIFF
--- a/.claude/skills/run-model-eval/SKILL.md
+++ b/.claude/skills/run-model-eval/SKILL.md
@@ -53,12 +53,17 @@ resumes from JSONL.**
    volume mount). Mock changes need
    `... up -d --build odoo-mock` — and never mid-sweep.
 5. **Stack env is exact:** `PINCHY_VERSION=latest DB_PASSWORD=eval_dev_pw
-docker compose -p pinchy-eval -f docker-compose.yml -f docker-compose.e2e.yml
--f docker-compose.eval.yml up --build -d`. `DB_PASSWORD` must be non-default
-   (Pinchy rotates `pinchy_dev` away). If openclaw won't stabilise with
-   `SecretRefResolutionError`: stale config volume — surgically delete
-   `/openclaw-config/openclaw.json*` in the pinchy container and restart
-   pinchy+openclaw (never `down -v`).
+PINCHY_BUILD_SHA=$(git rev-parse HEAD) docker compose -p pinchy-eval -f
+docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.eval.yml up
+--build -d`. `DB_PASSWORD` must be non-default (Pinchy rotates `pinchy_dev`
+   away). **`PINCHY_BUILD_SHA` is what makes the run fingerprint `comparable`
+   (#799):** a locally-built image bakes `build:"dev"`, so without this the sweep
+   can't anchor a cross-version regression baseline — set it to the platform
+   checkout's commit (a dirty tree still lands `comparable:false` via the
+   harness dirty-check, so a stamped-but-dirty run is never a false baseline).
+   If openclaw won't stabilise with `SecretRefResolutionError`: stale config
+   volume — surgically delete `/openclaw-config/openclaw.json*` in the pinchy
+   container and restart pinchy+openclaw (never `down -v`).
 6. **Key is seeded once.** Pass `OLLAMA_CLOUD_API_KEY` via env on the first
    `eval:models` run (it lands in the eval DB); later runs and the watchdog
    resume **keyless**. Never write the key to disk.

--- a/docker-compose.eval.yml
+++ b/docker-compose.eval.yml
@@ -55,6 +55,17 @@ services:
       # Passed through so `models` mode can seed settings.ollama_cloud_api_key
       # without baking a real key into the image or compose file.
       - OLLAMA_CLOUD_API_KEY=${OLLAMA_CLOUD_API_KEY:-}
+      # The run fingerprint (#799) reads `build` from /api/version, which is
+      # `process.env.PINCHY_BUILD_SHA` at request time. A locally-built eval
+      # image bakes the build-arg default "dev", so the fingerprint lands
+      # `comparable:false` and the sweep can't anchor a cross-version regression
+      # baseline. /api/version reads this at RUNTIME (not a NEXT_PUBLIC compile
+      # inline), so overriding it here is enough — no rebuild. Launch the sweep
+      # with `PINCHY_BUILD_SHA=$(git rev-parse HEAD)` to stamp the real commit;
+      # unset it defaults to "dev" (unchanged behavior). A dirty tree still lands
+      # comparable:false via the harness `harnessDirty` check, so a stamped-but-
+      # dirty run is never mistaken for a clean baseline.
+      - PINCHY_BUILD_SHA=${PINCHY_BUILD_SHA:-dev}
     extra_hosts:
       # Pinchy probes ollama_local_url from regenerateOpenClawConfig(); the
       # selftest's fake-ollama runs on the HOST (started by eval.spec.ts, same


### PR DESCRIPTION
## Why

The run fingerprint ([#799](https://github.com/heypinchy/pinchy/pull/799)) exists so a sweep can anchor a **cross-version regression baseline** — same models, different platform build, diff the deltas. That only works if the fingerprint is `comparable`, which requires the `build` field to uniquely identify the platform code.

But the eval stack builds its image locally with the `Dockerfile.pinchy` build-arg default `PINCHY_BUILD_SHA=dev`, so `/api/version` returned `build:"dev"` → **every sweep landed `comparable:false`**. The fingerprint was capturing metadata that could never do its one job.

## Fix

`/api/version` reads `process.env.PINCHY_BUILD_SHA` at **request time** — it's a plain server route, not a `NEXT_PUBLIC` compile-time inline — so a runtime compose-environment override is sufficient, no rebuild needed. This forwards `PINCHY_BUILD_SHA` in the **eval overlay only**, defaulting to `dev` (unchanged behavior when unset), and documents launching the stack with `PINCHY_BUILD_SHA=$(git rev-parse HEAD)` in the `run-model-eval` skill.

## Safety

- **Base compose untouched on purpose.** An empty-defaulting override there (`${PINCHY_BUILD_SHA:-}`) would blank the real SHA that CI bakes into production images, regressing prod `/api/version` to `dev`.
- **A dirty tree still lands `comparable:false`** via the harness `harnessDirty` check (`git status --porcelain`), so a stamped-but-dirty run is never mistaken for a clean baseline — stamping the commit doesn't defeat the dirty guard.

## Verification

`docker compose ... config` resolves `PINCHY_BUILD_SHA: <value>` into the pinchy service environment. This is the last prerequisite before a fingerprint-comparable sweep (the other — per-run token capture — is [#839](https://github.com/heypinchy/pinchy/pull/839)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)