### PR TITLE
feat(integrations): diagnose SMTP port blocks on the IMAP test route

### DIFF
--- a/docs/src/content/docs/guides/connect-email-imap.mdx
+++ b/docs/src/content/docs/guides/connect-email-imap.mdx
@@ -160,6 +160,52 @@ The server didn't respond in time — usually a network issue or an incorrect ho
 
 ---
 
+## Ports, TLS & cloud firewalls
+
+Pinchy runs the connection test from the exact server that will send your mail — so if the SMTP leg times out or gets refused, that's real evidence about what this server can reach, not a guess. We use it: on a connection timeout or refusal, we also probe the standard SMTP ports (`465`, `587`, `25`) directly from the container, and if a different port is reachable, we show a banner with a one-click "Switch & retry" button for it. Click it and we update the SMTP port and security setting for you and re-run the test — nothing switches silently.
+
+<Aside type="note">
+  This only ever happens for connection-level failures (timeout or refused). An
+  authentication or TLS/certificate failure never triggers a port probe — those
+  aren't firewall problems, so a different port wouldn't fix them.
+</Aside>
+
+### Why cloud hosts block SMTP ports
+
+Cloud providers block outbound mail ports by default on new servers — it's an anti-spam measure, not a Pinchy limitation. The exact ports blocked vary by provider:
+
+| Provider          | Blocked outbound | Open            | Unblocking                                                                         |
+| ----------------- | ---------------- | --------------- | ---------------------------------------------------------------------------------- |
+| Hetzner           | 25, 465          | 587             | Usually opens automatically after ~1 month of account age, or via a support ticket |
+| DigitalOcean      | 25, 465, 587     | none by default | Open a support ticket requesting outbound mail ports be unblocked                  |
+| AWS / GCP / Azure | 25               | 465, 587        | Port 25 stays blocked by policy; use 465 or 587 instead                            |
+
+Port `587` (STARTTLS submission) is the safest default for a new cloud server — it's the one port most providers leave open. Port `465` (implicit TLS) is the next most likely to work. Port `25` (unencrypted SMTP relay) is blocked almost everywhere and isn't worth troubleshooting for outbound mail.
+
+### Testing reachability yourself
+
+You can check the same thing Pinchy's probe checks, directly from the server (or a shell on the same host):
+
+```bash
+# Raw TCP reachability (no TLS, no auth) — mirrors what Pinchy's probe does
+nc -vz smtp.example.com 587
+
+# Full TLS handshake against an implicit-TLS port (465)
+openssl s_client -connect smtp.example.com:465
+```
+
+`nc` reporting "succeeded" (or `openssl` reaching a certificate dump instead of hanging) means the port is reachable from this server. A hang followed by nothing means it's filtered — usually the host's outbound firewall, not your mail provider.
+
+### Requesting an unblock
+
+If every standard port is blocked (Pinchy's "all outbound SMTP ports appear blocked" banner), the fix has to happen at the host level:
+
+- **Hetzner**: open a support ticket asking to unblock outbound SMTP for your server/project. New accounts are usually auto-unblocked after roughly a month of account age.
+- **DigitalOcean**: open a support ticket from the control panel requesting outbound mail ports be enabled for your account.
+- **AWS / GCP / Azure**: port 25 is blocked by long-standing policy and generally isn't unblocked on request — use port 465 or 587 instead, which these providers leave open.
+
+---
+
 ## What's next
 
 - [Connect Email](/guides/connect-email/) — overview and comparing Gmail, Microsoft 365, and IMAP

--- a/packages/web/src/__tests__/api/imap-test-route.test.ts
+++ b/packages/web/src/__tests__/api/imap-test-route.test.ts
@@ -60,6 +60,20 @@ vi.mock("nodemailer", () => ({
   createTransport: createTransportMock,
 }));
 
+// Only probeSmtpPorts is mocked here (raw TCP reachability probe) — everything
+// else in the module (testImapLogin/testSmtpVerify/classifyProbeError) runs
+// for real, driven by the imapflow/nodemailer mocks above, so the route's
+// leg-classification logic is exercised end to end.
+const mockProbeSmtpPorts = vi.fn();
+vi.mock("@/lib/integrations/imap-probe", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/integrations/imap-probe")>();
+  return {
+    ...actual,
+    probeSmtpPorts: (...args: Parameters<typeof actual.probeSmtpPorts>) =>
+      mockProbeSmtpPorts(...args),
+  };
+});
+
 import { NextRequest } from "next/server";
 import { routeContext } from "@/test-helpers/route";
 
@@ -90,6 +104,12 @@ describe("POST /api/integrations/imap/test", () => {
     mockImapClient.logout.mockResolvedValue(undefined);
     mockTransport.verify.mockResolvedValue(true);
     mockAppendAuditLog.mockResolvedValue(undefined);
+    mockProbeSmtpPorts.mockReset();
+    mockProbeSmtpPorts.mockResolvedValue([
+      { port: 465, reachable: false },
+      { port: 587, reachable: false },
+      { port: 25, reachable: false },
+    ]);
   });
 
   it("returns 401 when there is no session, without attempting any probe", async () => {
@@ -150,7 +170,9 @@ describe("POST /api/integrations/imap/test", () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toEqual({ ok: true });
+      expect(body).toEqual({ ok: true, imap: { ok: true }, smtp: { ok: true } });
+      // Reachability probe is only run when the SMTP leg actually fails.
+      expect(mockProbeSmtpPorts).not.toHaveBeenCalled();
 
       expect(mockImapClient.connect).toHaveBeenCalled();
       expect(mockImapClient.logout).toHaveBeenCalled();
@@ -176,7 +198,7 @@ describe("POST /api/integrations/imap/test", () => {
       expect(serializedEntry).not.toContain(validBody.password);
     });
 
-    it("returns 400 { ok: false, error } and writes a failure audit entry when the IMAP login fails", async () => {
+    it("returns 200 { ok: false, imap } and writes a failure audit entry when the IMAP login fails", async () => {
       mockImapClient.connect.mockRejectedValue(
         new Error("Authentication failed for user mailbox@example.com")
       );
@@ -185,33 +207,45 @@ describe("POST /api/integrations/imap/test", () => {
       const response = await POST(makeRequest(validBody), routeContext());
       const body = await response.json();
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
       expect(body.ok).toBe(false);
+      expect(body.imap).toEqual({
+        ok: false,
+        code: "auth",
+        message: expect.stringMatching(/authentication/i),
+      });
       expect(typeof body.error).toBe("string");
       expect(body.error.toLowerCase()).toContain("authentication");
 
-      // SMTP should not even be attempted once IMAP has already failed the test.
-      expect(createTransportMock).not.toHaveBeenCalled();
+      // Both legs run separately now — IMAP failing no longer short-circuits
+      // the SMTP probe, since the diagnostic contract always reports both.
+      expect(createTransportMock).toHaveBeenCalled();
+      expect(body.smtp).toEqual({ ok: true });
 
       expect(mockAppendAuditLog).toHaveBeenCalledTimes(1);
       const entry = mockAppendAuditLog.mock.calls[0][0];
       expect(entry.eventType).toBe("integration.credentials_tested");
       expect(entry.outcome).toBe("failure");
+      // Failure codes go into detail, never the raw error/stack trace.
+      expect(entry.detail.imapCode).toBe("auth");
 
       const serializedEntry = JSON.stringify(entry);
       expect(serializedEntry).not.toContain(validBody.password);
       expect(serializedEntry).not.toMatch(/at\s+Object/); // no raw stack trace
+      expect(serializedEntry).not.toContain("mailbox@example.com"); // no raw error text with PII
     });
 
-    it("returns 400 { ok: false, error } and writes a failure audit entry when the SMTP verify fails", async () => {
+    it("returns 200 { ok: false, smtp } and writes a failure audit entry when the SMTP verify fails", async () => {
       mockTransport.verify.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:587"));
 
       const { POST } = await import("@/app/api/integrations/imap/test/route");
       const response = await POST(makeRequest(validBody), routeContext());
       const body = await response.json();
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
       expect(body.ok).toBe(false);
+      expect(body.smtp.ok).toBe(false);
+      expect(body.smtp.code).toBe("refused");
       expect(typeof body.error).toBe("string");
 
       expect(mockImapClient.connect).toHaveBeenCalled();
@@ -221,9 +255,77 @@ describe("POST /api/integrations/imap/test", () => {
       const entry = mockAppendAuditLog.mock.calls[0][0];
       expect(entry.eventType).toBe("integration.credentials_tested");
       expect(entry.outcome).toBe("failure");
+      expect(entry.detail.smtpCode).toBe("refused");
 
       const serializedEntry = JSON.stringify(entry);
       expect(serializedEntry).not.toContain(validBody.password);
+    });
+
+    it("probes SMTP port reachability and suggests switching to 587 when SMTP times out on 465 and 587 is reachable", async () => {
+      mockTransport.verify.mockRejectedValue(new Error("connect ETIMEDOUT 1.2.3.4:465"));
+      mockProbeSmtpPorts.mockResolvedValue([
+        { port: 465, reachable: false },
+        { port: 587, reachable: true },
+        { port: 25, reachable: false },
+      ]);
+
+      const { POST } = await import("@/app/api/integrations/imap/test/route");
+      const response = await POST(makeRequest({ ...validBody, smtpPort: 465 }), routeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.ok).toBe(false);
+      expect(body.smtp.code).toBe("timeout");
+      expect(mockProbeSmtpPorts).toHaveBeenCalledWith("smtp.example.com");
+      expect(body.smtpPortProbe).toEqual(expect.arrayContaining([{ port: 587, reachable: true }]));
+      expect(body.suggestion).toEqual({
+        kind: "switch_smtp_port",
+        port: 587,
+        security: "starttls",
+      });
+    });
+
+    it("suggests switching to 465 (implicit TLS) when 587 fails and 465 is reachable", async () => {
+      mockTransport.verify.mockRejectedValue(new Error("connect ETIMEDOUT 1.2.3.4:587"));
+      mockProbeSmtpPorts.mockResolvedValue([
+        { port: 465, reachable: true },
+        { port: 587, reachable: false },
+        { port: 25, reachable: false },
+      ]);
+
+      const { POST } = await import("@/app/api/integrations/imap/test/route");
+      const response = await POST(makeRequest({ ...validBody, smtpPort: 587 }), routeContext());
+      const body = await response.json();
+
+      expect(body.suggestion).toEqual({ kind: "switch_smtp_port", port: 465, security: "tls" });
+    });
+
+    it("reports all_smtp_blocked when neither 465 nor 587 is reachable", async () => {
+      mockTransport.verify.mockRejectedValue(new Error("connect ETIMEDOUT 1.2.3.4:465"));
+      mockProbeSmtpPorts.mockResolvedValue([
+        { port: 465, reachable: false },
+        { port: 587, reachable: false },
+        { port: 25, reachable: false },
+      ]);
+
+      const { POST } = await import("@/app/api/integrations/imap/test/route");
+      const response = await POST(makeRequest({ ...validBody, smtpPort: 465 }), routeContext());
+      const body = await response.json();
+
+      expect(body.suggestion).toEqual({ kind: "all_smtp_blocked" });
+    });
+
+    it("does not probe SMTP port reachability for an auth failure (not a connection-level failure)", async () => {
+      mockTransport.verify.mockRejectedValue(new Error("535 Authentication failed"));
+
+      const { POST } = await import("@/app/api/integrations/imap/test/route");
+      const response = await POST(makeRequest(validBody), routeContext());
+      const body = await response.json();
+
+      expect(body.smtp.code).toBe("auth");
+      expect(mockProbeSmtpPorts).not.toHaveBeenCalled();
+      expect(body.smtpPortProbe).toBeUndefined();
+      expect(body.suggestion).toBeUndefined();
     });
 
     it("never includes the plaintext password in the audit detail across success and failure paths", async () => {

--- a/packages/web/src/__tests__/api/imap-test-route.test.ts
+++ b/packages/web/src/__tests__/api/imap-test-route.test.ts
@@ -300,6 +300,24 @@ describe("POST /api/integrations/imap/test", () => {
       expect(body.suggestion).toEqual({ kind: "switch_smtp_port", port: 465, security: "tls" });
     });
 
+    it("suggests switching to 465 when the failing port is 25 and only 465 is reachable", async () => {
+      // Regression: previously the 465 suggestion only fired when the failing
+      // port was exactly 587, so failing on 25 with 465 reachable (587 blocked)
+      // gave no suggestion at all despite a reachable alternative.
+      mockTransport.verify.mockRejectedValue(new Error("connect ETIMEDOUT 1.2.3.4:25"));
+      mockProbeSmtpPorts.mockResolvedValue([
+        { port: 465, reachable: true },
+        { port: 587, reachable: false },
+        { port: 25, reachable: false },
+      ]);
+
+      const { POST } = await import("@/app/api/integrations/imap/test/route");
+      const response = await POST(makeRequest({ ...validBody, smtpPort: 25 }), routeContext());
+      const body = await response.json();
+
+      expect(body.suggestion).toEqual({ kind: "switch_smtp_port", port: 465, security: "tls" });
+    });
+
     it("reports all_smtp_blocked when neither 465 nor 587 is reachable", async () => {
       mockTransport.verify.mockRejectedValue(new Error("connect ETIMEDOUT 1.2.3.4:465"));
       mockProbeSmtpPorts.mockResolvedValue([

--- a/packages/web/src/__tests__/components/imap-connect-step.test.tsx
+++ b/packages/web/src/__tests__/components/imap-connect-step.test.tsx
@@ -614,6 +614,37 @@ describe("ImapConnectStep", () => {
     expect(screen.queryByRole("button", { name: /switch to .* & retry/i })).not.toBeInTheDocument();
   });
 
+  it("does not claim the SMTP host was unreachable on an auth failure (server was reached)", async () => {
+    vi.mocked(apiPost).mockResolvedValueOnce({
+      ok: false,
+      imap: { ok: true },
+      smtp: {
+        ok: false,
+        code: "auth",
+        message: "Authentication failed — check the username and password",
+      },
+      error: "Authentication failed — check the username and password",
+    });
+
+    const user = userEvent.setup();
+    renderStep();
+    await user.click(screen.getByRole("button", { name: /enter server settings manually/i }));
+
+    await user.type(screen.getByLabelText(/^imap host$/i), "imap.example.com");
+    await user.type(screen.getByLabelText(/^smtp host$/i), "smtp.example.com");
+    await fillEmailAndPassword(user);
+
+    await user.click(screen.getByRole("button", { name: /test & save/i }));
+
+    // Per-leg status still shows the SMTP leg failed…
+    await waitFor(() => {
+      expect(screen.getByText(/smtp ✗/i)).toBeInTheDocument();
+    });
+    // …but must NOT say the host was unreachable — auth failures mean the
+    // server WAS reached, so a "couldn't reach" claim would be misleading.
+    expect(screen.queryByText(/couldn't reach/i)).not.toBeInTheDocument();
+  });
+
   it("surfaces a Save ApiError to the user without calling onSuccess", async () => {
     vi.mocked(apiPost).mockResolvedValueOnce({ ok: true }); // test
     vi.mocked(apiPost).mockRejectedValueOnce(

--- a/packages/web/src/__tests__/components/imap-connect-step.test.tsx
+++ b/packages/web/src/__tests__/components/imap-connect-step.test.tsx
@@ -514,6 +514,106 @@ describe("ImapConnectStep", () => {
     expect(apiPost).toHaveBeenCalledTimes(1);
   });
 
+  it("shows a switch-port banner on a switch_smtp_port suggestion, and retries with the new port on click", async () => {
+    vi.mocked(apiPost).mockResolvedValueOnce({
+      ok: false,
+      imap: { ok: true },
+      smtp: {
+        ok: false,
+        code: "timeout",
+        message: "Connection timed out — cloud hosts often block this port",
+      },
+      smtpPortProbe: [
+        { port: 465, reachable: false },
+        { port: 587, reachable: true },
+        { port: 25, reachable: false },
+      ],
+      suggestion: { kind: "switch_smtp_port", port: 587, security: "starttls" },
+      error: "Connection timed out — cloud hosts often block this port",
+    }); // first test: fails on 465
+    vi.mocked(apiPost).mockResolvedValueOnce({
+      ok: true,
+      imap: { ok: true },
+      smtp: { ok: true },
+    }); // retry test: succeeds on 587
+    vi.mocked(apiPost).mockResolvedValueOnce({ id: "conn-1", name: "someone@example.com" }); // create
+
+    const user = userEvent.setup();
+    const { onSuccess } = renderStep();
+    await user.click(screen.getByRole("button", { name: /enter server settings manually/i }));
+
+    await user.type(screen.getByLabelText(/^imap host$/i), "imap.example.com");
+    await user.type(screen.getByLabelText(/^smtp host$/i), "smtp.example.com");
+    await user.clear(screen.getByLabelText(/^smtp port$/i));
+    await user.type(screen.getByLabelText(/^smtp port$/i), "465");
+    await fillEmailAndPassword(user);
+
+    await user.click(screen.getByRole("button", { name: /test & save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/we can reach port 587 from this server/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /switch to 587 & retry/i })).toBeInTheDocument();
+    // Per-leg status is visible alongside the banner.
+    expect(screen.getByText(/imap ✓/i)).toBeInTheDocument();
+    expect(screen.getByText(/smtp ✗/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /switch to 587 & retry/i }));
+
+    // The form field updates to reflect the switch.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^smtp port$/i)).toHaveValue("587");
+    });
+
+    // The retry re-invoked the test endpoint with the new port.
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenNthCalledWith(
+        2,
+        "/api/integrations/imap/test",
+        expect.objectContaining({ smtpPort: 587, security: "starttls" })
+      );
+    });
+
+    // Retry succeeded, so the flow continues on to create the connection.
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({ id: "conn-1", name: "someone@example.com" });
+    });
+  });
+
+  it("shows an all-SMTP-blocked banner when no outbound SMTP port is reachable", async () => {
+    vi.mocked(apiPost).mockResolvedValueOnce({
+      ok: false,
+      imap: { ok: true },
+      smtp: {
+        ok: false,
+        code: "timeout",
+        message: "Connection timed out — cloud hosts often block this port",
+      },
+      smtpPortProbe: [
+        { port: 465, reachable: false },
+        { port: 587, reachable: false },
+        { port: 25, reachable: false },
+      ],
+      suggestion: { kind: "all_smtp_blocked" },
+      error: "Connection timed out — cloud hosts often block this port",
+    });
+
+    const user = userEvent.setup();
+    renderStep();
+    await user.click(screen.getByRole("button", { name: /enter server settings manually/i }));
+
+    await user.type(screen.getByLabelText(/^imap host$/i), "imap.example.com");
+    await user.type(screen.getByLabelText(/^smtp host$/i), "smtp.example.com");
+    await fillEmailAndPassword(user);
+
+    await user.click(screen.getByRole("button", { name: /test & save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/we can.t reach any outbound smtp port/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /switch to .* & retry/i })).not.toBeInTheDocument();
+  });
+
   it("surfaces a Save ApiError to the user without calling onSuccess", async () => {
     vi.mocked(apiPost).mockResolvedValueOnce({ ok: true }); // test
     vi.mocked(apiPost).mockRejectedValueOnce(

--- a/packages/web/src/__tests__/lib/integrations/probe.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/probe.test.ts
@@ -20,11 +20,12 @@ vi.mock("@/lib/integrations/brave-probe", () => ({
 const mockTestImapLogin = vi.fn();
 const mockTestSmtpVerify = vi.fn();
 // Only the network I/O (testImapLogin/testSmtpVerify) is mocked; friendlyError
-// comes from the REAL module via importActual. The imap branch of probe.ts
-// classifies transient-vs-auth by matching the real friendlyError wording
-// (/authentication failed/i), so re-implementing it here would let a reword of
-// the real string silently break auth-failure detection while this test stayed
-// green. Importing the real one makes that coupling a real compile/run check.
+// and classifyProbeError come from the REAL module via importActual. The imap
+// branch of probe.ts classifies transient-vs-auth via the real
+// classifyProbeError()'s code === "auth", so re-implementing that mapping
+// here would let a change to the real classifier silently break auth-failure
+// detection while this test stayed green. Importing the real one makes that
+// coupling a real compile/run check.
 vi.mock("@/lib/integrations/imap-probe", async (importActual) => {
   const actual = await importActual<typeof import("@/lib/integrations/imap-probe")>();
   return {

--- a/packages/web/src/app/api/integrations/imap/test/route.ts
+++ b/packages/web/src/app/api/integrations/imap/test/route.ts
@@ -1,16 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withAdmin } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
-import { imapTestSchema } from "@/lib/schemas/imap";
+import { imapTestSchema, type ImapTestResult, type ImapTestSuggestion } from "@/lib/schemas/imap";
 import { appendAuditLog, redactEmail } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
-import { testImapLogin, testSmtpVerify, friendlyError } from "@/lib/integrations/imap-probe";
+import {
+  testImapLogin,
+  testSmtpVerify,
+  classifyProbeError,
+  probeSmtpPorts,
+  type LegResult,
+  type SmtpPortProbe,
+} from "@/lib/integrations/imap-probe";
 
 // Matches an email-shaped username so we can redact it the same way other
 // audit fields redact identity data (see redactEmail() in @/lib/audit). Not
 // every IMAP username is an email address, so this is a heuristic, not a
 // validation rule.
 const EMAIL_LIKE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Both legs are always run — a firewalled SMTP port is exactly the diagnostic
+// this endpoint exists to surface, so a failed IMAP login must not hide it.
+async function runLeg(fn: () => Promise<void>): Promise<LegResult> {
+  try {
+    await fn();
+    return { ok: true };
+  } catch (error) {
+    const { code, message } = classifyProbeError(error);
+    return { ok: false, code, message };
+  }
+}
+
+function isReachable(portProbe: SmtpPortProbe[], port: number): boolean {
+  return portProbe.find((p) => p.port === port)?.reachable ?? false;
+}
+
+// Only ever suggests 465/587 (the two ports probeSmtpPorts checks alongside
+// 25) — never a port derived from anything beyond the fixed reachability
+// probe result.
+function buildSuggestion(failingPort: number, portProbe: SmtpPortProbe[]): ImapTestSuggestion {
+  if (isReachable(portProbe, 587) && failingPort !== 587) {
+    return { kind: "switch_smtp_port", port: 587, security: "starttls" };
+  }
+  if (isReachable(portProbe, 465) && failingPort === 587) {
+    return { kind: "switch_smtp_port", port: 465, security: "tls" };
+  }
+  if (!isReachable(portProbe, 465) && !isReachable(portProbe, 587)) {
+    return { kind: "all_smtp_blocked" };
+  }
+  return null;
+}
 
 export const POST = withAdmin(async (request: NextRequest, _ctx, session) => {
   const parsed = await parseRequestBody(imapTestSchema, request);
@@ -21,74 +60,54 @@ export const POST = withAdmin(async (request: NextRequest, _ctx, session) => {
 
   const identity = EMAIL_LIKE.test(input.username) ? redactEmail(input.username) : undefined;
 
-  try {
-    await testImapLogin(input);
-    await testSmtpVerify(input);
-  } catch (error) {
-    const reason = friendlyError(error);
+  const imap = await runLeg(() => testImapLogin(input));
+  const smtp = await runLeg(() => testSmtpVerify(input));
 
-    try {
-      await appendAuditLog({
-        eventType: "integration.credentials_tested",
-        actorType: "user",
-        actorId,
-        resource: "integration",
-        outcome: "failure",
-        error: { message: reason },
-        detail: {
-          imapHost: input.imapHost,
-          smtpHost: input.smtpHost,
-          reason,
-          ...(identity ?? {}),
-        },
-      });
-    } catch (auditErr) {
-      recordAuditFailure(auditErr, {
-        eventType: "integration.credentials_tested",
-        actorType: "user",
-        actorId,
-        resource: "integration",
-        outcome: "failure",
-        error: { message: reason },
-        detail: {
-          imapHost: input.imapHost,
-          smtpHost: input.smtpHost,
-          reason,
-          ...(identity ?? {}),
-        },
-      });
-    }
-
-    return NextResponse.json({ ok: false, error: reason }, { status: 400 });
+  let smtpPortProbe: SmtpPortProbe[] | undefined;
+  let suggestion: ImapTestSuggestion | undefined;
+  if (!smtp.ok && (smtp.code === "timeout" || smtp.code === "refused")) {
+    smtpPortProbe = await probeSmtpPorts(input.smtpHost);
+    suggestion = buildSuggestion(input.smtpPort, smtpPortProbe);
   }
 
+  const ok = imap.ok && smtp.ok;
+  // IMAP takes priority as the primary banner message: a broken IMAP login
+  // blocks reading mail entirely, which is more severe than an SMTP-only
+  // (send-side) problem.
+  const error = !imap.ok ? imap.message : !smtp.ok ? smtp.message : undefined;
+
+  const result: ImapTestResult = {
+    ok,
+    imap,
+    smtp,
+    ...(smtpPortProbe ? { smtpPortProbe } : {}),
+    ...(suggestion !== undefined ? { suggestion } : {}),
+    ...(error ? { error } : {}),
+  };
+
+  const auditDetail = {
+    imapHost: input.imapHost,
+    smtpHost: input.smtpHost,
+    ...(imap.ok ? {} : { imapCode: imap.code }),
+    ...(smtp.ok ? {} : { smtpCode: smtp.code }),
+    ...(identity ?? {}),
+  };
+
+  const auditEntry = {
+    eventType: "integration.credentials_tested" as const,
+    actorType: "user" as const,
+    actorId,
+    resource: "integration",
+    outcome: ok ? ("success" as const) : ("failure" as const),
+    ...(ok ? {} : { error: { message: error ?? "Connection test failed" } }),
+    detail: auditDetail,
+  };
+
   try {
-    await appendAuditLog({
-      eventType: "integration.credentials_tested",
-      actorType: "user",
-      actorId,
-      resource: "integration",
-      outcome: "success",
-      detail: {
-        imapHost: input.imapHost,
-        smtpHost: input.smtpHost,
-        ...(identity ?? {}),
-      },
-    });
+    await appendAuditLog(auditEntry);
   } catch (auditErr) {
-    recordAuditFailure(auditErr, {
-      eventType: "integration.credentials_tested",
-      actorType: "user",
-      actorId,
-      resource: "integration",
-      outcome: "success",
-      detail: {
-        imapHost: input.imapHost,
-        smtpHost: input.smtpHost,
-        ...(identity ?? {}),
-      },
-    });
+    recordAuditFailure(auditErr, auditEntry);
   }
 
-  return NextResponse.json({ ok: true });
+  return NextResponse.json(result);
 });

--- a/packages/web/src/app/api/integrations/imap/test/route.ts
+++ b/packages/web/src/app/api/integrations/imap/test/route.ts
@@ -42,7 +42,7 @@ function buildSuggestion(failingPort: number, portProbe: SmtpPortProbe[]): ImapT
   if (isReachable(portProbe, 587) && failingPort !== 587) {
     return { kind: "switch_smtp_port", port: 587, security: "starttls" };
   }
-  if (isReachable(portProbe, 465) && failingPort === 587) {
+  if (isReachable(portProbe, 465) && failingPort !== 465) {
     return { kind: "switch_smtp_port", port: 465, security: "tls" };
   }
   if (!isReachable(portProbe, 465) && !isReachable(portProbe, 587)) {

--- a/packages/web/src/components/imap-connect-step.tsx
+++ b/packages/web/src/components/imap-connect-step.tsx
@@ -14,7 +14,7 @@ import {
 import { Loader2, AlertTriangle, Eye, EyeOff } from "lucide-react";
 import { toast } from "sonner";
 import { apiGet, apiPost, ApiError } from "@/lib/api-client";
-import type { ImapTestInput, ImapCreateInput } from "@/lib/schemas/imap";
+import type { ImapTestInput, ImapCreateInput, ImapTestResult } from "@/lib/schemas/imap";
 
 interface AutodiscoverResponse {
   config: Partial<{
@@ -108,11 +108,16 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
     "idle"
   );
   const [testError, setTestError] = useState<string | null>(null);
+  // The full structured diagnostic from the last "Test & Save" attempt (only
+  // populated when the server actually returned one — an ApiError from a
+  // network/5xx failure has no per-leg breakdown, so testResult stays null).
+  const [testResult, setTestResult] = useState<ImapTestResult | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
 
   function updateField<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
     setTestError(null);
+    setTestResult(null);
     setSaveError(null);
     if (flightStatus === "failure") {
       setFlightStatus("idle");
@@ -202,42 +207,44 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
       return next;
     });
     setTestError(null);
+    setTestResult(null);
     setSaveError(null);
     if (flightStatus === "failure") {
       setFlightStatus("idle");
     }
   }
 
-  function buildTestBody(): ImapTestInput {
+  // `overrides` lets the "Switch to {port} & retry" banner re-run the test
+  // with the suggested SMTP port/security immediately, without waiting on a
+  // setForm() state update to land first (React state updates are not
+  // synchronous, so reading form.smtpPort right after setForm would still see
+  // the stale value). smtpPort is a number here (matching ImapTestInput),
+  // unlike FormState.smtpPort which holds the raw string input value.
+  type TestOverrides = { smtpPort?: number; security?: Security };
+
+  function buildTestBody(overrides?: TestOverrides): ImapTestInput {
     return {
       imapHost: form.imapHost,
       imapPort: Number(form.imapPort),
       smtpHost: form.smtpHost,
-      smtpPort: Number(form.smtpPort),
+      smtpPort: overrides?.smtpPort ?? Number(form.smtpPort),
       username: form.username,
       password: form.password,
-      security: form.security,
+      security: overrides?.security ?? form.security,
     };
   }
 
-  async function handleTestAndSave() {
+  async function handleTestAndSave(overrides?: TestOverrides) {
     setTestError(null);
+    setTestResult(null);
     setSaveError(null);
     setFlightStatus("testing");
 
-    try {
-      const result = await apiPost<{ ok: boolean; error?: string }>(
-        "/api/integrations/imap/test",
-        buildTestBody()
-      );
+    const testBody = buildTestBody(overrides);
+    let result: ImapTestResult;
 
-      if (!result.ok) {
-        setFlightStatus("failure");
-        setTestError(result.error ?? "Connection test failed");
-        setServerSettingsExpanded(true);
-        setUserExpanded(true);
-        return;
-      }
+    try {
+      result = await apiPost<ImapTestResult>("/api/integrations/imap/test", testBody);
     } catch (err) {
       setFlightStatus("failure");
       setTestError(err instanceof ApiError ? err.message : "Connection test failed");
@@ -246,10 +253,20 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
       return;
     }
 
+    setTestResult(result);
+
+    if (!result.ok) {
+      setFlightStatus("failure");
+      setTestError(result.error ?? "Connection test failed");
+      setServerSettingsExpanded(true);
+      setUserExpanded(true);
+      return;
+    }
+
     setFlightStatus("saving");
 
     const body: ImapCreateInput = {
-      ...buildTestBody(),
+      ...testBody,
       ...(form.senderName.trim() ? { senderName: form.senderName.trim() } : {}),
     };
 
@@ -267,6 +284,20 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
     }
   }
 
+  // The user clicks to apply a suggested port switch — we never auto-switch
+  // silently. Updates the visible form fields AND immediately re-runs the
+  // test with the same values (passed explicitly, see buildTestBody above).
+  function handleSwitchPortAndRetry(port: number, security: "starttls" | "tls") {
+    setForm((prev) => ({ ...prev, smtpPort: String(port), security }));
+    setTouched((prev) => {
+      const next = new Set(prev);
+      next.add("smtpPort");
+      next.add("security");
+      return next;
+    });
+    void handleTestAndSave({ smtpPort: port, security });
+  }
+
   const inFlight = flightStatus === "testing" || flightStatus === "saving";
   const canSubmit = !inFlight && form.email.trim().length > 0 && form.password.trim().length > 0;
 
@@ -274,6 +305,20 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
     !serverSettingsExpanded && CONFIDENT_SOURCES.has(source)
       ? `Server settings found — IMAP ${form.imapHost}:${form.imapPort} · SMTP ${form.smtpHost}:${form.smtpPort}`
       : null;
+
+  // Per-leg status line ("IMAP ✓ · SMTP ✗ (couldn't reach smtp.host:465)").
+  // Only renders for the new structured contract — a caught ApiError (no
+  // per-leg breakdown) or an older mocked `{ ok, error }` shape leaves
+  // testResult.imap/testResult.smtp undefined, so this stays hidden rather
+  // than throwing.
+  const legStatus =
+    testResult && !testResult.ok && testResult.imap && testResult.smtp
+      ? `IMAP ${testResult.imap.ok ? "✓" : "✗"} · SMTP ${testResult.smtp.ok ? "✓" : "✗"}${
+          !testResult.smtp.ok ? ` (couldn't reach ${form.smtpHost}:${form.smtpPort})` : ""
+        }`
+      : null;
+
+  const suggestion = testResult && !testResult.ok ? testResult.suggestion : undefined;
 
   return (
     <div className="space-y-4">
@@ -435,10 +480,45 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
             </Select>
           </div>
 
+          {legStatus && <p className="text-xs text-muted-foreground">{legStatus}</p>}
+
           {testError && (
             <div className="flex items-start gap-2 text-sm text-destructive">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
               <span>{testError}</span>
+            </div>
+          )}
+
+          {suggestion?.kind === "switch_smtp_port" && (
+            <div className="space-y-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/40">
+              <p>
+                Port {form.smtpPort} is commonly blocked by cloud hosts like Hetzner and
+                DigitalOcean — but we can reach port {suggestion.port} from this server.
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => handleSwitchPortAndRetry(suggestion.port, suggestion.security)}
+              >
+                Switch to {suggestion.port} & retry
+              </Button>
+            </div>
+          )}
+
+          {suggestion?.kind === "all_smtp_blocked" && (
+            <div className="space-y-1 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-900 dark:bg-amber-950/40">
+              <p>
+                We can&apos;t reach any outbound SMTP port (465, 587, or 25) from this server. Ask
+                your host to unblock outbound SMTP, or send through a relay.{" "}
+                <a
+                  href="https://docs.heypinchy.com/guides/connect-email-imap#ports-tls-and-cloud-firewalls"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  See the troubleshooting guide.
+                </a>
+              </p>
             </div>
           )}
         </div>
@@ -462,7 +542,7 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
             Cancel
           </Button>
         </div>
-        <Button type="button" disabled={!canSubmit} onClick={handleTestAndSave}>
+        <Button type="button" disabled={!canSubmit} onClick={() => handleTestAndSave()}>
           {flightStatus === "testing" ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/packages/web/src/components/imap-connect-step.tsx
+++ b/packages/web/src/components/imap-connect-step.tsx
@@ -311,10 +311,20 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
   // per-leg breakdown) or an older mocked `{ ok, error }` shape leaves
   // testResult.imap/testResult.smtp undefined, so this stays hidden rather
   // than throwing.
+  //
+  // The "couldn't reach" suffix is only truthful for connection-level failures
+  // (timeout/refused). An auth or TLS failure means the host WAS reached, so
+  // claiming it was unreachable there would be misleading.
+  const smtpUnreachable =
+    testResult &&
+    !testResult.ok &&
+    testResult.smtp &&
+    !testResult.smtp.ok &&
+    (testResult.smtp.code === "timeout" || testResult.smtp.code === "refused");
   const legStatus =
     testResult && !testResult.ok && testResult.imap && testResult.smtp
       ? `IMAP ${testResult.imap.ok ? "✓" : "✗"} · SMTP ${testResult.smtp.ok ? "✓" : "✗"}${
-          !testResult.smtp.ok ? ` (couldn't reach ${form.smtpHost}:${form.smtpPort})` : ""
+          smtpUnreachable ? ` (couldn't reach ${form.smtpHost}:${form.smtpPort})` : ""
         }`
       : null;
 

--- a/packages/web/src/lib/integrations/__tests__/imap-probe.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/imap-probe.test.ts
@@ -33,10 +33,48 @@ vi.mock("nodemailer", () => ({
   createTransport: createTransportMock,
 }));
 
+// Fake TCP socket for probeSmtpPorts, hoisted so it's visible to the
+// vi.mock("node:net", ...) factory below (vitest hoists vi.mock calls above
+// these consts/imports). Each call to the mocked `connect()` returns a fresh
+// EventEmitter-based fake socket the test drives by hand (emit "connect" /
+// "timeout" / "error") instead of racing real sockets or fake timers.
+const { mockNetConnect, fakeSockets } = vi.hoisted(() => {
+  const fakeSockets: Array<{
+    emit: (event: string, ...args: unknown[]) => void;
+    destroy: ReturnType<typeof vi.fn>;
+  }> = [];
+  const mockNetConnect = vi.fn((_options: unknown) => {
+    const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+    const socket = {
+      once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+        const existing = listeners.get(event) ?? [];
+        existing.push(listener);
+        listeners.set(event, existing);
+        return socket;
+      }),
+      removeAllListeners: vi.fn(() => {
+        listeners.clear();
+        return socket;
+      }),
+      destroy: vi.fn(),
+      emit: (event: string, ...args: unknown[]) => {
+        for (const listener of listeners.get(event) ?? []) listener(...args);
+      },
+    };
+    fakeSockets.push(socket);
+    return socket;
+  });
+  return { mockNetConnect, fakeSockets };
+});
+
+vi.mock("node:net", () => ({ connect: mockNetConnect, default: { connect: mockNetConnect } }));
+
 import {
   testImapLogin,
   testSmtpVerify,
   friendlyError,
+  classifyProbeError,
+  probeSmtpPorts,
   tlsModeForPort,
 } from "@/lib/integrations/imap-probe";
 
@@ -224,6 +262,88 @@ describe("imap-probe", () => {
     it("falls back to a generic message for unrecognized errors", () => {
       expect(friendlyError(new Error("something weird"))).toMatch(/connection failed/i);
       expect(friendlyError("not an Error instance")).toMatch(/connection failed/i);
+    });
+  });
+
+  describe("classifyProbeError", () => {
+    it.each([
+      ["ETIMEDOUT", new Error("connect ETIMEDOUT 1.2.3.4:465"), "timeout"],
+      ["'timed out' wording", new Error("Connection timed out"), "timeout"],
+      ["socket timeout", new Error("Socket timeout"), "timeout"],
+      ["ECONNREFUSED", new Error("connect ECONNREFUSED 127.0.0.1:465"), "refused"],
+      ["ENOTFOUND", new Error("getaddrinfo ENOTFOUND smtp.example.com"), "dns"],
+      ["EAI_AGAIN", new Error("getaddrinfo EAI_AGAIN smtp.example.com"), "dns"],
+      ["'auth' wording", new Error("Auth failed"), "auth"],
+      ["'invalid login' wording", new Error("Invalid login"), "auth"],
+      ["535 SMTP auth code", new Error("535 5.7.8 Authentication failed"), "auth"],
+      ["certificate error", new Error("unable to verify the first certificate"), "tls"],
+      ["self signed certificate", new Error("self signed certificate"), "tls"],
+      ["ssl wording", new Error("wrong version number (ssl)"), "tls"],
+      ["unmapped error", new Error("something totally unexpected"), "unknown"],
+    ] as const)("classifies %s as code %s", (_label, error, expectedCode) => {
+      const result = classifyProbeError(error);
+      expect(result.code).toBe(expectedCode);
+      expect(typeof result.message).toBe("string");
+      expect(result.message.length).toBeGreaterThan(0);
+    });
+
+    it("notes that cloud hosts often block the port in the timeout message", () => {
+      const result = classifyProbeError(new Error("connect ETIMEDOUT 1.2.3.4:465"));
+      expect(result.message).toMatch(/cloud host/i);
+    });
+
+    it("handles a non-Error value the same way friendlyError does", () => {
+      const result = classifyProbeError("not an Error instance");
+      expect(result.code).toBe("unknown");
+    });
+  });
+
+  describe("probeSmtpPorts", () => {
+    beforeEach(() => {
+      fakeSockets.length = 0;
+    });
+
+    it("connects to the default ports (465, 587, 25) in parallel with a 2500ms timeout each", async () => {
+      const resultPromise = probeSmtpPorts("smtp.example.com");
+
+      // All three connections must have been initiated synchronously
+      // (in parallel), before any of them settle.
+      expect(mockNetConnect).toHaveBeenCalledTimes(3);
+      expect(mockNetConnect).toHaveBeenCalledWith(
+        expect.objectContaining({ host: "smtp.example.com", port: 465, timeout: 2500 })
+      );
+      expect(mockNetConnect).toHaveBeenCalledWith(
+        expect.objectContaining({ host: "smtp.example.com", port: 587, timeout: 2500 })
+      );
+      expect(mockNetConnect).toHaveBeenCalledWith(
+        expect.objectContaining({ host: "smtp.example.com", port: 25, timeout: 2500 })
+      );
+
+      fakeSockets[0].emit("error", new Error("ECONNREFUSED")); // 465
+      fakeSockets[1].emit("connect"); // 587
+      fakeSockets[2].emit("timeout"); // 25
+
+      const results = await resultPromise;
+
+      expect(results).toEqual(
+        expect.arrayContaining([
+          { port: 465, reachable: false },
+          { port: 587, reachable: true },
+          { port: 25, reachable: false },
+        ])
+      );
+      for (const socket of fakeSockets) {
+        expect(socket.destroy).toHaveBeenCalled();
+      }
+    });
+
+    it("accepts a custom port list", async () => {
+      const resultPromise = probeSmtpPorts("smtp.example.com", [2525]);
+
+      expect(mockNetConnect).toHaveBeenCalledTimes(1);
+      fakeSockets[0].emit("connect");
+
+      await expect(resultPromise).resolves.toEqual([{ port: 2525, reachable: true }]);
     });
   });
 });

--- a/packages/web/src/lib/integrations/__tests__/imap-probe.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/imap-probe.test.ts
@@ -58,7 +58,14 @@ const { mockNetConnect, fakeSockets } = vi.hoisted(() => {
       }),
       destroy: vi.fn(),
       emit: (event: string, ...args: unknown[]) => {
-        for (const listener of listeners.get(event) ?? []) listener(...args);
+        const registered = listeners.get(event) ?? [];
+        // Mirror Node's EventEmitter: an "error" event with no listener throws
+        // (crashes the process), so a test that emits a late error reproduces
+        // the real unhandled-'error' hazard instead of silently swallowing it.
+        if (event === "error" && registered.length === 0) {
+          throw args[0] instanceof Error ? args[0] : new Error("Unhandled 'error' event");
+        }
+        for (const listener of registered) listener(...args);
       },
     };
     fakeSockets.push(socket);
@@ -255,6 +262,13 @@ describe("imap-probe", () => {
       );
     });
 
+    it("classifies a DNS failure on an auth-named host as connect-failure, not auth", () => {
+      // The hostname contains "auth"; the ENOTFOUND code must still win.
+      const message = friendlyError(new Error("getaddrinfo ENOTFOUND smtp-auth.example.com"));
+      expect(message).toMatch(/could not connect/i);
+      expect(message).not.toMatch(/authentication/i);
+    });
+
     it("maps TLS/certificate errors to a secure-connection message", () => {
       expect(friendlyError(new Error("self signed certificate"))).toMatch(/secure connection/i);
     });
@@ -280,6 +294,13 @@ describe("imap-probe", () => {
       ["self signed certificate", new Error("self signed certificate"), "tls"],
       ["ssl wording", new Error("wrong version number (ssl)"), "tls"],
       ["unmapped error", new Error("something totally unexpected"), "unknown"],
+      // Regression: the network-error CODE must win over a substring match on
+      // the (user-controlled) hostname. "smtp-auth.…" is a common mail host
+      // name; a DNS/timeout/refused failure on it must NOT be reported as an
+      // auth failure (which would also wrongly skip the port-reachability probe).
+      ["ENOTFOUND on an auth-named host", new Error("getaddrinfo ENOTFOUND smtp-auth.example.com"), "dns"], // prettier-ignore
+      ["ETIMEDOUT on an auth-named host", new Error("connect ETIMEDOUT 1.2.3.4:587 smtp-auth.example.com"), "timeout"], // prettier-ignore
+      ["ECONNREFUSED on an auth-named host", new Error("connect ECONNREFUSED smtp-auth.example.com:465"), "refused"], // prettier-ignore
     ] as const)("classifies %s as code %s", (_label, error, expectedCode) => {
       const result = classifyProbeError(error);
       expect(result.code).toBe(expectedCode);
@@ -344,6 +365,17 @@ describe("imap-probe", () => {
       fakeSockets[0].emit("connect");
 
       await expect(resultPromise).resolves.toEqual([{ port: 2525, reachable: true }]);
+    });
+
+    it("does not crash on a late error emitted after the port already resolved", async () => {
+      const resultPromise = probeSmtpPorts("smtp.example.com", [587]);
+      fakeSockets[0].emit("connect");
+      await expect(resultPromise).resolves.toEqual([{ port: 587, reachable: true }]);
+
+      // destroy() on a still-connecting socket can emit a late 'error'; the
+      // probe must keep an error listener attached so it's handled, not thrown
+      // as an unhandled 'error' event (which would crash the process).
+      expect(() => fakeSockets[0].emit("error", new Error("late ECONNRESET"))).not.toThrow();
     });
   });
 });

--- a/packages/web/src/lib/integrations/imap-probe.ts
+++ b/packages/web/src/lib/integrations/imap-probe.ts
@@ -1,5 +1,6 @@
 import { ImapFlow } from "imapflow";
 import nodemailer from "nodemailer";
+import { connect as netConnect } from "node:net";
 import type { ImapTestInput } from "@/lib/schemas/imap";
 
 // Shared IMAP/SMTP probe logic used by BOTH:
@@ -38,6 +39,95 @@ export function friendlyError(error: unknown): string {
     return "Could not establish a secure connection — check the security setting";
   }
   return "Connection failed — check your settings and try again";
+}
+
+// Structured counterpart to friendlyError(): a machine-readable `code` plus a
+// human-readable message, so callers (the IMAP test route) can branch on the
+// failure category — e.g. to decide whether it's worth probing raw SMTP port
+// reachability — instead of pattern-matching the friendly string again.
+// friendlyError() itself is kept unchanged/exported for its existing callers.
+export type ProbeFailureCode = "timeout" | "refused" | "dns" | "auth" | "tls" | "unknown";
+
+// Per-leg (IMAP or SMTP) outcome of a connection test — see ImapTestResult in
+// @/lib/schemas/imap for how the two legs combine into the full API response.
+export type LegResult = { ok: true } | { ok: false; code: ProbeFailureCode; message: string };
+
+export function classifyProbeError(error: unknown): { code: ProbeFailureCode; message: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes("auth") ||
+    lower.includes("invalid login") ||
+    lower.includes("invalid credentials") ||
+    lower.includes("535")
+  ) {
+    return { code: "auth", message: "Authentication failed — check the username and password" };
+  }
+  if (lower.includes("timed out") || lower.includes("timeout") || lower.includes("etimedout")) {
+    return {
+      code: "timeout",
+      message:
+        "Connection timed out — cloud hosts often block this port; try a different port or check the host and port",
+    };
+  }
+  if (lower.includes("econnrefused")) {
+    return { code: "refused", message: "Connection refused — check the host and port" };
+  }
+  if (lower.includes("enotfound") || lower.includes("eai_again")) {
+    return { code: "dns", message: "Could not resolve the host — check the hostname" };
+  }
+  if (lower.includes("ehostunreach") || lower.includes("could not connect")) {
+    return {
+      code: "refused",
+      message: "Could not connect to the server — check the host and port",
+    };
+  }
+  if (lower.includes("certificate") || lower.includes("self signed") || lower.includes("ssl")) {
+    return {
+      code: "tls",
+      message: "Could not establish a secure connection — check the security setting",
+    };
+  }
+  return { code: "unknown", message: "Connection failed — check your settings and try again" };
+}
+
+export type SmtpPortProbe = { port: number; reachable: boolean };
+
+// Bound the raw TCP probe so a filtered/black-holed port can't hang the
+// user-facing request. This is deliberately just a TCP connect — no TLS
+// handshake, no auth — since all we need to know is whether the OS-level
+// connection succeeds within a reasonable time.
+const SMTP_PORT_PROBE_TIMEOUT_MS = 2500;
+
+function probeTcpPort(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = netConnect({ host, port, timeout: timeoutMs });
+    const finish = (reachable: boolean) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(reachable);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+// SECURITY: this connects ONLY to the already-provided, caller-supplied
+// smtpHost on a fixed, hardcoded port list — never to a host/port derived
+// from user-controlled input beyond what the caller already validated and
+// intended to probe. Do not widen this to accept arbitrary ports/hosts.
+export async function probeSmtpPorts(
+  host: string,
+  ports: number[] = [465, 587, 25]
+): Promise<SmtpPortProbe[]> {
+  return Promise.all(
+    ports.map(async (port) => ({
+      port,
+      reachable: await probeTcpPort(host, port, SMTP_PORT_PROBE_TIMEOUT_MS),
+    }))
+  );
 }
 
 // A single `security` field can't be simultaneously correct for IMAP

--- a/packages/web/src/lib/integrations/imap-probe.ts
+++ b/packages/web/src/lib/integrations/imap-probe.ts
@@ -11,11 +11,27 @@ import type { ImapTestInput } from "@/lib/schemas/imap";
 // between the two callers.
 
 // Maps low-level probe errors to short, friendly messages that never leak a
-// stack trace or the password. Order matters: more specific patterns first.
+// stack trace or the password. Order matters: unambiguous network-error CODES
+// are matched BEFORE the fuzzy "auth" wordlist, because that wordlist matches
+// against the whole message — which includes the (user-controlled) hostname.
+// A host named e.g. "smtp-auth.example.com" would otherwise turn a DNS/timeout/
+// refused failure into a bogus "authentication failed".
 export function friendlyError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
 
+  if (lower.includes("timed out") || lower.includes("timeout") || lower.includes("etimedout")) {
+    return "Connection timed out — check the host and port";
+  }
+  if (
+    lower.includes("econnrefused") ||
+    lower.includes("enotfound") ||
+    lower.includes("eai_again") ||
+    lower.includes("ehostunreach") ||
+    lower.includes("could not connect")
+  ) {
+    return "Could not connect to the server — check the host and port";
+  }
   if (
     lower.includes("auth") ||
     lower.includes("invalid login") ||
@@ -23,17 +39,6 @@ export function friendlyError(error: unknown): string {
     lower.includes("535")
   ) {
     return "Authentication failed — check the username and password";
-  }
-  if (lower.includes("timed out") || lower.includes("timeout") || lower.includes("etimedout")) {
-    return "Connection timed out — check the host and port";
-  }
-  if (
-    lower.includes("econnrefused") ||
-    lower.includes("enotfound") ||
-    lower.includes("ehostunreach") ||
-    lower.includes("could not connect")
-  ) {
-    return "Could not connect to the server — check the host and port";
   }
   if (lower.includes("certificate") || lower.includes("self signed") || lower.includes("ssl")) {
     return "Could not establish a secure connection — check the security setting";
@@ -56,14 +61,12 @@ export function classifyProbeError(error: unknown): { code: ProbeFailureCode; me
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
 
-  if (
-    lower.includes("auth") ||
-    lower.includes("invalid login") ||
-    lower.includes("invalid credentials") ||
-    lower.includes("535")
-  ) {
-    return { code: "auth", message: "Authentication failed — check the username and password" };
-  }
+  // Unambiguous network-error CODES first. The "auth" branch below matches a
+  // fuzzy wordlist against the whole message — which includes the
+  // (user-controlled) hostname — so a host named e.g. "smtp-auth.example.com"
+  // would otherwise misclassify a DNS/timeout/refused failure as "auth" and
+  // wrongly skip the SMTP port-reachability probe the caller runs for
+  // connection-level failures.
   if (lower.includes("timed out") || lower.includes("timeout") || lower.includes("etimedout")) {
     return {
       code: "timeout",
@@ -82,6 +85,14 @@ export function classifyProbeError(error: unknown): { code: ProbeFailureCode; me
       code: "refused",
       message: "Could not connect to the server — check the host and port",
     };
+  }
+  if (
+    lower.includes("auth") ||
+    lower.includes("invalid login") ||
+    lower.includes("invalid credentials") ||
+    lower.includes("535")
+  ) {
+    return { code: "auth", message: "Authentication failed — check the username and password" };
   }
   if (lower.includes("certificate") || lower.includes("self signed") || lower.includes("ssl")) {
     return {
@@ -103,11 +114,18 @@ const SMTP_PORT_PROBE_TIMEOUT_MS = 2500;
 function probeTcpPort(host: string, port: number, timeoutMs: number): Promise<boolean> {
   return new Promise((resolve) => {
     const socket = netConnect({ host, port, timeout: timeoutMs });
+    let settled = false;
     const finish = (reachable: boolean) => {
-      socket.removeAllListeners();
+      if (settled) return;
+      settled = true;
       socket.destroy();
       resolve(reachable);
     };
+    // Keep the error listener attached for the socket's whole lifetime rather
+    // than removing all listeners on the first settle: destroy() on a
+    // still-connecting socket can emit a late 'error', and an 'error' event
+    // with no listener crashes the process. The `settled` guard makes any such
+    // late event a no-op instead of a second resolve.
     socket.once("connect", () => finish(true));
     socket.once("timeout", () => finish(false));
     socket.once("error", () => finish(false));

--- a/packages/web/src/lib/integrations/probe.ts
+++ b/packages/web/src/lib/integrations/probe.ts
@@ -2,7 +2,12 @@ import { OdooClient } from "odoo-node";
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
 import { probeBraveApiKey } from "@/lib/integrations/brave-probe";
 import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
-import { testImapLogin, testSmtpVerify, friendlyError } from "@/lib/integrations/imap-probe";
+import {
+  testImapLogin,
+  testSmtpVerify,
+  friendlyError,
+  classifyProbeError,
+} from "@/lib/integrations/imap-probe";
 import { imapTestSchema } from "@/lib/schemas/imap";
 
 /**
@@ -112,7 +117,10 @@ export async function probeIntegrationCredentials(
       // connection to auth_failed. Everything else (timeouts, connection refused,
       // TLS/cert errors, socket hang up, any unmapped error) is a transient hiccup,
       // so a healthy connection is never falsely flagged.
-      const isAuthFailure = /authentication failed/i.test(reason);
+      // Uses the shared per-leg classifier (also used by the "Test & Save"
+      // route) rather than re-matching friendlyError's wording, so the two
+      // callers can never classify the same error differently.
+      const isAuthFailure = classifyProbeError(err).code === "auth";
       return isAuthFailure
         ? { success: false, reason }
         : { success: false, transient: true, reason };

--- a/packages/web/src/lib/schemas/imap.ts
+++ b/packages/web/src/lib/schemas/imap.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { LegResult, SmtpPortProbe } from "@/lib/integrations/imap-probe";
 
 export const imapTestSchema = z.object({
   imapHost: z.string().min(1),
@@ -31,3 +32,27 @@ export const imapCreateSchema = imapTestSchema.extend({
 });
 
 export type ImapCreateInput = z.infer<typeof imapCreateSchema>;
+
+// Structured response of POST /api/integrations/imap/test, shared by the
+// route handler and the ImapConnectStep UI (typed client convention — see
+// AGENTS.md "Shared Schemas And Typed Client"). Consumed directly, not
+// zod-validated on the client: this is a server-authored diagnostic, not
+// user input.
+export type ImapTestSuggestion =
+  | { kind: "switch_smtp_port"; port: number; security: "starttls" | "tls" }
+  | { kind: "all_smtp_blocked" }
+  | null;
+
+export interface ImapTestResult {
+  ok: boolean;
+  imap: LegResult;
+  smtp: LegResult;
+  // Only present when the SMTP leg failed at the connection level (timeout or
+  // refused) and we ran a raw-TCP reachability probe against the standard
+  // SMTP ports to figure out why.
+  smtpPortProbe?: SmtpPortProbe[];
+  suggestion?: ImapTestSuggestion;
+  // Primary friendly banner text when !ok — mirrors the IMAP/SMTP leg that
+  // failed first (IMAP takes priority since it blocks reading mail at all).
+  error?: string;
+}


### PR DESCRIPTION
## Summary

- Cloud hosts (Hetzner, DigitalOcean, GCP/AWS/Azure) block outbound SMTP ports by default, so a Migadu/custom mailbox defaulting to SMTP port 465 fails Pinchy's IMAP "Test & Save" probe with a bare "Connection timed out" — no indication it's a host firewall block, not a mailbox misconfiguration.
- `POST /api/integrations/imap/test` now runs the IMAP and SMTP legs separately and returns a structured diagnostic (`{ ok, imap, smtp, smtpPortProbe?, suggestion?, error? }`, HTTP 200) instead of a bare `{ ok:false, error }` 400. On an SMTP connection-level failure (timeout/refused) it probes raw TCP reachability on 465/587/25 from the same container that would send mail, and suggests a reachable port to switch to, or reports all ports blocked.
- The IMAP connect dialog shows per-leg status, a "Switch to `{port}` & retry" banner the user must click (never auto-switches), and an all-ports-blocked banner linking to docs.
- New docs section: "Ports, TLS & cloud firewalls" on the IMAP guide (provider block matrix, manual `nc`/`openssl` checks, how to request an unblock).

## Contract

```ts
type ProbeFailureCode = "timeout" | "refused" | "dns" | "auth" | "tls" | "unknown";
type LegResult = { ok: true } | { ok: false; code: ProbeFailureCode; message: string };
type ImapTestResult = {
  ok: boolean;
  imap: LegResult;
  smtp: LegResult;
  smtpPortProbe?: { port: number; reachable: boolean }[];
  suggestion?: { kind: "switch_smtp_port"; port: number; security: "starttls" | "tls" } | { kind: "all_smtp_blocked" } | null;
  error?: string;
};
```

## Deviations from the brief

- **Response status changed from 400 to 200 on a diagnostic failure.** The old route returned HTTP 400 for a failed connection test; `apiPost`/`apiError` in `@/lib/api-client` throws on any non-2xx and only preserves `error`/`details` from the body, discarding everything else (`imap`, `smtp`, `suggestion`, ...). Keeping 400 would have made the suggestion banner unreachable through a real fetch. Switched to 200 with `ok` in the body, matching the existing convention in `packages/web/src/app/api/integrations/test-credentials/route.ts` (`{ success: false, error }` at 200).
- **IMAP and SMTP legs now both always run in the "Test & Save" route** (previously IMAP failure short-circuited SMTP). This is what the brief's numbered plan asks for ("Run IMAP and SMTP probes SEPARATELY... probe IMAP, probe SMTP"), and it's needed for the diagnostic contract to always report both legs. `probe.ts` (the *existing-connection* re-probe) intentionally keeps its original fail-fast behavior — its own test explicitly asserts SMTP is skipped once IMAP fails, and the brief only asked me not to break it there.
- Deploy-guide callouts (Hetzner/DigitalOcean) not added: neither `deploy-hetzner.mdx` nor `deploy-digitalocean.mdx` has an existing email/IMAP setup step or "what's next" pointer to the connect-email guide to attach a callout to. The new "Ports, TLS & cloud firewalls" section lives in `connect-email-imap.mdx` instead; a deploy-guide callout can follow separately if desired.

## Test plan

- [x] `classifyProbeError` table test (13 cases: timeout/refused/dns/auth/tls/unknown)
- [x] `probeSmtpPorts` — mocked `node:net` `connect()`, asserts parallel dispatch, 2500ms timeout option, and reachable/unreachable mapping
- [x] Route test: happy path, IMAP-auth-failure (SMTP still runs), SMTP-refused, SMTP-timeout-with-587-reachable → `switch_smtp_port`, SMTP-timeout-with-465-reachable (587 failing) → `switch_smtp_port` to 465, all-ports-blocked → `all_smtp_blocked`, auth failure → no port probe
- [x] UI test: `switch_smtp_port` suggestion renders banner + button, click sets the port/security and retries; `all_smtp_blocked` renders its banner
- [x] `probe.ts` existing-connection re-probe test suite unchanged/still green (28 tests)
- [x] Docs build (`cd docs && pnpm build`) — 66 pages, `connect-email-imap` included