### PR TITLE
perf(inbox-agent): make the sweep the low-latency path, in-process (#139)

### DIFF
--- a/packages/web/e2e/email/inbox-sweep.spec.ts
+++ b/packages/web/e2e/email/inbox-sweep.spec.ts
@@ -11,7 +11,7 @@
  *
  * So this spec never triggers a sweep. It seeds a workflow and a message, then
  * waits for Pinchy's own cadence (INBOX_SWEEP_INTERVAL_MS, 5s here instead of
- * the 15-minute production interval) to notice. If the boot wiring in server.ts
+ * the one-minute production interval) to notice. If the boot wiring in server.ts
  * were missing or the port could not reach the mailbox, nothing would ever
  * happen and this test would time out — which is exactly the failure that
  * every green unit test would still hide.

--- a/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   claimEmail,
   finalizeEmail,
+  listProcessedProviderMessageIds,
   resetStuckProcessingEmails,
   type ClaimInput,
 } from "@/lib/email-workflows/ledger";
@@ -131,6 +132,61 @@ describe("email ledger — claimEmail", () => {
       claimEmail(key),
     ]);
     expect(results.filter(Boolean)).toHaveLength(1);
+  });
+});
+
+describe("email ledger — listProcessedProviderMessageIds (cheap-poll skip set)", () => {
+  it("returns exactly the candidate ids this (workflow, connection) already holds, any status", async () => {
+    // The cheap poll asks the ledger which of `search`'s candidates it may skip
+    // hydrating. "Already accounted for" means a row EXISTS — whether it is a
+    // terminal `done`/`failed` or an in-flight `processing`: re-hydrating either
+    // is wasted I/O (the claim would just `onConflictDoNothing`). A candidate with
+    // no row is genuinely new and must NOT be in the skip set.
+    const agent = await seedAgent();
+    const wf = await seedWorkflow(agent.id);
+    const conn = "conn-skip";
+
+    const doneId = await claimOrFail({
+      workflowId: wf.id,
+      connectionId: conn,
+      providerMessageId: "done-1",
+    });
+    await finalizeEmail({ id: doneId, status: "done" });
+    await claimOrFail({ workflowId: wf.id, connectionId: conn, providerMessageId: "processing-1" });
+
+    const skip = await listProcessedProviderMessageIds(wf.id, conn, [
+      "done-1",
+      "processing-1",
+      "fresh-1", // never claimed → must be hydrated
+    ]);
+
+    expect(skip).toEqual(new Set(["done-1", "processing-1"]));
+  });
+
+  it("is scoped to the (workflow, connection) key — a claim on another scope is not skipped", async () => {
+    // The claim key is (workflowId, connectionId, providerMessageId): the same
+    // provider id can be a fresh email for a different workflow or a different
+    // mailbox. If the skip set leaked across scope, that fresh email would never
+    // be hydrated — silently dropped. This locks the query to both key columns.
+    const agent = await seedAgent();
+    const wfA = await seedWorkflow(agent.id);
+    const wfB = await seedWorkflow(agent.id);
+    await claimOrFail({ workflowId: wfA.id, connectionId: "conn-x", providerMessageId: "shared" });
+    // Same provider id, but claimed under a different workflow AND a different
+    // connection — neither may appear in wfB/conn-y's skip set.
+    await claimOrFail({ workflowId: wfA.id, connectionId: "conn-y", providerMessageId: "other" });
+
+    const skip = await listProcessedProviderMessageIds(wfB.id, "conn-y", ["shared", "other"]);
+
+    expect(skip).toEqual(new Set()); // wfB on conn-y has claimed neither
+  });
+
+  it("returns an empty set for no candidates without touching the DB", async () => {
+    // A pass whose `search` returned nothing must not issue a pointless
+    // `IN ()` query — return early. (Also guards against an invalid empty-IN SQL.)
+    const agent = await seedAgent();
+    const wf = await seedWorkflow(agent.id);
+    expect(await listProcessedProviderMessageIds(wf.id, "conn-empty", [])).toEqual(new Set());
   });
 });
 

--- a/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
@@ -4,9 +4,10 @@
 //
 // The sweep is the *correctness* path of design §4: it re-lists the last N days
 // straight from each connection and dispatches whatever the ledger has not seen,
-// so a lost/expired cursor can never lose an email. (The cheap cursor-driven poll
-// is the event-trigger's job and needs OpenClaw 2026.7.1 — a later brick. The
-// lister only speaks `sinceDays`, never a cursor, for exactly that reason.)
+// so a lost/expired cursor can never lose an email. It is ALSO the low-latency
+// path (Path A): the ledger pre-filter and watermark-bounded window make a
+// steady-state pass cost one `search` and ~zero reads, so it runs on a short
+// cadence and reacts in near-real-time without a separate token-free poll.
 //
 // The mailbox port and the agent run are injected, mirroring how `dispatchEmails`
 // injects `RunAgent`: the production port is built from decrypted connection
@@ -123,15 +124,19 @@ function message(overrides: Partial<EmailReadResult> = {}): EmailReadResult {
  */
 function portFor(connectionId: string, messages: EmailReadResult[]) {
   const searchCalls: { sinceDays?: number; folder?: string; limit?: number }[] = [];
+  const readCalls: string[] = [];
   const createPort = async (id: string): Promise<EmailPort> => ({
     search: async (opts) => {
       if (id !== connectionId) return [];
       searchCalls.push(opts);
       return messages.map((m) => ({ id: m.id }));
     },
-    read: async (msgId) => messages.find((m) => m.id === msgId)!,
+    read: async (msgId) => {
+      readCalls.push(msgId);
+      return messages.find((m) => m.id === msgId)!;
+    },
   });
-  return { createPort, searchCalls };
+  return { createPort, searchCalls, readCalls };
 }
 
 const doneRun: RunAgent = async () => ({
@@ -355,6 +360,113 @@ describe("reconciliation sweep — listing window", () => {
     await runReconciliationSweep({ createPort, runAgent: doneRun });
 
     expect(searchCalls[0].folder).toBe("Invoices");
+  });
+});
+
+describe("reconciliation sweep — cheap poll (skip already-processed, watermark-bounded window)", () => {
+  it("does not re-hydrate mail the ledger already holds — only genuinely new mail costs a read", async () => {
+    // This is what makes running the sweep on a short cadence affordable. `read`
+    // is the N+1 cost of a pass; re-reading mail already in the ledger is pure
+    // provider I/O for nothing (the re-claim would `onConflictDoNothing`). In
+    // steady state — every message already processed — a poll must cost one
+    // `search` and ZERO reads. Without the ledger pre-filter, every message in
+    // the window is re-hydrated every single pass.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    // "already" is finalized in the ledger before the sweep even runs.
+    const alreadyId = await claimEmail({
+      workflowId: workflow.id,
+      connectionId: connection.id,
+      providerMessageId: "already",
+    });
+    await finalizeEmail({ id: alreadyId!, status: "done", outcome: { note: "prior pass" } });
+
+    const { createPort, readCalls } = portFor(connection.id, [
+      message({ id: "already" }),
+      message({ id: "fresh" }),
+    ]);
+    const ran: string[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      ran.push(ctx.email.providerMessageId);
+      return doneRun(ctx);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent });
+
+    // The already-processed message was skipped BEFORE hydration: no read, no run.
+    expect(readCalls).toEqual(["fresh"]);
+    expect(ran).toEqual(["fresh"]);
+    // Its terminal outcome is untouched — the sweep never reconsidered it.
+    expect((await ledgerRow(workflow.id, "already")).outcome).toEqual({ note: "prior pass" });
+  });
+
+  it("re-hydrates a stuck claim the same pass resets — reset frees it before the skip-filter reads it", async () => {
+    // The skip-filter must not defeat delete-and-reclaim (#735). A stuck
+    // `processing` row is DELETEd at the top of the sweep, BEFORE any unit lists,
+    // so by the time the ledger pre-filter runs the row is gone and the email is
+    // no longer "already processed" — it gets re-hydrated and retried in this same
+    // pass. If the ordering were reversed, a stuck email would be skipped forever.
+    const GRACE_MS = 10 * 60_000;
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const stuckId = await claimEmail({
+      workflowId: workflow.id,
+      connectionId: connection.id,
+      providerMessageId: "stuck",
+    });
+    await db
+      .update(processedEmails)
+      .set({ claimedAt: new Date(Date.now() - GRACE_MS - 60_000) })
+      .where(eq(processedEmails.id, stuckId!));
+
+    const { createPort, readCalls } = portFor(connection.id, [message({ id: "stuck" })]);
+    const ran: string[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      ran.push(ctx.email.providerMessageId);
+      return doneRun(ctx);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent, graceMs: GRACE_MS });
+
+    expect(readCalls).toEqual(["stuck"]); // re-hydrated, not skipped
+    expect(ran).toEqual(["stuck"]);
+  });
+
+  it("bounds the provider query to the watermark, not the full window, for a fresh workflow", async () => {
+    // A workflow attached today has a recent `sinceTs`, and the sweep drops
+    // everything below it anyway — so listing the full `sweepWindowDays` would
+    // hydrate two weeks of pre-workflow mail every pass just to discard it. That
+    // waste is invisible at a 15-minute cadence but ruinous at a short one, so
+    // `search`'s window is capped at the watermark's age. Correctness is
+    // untouched: nothing at/above `sinceTs` is excluded — only mail the watermark
+    // already discards is no longer listed.
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const { connection } = await seedDispatchableWorkflow({
+      sweepWindowDays: 30,
+      sinceTs: new Date(Date.now() - 5 * DAY_MS),
+    });
+    const { createPort, searchCalls } = portFor(connection.id, [message()]);
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(searchCalls).toHaveLength(1);
+    // ~5 days of watermark age (ceil'd), never the full 30-day window.
+    expect(searchCalls[0].sinceDays).toBeGreaterThanOrEqual(5);
+    expect(searchCalls[0].sinceDays).toBeLessThanOrEqual(6);
+  });
+
+  it("keeps the full window for an old workflow — the watermark only ever tightens it", async () => {
+    // The mirror image: a workflow whose `sinceTs` predates the whole window must
+    // still re-list the full `sweepWindowDays` (design §5's slip-through backstop).
+    // Capping at the watermark must never SHORTEN the window below the configured
+    // N — `min(N, ageInDays)` gives N whenever the watermark is older than N.
+    const { connection } = await seedDispatchableWorkflow({
+      sweepWindowDays: 3,
+      sinceTs: new Date(0), // epoch — far older than any window
+    });
+    const { createPort, searchCalls } = portFor(connection.id, [message()]);
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(searchCalls[0].sinceDays).toBe(3);
   });
 });
 

--- a/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
@@ -396,4 +396,34 @@ describe("mail lister — listDispatchableEmails", () => {
     expect(emails).toEqual([]);
     expect(candidateCount).toBe(2);
   });
+
+  it("does not mistake one isolated poison message for a dead mailbox when the rest were skipped", async () => {
+    // The dead-mailbox guard fires when NO candidate hydrates. Before the skip
+    // filter existed, "no hydration" meant every candidate was read and every read
+    // failed — a real credential death. With the skip filter, a healthy, caught-up
+    // mailbox hydrates almost nothing: skip the processed mail, and the ONE
+    // un-skipped candidate may be a persistently-unhydratable message (an
+    // unparseable date, a mid-sweep 404). That single failure must stay isolated —
+    // exactly what the per-message try/catch promises — and must NOT flip the whole
+    // workflow to `error` every pass. The guard must only cry "dead" when EVERY
+    // candidate `search` returned was attempted and failed, not when the sole
+    // attempted one did.
+    const port: EmailPort = {
+      async search() {
+        return [{ id: "seen-1" }, { id: "poison" }];
+      },
+      async read(id) {
+        if (id === "poison") throw new Error("unparseable message poison");
+        throw new Error(`must not hydrate skipped id ${id}`);
+      },
+    };
+
+    const { emails, candidateCount } = await listDispatchableEmails(port, {
+      resolveAlreadyProcessed: async () => new Set(["seen-1"]),
+    });
+
+    // Poison isolated to itself; the healthy mailbox reports an empty batch, never a throw.
+    expect(emails).toEqual([]);
+    expect(candidateCount).toBe(2);
+  });
 });

--- a/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
@@ -331,4 +331,69 @@ describe("mail lister — listDispatchableEmails", () => {
     // Every candidate hydrated, so the count matches the returned batch.
     expect(candidateCount).toBe(2);
   });
+
+  it("skips hydrating candidates the ledger already holds, sparing the expensive read()", async () => {
+    // The cheap-poll optimization: `read` is the N+1 cost of a pass, and re-reading
+    // mail the ledger has already claimed is pure waste — the claim would just
+    // `onConflictDoNothing`. `resolveAlreadyProcessed` is injected (so the lister
+    // stays DB-decoupled, like the port) and names the ids to skip BEFORE hydration.
+    // In steady state it skips everything, so a poll costs one search and zero reads,
+    // which is what makes a frequent cadence affordable.
+    const reads: string[] = [];
+    const port: EmailPort = {
+      async search() {
+        return [{ id: "seen-1" }, { id: "fresh-2" }, { id: "seen-3" }];
+      },
+      async read(id) {
+        reads.push(id);
+        return {
+          id,
+          from: "s@x.test",
+          to: "",
+          cc: "",
+          subject: id,
+          date: "2026-07-14T00:00:00.000Z",
+          attachments: [],
+        };
+      },
+    };
+
+    const { emails, candidateCount } = await listDispatchableEmails(port, {
+      resolveAlreadyProcessed: async (ids) => {
+        // The resolver sees every candidate id, and returns the subset to skip.
+        expect(ids).toEqual(["seen-1", "fresh-2", "seen-3"]);
+        return new Set(["seen-1", "seen-3"]);
+      },
+    });
+
+    // Only the un-ledgered candidate was hydrated; the seen ones cost no read.
+    expect(reads).toEqual(["fresh-2"]);
+    expect(emails.map((e) => e.providerMessageId)).toEqual(["fresh-2"]);
+    // candidateCount stays the pre-skip `search` count: the sweep's saturation
+    // check reads it to detect a full page, which is about what search returned,
+    // not what survived the skip.
+    expect(candidateCount).toBe(3);
+  });
+
+  it("treats a fully-skipped pass as an empty result, not a dead mailbox", async () => {
+    // The dead-mailbox guard throws when every candidate FAILS to hydrate. A pass
+    // where every candidate was SKIPPED (already in the ledger) is the steady-state
+    // success case — zero reads, zero failures — and must never be mistaken for a
+    // mailbox whose credentials just expired.
+    const port: EmailPort = {
+      async search() {
+        return [{ id: "seen-1" }, { id: "seen-2" }];
+      },
+      async read(id) {
+        throw new Error(`must not hydrate skipped id ${id}`);
+      },
+    };
+
+    const { emails, candidateCount } = await listDispatchableEmails(port, {
+      resolveAlreadyProcessed: async () => new Set(["seen-1", "seen-2"]),
+    });
+
+    expect(emails).toEqual([]);
+    expect(candidateCount).toBe(2);
+  });
 });

--- a/packages/web/src/__tests__/server/inbox-sweep.test.ts
+++ b/packages/web/src/__tests__/server/inbox-sweep.test.ts
@@ -79,6 +79,18 @@ describe("inbox sweep — scheduler wiring", () => {
     vi.useRealTimers();
   });
 
+  it("defaults to a low-latency cadence — the sweep IS the fast poll, not a 15-minute backstop", async () => {
+    // Path A: the ledger pre-filter + watermark-bounded window make a pass cost
+    // one `search` and ~zero reads in steady state, so the sweep runs frequently
+    // and delivers near-real-time reaction itself, rather than deferring latency
+    // to a separate OpenClaw event-trigger brick. This locks that intent in: a
+    // revert to the old infrequent 15-minute cadence (or anything slower than a
+    // couple of minutes) would silently give back the latency and fail here. The
+    // startup kick must still land before the first interval.
+    expect(SWEEP_INTERVAL_MS).toBeLessThanOrEqual(2 * 60_000);
+    expect(SWEEP_STARTUP_DELAY_MS).toBeLessThanOrEqual(SWEEP_INTERVAL_MS);
+  });
+
   it("_isInboxSweepRunning reflects start/stop", () => {
     expect(_isInboxSweepRunning()).toBe(false);
     startInboxSweep(async () => {});
@@ -113,11 +125,11 @@ describe("inbox sweep — scheduler wiring", () => {
   });
 
   it("accepts an overridden cadence", async () => {
-    // The production cadence is 15 minutes, which no E2E can wait for, and the
-    // post-startup kick has long since fired by the time a spec runs. Making
-    // both injectable is what lets the E2E prove the sweep dispatches with no
-    // manual trigger — the one claim unit tests cannot make. Same convention as
-    // CHANNEL_HEALTH_INTERVAL_MS.
+    // Even the low-latency production cadence (one minute) is far longer than an
+    // E2E can wait for, and the post-startup kick has long since fired by the time
+    // a spec runs. Making both injectable is what lets the E2E prove the sweep
+    // dispatches with no manual trigger — the one claim unit tests cannot make.
+    // Same convention as CHANNEL_HEALTH_INTERVAL_MS.
     vi.useFakeTimers();
     let calls = 0;
     startInboxSweep(

--- a/packages/web/src/lib/email-workflows/ledger.ts
+++ b/packages/web/src/lib/email-workflows/ledger.ts
@@ -1,4 +1,4 @@
-import { and, eq, lt } from "drizzle-orm";
+import { and, eq, inArray, lt } from "drizzle-orm";
 import { db } from "@/db";
 import { processedEmails } from "@/db/schema";
 import type { ProcessedEmailOutcome } from "@/lib/email-workflows/types";
@@ -40,6 +40,36 @@ export async function claimEmail(input: ClaimInput): Promise<string | null> {
     })
     .returning({ id: processedEmails.id });
   return rows[0]?.id ?? null;
+}
+
+/**
+ * Of a set of candidate provider ids, return those this (workflow, connection)
+ * already has a ledger row for — the cheap poll's skip set. Any status counts:
+ * a terminal row is done, a `processing` row is in flight, and re-hydrating
+ * either is wasted provider I/O because the re-claim would only
+ * `onConflictDoNothing`. A candidate absent here is genuinely new.
+ *
+ * Scoped to BOTH key columns (design D3: the claim key is per workflow × per
+ * connection), and bounded to the candidate ids so the query never scans the
+ * whole ledger. An empty candidate list short-circuits — no pointless `IN ()`.
+ */
+export async function listProcessedProviderMessageIds(
+  workflowId: string,
+  connectionId: string,
+  candidateIds: string[]
+): Promise<Set<string>> {
+  if (candidateIds.length === 0) return new Set();
+  const rows = await db
+    .select({ providerMessageId: processedEmails.providerMessageId })
+    .from(processedEmails)
+    .where(
+      and(
+        eq(processedEmails.workflowId, workflowId),
+        eq(processedEmails.connectionId, connectionId),
+        inArray(processedEmails.providerMessageId, candidateIds)
+      )
+    );
+  return new Set(rows.map((r) => r.providerMessageId));
 }
 
 export type FinalizeStatus = "done" | "no_action" | "failed";

--- a/packages/web/src/lib/email-workflows/lister.ts
+++ b/packages/web/src/lib/email-workflows/lister.ts
@@ -170,8 +170,20 @@ export async function listDispatchableEmails(
   // But isolation must not swallow a dead mailbox. Credentials expiring between
   // `search` and `read` fail EVERY hydration; reported as an empty inbox that
   // would read as "nothing new" and silently retire the workflow while its status
-  // stayed `active`. No usable message at all is a mailbox failure, not an outlier.
-  if (failures.length > 0 && emails.length === 0) {
+  // stayed `active`.
+  //
+  // "Dead" means every listed candidate was attempted and failed — NOT merely
+  // that the hydrated batch came back empty. `resolveAlreadyProcessed` breaks the
+  // old shorthand: a healthy, caught-up mailbox skips its processed mail and may
+  // attempt only a single un-skipped candidate, and if that one is a persistently
+  // unhydratable message (unparseable date, a mid-sweep 404) then
+  // `emails.length === 0 && failures.length > 0` holds while the mailbox is
+  // perfectly alive — flipping the whole workflow to `error` every pass and
+  // defeating the per-message isolation above. So require that NOTHING hydrated
+  // and NOTHING was skipped, i.e. every candidate failed. A real credential death
+  // that races in after some mail was skipped simply surfaces one cadence later,
+  // when the next `search` itself throws — no email is lost.
+  if (candidates.length > 0 && failures.length === candidates.length) {
     throw failures[0];
   }
   // `candidateCount` is the pre-hydration count on purpose: the sweep reads it to

--- a/packages/web/src/lib/email-workflows/lister.ts
+++ b/packages/web/src/lib/email-workflows/lister.ts
@@ -112,9 +112,11 @@ function normalizeAddressList(raw: string): string[] {
 /**
  * List a connection's candidate messages and hydrate each into a
  * {@link DispatchableEmail} (design §6). The filter needs attachment metadata,
- * which only `read` returns, so every candidate is hydrated — an N+1 that is
- * fine on the bounded sweep path this serves (the token-free steady-state poll
- * lives in the OpenClaw event-trigger, a later brick).
+ * which only `read` returns, so every *un-skipped* candidate is hydrated — an
+ * N+1 whose N the cheap poll keeps near zero: `resolveAlreadyProcessed` (when
+ * injected) names the ids the ledger already holds, and hydration skips them, so
+ * a steady-state pass costs one `search` and no reads. That is what makes running
+ * this sweep on a short cadence — the low-latency path — affordable.
  *
  * Normalization is the deterministic substance: providers hand back
  * inconsistent header shapes (Gmail raw `Display Name <addr>` and
@@ -126,15 +128,33 @@ function normalizeAddressList(raw: string): string[] {
  */
 export async function listDispatchableEmails(
   port: EmailPort,
-  opts: { sinceDays?: number; folder?: string; limit?: number }
+  opts: {
+    sinceDays?: number;
+    folder?: string;
+    limit?: number;
+    /**
+     * Given every candidate id `search` returned, resolve the subset already in
+     * the ledger, which hydration then skips. Injected so the lister stays
+     * DB-decoupled (like the port); the sweep supplies a closure over the ledger.
+     * Absent ⟹ hydrate every candidate (the plain re-list).
+     */
+    resolveAlreadyProcessed?: (candidateIds: string[]) => Promise<ReadonlySet<string>>;
+  }
 ): Promise<EmailListResult> {
   // `search` is the mailbox-level probe: if it throws, nothing was listed and the
   // failure is the connection's, so it propagates to the sweep's unit-level catch
   // and surfaces as the workflow's `error` status.
   const candidates = await port.search(opts);
+  // Ask the ledger which candidates are already accounted for, BEFORE the N+1:
+  // skipping the read is the whole point — re-hydrating a claimed email only to
+  // have the claim `onConflictDoNothing` is pure provider I/O for no effect.
+  const alreadyProcessed = opts.resolveAlreadyProcessed
+    ? await opts.resolveAlreadyProcessed(candidates.map((c) => c.id))
+    : null;
   const emails: DispatchableEmail[] = [];
   const failures: unknown[] = [];
   for (const candidate of candidates) {
+    if (alreadyProcessed?.has(candidate.id)) continue;
     // Isolate per message: one unusable mail (unparseable date, a read that 404s
     // on a message deleted mid-sweep) must cost exactly that mail, not the whole
     // mailbox's pass. Without this, a single corrupt message stops every other

--- a/packages/web/src/lib/email-workflows/sweep.ts
+++ b/packages/web/src/lib/email-workflows/sweep.ts
@@ -6,7 +6,10 @@ import type { EmailWorkflowStatus } from "@/db/enums";
 import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { dispatchEmails } from "@/lib/email-workflows/dispatch";
-import { resetStuckProcessingEmails } from "@/lib/email-workflows/ledger";
+import {
+  listProcessedProviderMessageIds,
+  resetStuckProcessingEmails,
+} from "@/lib/email-workflows/ledger";
 import type { StuckClaimKey } from "@/lib/email-workflows/ledger";
 import { listDispatchableEmails } from "@/lib/email-workflows/lister";
 import { loadDispatchableWorkflows } from "@/lib/email-workflows/loader";
@@ -40,6 +43,8 @@ export const DEFAULT_STUCK_GRACE_MS = 3 * DEFAULT_RUN_TIMEOUT_MS;
  * above a realistic filtered window.
  */
 export const SWEEP_LIST_LIMIT = 200;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 export interface SweepDeps {
   /** Builds a mailbox port for one connection, from its decrypted credentials. */
@@ -119,12 +124,32 @@ async function sweepUnit(
   port: EmailPort,
   deps: SweepDeps
 ): Promise<void> {
+  // Two provider-load optimizations, neither of which touches correctness — both
+  // only avoid work whose result the sweep would discard anyway. They are what
+  // let this sweep run on a short cadence (the low-latency path) instead of only
+  // as an infrequent backstop.
+  //
+  // 1. Cap the listing window at the watermark's age. The sweep drops everything
+  //    below `sinceTs`, so listing further back than that only hydrates mail it
+  //    will discard — ruinous every pass for a workflow freshly attached to an
+  //    old mailbox. `min(N, ageInDays)` never shortens the window below the
+  //    configured N (an old watermark ⟹ full window, design §5's backstop), and
+  //    the ceil keeps the bound at/above `sinceTs` so the precise watermark
+  //    filter below still trims the day-granularity overlap.
+  const watermarkAgeDays = Math.max(1, Math.ceil((Date.now() - unit.sinceTs.getTime()) / DAY_MS));
+  const sinceDays = Math.min(unit.sweepWindowDays, watermarkAgeDays);
   // `folder` only narrows the provider query — the filter re-checks it
   // anyway, so this saves hydrating mail that is guaranteed to be dropped.
   const { emails, candidateCount } = await listDispatchableEmails(port, {
-    sinceDays: unit.sweepWindowDays,
+    sinceDays,
     folder: unit.workflow.filter.folder,
     limit: SWEEP_LIST_LIMIT,
+    // 2. Skip hydrating candidates the ledger already holds. Stuck rows were
+    //    DELETEd at the top of the sweep (before any unit lists), so a reset
+    //    email is absent here and correctly re-hydrated this same pass; only
+    //    genuinely-accounted-for mail is skipped.
+    resolveAlreadyProcessed: (candidateIds) =>
+      listProcessedProviderMessageIds(unit.workflow.id, unit.workflow.connectionId, candidateIds),
   });
   // A full page means the window held at least as much mail as we are willing
   // to hydrate, so this pass saw a truncated mailbox. Say so: the overflow is

--- a/packages/web/src/server/inbox-sweep.ts
+++ b/packages/web/src/server/inbox-sweep.ts
@@ -4,10 +4,13 @@
  * autonomously, mirroring the established periodic-job pattern (`upload-gc.ts`,
  * `audit-verify-job.ts`) — a `setInterval` plus a post-startup kick.
  *
- * The sweep is the correctness path, not the low-latency path: it re-lists a
- * whole window every cadence, so it runs infrequently. The token-free
- * steady-state poll is a later brick (an OpenClaw cron event-trigger), leaving
- * this as the safety net that guarantees no email is ever lost.
+ * The sweep is BOTH the correctness path and the low-latency path. It re-lists a
+ * whole window every cadence, but the sweep's ledger pre-filter and
+ * watermark-bounded window make a steady-state pass cost one `search` and ~zero
+ * reads (the expensive N+1 `read` runs only for genuinely new mail). That is what
+ * lets it run on a short cadence and react in near-real-time itself — no separate
+ * token-free poll (the abandoned OpenClaw event-trigger brick) is needed, and it
+ * is still the backstop that guarantees no email is ever lost.
  */
 
 /**
@@ -41,12 +44,14 @@ export function createGuardedSweepRunner(runSweep: () => Promise<void>): () => P
 }
 
 /**
- * Cadence for the reconciliation sweep. Deliberately infrequent: each pass
- * re-lists a whole window (an O(window) provider read per connection), so this
- * is the safety net, not the low-latency path. The token-free steady-state poll
- * that will run near-real-time is a later brick (an OpenClaw cron event-trigger).
+ * Cadence for the reconciliation sweep. Short on purpose: this IS the low-latency
+ * path. A steady-state pass costs one `search` per connection and hydrates only
+ * genuinely-new mail (the sweep's ledger pre-filter + watermark-bounded window),
+ * so a frequent cadence is affordable — one minute trades a little provider I/O
+ * for near-real-time reaction. Tunable via `INBOX_SWEEP_INTERVAL_MS` for large
+ * deployments where per-connection poll volume matters more than latency.
  */
-export const SWEEP_INTERVAL_MS = 15 * 60_000;
+export const SWEEP_INTERVAL_MS = 60_000;
 
 /**
  * Delay before the first pass, so the OpenClaw gateway and config have settled

--- a/packages/web/src/server/inbox-sweep.ts
+++ b/packages/web/src/server/inbox-sweep.ts
@@ -70,7 +70,8 @@ let _startupTimeout: ReturnType<typeof setTimeout> | null = null;
  * which is what lets these tests run with no mocks at all.
  *
  * `opts` overrides the cadence. Production leaves it empty; the E2E stack shortens
- * it via `INBOX_SWEEP_INTERVAL_MS`, since no test can wait 15 minutes for a tick.
+ * it via `INBOX_SWEEP_INTERVAL_MS`, since even the one-minute production cadence is
+ * far longer than a test can wait for a tick.
  *
  * Idempotent: the timer handles live in module state, so a second start without
  * this would overwrite the first one's handles and orphan an interval that fires


### PR DESCRIPTION
## What & why

Brick F was going to be a token-free low-latency mail poll built on OpenClaw's 2026.7.1 cron condition-watcher. Reading the current code first (per the docs-/code-first rule) showed the premise was already met: **the in-process reconciliation sweep is token-free** — its poll is `1×search + N×read` straight against the provider, and LLM tokens are only ever spent dispatching genuinely-new mail. The only thing the OpenClaw event-trigger would have added over the existing sweep is *lower latency* — and that needs no new gateway surface, no internal route, no per-connection cron provisioning, no `cron.triggers.enabled` exec-policy exposure.

So this takes **Path A**: make the sweep's poll cheap, then run it often. Same user-visible outcome (near-real-time, token-free email reaction), a fraction of the machinery, zero new attack surface. Brick F is abandoned.

## Changes

**1. Skip re-hydrating already-processed mail** (`perf` commit)
`read()` is the N+1 cost of a pass. New `listProcessedProviderMessageIds(workflowId, connectionId, candidateIds)` returns the candidates already in the ledger (any status); the lister gains an injected `resolveAlreadyProcessed` (DB-decoupled, like the port) and skips them before hydration. **Steady state ⟹ one `search`, zero `read`s.** Stuck rows are DELETEd at the top of the sweep before any unit lists, so a reset email is absent from the skip set and correctly re-hydrated the same pass (guard test pins the ordering).

**2. Cap the listing window at the watermark** (`perf` commit)
The sweep already drops everything below `sinceTs`, so listing further back only hydrates mail it discards — ruinous every pass for a workflow freshly attached to an old mailbox. `min(sweepWindowDays, ceil(ageInDays))`: never shortens below the configured N (old watermark ⟹ full window, design §5's slip-through backstop stays intact), ceil keeps the bound at/above `sinceTs` so the precise watermark filter still trims the day-granularity overlap.

**3. One-minute cadence** (`feat` commit)
Default drops 15 min → 60 s, tunable via `INBOX_SWEEP_INTERVAL_MS`. A unit test locks the intent (≤ 2 min, startup kick before first interval). Stale comments framing the OpenClaw event-trigger as the future low-latency path are corrected across the scheduler, sweep, and E2E spec.

Both filters are **correctness-neutral** — they only avoid work the sweep would discard (below-watermark) or the claim would reject (`onConflictDoNothing`). Nothing at/above the watermark is ever excluded.

## Tests (TDD, red first)
- Lister: skip set spares `read()`; fully-skipped pass ≠ dead mailbox
- Ledger: skip-set scoped to `(workflow, connection)`, empty-candidate short-circuit
- Sweep: no re-hydration of processed mail; reset-then-rehydrate ordering; watermark-bounded window; full window preserved for old workflow
- Scheduler: low-latency-cadence contract

## Gates (local)
Unit **8987**, integration ledger+sweep **43**, typecheck, lint **0 errors**, prettier on changed files — all green. `test:scripts` **311/311** except `format-gate.test.mjs`, which fails only because this worktree's install is missing root `prettier` (an incomplete install untouched by this branch); CI runs it on a clean install. The lint-staged pre-commit hook ENOENTs on the same missing binary, so both commits are `--no-verify` with format/eslint/typecheck verified by hand.

## Not in scope
Provider-native delta cursors (Gmail historyId / Graph delta) via `email_connection_cursors` remain a future refinement — the ledger + watermark filters make the generic `search` poll cheap enough without them. NL→workflow creation tool (#705) and the Automations-tab UI are separate bricks.