### PR TITLE
fix(openclaw-config): stop fanning out integration blobs across permission rows

### DIFF
--- a/packages/web/src/__tests__/api/agent-integrations.test.ts
+++ b/packages/web/src/__tests__/api/agent-integrations.test.ts
@@ -80,6 +80,7 @@ vi.mock("@/lib/audit-deferred", () => ({
 import { GET, PUT, DELETE } from "@/app/api/agents/[agentId]/integrations/route";
 import { NextRequest } from "next/server";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { agentConnectionPermissions, integrationConnections } from "@/db/schema";
 
 const AGENT_ID = "agent-1";
 const CONNECTION_ID = "conn-1";
@@ -117,10 +118,13 @@ describe("GET /api/agents/[agentId]/integrations", () => {
   });
 
   it("returns empty array when no permissions exist", async () => {
-    mockSelectFrom.mockReturnValueOnce({
-      innerJoin: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([]),
-      }),
+    // Two-query shape: permissions come back empty, so the connections query
+    // is skipped entirely and grouping yields [].
+    mockSelectFrom.mockImplementation((table: unknown) => {
+      if (table === agentConnectionPermissions) {
+        return { where: vi.fn().mockResolvedValue([]) };
+      }
+      throw new Error(`unexpected table passed to .from(): ${String(table)}`);
     });
 
     const req = new NextRequest(`http://localhost:7777/api/agents/${AGENT_ID}/integrations`);
@@ -132,29 +136,28 @@ describe("GET /api/agents/[agentId]/integrations", () => {
   });
 
   it("returns permissions grouped by connection", async () => {
-    mockSelectFrom.mockReturnValueOnce({
-      innerJoin: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([
-          {
-            integration_connections: {
+    mockSelectFrom.mockImplementation((table: unknown) => {
+      if (table === agentConnectionPermissions) {
+        return {
+          where: vi.fn().mockResolvedValue([
+            { connectionId: CONNECTION_ID, model: "res.partner", operation: "read" },
+            { connectionId: CONNECTION_ID, model: "res.partner", operation: "create" },
+          ]),
+        };
+      }
+      if (table === integrationConnections) {
+        return {
+          where: vi.fn().mockResolvedValue([
+            {
               id: CONNECTION_ID,
               name: "My Odoo",
               type: "odoo",
               data: { models: [{ model: "res.partner", name: "Contact" }] },
             },
-            agent_connection_permissions: { model: "res.partner", operation: "read" },
-          },
-          {
-            integration_connections: {
-              id: CONNECTION_ID,
-              name: "My Odoo",
-              type: "odoo",
-              data: { models: [{ model: "res.partner", name: "Contact" }] },
-            },
-            agent_connection_permissions: { model: "res.partner", operation: "create" },
-          },
-        ]),
-      }),
+          ]),
+        };
+      }
+      throw new Error(`unexpected table passed to .from(): ${String(table)}`);
     });
 
     const req = new NextRequest(`http://localhost:7777/api/agents/${AGENT_ID}/integrations`);
@@ -170,6 +173,64 @@ describe("GET /api/agents/[agentId]/integrations", () => {
       { model: "res.partner", modelName: "Contact", operation: "read" },
       { model: "res.partner", modelName: "Contact", operation: "create" },
     ]);
+  });
+
+  // Regression guard for the same boot-OOM fan-out class fixed in build.ts
+  // (loadAgentConnectionPermissions). The old handler used a projection-less
+  // `.innerJoin(integrationConnections, …)`, which materializes the full
+  // `integrationConnections.data` blob ONCE PER PERMISSION ROW. An agent with
+  // many model permissions on a big-blob Odoo connection would fan a multi-
+  // hundred-kB catalog out across every row in a single admin request. The
+  // fix loads permissions and the referenced connections as two separate
+  // queries and stitches them in memory, so each connection blob is fetched
+  // exactly once. This mock provides NO `.innerJoin` on the permissions query
+  // — a revert to the fan-out join throws here instead of silently passing.
+  it("fetches each connection blob once (no per-permission-row fan-out) and still groups correctly", async () => {
+    const bigBlob = {
+      models: Array.from({ length: 300 }, (_, i) => ({ model: `model.${i}`, name: `Model ${i}` })),
+    };
+    const connection = {
+      id: CONNECTION_ID,
+      name: "Big Odoo",
+      type: "odoo",
+      data: bigBlob,
+    };
+    const permissionRows = Array.from({ length: 40 }, (_, i) => ({
+      agentId: AGENT_ID,
+      connectionId: CONNECTION_ID,
+      model: `model.${i}`,
+      operation: "read",
+    }));
+
+    let integrationConnectionsFromCalls = 0;
+    mockSelectFrom.mockImplementation((table: unknown) => {
+      if (table === agentConnectionPermissions) {
+        return { where: vi.fn().mockResolvedValue(permissionRows) };
+      }
+      if (table === integrationConnections) {
+        integrationConnectionsFromCalls++;
+        return { where: vi.fn().mockResolvedValue([connection]) };
+      }
+      throw new Error(`unexpected table passed to .from(): ${String(table)}`);
+    });
+
+    const req = new NextRequest(`http://localhost:7777/api/agents/${AGENT_ID}/integrations`);
+    const res = await GET(req, makeParams(AGENT_ID));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // All 40 permissions grouped under the single connection…
+    expect(body).toHaveLength(1);
+    expect(body[0].connectionId).toBe(CONNECTION_ID);
+    expect(body[0].permissions).toHaveLength(40);
+    expect(body[0].permissions[0]).toEqual({
+      model: "model.0",
+      modelName: "Model 0",
+      operation: "read",
+    });
+    // …while the connection (and its blob) is queried exactly once, not once
+    // per permission row.
+    expect(integrationConnectionsFromCalls).toBe(1);
   });
 });
 

--- a/packages/web/src/__tests__/api/imap-preexisting-connection.test.ts
+++ b/packages/web/src/__tests__/api/imap-preexisting-connection.test.ts
@@ -407,19 +407,36 @@ describe("Pre-existing IMAP connection — cross-route invariant (listed ⟹ rea
         },
       ];
 
+      // Table-identity routing (see @/test-helpers/db-mock) doesn't survive
+      // this file's vi.resetModules() + dynamic-import pattern: the schema
+      // tables imported at this file's top level are a DIFFERENT module
+      // instance than the one build.ts sees when dynamically re-imported
+      // below, so `===` comparisons against them would silently fail. Route
+      // by call order instead, matching build.ts's query sequence:
+      //   1. agents (bare) · 2. agentConnectionPermissions (bare) ·
+      //   3. integrationConnections active-conn dedup (.where()) ·
+      //   4. integrationConnections web-search (.where()) · 5. channelLinks (bare)
+      const permRows = preExistingPermissionRows.map((r) => r.agent_connection_permissions);
+      const activeConnections = [preExistingPermissionRows[0]!.integration_connections];
+      let callCount = 0;
       vi.doMock("@/db", () => ({
         db: {
           select: vi.fn().mockImplementation(() => ({
-            from: vi.fn().mockImplementation(() =>
-              Object.assign(Promise.resolve(agentsData), {
-                innerJoin: vi.fn().mockReturnValue(
-                  Object.assign(Promise.resolve(preExistingPermissionRows), {
-                    where: vi.fn().mockResolvedValue(preExistingPermissionRows),
-                  })
-                ),
+            from: vi.fn().mockImplementation(() => {
+              callCount++;
+              if (callCount === 1) {
+                return Promise.resolve(agentsData);
+              }
+              if (callCount === 2) {
+                return Promise.resolve(permRows);
+              }
+              if (callCount === 3) {
+                return { where: vi.fn().mockResolvedValue(activeConnections) };
+              }
+              return Object.assign(Promise.resolve([]), {
                 where: vi.fn().mockResolvedValue([]),
-              })
-            ),
+              });
+            }),
           })),
         },
       }));

--- a/packages/web/src/__tests__/lib/openclaw-config-email.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-email.test.ts
@@ -87,6 +87,7 @@ import { writeFileSync, readFileSync, existsSync } from "fs";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { db } from "@/db";
 import { getSetting } from "@/lib/settings";
+import { mockJoinedPermissionsDb } from "@/test-helpers/db-mock";
 
 const mockedWriteFileSync = vi.mocked(writeFileSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
@@ -152,18 +153,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
@@ -237,18 +227,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
@@ -330,18 +309,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
@@ -396,18 +364,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
@@ -474,18 +431,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     await regenerateOpenClawConfig();
 
@@ -567,18 +513,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
@@ -659,18 +594,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
@@ -741,18 +665,7 @@ describe("pinchy-email config generation", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: vi.fn().mockReturnValue(
-            Object.assign(Promise.resolve(permissionsData), {
-              where: vi.fn().mockResolvedValue(permissionsData),
-            })
-          ),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({

--- a/packages/web/src/__tests__/lib/openclaw-config-permissions-fanout.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-permissions-fanout.test.ts
@@ -1,0 +1,180 @@
+// Regression guard for the boot-OOM fan-out bug found on staging during
+// v0.9.0 release verification.
+//
+// `regenerateOpenClawConfig` used to load agent connection permissions with
+// `.innerJoin(integrationConnections, ...)` and NO column projection. That
+// fans the full `integrationConnections.data` jsonb blob out across every
+// permission row that references the connection. On staging, one Odoo
+// connection carried an 837 kB `data` blob (the cached Odoo model catalog)
+// and 426 permission rows pointed at it — the join transferred and
+// materialized ~426 * 837 kB ~= 348 MB in the `allPermissions` array on
+// every config regeneration, OOM-crashing the boot under the 1 GB container
+// memory limit.
+//
+// `loadAgentConnectionPermissions` replaces the single fan-out join with two
+// queries + in-memory reconstruction, so each connection (and its blob) is
+// fetched exactly once and shared BY REFERENCE across every permission row
+// that points at it. This test asserts that sharing directly: it is false
+// under the old per-row join (each row gets its own connection object) and
+// true after the fix.
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    default: { ...actual },
+  };
+});
+
+vi.mock("@/db", () => ({
+  db: { select: vi.fn() },
+}));
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (val: string) => val,
+  encrypt: (val: string) => val,
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+vi.mock("@/server/restart-state", () => ({
+  restartState: { notifyRestart: vi.fn() },
+}));
+
+vi.mock("@/lib/migrate-onboarding", () => ({
+  migrateExistingSmithers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/openclaw-secrets", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/openclaw-secrets")>();
+  return {
+    ...actual,
+    writeSecretsFile: vi.fn(),
+    readSecretsFile: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: vi.fn().mockResolvedValue(""),
+  fetchOllamaLocalModelsFromUrl: vi.fn().mockResolvedValue([]),
+}));
+
+import { loadAgentConnectionPermissions } from "@/lib/openclaw-config/build";
+import { db } from "@/db";
+import { agentConnectionPermissions, integrationConnections } from "@/db/schema";
+
+type FakeDb = { select: ReturnType<typeof vi.fn> };
+
+/**
+ * Build a fake db whose `.from()` routes by table identity, mirroring the
+ * real two-query shape `loadAgentConnectionPermissions` issues:
+ *   - `db.select().from(agentConnectionPermissions)` — bare, resolves directly.
+ *   - `db.select().from(integrationConnections).where(...)` — resolves via `.where()`.
+ */
+function fakeDb(permissionRows: unknown[], activeConnections: unknown[]): FakeDb {
+  return {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation((table: unknown) => {
+        if (table === agentConnectionPermissions) {
+          return Promise.resolve(permissionRows);
+        }
+        if (table === integrationConnections) {
+          return { where: vi.fn().mockResolvedValue(activeConnections) };
+        }
+        throw new Error(`unexpected table passed to .from(): ${String(table)}`);
+      }),
+    })),
+  };
+}
+
+describe("loadAgentConnectionPermissions (fan-out fix)", () => {
+  it("materializes a connection with a large data blob exactly once and shares it by reference across every permission row", async () => {
+    const bigBlob = {
+      models: Array.from({ length: 500 }, (_, i) => ({ model: `model.${i}`, name: `Model ${i}` })),
+    };
+    const connection = {
+      id: "conn-odoo-1",
+      type: "odoo",
+      name: "Big Odoo",
+      status: "active",
+      credentials: "{}",
+      data: bigBlob,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const permissionRows = Array.from({ length: 50 }, (_, i) => ({
+      agentId: `agent-${i}`,
+      connectionId: "conn-odoo-1",
+      model: "res.partner",
+      operation: "read",
+    }));
+
+    const result = await loadAgentConnectionPermissions(
+      fakeDb(permissionRows, [connection]) as unknown as typeof db
+    );
+
+    expect(result).toHaveLength(50);
+    // The load-bearing assertion: every reconstructed row must point at the
+    // SAME connection object. Under the old `.innerJoin()` fan-out, the DB
+    // driver materializes a fresh row (and a fresh nested connection object)
+    // per joined row, so this would be false; the fix fetches the connection
+    // once and reuses the reference across all 50 rows.
+    const [first, ...rest] = result;
+    expect(first.integration_connections).toBe(connection);
+    for (const row of rest) {
+      expect(row.integration_connections).toBe(first.integration_connections);
+    }
+  });
+
+  it("keeps inner-join semantics: excludes permissions whose connection is pending", async () => {
+    const activeConn = { id: "conn-active", type: "odoo", status: "active" };
+    // "conn-pending" is deliberately NOT included in activeConnections, since
+    // the connections query filters `status != "pending"` at the DB level.
+    const permissionRows = [
+      { agentId: "a1", connectionId: "conn-active", model: "res.partner", operation: "read" },
+      { agentId: "a2", connectionId: "conn-pending", model: "res.partner", operation: "read" },
+    ];
+
+    const result = await loadAgentConnectionPermissions(
+      fakeDb(permissionRows, [activeConn]) as unknown as typeof db
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].agent_connection_permissions.agentId).toBe("a1");
+  });
+
+  it("excludes permissions whose connection no longer exists", async () => {
+    const permissionRows = [
+      { agentId: "a1", connectionId: "conn-deleted", model: "res.partner", operation: "read" },
+    ];
+
+    const result = await loadAgentConnectionPermissions(
+      fakeDb(permissionRows, []) as unknown as typeof db
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("preserves permission-row iteration order across multiple connections", async () => {
+    const connA = { id: "conn-a", type: "odoo", status: "active" };
+    const connB = { id: "conn-b", type: "odoo", status: "active" };
+    const permissionRows = [
+      { agentId: "a1", connectionId: "conn-b", model: "m1", operation: "read" },
+      { agentId: "a2", connectionId: "conn-a", model: "m2", operation: "read" },
+    ];
+
+    const result = await loadAgentConnectionPermissions(
+      fakeDb(permissionRows, [connA, connB]) as unknown as typeof db
+    );
+
+    expect(result.map((r) => r.agent_connection_permissions.agentId)).toEqual(["a1", "a2"]);
+    expect(result[0].integration_connections).toBe(connB);
+    expect(result[1].integration_connections).toBe(connA);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config-tools-md.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-tools-md.test.ts
@@ -109,6 +109,7 @@ vi.mock("@/lib/provider-models", () => ({
 import { readFileSync } from "fs";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { db } from "@/db";
+import { mockJoinedPermissionsDb } from "@/test-helpers/db-mock";
 import { generateToolsContent } from "@/lib/workspace";
 import {
   OPENCLAW_DEFAULT_BOOTSTRAP_MAX_CHARS,
@@ -181,26 +182,20 @@ function emailPermission(
 }
 
 /**
- * Wire the db mock: plain from() → agents, from().innerJoin().where() →
- * permission rows, from().where() → web-search connections.
+ * Wire the db mock: agents table, `agentConnectionPermissions` bare
+ * (`loadAgentConnectionPermissions`'s two-query fan-out fix — see
+ * @/test-helpers/db-mock), and `integrationConnections` for both the
+ * de-duplicated active connections and (on a later call) web-search
+ * connections.
  */
 function mockDb(
   agentsData: Array<Record<string, unknown>>,
   permissionsData: PermissionRow[],
   webSearchConnections: Array<Record<string, unknown>> = []
 ) {
-  mockedDb.select.mockReturnValue({
-    from: vi.fn().mockImplementation(() =>
-      Object.assign(Promise.resolve(agentsData), {
-        innerJoin: vi.fn().mockReturnValue(
-          Object.assign(Promise.resolve(permissionsData), {
-            where: vi.fn().mockResolvedValue(permissionsData),
-          })
-        ),
-        where: vi.fn().mockResolvedValue(webSearchConnections),
-      })
-    ),
-  } as never);
+  mockedDb.select.mockReturnValue(
+    mockJoinedPermissionsDb(agentsData, permissionsData, webSearchConnections) as never
+  );
 }
 
 function agentRow(id: string, overrides: Partial<Record<string, unknown>> = {}) {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -193,6 +193,7 @@ import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-con
 import { getPendingConfigPushCount, _resetConfigPushState } from "@/lib/openclaw-config/push-state";
 import { db } from "@/db";
 import { getSetting } from "@/lib/settings";
+import { mockJoinedPermissionsDb } from "@/test-helpers/db-mock";
 import { fetchOllamaLocalModelsFromUrl, fetchProviderModels } from "@/lib/provider-models";
 
 const mockedFetchProviderModels = vi.mocked(fetchProviderModels);
@@ -4523,9 +4524,10 @@ describe("pinchy-web config", () => {
             innerJoin: mockInnerJoin([]),
           });
         }
-        // callCount 2 = agentConnectionPermissions (chained with innerJoin)
-        // callCount 3 = integrationConnections for web-search (with where)
-        if (callCount === 3) {
+        // callCount 2 = agentConnectionPermissions (bare, no where/innerJoin)
+        // callCount 3 = integrationConnections for active-connection dedup (where)
+        // callCount 4 = integrationConnections for web-search (where)
+        if (callCount === 4) {
           return Object.assign(Promise.resolve(webSearchConnections), {
             innerJoin: mockInnerJoin([]),
             where: vi.fn().mockResolvedValue(webSearchConnections),
@@ -4631,7 +4633,7 @@ describe("pinchy-web config", () => {
             innerJoin: mockInnerJoin([]),
           });
         }
-        if (callCount === 3) {
+        if (callCount === 4) {
           return Object.assign(Promise.resolve(webSearchConnections), {
             innerJoin: mockInnerJoin([]),
             where: vi.fn().mockResolvedValue(webSearchConnections),
@@ -4686,7 +4688,7 @@ describe("pinchy-web config", () => {
             innerJoin: mockInnerJoin([]),
           });
         }
-        if (callCount === 3) {
+        if (callCount === 4) {
           return Object.assign(Promise.resolve(webSearchConnections), {
             innerJoin: mockInnerJoin([]),
             where: vi.fn().mockResolvedValue(webSearchConnections),
@@ -4752,7 +4754,7 @@ describe("pinchy-web config", () => {
             innerJoin: mockInnerJoin([]),
           });
         }
-        if (callCount === 3) {
+        if (callCount === 4) {
           return Object.assign(Promise.resolve(webSearchConnections), {
             innerJoin: mockInnerJoin([]),
             where: vi.fn().mockResolvedValue(webSearchConnections),
@@ -4826,7 +4828,7 @@ describe("pinchy-web: credentials fetched on demand via Pinchy API (#209)", () =
             innerJoin: mockInnerJoin([]),
           });
         }
-        if (callCount === 3) {
+        if (callCount === 4) {
           return Object.assign(Promise.resolve(webSearchConnections), {
             innerJoin: mockInnerJoin([]),
             where: vi.fn().mockResolvedValue(webSearchConnections),
@@ -4924,14 +4926,7 @@ describe("pinchy-odoo config size", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: mockInnerJoin(permissionsData),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     await regenerateOpenClawConfig();
 
@@ -4991,14 +4986,7 @@ describe("pinchy-odoo config size", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: mockInnerJoin(permissionsData),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     // Make decrypt throw to verify it is NOT called during config write.
     mockDecrypt.mockImplementation(() => {
@@ -5083,14 +5071,7 @@ describe("pinchy-odoo: credentials fetched on demand via Pinchy API (#209)", () 
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(Promise.resolve(agentsData), {
-          innerJoin: mockInnerJoin(permissionsData),
-          where: vi.fn().mockResolvedValue([]),
-        })
-      ),
-    } as never);
+    mockedDb.select.mockReturnValue(mockJoinedPermissionsDb(agentsData, permissionsData) as never);
 
     await regenerateOpenClawConfig();
 
@@ -5817,10 +5798,11 @@ describe("restart-state integration", () => {
             { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
           );
         }
-        // callCount 2 = agentConnectionPermissions (chained with innerJoin)
-        // callCount 3 = integrationConnections for web-search (chained with where)
-        // callCount 4 = channel_links table: both users linked
-        if (callCount === 4) {
+        // callCount 2 = agentConnectionPermissions (bare, no where/innerJoin)
+        // callCount 3 = integrationConnections for active-connection dedup (where)
+        // callCount 4 = integrationConnections for web-search (where)
+        // callCount 5 = channel_links table: both users linked
+        if (callCount === 5) {
           return Object.assign(
             Promise.resolve([
               { userId: "user-a", channel: "telegram", channelUserId: "111222333" },
@@ -5936,10 +5918,11 @@ describe("restart-state integration", () => {
             { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
           );
         }
-        // callCount 2 = agentConnectionPermissions (chained with innerJoin)
-        // callCount 3 = integrationConnections for web-search (chained with where)
-        // callCount 4 = channel_links table
-        if (callCount === 4) {
+        // callCount 2 = agentConnectionPermissions (bare, no where/innerJoin)
+        // callCount 3 = integrationConnections for active-connection dedup (where)
+        // callCount 4 = integrationConnections for web-search (where)
+        // callCount 5 = channel_links table
+        if (callCount === 5) {
           return Object.assign(
             Promise.resolve([{ userId: "user-1", channel: "telegram", channelUserId: "999888" }]),
             { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
@@ -6030,7 +6013,7 @@ describe("restart-state integration", () => {
             { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
           );
         }
-        if (callCount === 4) {
+        if (callCount === 5) {
           // channel_links table — a linked Telegram user exists.
           return Object.assign(
             Promise.resolve([{ userId: "user-1", channel: "telegram", channelUserId: "999888" }]),
@@ -7106,25 +7089,20 @@ describe("pinchy-* plugin gatewayToken as SecretRef", () => {
       },
     ];
 
-    mockedDb.select.mockReturnValue({
-      from: vi.fn().mockImplementation(() =>
-        Object.assign(
-          Promise.resolve([
-            {
-              id: "email-agent",
-              name: "Email Agent",
-              model: "anthropic/claude-haiku-4-5-20251001",
-              allowedTools: ["pinchy_email_read"],
-              createdAt: new Date(),
-            },
-          ]),
+    mockedDb.select.mockReturnValue(
+      mockJoinedPermissionsDb(
+        [
           {
-            innerJoin: mockInnerJoin(emailPermissionsData),
-            where: vi.fn().mockResolvedValue([]),
-          }
-        )
-      ),
-    } as never);
+            id: "email-agent",
+            name: "Email Agent",
+            model: "anthropic/claude-haiku-4-5-20251001",
+            allowedTools: ["pinchy_email_read"],
+            createdAt: new Date(),
+          },
+        ],
+        emailPermissionsData
+      ) as never
+    );
 
     await regenerateOpenClawConfig();
 

--- a/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { agentConnectionPermissions, integrationConnections, agents } from "@/db/schema";
@@ -18,15 +18,34 @@ type RouteContext = { params: Promise<{ agentId: string }> };
 export const GET = withAdmin<RouteContext>(async (_req, { params }) => {
   const { agentId } = await params;
 
-  // Join permissions with connections
-  const rows = await db
+  // Join permissions with connections WITHOUT a projection-less
+  // `.innerJoin(integrationConnections, …)`. That returns every column of both
+  // tables — including the potentially large `integrationConnections.data`
+  // jsonb blob (a cached Odoo model catalog) — ONE ROW PER PERMISSION, fanning
+  // the blob out across every permission row that references the connection.
+  // Same fan-out class as the boot-OOM fixed in build.ts
+  // (loadAgentConnectionPermissions); here it is bounded to a single agent but
+  // still amplifies (blob size) × (this agent's permission-row count) in one
+  // admin request. Load permissions and their referenced connections as two
+  // queries and stitch them in memory so each connection blob is fetched once.
+  const perms = await db
     .select()
     .from(agentConnectionPermissions)
-    .innerJoin(
-      integrationConnections,
-      eq(agentConnectionPermissions.connectionId, integrationConnections.id)
-    )
     .where(eq(agentConnectionPermissions.agentId, agentId));
+  const connectionIds = [...new Set(perms.map((p) => p.connectionId))];
+  const connections = connectionIds.length
+    ? await db
+        .select()
+        .from(integrationConnections)
+        .where(inArray(integrationConnections.id, connectionIds))
+    : [];
+  const connById = new Map(connections.map((c) => [c.id, c]));
+  // Preserve inner-join semantics: a permission is included only if its
+  // connection still exists.
+  const rows = perms.flatMap((perm) => {
+    const conn = connById.get(perm.connectionId);
+    return conn ? [{ agent_connection_permissions: perm, integration_connections: conn }] : [];
+  });
 
   // Group by connection
   const grouped = new Map<

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -141,6 +141,46 @@ const OLLAMA_LOCAL_DEFAULT_CONTEXT_WINDOW = 32_768;
  */
 const OLLAMA_LOCAL_MAX_TOKENS_CAP = 8_192;
 
+/**
+ * Loads every non-pending agent-connection permission joined with its
+ * integration connection, WITHOUT fanning the connection row out per
+ * permission row.
+ *
+ * The naive query (`.select().from(agentConnectionPermissions)
+ * .innerJoin(integrationConnections, ...)`) returns all columns of BOTH
+ * tables — including the potentially large `integrationConnections.data`
+ * jsonb blob (e.g. a cached Odoo model catalog) — ONE ROW PER PERMISSION.
+ * On staging, one Odoo connection carried an 837 kB `data` blob and 426
+ * permission rows pointed at it: the join transferred and materialized
+ * ~426 * 837 kB ~= 348 MB in the resulting array on every config
+ * regeneration, OOM-crashing the boot under a 1 GB container memory limit.
+ *
+ * This loads permissions and (active) connections as two separate queries
+ * and reconstructs the joined shape in memory, so each connection — and its
+ * blob — is fetched exactly once and shared BY REFERENCE across every
+ * permission row that references it.
+ *
+ * Preserves the original inner-join semantics: a permission row is included
+ * only if its connection exists and is not `"pending"`.
+ */
+export async function loadAgentConnectionPermissions(dbClient: typeof db): Promise<
+  Array<{
+    agent_connection_permissions: typeof agentConnectionPermissions.$inferSelect;
+    integration_connections: typeof integrationConnections.$inferSelect;
+  }>
+> {
+  const permRows = await dbClient.select().from(agentConnectionPermissions);
+  const activeConns = await dbClient
+    .select()
+    .from(integrationConnections)
+    .where(ne(integrationConnections.status, "pending"));
+  const connById = new Map(activeConns.map((c) => [c.id, c]));
+  return permRows.flatMap((perm) => {
+    const conn = connById.get(perm.connectionId);
+    return conn ? [{ agent_connection_permissions: perm, integration_connections: conn }] : [];
+  });
+}
+
 export async function regenerateOpenClawConfig() {
   // `readExistingConfig` distinguishes two recoverable failure modes:
   //   - ENOENT / parse error → returns {} (cold start; we build the first config from scratch).
@@ -264,14 +304,10 @@ export async function regenerateOpenClawConfig() {
   // on disk before that measurement, or its size would only be reflected one
   // regeneration behind.
   // Only include active connections — pending ones have no usable credentials.
-  const allPermissions = await db
-    .select()
-    .from(agentConnectionPermissions)
-    .innerJoin(
-      integrationConnections,
-      eq(agentConnectionPermissions.connectionId, integrationConnections.id)
-    )
-    .where(ne(integrationConnections.status, "pending"));
+  // See loadAgentConnectionPermissions for why this is two queries + an
+  // in-memory reconstruction rather than a single `.innerJoin()` (#OOM
+  // fan-out fix, v0.9.0 release verification).
+  const allPermissions = await loadAgentConnectionPermissions(db);
 
   // Aggregate email permissions per agent. LATENT FIRST-WINS BEHAVIOR: the
   // pinchy-email plugin config supports exactly ONE connectionId per agent

--- a/packages/web/src/test-helpers/db-mock.ts
+++ b/packages/web/src/test-helpers/db-mock.ts
@@ -1,0 +1,68 @@
+import { vi } from "vitest";
+import { agentConnectionPermissions, integrationConnections, channelLinks } from "@/db/schema";
+
+/**
+ * Wires a `db.select()` mock for tests exercising the two-query permissions
+ * load (`loadAgentConnectionPermissions` in `@/lib/openclaw-config/build`,
+ * added to fix a boot-OOM fan-out bug: the old single `.innerJoin()` query
+ * fanned the (potentially large) `integrationConnections.data` blob out
+ * across every permission row referencing it).
+ *
+ * Routes `.from()` by table identity:
+ *   - `.from(agents)` (or any other table) → `agentsData`, bare-awaited —
+ *     mirrors `db.select().from(agents)`.
+ *   - `.from(agentConnectionPermissions)` → the permission rows extracted
+ *     from `permissionsData`, bare-awaited (no `.where()`/`.innerJoin()`).
+ *   - `.from(integrationConnections).where(...)` → the de-duplicated set of
+ *     connections referenced by `permissionsData` on the FIRST call, and
+ *     `webSearchConnections` on subsequent calls — matching build.ts's query
+ *     order (permissions' active-connection query runs before the later,
+ *     separate web-search connections query).
+ *   - `.from(channelLinks)` → `[]` (callers needing channel-links data
+ *     should wire that table directly).
+ *
+ * `permissionsData` uses the old joined-row shape (`{
+ * agent_connection_permissions, integration_connections }`) that test
+ * fixtures already use throughout this codebase — this helper reconstructs
+ * the two-query split from it so existing fixtures don't need reshaping.
+ */
+export function mockJoinedPermissionsDb(
+  agentsData: unknown[],
+  permissionsData: Array<{
+    agent_connection_permissions: unknown;
+    integration_connections: Record<string, unknown>;
+  }>,
+  webSearchConnections: unknown[] = []
+) {
+  const permRows = permissionsData.map((r) => r.agent_connection_permissions);
+  const seenConnIds = new Set<unknown>();
+  const activeConnections: unknown[] = [];
+  for (const row of permissionsData) {
+    const conn = row.integration_connections;
+    if (!seenConnIds.has(conn.id)) {
+      seenConnIds.add(conn.id);
+      activeConnections.push(conn);
+    }
+  }
+
+  let integrationConnectionsCallCount = 0;
+  return {
+    from: vi.fn().mockImplementation((table: unknown) => {
+      if (table === agentConnectionPermissions) {
+        return Promise.resolve(permRows);
+      }
+      if (table === integrationConnections) {
+        integrationConnectionsCallCount++;
+        const result =
+          integrationConnectionsCallCount === 1 ? activeConnections : webSearchConnections;
+        return { where: vi.fn().mockResolvedValue(result) };
+      }
+      if (table === channelLinks) {
+        return Promise.resolve([]);
+      }
+      return Object.assign(Promise.resolve(agentsData), {
+        where: vi.fn().mockResolvedValue(agentsData),
+      });
+    }),
+  };
+}


### PR DESCRIPTION
## Summary

- `regenerateOpenClawConfig()` loaded agent-connection permissions with a single `.innerJoin(integrationConnections, ...)` and no column projection, which fans the full `integrationConnections.data` jsonb blob out across every permission row that references the connection.
- Confirmed on staging during v0.9.0 release verification: one Odoo connection carried an 837 kB `data` blob (cached Odoo model catalog); 426 `agent_connection_permissions` rows pointed at it. The join transferred/materialized ~426 * 837 kB ≈ 348 MB in the `allPermissions` array on every config regeneration. Under this release's new `mem_limit: 1g` default, this OOM-crashed the boot in a restart loop ~5s after "Pinchy ready". Confirmed fixed (steady-state ~371 MB) with this change; at `PINCHY_MEM_LIMIT=3g` it also boots fine either way, but the amplification is `(connection.data size) × (permission-row count)`, so real production instances would OOM at *any* reasonable memory limit — this is a query defect, not a limit-too-low issue.
- Fix: new exported `loadAgentConnectionPermissions` (`packages/web/src/lib/openclaw-config/build.ts`) replaces the fan-out join with two queries (permissions, then active/non-pending connections) reconstructed in memory via a `Map` keyed by connection id, so each connection — and its blob — is fetched exactly once and shared **by reference** across every permission row that points at it. Inner-join semantics are preserved (a permission is included only if its connection exists and is not `"pending"`). The two downstream consumers (email + Odoo config aggregation) are untouched — they already read the same `{ agent_connection_permissions, integration_connections }` row shape.
- Does **not** change `docker-compose.yml`'s `mem_limit` (intentional per #263) — this PR is the query fix only.

## Test plan

- [x] New regression test `packages/web/src/__tests__/lib/openclaw-config-permissions-fanout.test.ts` exercises `loadAgentConnectionPermissions` directly against a fake db: 50 permission rows sharing one large-blob connection all reference the **same** connection object (RED without the fix — the function didn't exist; GREEN after), plus pending-connection exclusion, missing-connection exclusion, and permission-row order preservation.
- [x] Updated `db.select()` mocks in `openclaw-config.test.ts`, `openclaw-config-email.test.ts`, `openclaw-config-tools-md.test.ts`, and `imap-preexisting-connection.test.ts` to route by the new two-query shape via a shared helper (`packages/web/src/test-helpers/db-mock.ts:mockJoinedPermissionsDb`). All pre-existing assertions (email/Odoo config emission, web-search connections, telegram peer bindings) pass unchanged.
- [x] `pnpm -C packages/web test` — 9009 passed, 16 skipped (full suite).
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm -C packages/web lint` — 0 errors (pre-existing warnings only, none in touched files).
- [x] `pnpm test:scripts` — 370 passed.
- [x] `pnpm format:check` — clean.