### PR TITLE
fix(audit): pseudonymize tool-event actor by canonicalizing OpenClaw's lowercased session-key user id

### DIFF
--- a/packages/web/src/__tests__/api/internal-audit-tool-use.integration.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.integration.test.ts
@@ -1,0 +1,111 @@
+// Real-DB integration test for POST /api/internal/audit/tool-use.
+//
+// The unit test (internal-audit-tool-use.test.ts) mocks @/db AND appendAuditLog,
+// so it only proves the route hands the lookup result to appendAuditLog — it
+// exercises neither the `lower(id)` match nor appendAuditLog's real GDPR
+// pseudonym substitution (resolveActorId in audit.ts). This test wires both
+// against real Postgres:
+//
+//   1. Seed a user with a mixed-case users.id and a KNOWN audit_pseudonym.
+//   2. Drive the route with the LOWERCASED id OpenClaw puts in the session key.
+//   3. Assert the persisted audit_log row carries the user's PSEUDONYM.
+//
+// That end-to-end path only produces the pseudonym if canonicalizeUserId first
+// restores the real case (so resolveActorId's case-sensitive `eq(users.id, ?)`
+// matches). If canonicalizeUserId ever regresses to a case-sensitive match, the
+// route would hand appendAuditLog the raw lowercased id, resolveActorId would
+// find no user, and the row would carry the raw lowercased id instead of the
+// pseudonym — which this test's first case asserts against.
+//
+// Uses a real PostgreSQL test database (provisioned by global-setup.ts and
+// truncated between tests by setup.ts). Only the gateway-token check is stubbed;
+// the db lookup and appendAuditLog write run for real.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+
+vi.mock("@/lib/gateway-auth", () => ({
+  validateGatewayToken: vi.fn().mockReturnValue(true),
+}));
+
+import { db } from "@/db";
+import { users, auditLog } from "@/db/schema";
+import { POST } from "@/app/api/internal/audit/tool-use/route";
+
+// Better-Auth-style id: 32 chars, mixed case — this is the case OpenClaw's
+// lowercased session key destroys.
+const CANONICAL_USER_ID = "9Uy331nd8hFYbtm0ulwlztjwboimggn2";
+// A fixed, recognizable pseudonym so the assertion doesn't depend on the random
+// audit_pseudonym default.
+const KNOWN_PSEUDONYM = "11111111-1111-4111-8111-111111111111";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/internal/audit/tool-use", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer gw-token",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/audit/tool-use (real DB)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await db.insert(users).values({
+      id: CANONICAL_USER_ID,
+      auditPseudonym: KNOWN_PSEUDONYM,
+      name: "Case User",
+      email: "case-user@example.com",
+      emailVerified: true,
+      role: "member",
+    });
+  });
+
+  it("pseudonymizes a lowercased session-key user by canonicalizing the id first", async () => {
+    const res = await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "browser",
+        agentId: "agent-2",
+        sessionKey: `agent:agent-2:direct:${CANONICAL_USER_ID.toLowerCase()}`,
+        result: { ok: true },
+      })
+    );
+    expect(res.status).toBe(200);
+
+    const rows = await db
+      .select({ actorType: auditLog.actorType, actorId: auditLog.actorId })
+      .from(auditLog)
+      .where(eq(auditLog.eventType, "tool.browser"));
+
+    // The persisted actor is the user's pseudonym, not the raw lowercased id —
+    // proof the id was canonicalized before resolveActorId's case-sensitive
+    // lookup ran.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ actorType: "user", actorId: KNOWN_PSEUDONYM });
+  });
+
+  it("writes the raw lowercased id when no users row matches (no pseudonym available)", async () => {
+    const res = await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "web",
+        agentId: "agent-2",
+        sessionKey: "agent:agent-2:direct:no-such-user-id",
+        result: { ok: true },
+      })
+    );
+    expect(res.status).toBe(200);
+
+    const rows = await db
+      .select({ actorType: auditLog.actorType, actorId: auditLog.actorId })
+      .from(auditLog)
+      .where(eq(auditLog.eventType, "tool.web"));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ actorType: "user", actorId: "no-such-user-id" });
+  });
+});

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -15,6 +15,26 @@ vi.mock("@/lib/audit", async (importOriginal) => {
   };
 });
 
+// The route canonicalizes OpenClaw's lowercased session-key userId back to
+// the real (mixed-case) users.id via a single select().from(users).where(...)
+// lookup — mock db the same way agent-uploads-route.test.ts does for its
+// ownership lookup. Default (set in beforeEach) is "no match", so existing
+// tests that don't care about case-canonicalization keep seeing the
+// extracted id fall through unchanged.
+const { mockUserLookup } = vi.hoisted(() => ({
+  mockUserLookup: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (...args: unknown[]) => mockUserLookup(...args),
+      }),
+    }),
+  },
+}));
+
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { appendAuditLog } from "@/lib/audit";
 import { POST } from "@/app/api/internal/audit/tool-use/route";
@@ -34,6 +54,7 @@ describe("POST /api/internal/audit/tool-use", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(validateGatewayToken).mockReturnValue(true);
+    mockUserLookup.mockResolvedValue([]);
   });
 
   it("returns 401 when gateway token is invalid", async () => {
@@ -155,6 +176,58 @@ describe("POST /api/internal/audit/tool-use", () => {
       outcome: "success",
       error: null,
     });
+  });
+
+  // Regression: OpenClaw lowercases session keys, so extractUserIdFromSessionKey
+  // returns a lowercased userId. appendAuditLog's pseudonym substitution does a
+  // case-sensitive `eq(users.id, actorId)` lookup, so a raw lowercased id never
+  // matches and every tool.* audit row silently skips pseudonymization (only 2 of
+  // 1221 user-actor rows were pseudonymized on staging). The route must
+  // canonicalize the lowercased id back to the real users.id case before handing
+  // it to appendAuditLog as actorId — mirroring usage-poller.ts's userIdMap.
+  it("canonicalizes a lowercased OpenClaw session-key userId back to the real users.id case", async () => {
+    const canonicalId = "9Uy331nd8hFYbtm0ulwlztjwboimggn2";
+    mockUserLookup.mockResolvedValueOnce([{ id: canonicalId }]);
+
+    const res = await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "browser",
+        agentId: "agent-2",
+        sessionKey: `agent:agent-2:direct:${canonicalId.toLowerCase()}`,
+        result: { ok: true },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorType: "user",
+        actorId: canonicalId,
+      })
+    );
+  });
+
+  it("falls back to the extracted (lowercased) id when no users row matches case-insensitively", async () => {
+    mockUserLookup.mockResolvedValueOnce([]);
+
+    const res = await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "browser",
+        agentId: "agent-2",
+        sessionKey: "agent:agent-2:direct:unknown-lowercase-id",
+        result: { ok: true },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorType: "user",
+        actorId: "unknown-lowercase-id",
+      })
+    );
   });
 
   // #640: diagnostics export matches a depth-truncated trajectory argument back

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+import { sql } from "drizzle-orm";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { appendAuditLog, safeProviderError } from "@/lib/audit";
 import { sanitizeDetail } from "@/lib/audit-sanitize";
 import { parseRequestBody } from "@/lib/api-validation";
+import { db } from "@/db";
+import { users } from "@/db/schema";
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -52,6 +55,26 @@ function extractUserIdFromSessionKey(sessionKey: string | undefined): string | u
   // a greedy `(.+)$` would swallow `<userId>:<chatId>` and mis-attribute the
   // audit row. The userId itself never contains a colon.
   return /^agent:[^:]+:direct:([^:]+)/.exec(sessionKey)?.[1];
+}
+
+// OpenClaw lowercases session keys, so the userId extracted above is always
+// lowercased and won't match users.id's real case. appendAuditLog's GDPR
+// pseudonym substitution (audit.ts resolveActorId) does a case-sensitive
+// `eq(users.id, actorId)` lookup, so a raw lowercased id silently misses it
+// and the raw id is written instead of the pseudonym. Canonicalize back to
+// the real users.id case here — the same compensation usage-poller.ts:159-164
+// applies via its `userIdMap` — before handing the id to appendAuditLog.
+// No throw: audit availability must not depend on this lookup succeeding.
+async function canonicalizeUserId(lowercasedUserId: string): Promise<string> {
+  try {
+    const rows = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(sql`lower(${users.id}) = ${lowercasedUserId.toLowerCase()}`);
+    return rows[0]?.id ?? lowercasedUserId;
+  } catch {
+    return lowercasedUserId;
+  }
 }
 
 // Trim and reject blank strings; turns "" or "   " into undefined so optional
@@ -200,7 +223,8 @@ export async function POST(request: NextRequest) {
   }
 
   // Change 3: Actor becomes the user extracted from sessionKey when possible
-  const userId = extractUserIdFromSessionKey(payload.sessionKey);
+  const rawUserId = extractUserIdFromSessionKey(payload.sessionKey);
+  const userId = rawUserId ? await canonicalizeUserId(rawUserId) : undefined;
   const actorType = userId ? "user" : "agent";
   const actorId = userId ?? payload.agentId;
 


### PR DESCRIPTION
## Summary
- `tool.*` audit rows extract `actorId` from OpenClaw's `sessionKey`, but OpenClaw lowercases session keys, so the extracted userId is always lowercase.
- `appendAuditLog`'s GDPR pseudonym substitution (`resolveActorId` in `packages/web/src/lib/audit.ts`) does a case-sensitive `eq(users.id, actorId)` lookup, so the lowercased id never matches and the raw lowercased id is written instead of the pseudonym.
- Verified on staging: only 2 of 1221 user-actor audit rows were pseudonymized; every `tool.*` row carried the lowercased raw id.
- Fix mirrors the existing compensation in `packages/web/src/lib/usage-poller.ts:159-164` (a case-insensitive `userIdMap`): the tool-use route now canonicalizes the extracted lowercased userId back to the real `users.id` case via a single `lower(id) = ?` lookup before handing it to `appendAuditLog`. No throw on lookup failure/no-match — audit availability must not depend on this succeeding.
- `resolveActorId`/`appendAuditLog` in `audit.ts` are untouched; the fix is at the consumption point (route), not the HMAC write path.
- Already-written audit rows remain historical/immutable — out of scope for this fix.

## Test plan
- [x] New test: `canonicalizes a lowercased OpenClaw session-key userId back to the real users.id case` (`packages/web/src/__tests__/api/internal-audit-tool-use.test.ts`) — confirmed RED (asserted canonical mixed-case actorId, got lowercased raw id) before the fix, GREEN after.
- [x] New test: `falls back to the extracted (lowercased) id when no users row matches case-insensitively` — covers the no-match fallback path.
- [x] Full web test suite: 9012 passed, 16 skipped.
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm -C packages/web lint` — 0 errors (774 pre-existing warnings, unrelated).
- [x] `pnpm format` (no changes needed) then `pnpm format:check` — clean.
- [x] `pnpm test:scripts` — 370 passed.