### PR TITLE
feat(eval): dated multi-hoster price snapshot + cost methodology for the published $ (#798)

### DIFF
--- a/packages/web/eval/README.md
+++ b/packages/web/eval/README.md
@@ -355,7 +355,8 @@ cacheWrite`), which differ only in billing, so caching hosters aren't
 - `costUsd` — summed `estimated_cost_usd`, present only when a provider prices
   per token. Absent for Ollama Cloud, which is subscription-billed (no per-token
   price); the published `$` figure is a labeled multi-hoster range computed
-  offline from the token counts, never this column.
+  offline from the token counts, never this column. The price snapshot and the
+  offline formula live in [`pricing/`](pricing/README.md).
 
 The scorecard exposes two medians: `medianTokens` (over all runs) and
 **`medianTokensPerCompletedTask`** (over PASSING runs only). The latter is the

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -239,3 +239,7 @@ happen; we make it detectable and ask to be excluded.
   ([`../elicitation-protocol.md`](../elicitation-protocol.md)): every model runs on
   Pinchy's real production path with untuned, uniform sampling — no per-model
   scaffold to over- or under-build.
+- Any `$` figure is a **market-rate proxy**, not what we paid: Ollama Cloud is
+  subscription-billed, so the cost is computed offline from the captured token
+  counts against a dated, multi-hoster open-market price range. Source, range
+  semantics, and the formula: [`../pricing/README.md`](../pricing/README.md).

--- a/packages/web/eval/pricing/README.md
+++ b/packages/web/eval/pricing/README.md
@@ -1,0 +1,89 @@
+# Cost methodology — the published `$ per completed task` (pinchy#798)
+
+This directory holds the **price snapshot** (`model-pricing.ts`) that turns the
+per-run token counts captured in #798 into the `$` figure we publish next to
+each model. It is the "verified price source" the reliability hub cites.
+
+## Why it's a proxy, not an invoice
+
+Pinchy runs every benchmarked model over **Ollama Cloud**, which is
+**subscription-billed** (Free / Pro / Max plans), not per-token. There is no
+per-token invoice to read back — `usage_records.estimated_cost_usd` is `null`
+for every Ollama-Cloud run, so `RunResult.tokens.costUsd` is absent.
+
+The published `$` is therefore a **market-rate proxy**: what the _same
+open-weight model_ would cost per token if bought from third-party inference
+hosters. It answers "if you self-hosted or bought this model's tokens on the
+open market, what would this task cost?" — **not** "what did we pay Ollama."
+Every surface that shows the `$` must label it that way.
+
+## The source (why it's credible)
+
+Single-hoster list prices are not representative — the same open-weight model is
+served by many hosters at prices that routinely differ 3–4×. So the primary
+source is the one that already aggregates _across providers_:
+
+- **PRIMARY — OpenRouter per-model pages.** OpenRouter publishes a
+  **weighted-average across the providers actually serving each model**, plus
+  the individual provider prices. That cross-provider average is the number we
+  anchor on.
+- **CROSS-CHECK — Artificial Analysis** provider tables (price + the AA
+  intelligence index), and the **direct list prices of Together / Fireworks /
+  DeepInfra** where a model is multi-hosted.
+
+Both are widely-cited, vendor-neutral aggregators, which is the bar for a public
+comparison that won't be dismissed as a marketing benchmark.
+
+## Range, not a point — and dated
+
+Each entry brackets the spread we found across surveyed hosters
+(`inputMin..inputMax` / `outputMin..outputMax`, USD per 1,000,000 tokens),
+including first-party-vs-realized-after-caching where those diverge. We publish
+the **range**; the median is derivable from it. Reporting a single number would
+hide the 3–4× serving spread that is itself a real finding.
+
+`MODEL_PRICING.asOf` is the **capture date**, shown for transparency. Bleeding-
+edge model prices drift fast, so this table is **re-captured at each sweep** (see
+the run-model-eval runbook) so the published `$` is dated to the data it labels.
+Git history is the audit trail of prior snapshots.
+
+`confidence` is honest about each row:
+
+- `high` — a direct listing (usually OpenRouter), often cross-checked.
+- `medium` — a single listing, or a variant match that wants a sweep-time re-check.
+- `approx` — no direct listing for that exact model/size; bracketed from a
+  same-family neighbour or a sized-up commercial variant. **Must** be
+  re-captured before the number is published.
+
+## The offline computation
+
+The `$` is computed **offline from the captured token counts**, never from the
+`estimated_cost_usd` column (which is null here). Per run:
+
+```
+runCostUsd = prompt_tokens / 1e6 * inputPrice
+           + completion_tokens / 1e6 * outputPrice
+```
+
+evaluated at both ends of the price range to yield a `[min, max]` per run, then
+reduced over the **passing** runs (mirroring `medianTokensPerCompletedTask`, the
+published token metric) to a per-model published `$` range. `prompt` here is the
+#798 sum of all three prompt classes (`input + cacheRead + cacheWrite`), so the
+input side isn't under-counted on caching hosters.
+
+> The computation and its wiring into `export-scorecard.ts` land with the
+> re-sweep, when real captured tokens exist to validate the output shape against.
+> This directory ships the **verified source + method** that computation reads.
+
+## Updating this table
+
+1. For each id in the curated catalog, open its OpenRouter model page; record the
+   weighted-average and the provider min/max into `inputMin/Max`, `outputMin/Max`.
+2. Cross-check against Artificial Analysis / a direct hoster where listed.
+3. Set `confidence` and a one-line `note` with the provenance.
+4. Bump `asOf` to the capture date.
+5. `pnpm -C packages/web test eval/pricing` — the parity guard fails if the
+   catalog gained/lost a model, and the shape guard fails on an incoherent range.
+
+The `Record<OllamaCloudModelId, …>` type makes a missing/extra id a **compile
+error**, so the snapshot cannot silently drift out of sync with what we benchmark.

--- a/packages/web/eval/pricing/__tests__/model-pricing.test.ts
+++ b/packages/web/eval/pricing/__tests__/model-pricing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS } from "../../../src/lib/ollama-cloud-models";
+import { MODEL_PRICING } from "../model-pricing";
+
+/**
+ * Guards the checked-in price snapshot that feeds the published $ figure for
+ * pinchy#798. The prices themselves are a dated, hand-captured market-rate
+ * proxy (Ollama Cloud is subscription-billed — see pricing/README.md); these
+ * tests only enforce that the snapshot stays STRUCTURALLY honest and in sync
+ * with the curated catalog, so a catalog change can't silently orphan a price.
+ */
+describe("MODEL_PRICING snapshot", () => {
+  it("carries an ISO capture date and named primary + cross-check sources", () => {
+    expect(MODEL_PRICING.asOf).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(MODEL_PRICING.primarySource).toMatch(/OpenRouter/i);
+    expect(MODEL_PRICING.crossCheck.length).toBeGreaterThan(0);
+  });
+
+  it("prices every curated catalog model and only those (parity with the catalog)", () => {
+    const priced = Object.keys(MODEL_PRICING.entries).sort();
+    const curated = [...TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS].sort();
+    expect(priced).toEqual(curated);
+  });
+
+  it("has coherent, non-negative price ranges (0 ≤ min ≤ max)", () => {
+    for (const [id, e] of Object.entries(MODEL_PRICING.entries)) {
+      expect(e.inputMin, id).toBeGreaterThanOrEqual(0);
+      expect(e.outputMin, id).toBeGreaterThanOrEqual(0);
+      expect(e.inputMax, id).toBeGreaterThanOrEqual(e.inputMin);
+      expect(e.outputMax, id).toBeGreaterThanOrEqual(e.outputMin);
+    }
+  });
+
+  it("labels every entry with a confidence level and a provenance note", () => {
+    for (const [id, e] of Object.entries(MODEL_PRICING.entries)) {
+      expect(["high", "medium", "approx"], id).toContain(e.confidence);
+      expect(e.note.trim().length, id).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps every price plausibly bounded (< $50 / M tokens) so a typo can't silently 100× the published cost", () => {
+    for (const [id, e] of Object.entries(MODEL_PRICING.entries)) {
+      expect(e.inputMax, id).toBeLessThan(50);
+      expect(e.outputMax, id).toBeLessThan(50);
+    }
+  });
+});

--- a/packages/web/eval/pricing/model-pricing.ts
+++ b/packages/web/eval/pricing/model-pricing.ts
@@ -197,7 +197,7 @@ export const MODEL_PRICING: PricingSnapshot = {
     "qwen3.5:397b": {
       inputMin: 0.3,
       inputMax: 0.5,
-      outputMin: 1.5,
+      outputMin: 1.56,
       outputMax: 2.0,
       confidence: "approx",
       note: "397B open-weight not directly listed on aggregators; bracketed above Qwen3.5-Plus ($0.26/$1.56) for the flagship size. Re-capture at sweep.",

--- a/packages/web/eval/pricing/model-pricing.ts
+++ b/packages/web/eval/pricing/model-pricing.ts
@@ -1,0 +1,206 @@
+import type { OllamaCloudModelId } from "../../src/lib/ollama-cloud-models";
+
+/**
+ * Dated, source-verified market-rate price snapshot for the curated Ollama
+ * Cloud catalog — the input to the published $ figure for pinchy#798.
+ *
+ * WHY a snapshot and not a live lookup: Pinchy runs these models over Ollama
+ * Cloud, which is SUBSCRIPTION-billed (Free / Pro / Max plans), so there is no
+ * per-token invoice to read back — `usage_records.estimatedCostUsd` is null for
+ * every Ollama-Cloud run. The published "$ per completed task" is therefore a
+ * MARKET-RATE PROXY: what the same open-weight model would cost per token if
+ * bought from third-party inference hosters. It is NOT what we paid.
+ *
+ * Source + method (see pricing/README.md for the full contract):
+ * - PRIMARY: OpenRouter's per-model pages, which publish a weighted-average
+ *   across the providers actually serving each model. That "across providers"
+ *   is the whole point — a single hoster's list price is not representative.
+ * - CROSS-CHECK: Artificial Analysis provider tables + the direct list prices
+ *   of Together / Fireworks / DeepInfra where a model is multi-hosted.
+ * - RANGE, not a point: `inputMin..inputMax` / `outputMin..outputMax` bracket
+ *   the spread across surveyed hosters (and first-party vs. realized-after-
+ *   caching where they diverge). Publish the range; the median is derivable.
+ *
+ * `asOf` is the capture date and MUST move whenever the numbers do. Bleeding-
+ * edge model prices drift fast, so the run-model-eval runbook re-captures this
+ * table at each sweep so the published $ is dated to the data it labels. Git
+ * history is the audit trail of prior snapshots.
+ *
+ * `entries` is typed `Record<OllamaCloudModelId, …>`, so adding/removing a
+ * catalog model is a compile error here until this table is updated — the
+ * price snapshot cannot silently drift out of sync with what we benchmark.
+ */
+
+export type PriceConfidence = "high" | "medium" | "approx";
+
+/** USD per 1,000,000 tokens, as a range across the surveyed hosters. */
+export interface ModelPriceEntry {
+  inputMin: number;
+  inputMax: number;
+  outputMin: number;
+  outputMax: number;
+  confidence: PriceConfidence;
+  /** Where the numbers came from + any caveat (variant, proxy, free tier). */
+  note: string;
+}
+
+export interface PricingSnapshot {
+  /** ISO date (YYYY-MM-DD) the prices were captured. */
+  asOf: string;
+  primarySource: string;
+  crossCheck: string;
+  entries: Record<OllamaCloudModelId, ModelPriceEntry>;
+}
+
+export const MODEL_PRICING: PricingSnapshot = {
+  asOf: "2026-07-21",
+  primarySource: "OpenRouter per-model pages (weighted-average across serving providers)",
+  crossCheck:
+    "Artificial Analysis provider tables; direct list prices from Together / Fireworks / DeepInfra where multi-hosted",
+  entries: {
+    "deepseek-v4-flash": {
+      inputMin: 0.054,
+      inputMax: 0.14,
+      outputMin: 0.242,
+      outputMax: 0.28,
+      confidence: "high",
+      note: "OpenRouter weighted-avg (Jun 2026) realized $0.054/$0.242; DeepSeek first-party $0.14/$0.28.",
+    },
+    "deepseek-v4-pro": {
+      inputMin: 0.435,
+      inputMax: 0.435,
+      outputMin: 0.87,
+      outputMax: 0.87,
+      confidence: "high",
+      note: "OpenRouter (Jul 2026). Single canonical listing — no provider spread captured yet.",
+    },
+    "gemma4:31b": {
+      inputMin: 0.1,
+      inputMax: 0.14,
+      outputMin: 0.35,
+      outputMax: 0.35,
+      confidence: "high",
+      note: "OpenRouter $0.10/$0.35; TokenCost lists $0.14/M input — narrow spread.",
+    },
+    "glm-5.1": {
+      inputMin: 0.966,
+      inputMax: 0.966,
+      outputMin: 3.036,
+      outputMax: 3.036,
+      confidence: "high",
+      note: "OpenRouter (Jul 2026). Note: OR prices 5.1 ABOVE 5.2 — 5.1 is the less price-optimized release.",
+    },
+    "glm-5.2": {
+      inputMin: 0.447,
+      inputMax: 0.447,
+      outputMin: 3.31,
+      outputMax: 3.31,
+      confidence: "high",
+      note: "OpenRouter weighted-avg (Jun 2026), confirmed twice across sources.",
+    },
+    "gpt-oss:20b": {
+      inputMin: 0.05,
+      inputMax: 0.07,
+      outputMin: 0.2,
+      outputMax: 0.3,
+      confidence: "high",
+      note: "Together $0.05/$0.20; Fireworks $0.07/$0.30.",
+    },
+    "gpt-oss:120b": {
+      inputMin: 0.039,
+      inputMax: 0.15,
+      outputMin: 0.19,
+      outputMax: 0.6,
+      confidence: "high",
+      note: "DeepInfra $0.039/$0.19 (cheapest); Together & Fireworks both $0.15/$0.60.",
+    },
+    "kimi-k2.5": {
+      inputMin: 0.6,
+      inputMax: 0.6,
+      outputMin: 2.0,
+      outputMax: 3.0,
+      confidence: "medium",
+      note: "OpenRouter input $0.60; output varies by provider (~$2.00–3.00). Re-capture at sweep.",
+    },
+    "kimi-k2.6": {
+      inputMin: 0.66,
+      inputMax: 0.66,
+      outputMin: 3.41,
+      outputMax: 3.41,
+      confidence: "high",
+      note: "OpenRouter (Jul 2026).",
+    },
+    "kimi-k2.7-code": {
+      inputMin: 0.66,
+      inputMax: 0.66,
+      outputMin: 3.41,
+      outputMax: 3.41,
+      confidence: "approx",
+      note: "No direct listing found; proxied from kimi-k2.6 (same family). Re-capture at sweep.",
+    },
+    "minimax-m2.5": {
+      inputMin: 0.24,
+      inputMax: 0.24,
+      outputMin: 0.96,
+      outputMax: 0.96,
+      confidence: "approx",
+      note: "No direct listing found; proxied from minimax-m2.7 (same family). Re-capture at sweep.",
+    },
+    "minimax-m2.7": {
+      inputMin: 0.24,
+      inputMax: 0.24,
+      outputMin: 0.96,
+      outputMax: 0.96,
+      confidence: "high",
+      note: "OpenRouter (Jul 2026).",
+    },
+    "minimax-m3": {
+      inputMin: 0.098,
+      inputMax: 0.3,
+      outputMin: 1.2,
+      outputMax: 1.21,
+      confidence: "high",
+      note: "OpenRouter weighted-avg (Jun 2026) $0.098/$1.21; first-party $0.30/$1.20.",
+    },
+    "mistral-large-3:675b": {
+      inputMin: 0.5,
+      inputMax: 0.5,
+      outputMin: 1.5,
+      outputMax: 1.5,
+      confidence: "medium",
+      note: "OpenRouter Mistral Large 3 (2512) (Jul 2026). Single listing — verify the 675B open-weight variant at sweep.",
+    },
+    "nemotron-3-nano:30b": {
+      inputMin: 0.05,
+      inputMax: 0.05,
+      outputMin: 0.2,
+      outputMax: 0.2,
+      confidence: "high",
+      note: "OpenRouter paid tier $0.05/$0.20; a $0 free tier also exists (not used for the proxy).",
+    },
+    "nemotron-3-super": {
+      inputMin: 0.08,
+      inputMax: 0.08,
+      outputMin: 0.45,
+      outputMax: 0.45,
+      confidence: "high",
+      note: "OpenRouter paid tier $0.08/$0.45; a $0 free tier also exists (not used for the proxy).",
+    },
+    "nemotron-3-ultra": {
+      inputMin: 0.423,
+      inputMax: 0.423,
+      outputMin: 2.61,
+      outputMax: 2.61,
+      confidence: "high",
+      note: "OpenRouter weighted-avg (Jun 2026).",
+    },
+    "qwen3.5:397b": {
+      inputMin: 0.3,
+      inputMax: 0.5,
+      outputMin: 1.5,
+      outputMax: 2.0,
+      confidence: "approx",
+      note: "397B open-weight not directly listed on aggregators; bracketed above Qwen3.5-Plus ($0.26/$1.56) for the flagship size. Re-capture at sweep.",
+    },
+  },
+};


### PR DESCRIPTION
## What

Establishes the **verified price source** behind the `$ per completed task`
figure #798 will publish, as a dated, reviewable repo artifact.

Ollama Cloud is subscription-billed, so `usage_records.estimatedCostUsd` is
`null` for every benchmarked run — the published `$` cannot be a per-token
invoice. It is a **market-rate proxy**: what the *same open-weight model* costs
per token on third-party inference hosters.

## Adds `packages/web/eval/pricing/`

- **`model-pricing.ts`** — a dated (`asOf: 2026-07-21`), source-verified snapshot
  for **all 18 curated Ollama Cloud models**. Typed `Record<OllamaCloudModelId, …>`
  so adding/removing a catalog model is a **compile error**, not silent drift.
  Each price is a **range across surveyed hosters** (`inputMin..inputMax` /
  `outputMin..outputMax`, USD per 1M tokens), with a `confidence`
  (`high`/`medium`/`approx`) and a provenance `note`.
- **`README.md`** — the methodology: why it's a proxy, the source and why it's
  credible, range-not-a-point, the offline formula, and the re-capture procedure.
- **`__tests__/model-pricing.test.ts`** — parity guard (prices exactly the
  curated catalog) + shape guard (coherent, bounded, labeled ranges). 5 tests.

## Source & method (per user request: verified, multi-hoster, dated, range)

- **Primary:** OpenRouter per-model pages — a **weighted-average across the
  providers actually serving each model** (single-hoster list prices differ 3–4×,
  so cross-provider is the whole point).
- **Cross-check:** Artificial Analysis provider tables; direct Together /
  Fireworks / DeepInfra list prices where multi-hosted.
- 13 rows `high` confidence, 2 `medium`, 3 `approx` (no direct listing for the
  exact size — `kimi-k2.7-code`, `minimax-m2.5`, `qwen3.5:397b` — bracketed from a
  neighbour and flagged for sweep-time re-capture). Nothing fabricated.

## Deliberately out of scope

The offline computation and its `export-scorecard.ts` wiring land **with the
re-sweep**, when real captured tokens exist to validate the output shape. This PR
ships the *source + method* that computation reads — the formula is documented so
the granularity (per-run `$` then median over passing runs) is decided, not guessed.

## Gates

`tsc --noEmit` ✓ · `eslint` ✓ · `prettier --check` ✓ · pricing tests 5/5 ✓

Cross-linked from `eval/README.md` (#798 token section) and `data/README.md` caveats.