### PR TITLE
docs(eval): elicitation-fairness protocol (#800)

### DIFF
--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -235,3 +235,7 @@ happen; we make it detectable and ask to be excluded.
   on the failure scenarios by _incapacity_ (they never get far enough to lie or
   duplicate), not diligence — always read a failure-scenario score next to the
   happy-path score. The graders flag these where possible.
+- "You integrated model X badly" is answered by the elicitation protocol
+  ([`../elicitation-protocol.md`](../elicitation-protocol.md)): every model runs on
+  Pinchy's real production path with untuned, uniform sampling — no per-model
+  scaffold to over- or under-build.

--- a/packages/web/eval/elicitation-protocol.md
+++ b/packages/web/eval/elicitation-protocol.md
@@ -4,8 +4,8 @@ The strongest objection to any per-model reliability number is **"you just
 integrated model X badly."** This document is the answer: it states exactly how
 every model is elicited, so a low score is a property of the model on our real
 serving path — not of a scaffold we under-built for it. It follows the METR
-elicitation-protocol framing (evaluations.metr.org/elicitation-protocol) and is
-part of the methodology (`model-selection-methodology.md` sits above it).
+elicitation-protocol framing (https://evaluations.metr.org/elicitation-protocol/)
+and is part of the methodology (`model-selection-methodology.md` sits above it).
 
 ## The core fairness property: there is no eval-special scaffold
 
@@ -48,8 +48,8 @@ The only per-model differences are the catalog entries in
 Rather than duplicate a table that would drift, this doc points at the catalog
 as the source of truth and states the invariants:
 
-- `maxTokens` is a uniform 8192 output hint across the catalog (the one
-  exception is documented in the catalog).
+- `maxTokens` is a uniform 8192 output hint across every catalog entry, with no
+  per-model exception — a shared output ceiling can advantage no one model.
 - `reasoning` and `vision` are read from each model's `ollama.com/library`
   capability tags, then **corrected against the live `/v1` endpoint** where the
   page lies (e.g. a model that advertises vision but returns HTTP 500 on an

--- a/packages/web/eval/elicitation-protocol.md
+++ b/packages/web/eval/elicitation-protocol.md
@@ -1,0 +1,125 @@
+# Elicitation protocol — proving a fair scaffold (pinchy#800)
+
+The strongest objection to any per-model reliability number is **"you just
+integrated model X badly."** This document is the answer: it states exactly how
+every model is elicited, so a low score is a property of the model on our real
+serving path — not of a scaffold we under-built for it. It follows the METR
+elicitation-protocol framing (evaluations.metr.org/elicitation-protocol) and is
+part of the methodology (`model-selection-methodology.md` sits above it).
+
+## The core fairness property: there is no eval-special scaffold
+
+Eval-v1 does not build a bespoke agent for each model. It drives the **real
+Pinchy production path** end to end: `dispatchAndScrape` (`eval/run-eval.ts`)
+types the task into the actual chat UI and scrapes the assistant's final
+message, exactly as a Pinchy user would. The agent, its tools, its system
+prompt, and its OpenClaw config are the same objects a customer gets.
+
+This is the whole fairness argument in one line: **every model is elicited the
+way Pinchy actually runs it.** A number here is not "model X in a lab rig" — it
+is "model X as a Pinchy customer would deploy it." We cannot be accused of a
+hand-tuned scaffold because there is no scaffold to tune.
+
+## Sampling and decoding — uniform, provider-default, untuned
+
+Pinchy sets **no** per-model sampling parameters. It writes no `temperature`,
+`top_p`, `top_k`, or seed into `openclaw.json`, so every model runs on the
+OpenClaw / Ollama Cloud `/v1` provider defaults. Verified by absence:
+`rg 'temperature|top_p|sampling'` over `src/lib/openclaw-config/` is empty.
+
+- **No per-model tuning means no per-model advantage.** We do not sweep
+  temperature to flatter one model, because the product does not, and the eval
+  is the product.
+- **Thinking is on by default and not per-model toggled.** OpenClaw defaults
+  `reasoning_effort` to `"high"` and Pinchy never sets `ChatOptions.thinking`,
+  so a thinking-by-default model thinks; a catalog `reasoning:false` model does
+  not. This is model-level, emitted uniformly from the catalog flag — see
+  methodology **R5**. It is a documented property of each model, not a knob we
+  turned for some and not others.
+- **Runs are independent samples.** N=12 per cell are separate dispatches
+  against freshly reset+seeded mocks (`eval/eval-shared.ts`), so the only
+  variation between a cell's runs is the model's own nondeterminism on the
+  provider defaults.
+
+## Per-model configuration — one source of truth, every difference justified
+
+The only per-model differences are the catalog entries in
+`src/lib/ollama-cloud-models.ts`, and each one carries an inline justification.
+Rather than duplicate a table that would drift, this doc points at the catalog
+as the source of truth and states the invariants:
+
+- `maxTokens` is a uniform 8192 output hint across the catalog (the one
+  exception is documented in the catalog).
+- `reasoning` and `vision` are read from each model's `ollama.com/library`
+  capability tags, then **corrected against the live `/v1` endpoint** where the
+  page lies (e.g. a model that advertises vision but returns HTTP 500 on an
+  `image_url` payload is flagged `vision:false`). The corrections are the
+  fairness-relevant part: we do not hand a model an input its serving path can't
+  take and then score the failure.
+- `contextTokens` (a runtime context-budget cap below the native window) is set
+  for **exactly one** model, `deepseek-v4-pro`, and only because its long-context
+  quality knees well before its advertised 512K and an uncapped budget produced
+  a real confabulation incident ("Piper", 2026-07-15). Capping it makes
+  OpenClaw's compaction fire in time — a correction that helps the model, not a
+  handicap. No other model is capped.
+
+## Tool-call elicitation and known serving quirks
+
+Every model is given the same tools, registered by the Pinchy plugins, in the
+same OpenAI-style tool schema. Two serving-layer realities shape what "fair"
+means here, and both are handled at the platform, not by penalizing a model:
+
+- **The `/v1` tool-arg encoding.** Ollama's `/v1` path rejects object-valued
+  tool arguments with a 400 on some models — the failure mode the `line-items`
+  scenario (nested `invoice_line_ids` command triplets) exists to surface. A
+  model that cannot emit the required nested arguments over this path fails the
+  scenario; that is a real capability result on our serving path, and it is why
+  the scenario is in the suite.
+- **Tool-call-as-text leaks.** Some models emit a tool call as plain assistant
+  text instead of a structured `tool_calls` payload (the `default_api`
+  signature; historically Gemini-family). Where this is a known, persistent
+  break rather than model behavior we want to measure, the model is in the
+  tools-blocklist (pinchy#344) and never wired into a slot — it is excluded, not
+  scored as a failure.
+
+Known per-model serving issues are already held in the catalog comments and the
+methodology's R-rules (gemma cross-turn id corruption; glm loop when
+`reasoning_content` is dropped; kimi native vision unreliable over `/v1`;
+deepseek-v4-pro context knee). This doc consolidates them by reference so the
+"we already know this informally" objection has a written home.
+
+## Retry and timeout policy — no silent re-rolls
+
+- **No run is retried to improve its outcome.** A dispatch is graded once. The
+  `attempt < 24` loop in `scrapeFinalAssistantMessage` is a 6-second poll for
+  the final message to stabilize, not a re-run of the task.
+- **A model hang is a model failure.** A run that never stops generating hits a
+  5-minute cap and is tagged `run-timeout`, graded as a failure — it is model
+  behavior, and re-rolling it would launder unreliability into a better score.
+- **A transport death is an invalid trial, not a failure.** When the LLM request
+  itself dies (the model never answered), the run is tagged `run-infra-error`,
+  **excluded** from the cell's n, and the cell is marked `pendingRerun` until
+  coverage is restored (`export-scorecard.ts`). We never credit an infra error
+  as either a pass or a model failure.
+
+## Spurious vs. real failures (the classification)
+
+METR's second half is labeling each failing cell's dominant failure as a
+**spurious bottleneck** (fixable by us: tool format, prompt, scaffold, a serving
+quirk we could route around) vs. a **real failure** (the model, fairly elicited,
+did the wrong thing). The rule that keeps this honest:
+
+- A **spurious** bottleneck is a bug report against the harness, not the model.
+  It must produce a concrete harness fix and a re-run — it never stands as a
+  published model result. (The uniform-0%-amount artifact in the first sweep is
+  the archetype: a mock-fidelity defect, fixed, not a model ranking.)
+- A **real** failure stands, read next to the happy-path score so incapacity is
+  never mistaken for diligence (the confound the methodology already flags for
+  mistral-large-3 / gpt-oss).
+
+The per-cell labeling is a **one-time review of trajectories** and is therefore
+done **against the dataset it describes**: it is deferred to the re-sweep's fresh
+18-model trajectories, because labeling the superseded cohort would be discarded
+when the new dataset lands. This document is the durable half — the protocol that
+proves fair elicitation regardless of which cohort is current; the per-cohort
+labels attach to each published sweep.

--- a/packages/web/eval/model-selection-methodology.md
+++ b/packages/web/eval/model-selection-methodology.md
@@ -10,6 +10,11 @@ This document does not choose models by itself. It encodes _how we decide_ so th
 default-model change — which lands on every self-hosted customer — is auditable, not
 folklore.
 
+The scorecard at the top of the evidence hierarchy is only as trustworthy as the
+elicitation behind it. [`elicitation-protocol.md`](elicitation-protocol.md) is the
+companion that proves every model got a fair scaffold (METR framing), so a low score
+is the model's, not a rig we under-built for it.
+
 ---
 
 ## The evidence hierarchy (the DNA)


### PR DESCRIPTION
## What

Delivers **Part 1** of #800 — the METR-style **elicitation protocol** that
proves every benchmarked model got a fair scaffold. It turns the strongest
objection to any per-model number — *"you just integrated model X badly"* — into
a documented, code-verified answer.

## The core argument (verified against the harness)

There is **no eval-special scaffold**: `dispatchAndScrape` drives the real Pinchy
production path — the same agent, tools, system prompt, and `openclaw.json` a
customer gets. So a number is "model X as a Pinchy customer would deploy it," not
a lab rig we tuned.

Verified facts the doc rests on:
- **No per-model sampling.** `rg 'temperature|top_p|sampling'` over
  `src/lib/openclaw-config/` is empty → uniform provider defaults for every model.
  Thinking is the model-level `reasoning` flag (methodology R5), not a per-model knob.
- **No re-rolls.** The `attempt < 24` loop is a 6s message-stabilize poll, not a
  run retry. A hang → graded `run-timeout` (model behavior); a transport death →
  excluded `run-infra-error` invalid trial.
- **One justified per-model cap.** Only `deepseek-v4-pro` carries a `contextTokens`
  budget cap — a correction that *helps* the model (the Piper confabulation
  incident), not a handicap.

## Deliberately scoped

**Part 2** (labeling each failing cell spurious-vs-real from trajectories) is a
one-time review that attaches to the dataset it describes, so it's **deferred to
the re-sweep's fresh 18-model trajectories** — labeling the soon-superseded
14-model cohort would be thrown away. This doc is the durable half; the doc
itself states that split.

Cross-linked from `model-selection-methodology.md` and `data/README.md` caveats.
No code — pure methodology documentation. Off `main`, non-stacked.