### PR TITLE
feat(kb): admin reindex UI + doc/scope squared with native embedder (#714)

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -44,7 +44,9 @@ Click **Save** to apply the permissions.
 
 ## 6. Index the documents
 
-Granting a directory doesn't index it automatically — an admin has to trigger indexing. Call the reindex endpoint for the agent:
+Granting a directory doesn't index it automatically — an admin has to trigger indexing. The simplest way is right where you granted the directories: in the agent's **Permissions** tab, the **Knowledge Base** section has an **Index** control. Click **Reindex now** and the section shows the run inline — discovery, a live progress bar, and the last run's outcome — so you never have to leave the page or read a log.
+
+The same action is available over the API, which is what you'd script for scheduled re-indexing:
 
 ```bash
 curl -X POST -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/knowledge/reindex"
@@ -70,7 +72,9 @@ One index run happens at a time, across your whole Pinchy — the index is share
 
 ## 7. Watch the run
 
-Ask the same endpoint how it's going:
+If you triggered the reindex from the **Permissions** tab, the **Index** control already does this for you — it polls in the background and renders the progress bar and the counts below the button until the run finishes. The rest of this section explains those same numbers, whether you read them there or over the API.
+
+Over the API, ask the same endpoint how it's going:
 
 ```bash
 curl -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/knowledge/reindex"

--- a/packages/web/src/__tests__/api/knowledge-reindex.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-reindex.test.ts
@@ -186,7 +186,10 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
 
     expect(res.status).toBe(409);
     expect(await res.json()).toMatchObject({
-      error: expect.stringContaining("already"),
+      // The message itself must name the blocking agent: the web client's
+      // ApiError only carries `error`, so a name in a sibling field never
+      // reaches the toast an admin actually sees.
+      error: expect.stringContaining("Legal KB"),
       jobId: "job-running",
       status: "running",
       // Where to go and watch it.

--- a/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
@@ -88,6 +88,26 @@ vi.mock("@/components/web-search-permission-section", () => ({
   },
 }));
 
+// Captured so wiring tests can assert WHAT the parent feeds the reindex
+// section (saved grants, not the unsaved picker selection) without pulling the
+// section's own fetch/poll machinery into this suite.
+let capturedReindexProps: {
+  agentId: string;
+  allowedPathCount: number;
+  hasUnsavedPathChanges?: boolean;
+} | null = null;
+
+vi.mock("@/components/knowledge-reindex-section", () => ({
+  KnowledgeReindexSection: (props: {
+    agentId: string;
+    allowedPathCount: number;
+    hasUnsavedPathChanges?: boolean;
+  }) => {
+    capturedReindexProps = props;
+    return <div data-testid="knowledge-reindex-section" />;
+  },
+}));
+
 vi.mock("@/components/email-permission-section", () => ({
   EmailPermissionSection: ({
     onChange,
@@ -104,6 +124,7 @@ vi.mock("@/components/email-permission-section", () => ({
 beforeEach(() => {
   capturedOdooOnChange = null;
   capturedWebSearchOnChange = null;
+  capturedReindexProps = null;
 });
 
 describe("AgentSettingsPermissions", () => {
@@ -231,6 +252,70 @@ describe("AgentSettingsPermissions", () => {
     );
 
     expect(screen.getByText("Allowed Directories")).toBeInTheDocument();
+  });
+
+  it("gates the reindex section on SAVED grants, not the unsaved picker selection", async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsPermissions
+        agent={defaultAgent}
+        directories={defaultDirectories}
+        connections={[]}
+        isAdmin={true}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(capturedReindexProps).toMatchObject({
+      agentId: "agent-1",
+      allowedPathCount: 0,
+      hasUnsavedPathChanges: false,
+    });
+
+    // Tick a directory WITHOUT saving: the server still sees zero grants, so
+    // the reindex gate must not open — but the section learns about the dirt.
+    await user.click(screen.getByRole("checkbox", { name: "docs" }));
+
+    expect(capturedReindexProps).toMatchObject({
+      allowedPathCount: 0,
+      hasUnsavedPathChanges: true,
+    });
+  });
+
+  it("feeds the reindex section the saved grant count for an agent with saved paths", () => {
+    const agentWithPaths = {
+      ...defaultAgent,
+      pluginConfig: { "pinchy-files": { allowed_paths: ["/data/docs", "/data/reports"] } },
+    };
+
+    render(
+      <AgentSettingsPermissions
+        agent={agentWithPaths}
+        directories={defaultDirectories}
+        connections={[]}
+        isAdmin={true}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(capturedReindexProps).toMatchObject({
+      allowedPathCount: 2,
+      hasUnsavedPathChanges: false,
+    });
+  });
+
+  it("hides the reindex section for non-admins", () => {
+    render(
+      <AgentSettingsPermissions
+        agent={defaultAgent}
+        directories={defaultDirectories}
+        connections={[]}
+        isAdmin={false}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId("knowledge-reindex-section")).not.toBeInTheDocument();
   });
 
   describe("conditional integration sections", () => {

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { KnowledgeReindexSection } from "@/components/knowledge-reindex-section";
+import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { toast } from "sonner";
+
+// Mock the network layer but keep the REAL ApiError class so the component's
+// `instanceof ApiError` branch is exercised against the same constructor.
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return { ...actual, apiGet: vi.fn(), apiPost: vi.fn() };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+
+const mockGet = vi.mocked(apiGet);
+const mockPost = vi.mocked(apiPost);
+
+type Job = {
+  id: string;
+  status: "pending" | "running" | "succeeded" | "failed";
+  processed: number;
+  total: number | null;
+  counts: {
+    indexed: number;
+    skipped: number;
+    removed: number;
+    unsearchable: number;
+    failed: number;
+  } | null;
+  error: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+};
+
+function job(overrides: Partial<Job>): Job {
+  return {
+    id: "job-1",
+    status: "succeeded",
+    processed: 0,
+    total: 0,
+    counts: null,
+    error: null,
+    createdAt: "2026-07-21T10:00:00.000Z",
+    startedAt: "2026-07-21T10:00:01.000Z",
+    finishedAt: "2026-07-21T10:05:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("KnowledgeReindexSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ job: null });
+  });
+
+  it("shows a 'not yet indexed' state and an enabled trigger when directories are granted", async () => {
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
+    expect(screen.getByText(/not.*indexed/i)).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith("/api/agents/a1/knowledge/reindex");
+  });
+
+  it("disables the trigger and explains why when no directories are granted", async () => {
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={0} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeDisabled());
+    expect(screen.getByText(/grant.*director/i)).toBeInTheDocument();
+  });
+
+  it("triggers a reindex and then reflects live progress from polling", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({ jobId: "job-9", status: "pending", pathCount: 2 });
+    // After the POST, the first poll returns a running job at 3/10.
+    mockGet
+      .mockResolvedValueOnce({ job: null }) // initial mount fetch
+      .mockResolvedValue({
+        job: job({ status: "running", processed: 3, total: 10, counts: null }),
+      });
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} pollIntervalMs={20} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: /reindex/i }));
+
+    expect(mockPost).toHaveBeenCalledWith("/api/agents/a1/knowledge/reindex", {});
+
+    // Progress surfaces the processed/total the poll reports.
+    await waitFor(() => expect(screen.getByText(/3/)).toBeInTheDocument());
+    expect(screen.getByText(/10/)).toBeInTheDocument();
+    // The trigger is disabled while a run is in flight.
+    expect(screen.getByRole("button", { name: /reindex/i })).toBeDisabled();
+  });
+
+  it("summarizes the last successful run, emphasizing unsearchable and failed docs", async () => {
+    mockGet.mockResolvedValue({
+      job: job({
+        status: "succeeded",
+        processed: 100,
+        total: 100,
+        counts: { indexed: 90, skipped: 5, removed: 0, unsearchable: 4, failed: 1 },
+      }),
+    });
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+    await waitFor(() => expect(screen.getByText(/last indexed/i)).toBeInTheDocument());
+    // The counters that mean "this document will never answer a question".
+    expect(screen.getByText(/4/)).toBeInTheDocument(); // unsearchable
+    expect(screen.getByText(/unsearchable/i)).toBeInTheDocument();
+    expect(screen.getByText(/failed/i)).toBeInTheDocument();
+    // Button is enabled again — the run is over.
+    expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled();
+  });
+
+  it("surfaces a concurrent-run conflict (409) as an error toast", async () => {
+    const user = userEvent.setup();
+    mockPost.mockRejectedValue(new ApiError(409, "A knowledge base reindex is already running"));
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: /reindex/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("A knowledge base reindex is already running")
+    );
+  });
+
+  it("treats a server-side no-op (nothing to index) as info, not an error", async () => {
+    const user = userEvent.setup();
+    mockPost.mockResolvedValue({ jobId: null, status: "noop", pathCount: 0 });
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: /reindex/i }));
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalled();
+    // No phantom running state — the button stays usable.
+    expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled();
+  });
+});

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -120,17 +120,109 @@ describe("KnowledgeReindexSection", () => {
     expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled();
   });
 
-  it("surfaces a concurrent-run conflict (409) as an error toast", async () => {
+  it("surfaces a concurrent-run conflict (409) as an error toast naming the blocking agent", async () => {
     const user = userEvent.setup();
-    mockPost.mockRejectedValue(new ApiError(409, "A knowledge base reindex is already running"));
+    // The real route puts the blocking agent's name INTO the message — the only
+    // field ApiError carries to the toast (the `agent` sibling field is lost).
+    const message = 'A knowledge base reindex is already running for agent "Legal KB"';
+    mockPost.mockRejectedValue(new ApiError(409, message));
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: /reindex/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(message));
+  });
+
+  it("surfaces a missing embedder (503) as an error toast with the route's message", async () => {
+    const user = userEvent.setup();
+    mockPost.mockRejectedValue(new ApiError(503, "Knowledge base embedding model not available"));
 
     render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
     await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
     await user.click(screen.getByRole("button", { name: /reindex/i }));
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("A knowledge base reindex is already running")
+      expect(toast.error).toHaveBeenCalledWith("Knowledge base embedding model not available")
     );
+    // No phantom run to watch — the button recovers.
+    expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled();
+  });
+
+  it("names the discovery phase instead of faking a percentage while total is unknown", async () => {
+    mockGet.mockResolvedValue({
+      job: job({ status: "running", processed: 0, total: null }),
+    });
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+    await waitFor(() => expect(screen.getByText(/discovering documents/i)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /reindex/i })).toBeDisabled();
+  });
+
+  it("renders a failed run as a destructive alert with the error and the counts", async () => {
+    mockGet.mockResolvedValue({
+      job: job({
+        status: "failed",
+        processed: 40,
+        total: 100,
+        error: "Embedding model crashed",
+        counts: { indexed: 30, skipped: 9, removed: 0, unsearchable: 0, failed: 1 },
+      }),
+    });
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+    await waitFor(() => expect(screen.getByText(/last reindex failed/i)).toBeInTheDocument());
+    expect(screen.getByText("Embedding model crashed")).toBeInTheDocument();
+    expect(screen.getByText(/1 failed/)).toBeInTheDocument();
+    // A failed run is over — the admin can immediately try again.
+    expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled();
+  });
+
+  it("clamps the progress bar at 100% even if processed overshoots total", async () => {
+    mockGet.mockResolvedValue({
+      job: job({ status: "running", processed: 12, total: 10 }),
+    });
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+    const bar = await screen.findByRole("progressbar");
+    await waitFor(() => expect(bar).toHaveAttribute("aria-valuenow", "100"));
+  });
+
+  it("warns that a reindex uses the saved grants while directory changes are unsaved", async () => {
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} hasUnsavedPathChanges />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
+    expect(screen.getByText(/saved grants/i)).toBeInTheDocument();
+  });
+
+  it("ignores a slow status read that resolves after a reindex was triggered", async () => {
+    const user = userEvent.setup();
+    let resolveMountGet!: (value: { job: Job | null }) => void;
+    mockGet
+      // The mount-time GET hangs until we resolve it by hand, mid-run.
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ job: Job | null }>((resolve) => {
+            resolveMountGet = resolve;
+          })
+      )
+      .mockResolvedValue({
+        job: job({ status: "running", processed: 1, total: 5, counts: null }),
+      });
+    mockPost.mockResolvedValue({ jobId: "job-9", status: "pending", pathCount: 2 });
+
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} pollIntervalMs={20} />);
+    await user.click(screen.getByRole("button", { name: /reindex/i }));
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled());
+
+    // The pre-click read finally answers "no job ever ran". It is stale — it
+    // must not clear the run the admin just started and is watching.
+    resolveMountGet({ job: null });
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled();
   });
 
   it("treats a server-side no-op (nothing to index) as info, not an error", async () => {

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
@@ -157,7 +157,10 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
     );
     return NextResponse.json(
       {
-        error: "A knowledge base reindex is already running",
+        // The agent's name lives in the message, not only in the `agent`
+        // field: the web client surfaces ApiError.message verbatim, so this
+        // string is the one place the name is guaranteed to reach the admin.
+        error: `A knowledge base reindex is already running for agent "${blocking.name}"`,
         jobId: enqueued.job.id,
         status: enqueued.job.status,
         agent: blocking,

--- a/packages/web/src/components/agent-settings-permissions.tsx
+++ b/packages/web/src/components/agent-settings-permissions.tsx
@@ -12,6 +12,7 @@ import {
 import { OdooPermissionSection } from "@/components/odoo-permission-section";
 import { EmailPermissionSection } from "@/components/email-permission-section";
 import { WebSearchPermissionSection } from "@/components/web-search-permission-section";
+import { KnowledgeReindexSection } from "@/components/knowledge-reindex-section";
 import type { Connection as OdooConnection } from "@/hooks/use-odoo-permissions";
 import type { AgentPluginConfig } from "@/db/schema";
 import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
@@ -265,6 +266,13 @@ export function AgentSettingsPermissions({
               onChange={handlePathsChange}
             />
           </div>
+        )}
+
+        {/* Admin-only reindex trigger + progress. The async worker/queue is
+            server-side (#714); this is the surface to start a run and watch it.
+            Gated on isAdmin because the route is admin-only (withAdmin). */}
+        {isAdmin && (
+          <KnowledgeReindexSection agentId={agent.id} allowedPathCount={allowedPaths.length} />
         )}
 
         {/* Explicit KB tool toggles (safe, non-integration) — empty after pinchy_ls/pinchy_read became implicit */}

--- a/packages/web/src/components/agent-settings-permissions.tsx
+++ b/packages/web/src/components/agent-settings-permissions.tsx
@@ -109,6 +109,14 @@ export function AgentSettingsPermissions({
 
   const hasWebToolChecked = webTools.some((tool) => allowedKbTools.includes(tool.id));
 
+  // A reindex operates on the SAVED grants (the route reads pluginConfig), so
+  // the reindex section is gated on the persisted paths — never on the picker's
+  // unsaved selection, which the server cannot see yet. The parent refetches
+  // the agent after a save, so this recomputes to the new truth on its own.
+  const savedAllowedPaths = agent.pluginConfig?.["pinchy-files"]?.allowed_paths ?? [];
+  const hasUnsavedPathChanges =
+    JSON.stringify([...allowedPaths].sort()) !== JSON.stringify([...savedAllowedPaths].sort());
+
   // Check if the agent has sensitive data access (any allowed paths or odoo/email tools)
   const hasSensitiveDataAccess =
     allowedPaths.length > 0 || odooIntegration !== null || emailIntegration !== null;
@@ -272,7 +280,11 @@ export function AgentSettingsPermissions({
             server-side (#714); this is the surface to start a run and watch it.
             Gated on isAdmin because the route is admin-only (withAdmin). */}
         {isAdmin && (
-          <KnowledgeReindexSection agentId={agent.id} allowedPathCount={allowedPaths.length} />
+          <KnowledgeReindexSection
+            agentId={agent.id}
+            allowedPathCount={savedAllowedPaths.length}
+            hasUnsavedPathChanges={hasUnsavedPathChanges}
+          />
         )}
 
         {/* Explicit KB tool toggles (safe, non-integration) — empty after pinchy_ls/pinchy_read became implicit */}

--- a/packages/web/src/components/knowledge-reindex-section.tsx
+++ b/packages/web/src/components/knowledge-reindex-section.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import type { IngestResult } from "@/lib/knowledge/types";
+import type { KnowledgeReindexRequest } from "@/lib/schemas/knowledge-base";
+
+type JobStatus = "pending" | "running" | "succeeded" | "failed";
+
+/** The status projection returned by GET …/knowledge/reindex (dates as ISO strings over JSON). */
+interface ReindexJob {
+  id: string;
+  status: JobStatus;
+  processed: number;
+  total: number | null;
+  counts: IngestResult | null;
+  error: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+/** POST …/knowledge/reindex: 202 carries a jobId; the no-op path carries jobId=null. */
+interface ReindexPostResponse {
+  jobId: string | null;
+  status: string;
+  pathCount: number;
+}
+
+const ACTIVE_STATUSES: readonly JobStatus[] = ["pending", "running"];
+const isActive = (job: ReindexJob | null): boolean =>
+  job !== null && ACTIVE_STATUSES.includes(job.status);
+
+export interface KnowledgeReindexSectionProps {
+  agentId: string;
+  /**
+   * How many directories the agent is granted. With none, a reindex is a
+   * server-side no-op, so the trigger is disabled and the reason is shown
+   * instead of letting the admin click into an honest-but-confusing no-op.
+   */
+  allowedPathCount: number;
+  /** Poll cadence while a run is in flight. Injectable so tests need not wait seconds. */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Admin control for the async knowledge-base reindex (#714): trigger a run and
+ * watch it. The heavy lifting (queue, worker, audit) is server-side; this is the
+ * surface that lets an admin start an index and see progress/outcome without
+ * reading logs.
+ *
+ * Belongs under the "Allowed Directories" picker because a reindex operates on
+ * exactly the folders granted there.
+ */
+export function KnowledgeReindexSection({
+  agentId,
+  allowedPathCount,
+  pollIntervalMs = 3000,
+}: KnowledgeReindexSectionProps) {
+  const [job, setJob] = useState<ReindexJob | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const url = `/api/agents/${agentId}/knowledge/reindex`;
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await apiGet<{ job: ReindexJob | null }>(url);
+      setJob(res.job);
+    } catch {
+      // A failed status read is non-fatal: keep the last-known state and let the
+      // next poll (or the user) retry. Deliberately no toast — a polling error
+      // would spam one every interval.
+    }
+  }, [url]);
+
+  useEffect(() => {
+    void fetchStatus();
+  }, [fetchStatus]);
+
+  // Poll ONLY while a run is in flight; the effect tears the interval down the
+  // moment the status leaves pending/running, so a finished run stops polling.
+  const active = isActive(job);
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => void fetchStatus(), pollIntervalMs);
+    return () => clearInterval(id);
+  }, [active, fetchStatus, pollIntervalMs]);
+
+  const handleReindex = useCallback(async () => {
+    setSubmitting(true);
+    try {
+      const res = await apiPost<ReindexPostResponse, KnowledgeReindexRequest>(url, {});
+      if (res.jobId === null) {
+        // Server-side no-op (nothing granted, or nothing left after narrowing):
+        // honest info, not an error — there is simply no work to watch.
+        toast.info("Nothing to index — grant at least one directory first.");
+        return;
+      }
+      // Optimistically show the queued run so the trigger locks immediately; the
+      // poll fills in real discovery/progress on its next tick.
+      setJob({
+        id: res.jobId,
+        status: "pending",
+        processed: 0,
+        total: null,
+        counts: null,
+        error: null,
+        createdAt: new Date().toISOString(),
+        startedAt: null,
+        finishedAt: null,
+      });
+      void fetchStatus();
+    } catch (err) {
+      // 409 (already running), 503 (embedder missing) and 500 all arrive here as
+      // an ApiError whose message is the route's human-readable `error`.
+      toast.error(err instanceof ApiError ? err.message : "Reindex could not be started.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [url, fetchStatus]);
+
+  const triggerDisabled = allowedPathCount === 0 || active || submitting;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-4">
+        <h4 className="text-sm font-medium">Index</h4>
+        <Button size="sm" variant="outline" onClick={handleReindex} disabled={triggerDisabled}>
+          {active ? "Reindexing…" : "Reindex now"}
+        </Button>
+      </div>
+
+      {allowedPathCount === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Grant at least one directory above to enable indexing.
+        </p>
+      ) : active ? (
+        <RunningState job={job!} />
+      ) : job?.status === "succeeded" ? (
+        <SucceededState job={job} />
+      ) : job?.status === "failed" ? (
+        <FailedState job={job} />
+      ) : (
+        <p className="text-sm text-muted-foreground">Not yet indexed.</p>
+      )}
+    </div>
+  );
+}
+
+function RunningState({ job }: { job: ReindexJob }) {
+  // `total` is null until discovery has walked every root — an indeterminate
+  // phase we name rather than fake a percentage for.
+  if (job.total === null) {
+    return (
+      <div className="space-y-2">
+        <Progress value={0} />
+        <p className="text-sm text-muted-foreground">Discovering documents…</p>
+      </div>
+    );
+  }
+  const pct = job.total > 0 ? Math.round((job.processed / job.total) * 100) : 0;
+  return (
+    <div className="space-y-2">
+      <Progress value={pct} />
+      <p className="text-sm text-muted-foreground">
+        Indexing {job.processed} of {job.total} documents…
+      </p>
+    </div>
+  );
+}
+
+function SucceededState({ job }: { job: ReindexJob }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-muted-foreground">Last indexed {formatWhen(job.finishedAt)}.</p>
+      {job.counts && <CountsSummary counts={job.counts} />}
+    </div>
+  );
+}
+
+function FailedState({ job }: { job: ReindexJob }) {
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>Last reindex failed</AlertTitle>
+      <AlertDescription className="space-y-2">
+        {job.error && <span>{job.error}</span>}
+        {job.counts && <CountsSummary counts={job.counts} />}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/**
+ * The per-run findings. `unsearchable` and `failed` are the counters that mean
+ * "this document will never answer a question", so they are always shown — even
+ * at zero — rather than folded into a single "done" number.
+ */
+function CountsSummary({ counts }: { counts: IngestResult }) {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+      <span className="text-muted-foreground">{counts.indexed} indexed</span>
+      <span className="text-muted-foreground">{counts.skipped} skipped</span>
+      {counts.removed > 0 && (
+        <span className="text-muted-foreground">{counts.removed} removed</span>
+      )}
+      <span
+        className={
+          counts.unsearchable > 0 ? "text-amber-600 dark:text-amber-500" : "text-muted-foreground"
+        }
+      >
+        {counts.unsearchable} unsearchable
+      </span>
+      <span className={counts.failed > 0 ? "text-destructive" : "text-muted-foreground"}>
+        {counts.failed} failed
+      </span>
+    </div>
+  );
+}
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return "just now";
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "just now" : d.toLocaleString();
+}

--- a/packages/web/src/components/knowledge-reindex-section.tsx
+++ b/packages/web/src/components/knowledge-reindex-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -44,6 +44,12 @@ export interface KnowledgeReindexSectionProps {
    * instead of letting the admin click into an honest-but-confusing no-op.
    */
   allowedPathCount: number;
+  /**
+   * True while the directory picker holds selections that differ from the
+   * saved grants. A reindex only ever sees the SAVED grants, so the section
+   * says so instead of letting the admin believe unsaved checkmarks count.
+   */
+  hasUnsavedPathChanges?: boolean;
   /** Poll cadence while a run is in flight. Injectable so tests need not wait seconds. */
   pollIntervalMs?: number;
 }
@@ -60,16 +66,25 @@ export interface KnowledgeReindexSectionProps {
 export function KnowledgeReindexSection({
   agentId,
   allowedPathCount,
+  hasUnsavedPathChanges = false,
   pollIntervalMs = 3000,
 }: KnowledgeReindexSectionProps) {
   const [job, setJob] = useState<ReindexJob | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const url = `/api/agents/${agentId}/knowledge/reindex`;
 
+  // Monotonic ticket per status read: a response only lands if it is still the
+  // NEWEST read issued. Reads overlap (mount fetch, post-trigger fetch, poll
+  // ticks), and a slow early response must not overwrite a later one — the
+  // mount-time `job: null` arriving after a trigger would silently clear the
+  // run the admin just started.
+  const fetchSeq = useRef(0);
+
   const fetchStatus = useCallback(async () => {
+    const seq = ++fetchSeq.current;
     try {
       const res = await apiGet<{ job: ReindexJob | null }>(url);
-      setJob(res.job);
+      if (seq === fetchSeq.current) setJob(res.job);
     } catch {
       // A failed status read is non-fatal: keep the last-known state and let the
       // next poll (or the user) retry. Deliberately no toast — a polling error
@@ -134,12 +149,19 @@ export function KnowledgeReindexSection({
         </Button>
       </div>
 
+      {hasUnsavedPathChanges && (
+        <p className="text-sm text-muted-foreground">
+          You have unsaved directory changes — a reindex uses the saved grants. Save to include
+          them.
+        </p>
+      )}
+
       {allowedPathCount === 0 ? (
         <p className="text-sm text-muted-foreground">
-          Grant at least one directory above to enable indexing.
+          Grant at least one directory to enable indexing.
         </p>
-      ) : active ? (
-        <RunningState job={job!} />
+      ) : active && job ? (
+        <RunningState job={job} />
       ) : job?.status === "succeeded" ? (
         <SucceededState job={job} />
       ) : job?.status === "failed" ? (
@@ -162,7 +184,9 @@ function RunningState({ job }: { job: ReindexJob }) {
       </div>
     );
   }
-  const pct = job.total > 0 ? Math.round((job.processed / job.total) * 100) : 0;
+  // Clamped: `processed` can momentarily overshoot a stale `total` snapshot,
+  // and a >100 value flips the Radix progressbar into its indeterminate state.
+  const pct = job.total > 0 ? Math.min(100, Math.round((job.processed / job.total) * 100)) : 0;
   return (
     <div className="space-y-2">
       <Progress value={pct} />

--- a/packages/web/src/components/ui/progress.tsx
+++ b/packages/web/src/components/ui/progress.tsx
@@ -14,6 +14,9 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn("bg-primary/20 relative h-2 w-full overflow-hidden rounded-full", className)}
+      // Forward `value` so Radix exposes aria-valuenow; without it every bar is
+      // announced as indeterminate no matter how full it is drawn.
+      value={value}
       {...props}
     >
       <ProgressPrimitive.Indicator


### PR DESCRIPTION
## Summary

Closes the last open piece of **#714 Part 1**: the Knowledge Base reindex had a fully-shipped, integration-tested async backend (queue table `kb_index_jobs` + migration `0055`, enqueue route with 202/409/503/no-op and `jobId` audit, GET status projection, and the in-process `kb-index-worker` started in `server.ts` / stopped on SIGTERM) — but **nothing in the UI consumed it**. An admin could only trigger and watch a reindex with `curl`.

This adds the admin surface and squares the docs + issue scope with reality after #715 (native bundled embedder).

## What changed

- **`KnowledgeReindexSection`** — a new admin-only control rendered under the agent's **Permissions → Knowledge Base → Allowed Directories**:
  - **Reindex now** button → `POST …/knowledge/reindex`.
  - Polls the status `GET` while a run is in flight (poll interval injectable for tests), tearing the interval down the moment the run finishes.
  - Surfaces **discovery** (`total` still null), a **live progress bar** (`processed/total`), and the **last-run outcome** — `indexed`/`skipped`/`unsearchable`/`failed`, with `unsearchable` and `failed` emphasized because those are the counters that mean a document will never answer a question.
  - Honest terminal states via toast: **409** (already running — the message names the blocking agent, see review fixes below), **503** (embedder missing), and **no-op** (nothing granted) as info, not an error.
  - Gated on `isAdmin` to match the `withAdmin` route.
- **Docs** (`guides/create-knowledge-base-agent.mdx`): sections 6/7 now lead with the UI control (the "activate without reading source" goal of #714), keeping `curl` as the API-first alternative for scripted/scheduled re-indexing.

## Review fixes (second commit)

A code review of the first commit surfaced two real issues plus polish; all fixed and covered by tests:

- **Reindex gate now reads the SAVED grants, not the picker's unsaved selection.** The route only ever sees `pluginConfig`, so an unsaved checkmark used to enable the button into a guaranteed no-op (and unchecking used to disable it even though the server would happily reindex). The section is now fed the persisted `allowed_paths` count and shows an inline hint while directory changes are unsaved.
- **The 409 message itself names the blocking agent.** The route put the name only in a sibling `agent` field, but the web client's `ApiError` carries only `error` — the name never reached the toast. The message now reads `A knowledge base reindex is already running for agent "…"`.
- **Stale-read guard:** status reads carry a monotonic ticket; a slow pre-trigger GET resolving after the admin started a run can no longer clear the optimistic state, and out-of-order poll responses can no longer rewind progress.
- **Progress a11y + clamp:** the shared `ui/progress.tsx` never forwarded `value` to the Radix root, so every bar was announced as indeterminate (`aria-valuenow` missing) — now forwarded; the reindex bar additionally clamps at 100%.
- Copy: dropped the dangling "above" when no directory picker is rendered; removed a `job!` non-null assertion.

## Scope corrections (in #714)

- The original **Part 2** (one-click Ollama activation, 1.2 GB `bge-m3` pull, `--profile knowledge` overlay) is **obsolete** — #715 bundled `embeddinggemma` in-process, so there is nothing to activate.
- The "OpenAI-compatible escape hatch" is a **latent capability** in `embeddings.ts` but **deliberately not exposed** (`kbEmbeddingConfig()` is fixed to `provider: "local"`). Wiring a config surface is out of scope by YAGNI; left as a follow-up if a real customer needs a remote embedder.
- Swept `components/` + `app/` for stale Ollama/`bge-m3` install copy — none found.

## Test plan

- [x] `knowledge-reindex-section.test.tsx` — 12 cases: not-yet-indexed, no-directories-granted (disabled + hint), trigger→live progress via polling, succeeded summary emphasizing unsearchable/failed, 409 conflict → error toast naming the blocking agent, 503 → error toast, server no-op → info toast, discovery phase (`total: null`), failed-run alert, progress clamp at 100%, unsaved-changes hint, stale-read guard.
- [x] `agent-settings-permissions.test.tsx` (34/34) — including new wiring tests: saved-grant gating vs unsaved picker selection, saved-count pass-through, section hidden for non-admins.
- [x] `knowledge-reindex.test.ts` (route, 18/18) — 409 test now pins the blocking agent's name in the `error` message itself.
- [x] `pnpm -C packages/web typecheck` (0 errors), `pnpm format:check`, `pnpm -C packages/web lint` (0 errors).
- [x] Full `pnpm -C packages/web test`: all suites touched by this PR green; the only failures in full parallel runs were load-flaky, unrelated files (`timezone-settings`, `enterprise-banner`, `openclaw-config`) that pass 252/252 when run in isolation and vary between runs.

No schema/migration change — the KB backend already shipped in prior PRs.
