### PR TITLE
feat(automations): write-API to create Inbox Agent email workflows (#139)

### DIFF
--- a/packages/web/src/__tests__/api/automations-create.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-create.integration.test.ts
@@ -1,0 +1,244 @@
+// Real-DB integration tests for POST /api/automations — the single write path
+// for the Inbox Agent's email workflows (design §5; the foundation both the
+// Automations form #139 and the conversational create tool #705 write through).
+//
+// Why real DB, not mocked chains: the load-bearing behavior here is a
+// transactional two-table write (email_workflows + email_workflow_connections)
+// with a per-connection watermark, plus scope-based RBAC that queries the
+// agent's ownership and its connection permissions. Mocking @/db would assert
+// nothing about any of that. So @/db runs for real against a freshly migrated
+// Postgres (global-setup.ts), truncated between cases (setup.ts).
+//
+// What stays mocked, and why:
+//   - @/lib/auth.getSession — the only way to drive the withAuth scope branches
+//     (member vs admin, owner vs not) deterministically.
+//   - @/lib/audit-deferred.deferAuditLog — a thin next/after wrapper whose
+//     callback does not run under a direct handler call; we assert the payload
+//     it was handed instead of round-tripping through `after()`.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+  agents,
+  users,
+  emailWorkflows,
+  emailWorkflowConnections,
+  agentConnectionPermissions,
+  integrationConnections,
+} from "@/db/schema";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
+
+const { getSessionMock, deferAuditLogMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  deferAuditLogMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+  auth: { api: { getSession: getSessionMock } },
+}));
+
+vi.mock("@/lib/audit-deferred", () => ({
+  deferAuditLog: (...args: unknown[]) => deferAuditLogMock(...args),
+}));
+
+// Imported after the mocks are registered.
+const { POST } = await import("@/app/api/automations/route");
+
+const OWNER = "user-owner";
+const OTHER = "user-other";
+const ADMIN = "user-admin";
+
+function asMember(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "member" } });
+}
+function asAdmin(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "admin" } });
+}
+
+async function seedUser(id: string, role: "member" | "admin" = "member") {
+  await db.insert(users).values({ id, name: id, email: `${id}@test.com`, role });
+}
+
+async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) {
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Smithers",
+      model: "ollama-cloud/gemini-3-flash",
+      greetingMessage: "Hi",
+      isPersonal: opts.isPersonal,
+      ownerId: opts.ownerId,
+    })
+    .returning();
+  return row;
+}
+
+async function seedConnection(id: string) {
+  const [row] = await db
+    .insert(integrationConnections)
+    .values({ id, type: "imap", name: "Invoices mailbox", credentials: "enc:placeholder" })
+    .returning();
+  return row;
+}
+
+async function grantEmailPermission(agentId: string, connectionId: string) {
+  await db
+    .insert(agentConnectionPermissions)
+    .values({ agentId, connectionId, model: "email", operation: "read" });
+}
+
+function postBody(body: Record<string, unknown>) {
+  return makeNextRequest("http://localhost/api/automations", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = (agentId: string, connectionId: string) => ({
+  agentId,
+  name: "File supplier invoices",
+  filter: { hasAttachment: true, attachmentType: "application/pdf" },
+  action: "Draft a supplier bill in Odoo from the attached invoice.",
+  connectionIds: [connectionId],
+  sweepWindowDays: 30,
+});
+
+async function loadWorkflows(agentId: string) {
+  return db.select().from(emailWorkflows).where(eq(emailWorkflows.agentId, agentId));
+}
+
+describe("POST /api/automations — create email workflow", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // agents.owner_id and email_workflows.created_by both FK to user.id, so the
+    // actors must exist before any agent/workflow references them.
+    await seedUser(OWNER);
+    await seedUser(OTHER);
+    await seedUser(ADMIN, "admin");
+  });
+
+  it("lets a member create a workflow on their own personal agent + a permitted connection", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-own");
+    await grantEmailPermission(agent.id, "conn-own");
+
+    const before = Date.now();
+    const res = await POST(postBody(validBody(agent.id, "conn-own")), routeContext());
+    expect(res.status).toBe(201);
+
+    // Propose, don't self-activate: the workflow lands pending + disabled, its
+    // creator recorded, never active — activation is a separate human step.
+    const [wf] = await loadWorkflows(agent.id);
+    expect(wf).toBeDefined();
+    expect(wf.enabled).toBe(false);
+    expect(wf.status).toBe("pending");
+    expect(wf.createdBy).toBe(OWNER);
+    expect(wf.name).toBe("File supplier invoices");
+    expect(wf.sweepWindowDays).toBe(30);
+    expect(wf.filter).toEqual({ hasAttachment: true, attachmentType: "application/pdf" });
+
+    // The connection is attached with a NOW watermark, so the new workflow
+    // never retroactively processes historical mail (design §8).
+    const conns = await db
+      .select()
+      .from(emailWorkflowConnections)
+      .where(eq(emailWorkflowConnections.workflowId, wf.id));
+    expect(conns).toHaveLength(1);
+    expect(conns[0].connectionId).toBe("conn-own");
+    expect(conns[0].sinceTs.getTime()).toBeGreaterThanOrEqual(before - 1000);
+    expect(conns[0].sinceTs.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+
+    // Audited: email_workflow.created, names snapshotted, ids-only (no PII).
+    expect(deferAuditLogMock).toHaveBeenCalledTimes(1);
+    const entry = deferAuditLogMock.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      eventType: "email_workflow.created",
+      actorType: "user",
+      actorId: OWNER,
+      outcome: "success",
+    });
+    expect(entry.detail).toMatchObject({
+      workflow: { id: wf.id, name: "File supplier invoices" },
+      agent: { id: agent.id, name: "Smithers" },
+      connectionCount: 1,
+      enabled: false,
+      status: "pending",
+    });
+  });
+
+  it("forbids a member from creating a workflow on a shared agent (admin-only scope)", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    await seedConnection("conn-shared");
+    await grantEmailPermission(agent.id, "conn-shared");
+
+    const res = await POST(postBody(validBody(agent.id, "conn-shared")), routeContext());
+    expect(res.status).toBe(403);
+    expect(await loadWorkflows(agent.id)).toHaveLength(0);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("forbids a member from creating a workflow on someone else's personal agent", async () => {
+    asMember(OTHER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-x");
+    await grantEmailPermission(agent.id, "conn-x");
+
+    const res = await POST(postBody(validBody(agent.id, "conn-x")), routeContext());
+    expect(res.status).toBe(403);
+    expect(await loadWorkflows(agent.id)).toHaveLength(0);
+  });
+
+  it("lets an admin create a workflow on a shared agent", async () => {
+    asAdmin(ADMIN);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    await seedConnection("conn-shared2");
+    await grantEmailPermission(agent.id, "conn-shared2");
+
+    const res = await POST(postBody(validBody(agent.id, "conn-shared2")), routeContext());
+    expect(res.status).toBe(201);
+    const [wf] = await loadWorkflows(agent.id);
+    expect(wf.status).toBe("pending");
+    expect(wf.createdBy).toBe(ADMIN);
+  });
+
+  it("rejects a connection the agent has no email permission for — no partial write", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-unpermitted"); // exists, but no permission granted
+
+    const res = await POST(postBody(validBody(agent.id, "conn-unpermitted")), routeContext());
+    expect(res.status).toBe(400);
+    // The two-table write is transactional: a bad connection writes NOTHING.
+    expect(await loadWorkflows(agent.id)).toHaveLength(0);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown agent", async () => {
+    asMember(OWNER);
+    const res = await POST(postBody(validBody("no-such-agent", "conn-any")), routeContext());
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an unknown connection id", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    const res = await POST(postBody(validBody(agent.id, "ghost-conn")), routeContext());
+    expect(res.status).toBe(400);
+    expect(await loadWorkflows(agent.id)).toHaveLength(0);
+  });
+
+  it("returns 401 for an unauthenticated caller", async () => {
+    getSessionMock.mockResolvedValue(null);
+    const res = await POST(postBody(validBody("a", "c")), routeContext());
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/web/src/__tests__/api/automations-create.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-create.integration.test.ts
@@ -87,10 +87,10 @@ async function seedConnection(id: string) {
   return row;
 }
 
-async function grantEmailPermission(agentId: string, connectionId: string) {
+async function grantEmailPermission(agentId: string, connectionId: string, operation = "read") {
   await db
     .insert(agentConnectionPermissions)
-    .values({ agentId, connectionId, model: "email", operation: "read" });
+    .values({ agentId, connectionId, model: "email", operation });
 }
 
 function postBody(body: Record<string, unknown>) {
@@ -156,13 +156,16 @@ describe("POST /api/automations — create email workflow", () => {
     expect(conns[0].sinceTs.getTime()).toBeGreaterThanOrEqual(before - 1000);
     expect(conns[0].sinceTs.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
 
-    // Audited: email_workflow.created, names snapshotted, ids-only (no PII).
+    // Audited: email_workflow.created with the resource pointer, {id, name}
+    // snapshots (name scrubbed — see the PII test below), connections as ids
+    // only (their names can carry addresses).
     expect(deferAuditLogMock).toHaveBeenCalledTimes(1);
     const entry = deferAuditLogMock.mock.calls[0][0];
     expect(entry).toMatchObject({
       eventType: "email_workflow.created",
       actorType: "user",
       actorId: OWNER,
+      resource: `email_workflow:${wf.id}`,
       outcome: "success",
     });
     expect(entry.detail).toMatchObject({
@@ -208,6 +211,64 @@ describe("POST /api/automations — create email workflow", () => {
     const [wf] = await loadWorkflows(agent.id);
     expect(wf.status).toBe("pending");
     expect(wf.createdBy).toBe(ADMIN);
+  });
+
+  it("rejects a connection whose only email permission is send — a workflow must READ mail", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-send-only");
+    await grantEmailPermission(agent.id, "conn-send-only", "send");
+
+    const res = await POST(postBody(validBody(agent.id, "conn-send-only")), routeContext());
+    expect(res.status).toBe(400);
+    expect(await loadWorkflows(agent.id)).toHaveLength(0);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a legacy 'search' permission row as a read grant", async () => {
+    // Pre-#328 template creation could write raw per-tool operations ("search",
+    // "list") without an accompanying "read" row; the runtime treats them as
+    // read aliases (tool-registry.getEmailToolsForOperations), so the gate
+    // here must too — otherwise a legacy agent can't get a workflow at all.
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-legacy");
+    await grantEmailPermission(agent.id, "conn-legacy", "search");
+
+    const res = await POST(postBody(validBody(agent.id, "conn-legacy")), routeContext());
+    expect(res.status).toBe(201);
+    expect(await loadWorkflows(agent.id)).toHaveLength(1);
+  });
+
+  it("scrubs email addresses from the workflow name before it lands in the audit detail", async () => {
+    // The name is free user text and the audit log is append-only + HMAC-signed
+    // (GDPR Art. 17: no erasure once written), so an address in the name must
+    // never reach `detail` — same treatment as the IMAP route's connectionName.
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-pii");
+    await grantEmailPermission(agent.id, "conn-pii");
+
+    const res = await POST(
+      postBody({
+        ...validBody(agent.id, "conn-pii"),
+        name: "Forward mail from boss@acme.com",
+      }),
+      routeContext()
+    );
+    expect(res.status).toBe(201);
+
+    // The stored workflow and the API response keep the raw name — only the
+    // un-erasable audit detail is scrubbed.
+    const [wf] = await loadWorkflows(agent.id);
+    expect(wf.name).toBe("Forward mail from boss@acme.com");
+    expect(await res.json()).toMatchObject({ name: "Forward mail from boss@acme.com" });
+
+    const entry = deferAuditLogMock.mock.calls[0][0];
+    expect(entry.detail.workflow).toEqual({
+      id: wf.id,
+      name: "Forward mail from <email-redacted>",
+    });
   });
 
   it("rejects a connection the agent has no email permission for — no partial write", async () => {

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -44,6 +44,15 @@ describe("AuditLogEntry channel.auto_disabled (#477 layer 2)", () => {
   });
 });
 
+describe("AuditLogEntry email_workflow.created (Inbox Agent, #139)", () => {
+  it("keeps the event in the curated union", () => {
+    // The write side typechecks via the `${AuditResource}.created` template
+    // family, which the subset test below can't see in reverse — so pin the
+    // membership explicitly, like every other `.created` family.
+    expectTypeOf<"email_workflow.created">().toExtend<AuditEventType>();
+  });
+});
+
 describe("AuditEventType is a subset of AuditLogEntry['eventType']", () => {
   it("every curated event type is one appendAuditLog can record", () => {
     // Intentionally NOT equal (the entry type is strictly broader), but the

--- a/packages/web/src/__tests__/lib/schemas/automations.test.ts
+++ b/packages/web/src/__tests__/lib/schemas/automations.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { createAutomationSchema } from "@/lib/schemas/automations";
+import { AUTOMATION_MAX_CONNECTIONS, createAutomationSchema } from "@/lib/schemas/automations";
 
 // The shared request schema for POST /api/automations. Both the route handler
 // (parseRequestBody) and — later — the client form / the conversational
@@ -39,6 +39,22 @@ describe("createAutomationSchema", () => {
   it("requires at least one connection — a workflow with no mailbox is inert", () => {
     const result = createAutomationSchema.safeParse({ ...valid, connectionIds: [] });
     expect(result.success).toBe(false);
+  });
+
+  it("caps connectionIds — an absurd list must not balloon the error echo or audit detail", () => {
+    const ids = (n: number) => Array.from({ length: n }, (_, i) => `conn-${i}`);
+    expect(
+      createAutomationSchema.safeParse({
+        ...valid,
+        connectionIds: ids(AUTOMATION_MAX_CONNECTIONS),
+      }).success
+    ).toBe(true);
+    expect(
+      createAutomationSchema.safeParse({
+        ...valid,
+        connectionIds: ids(AUTOMATION_MAX_CONNECTIONS + 1),
+      }).success
+    ).toBe(false);
   });
 
   it("rejects a blank or whitespace-only name", () => {

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -11,7 +11,9 @@ import {
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
 import { createAutomationSchema } from "@/lib/schemas/automations";
+import { scrubEmails } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
+import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
 
 /**
  * POST /api/automations — create an Inbox Agent email workflow (design §5).
@@ -61,9 +63,12 @@ export const POST = withAuth(async (request, _ctx, session) => {
     );
   }
 
-  // Every requested mailbox must be one the agent is allowed to read. An unknown
-  // connection id has no permission row either, so this single check rejects
-  // both "no access" and "no such connection" — a workflow must never point at a
+  // Every requested mailbox must be one the agent is allowed to READ — a
+  // workflow's trigger lists and reads mail, so a draft/send-only grant is not
+  // enough. EMAIL_READ_OPERATIONS includes the legacy "search"/"list" aliases
+  // the runtime already treats as read (tool-registry). An unknown connection
+  // id has no permission row either, so this single check rejects "no read
+  // access" and "no such connection" alike — a workflow must never point at a
   // mailbox its agent can't open.
   const requestedConnectionIds = [...new Set(connectionIds)];
   const permittedRows = await db
@@ -73,6 +78,7 @@ export const POST = withAuth(async (request, _ctx, session) => {
       and(
         eq(agentConnectionPermissions.agentId, agentId),
         eq(agentConnectionPermissions.model, "email"),
+        inArray(agentConnectionPermissions.operation, [...EMAIL_READ_OPERATIONS]),
         inArray(agentConnectionPermissions.connectionId, requestedConnectionIds)
       )
     );
@@ -105,14 +111,17 @@ export const POST = withAuth(async (request, _ctx, session) => {
   });
 
   // Deferred: the rows are committed and non-rollbackable, so an audit outage
-  // must not fail the create. Ids only — connection names can carry addresses.
+  // must not fail the create. Connections as ids only (their names can carry
+  // addresses), and the free-text workflow name scrubbed — the audit log is
+  // append-only + HMAC-signed, so an address written here is un-erasable.
   deferAuditLog({
     actorType: "user",
     actorId: userId,
     eventType: "email_workflow.created",
+    resource: `email_workflow:${workflow.id}`,
     outcome: "success",
     detail: {
-      workflow: { id: workflow.id, name: workflow.name },
+      workflow: { id: workflow.id, name: scrubEmails(workflow.name) },
       agent: { id: agent.id, name: agent.name },
       connectionCount: requestedConnectionIds.length,
       connectionIds: requestedConnectionIds,

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+  agents,
+  emailWorkflows,
+  emailWorkflowConnections,
+  agentConnectionPermissions,
+} from "@/db/schema";
+import { withAuth } from "@/lib/api-auth";
+import { parseRequestBody } from "@/lib/api-validation";
+import { createAutomationSchema } from "@/lib/schemas/automations";
+import { deferAuditLog } from "@/lib/audit-deferred";
+
+/**
+ * POST /api/automations — create an Inbox Agent email workflow (design §5).
+ *
+ * The single write path both the Automations form (#139) and the conversational
+ * create tool (#705) go through, so one schema, one RBAC gate, one audit event
+ * cover every way a workflow is born ("same object, one system").
+ *
+ * Scope-based access (design §7, #705): a member may create a workflow on a
+ * personal agent they OWN; anything touching a shared agent requires an admin.
+ * "Own connections" maps to the connections the agent is actually permitted to
+ * read (agent_connection_permissions) — integration_connections has no per-user
+ * owner, so agent-scoped permission is the real, code-backed boundary.
+ *
+ * Propose, don't self-activate: the workflow is always written `pending` +
+ * `disabled`. Enabling it is a separate, human-gated step in the Automations tab
+ * — an agent (or a form) must never grant itself standing autonomous authority.
+ */
+export const POST = withAuth(async (request, _ctx, session) => {
+  const parsed = await parseRequestBody(createAutomationSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { agentId, name, filter, action, connectionIds, sweepWindowDays } = parsed.data;
+
+  const userId = session.user.id!;
+  const isAdmin = session.user.role === "admin";
+
+  const [agent] = await db
+    .select({
+      id: agents.id,
+      name: agents.name,
+      isPersonal: agents.isPersonal,
+      ownerId: agents.ownerId,
+    })
+    .from(agents)
+    .where(eq(agents.id, agentId));
+  if (!agent) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  // A member may act only on a personal agent they own; a shared agent (or
+  // someone else's personal agent) is admin-only.
+  const isOwnPersonalAgent = agent.isPersonal && agent.ownerId === userId;
+  if (!isOwnPersonalAgent && !isAdmin) {
+    return NextResponse.json(
+      { error: "You do not have permission to create a workflow on this agent" },
+      { status: 403 }
+    );
+  }
+
+  // Every requested mailbox must be one the agent is allowed to read. An unknown
+  // connection id has no permission row either, so this single check rejects
+  // both "no access" and "no such connection" — a workflow must never point at a
+  // mailbox its agent can't open.
+  const requestedConnectionIds = [...new Set(connectionIds)];
+  const permittedRows = await db
+    .selectDistinct({ connectionId: agentConnectionPermissions.connectionId })
+    .from(agentConnectionPermissions)
+    .where(
+      and(
+        eq(agentConnectionPermissions.agentId, agentId),
+        eq(agentConnectionPermissions.model, "email"),
+        inArray(agentConnectionPermissions.connectionId, requestedConnectionIds)
+      )
+    );
+  const permitted = new Set(permittedRows.map((r) => r.connectionId));
+  const missing = requestedConnectionIds.filter((id) => !permitted.has(id));
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { error: `The agent has no email access to connection(s): ${missing.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  // Transactional two-table write: the workflow and its connection watermarks
+  // land together or not at all. `sinceTs = now` is the per-connection floor, so
+  // a fresh workflow never retroactively processes historical mail (design §8).
+  const now = new Date();
+  const workflow = await db.transaction(async (tx) => {
+    const [wf] = await tx
+      .insert(emailWorkflows)
+      .values({ agentId, name, filter, action, sweepWindowDays, createdBy: userId })
+      .returning();
+    await tx.insert(emailWorkflowConnections).values(
+      requestedConnectionIds.map((connectionId) => ({
+        workflowId: wf.id,
+        connectionId,
+        sinceTs: now,
+      }))
+    );
+    return wf;
+  });
+
+  // Deferred: the rows are committed and non-rollbackable, so an audit outage
+  // must not fail the create. Ids only — connection names can carry addresses.
+  deferAuditLog({
+    actorType: "user",
+    actorId: userId,
+    eventType: "email_workflow.created",
+    outcome: "success",
+    detail: {
+      workflow: { id: workflow.id, name: workflow.name },
+      agent: { id: agent.id, name: agent.name },
+      connectionCount: requestedConnectionIds.length,
+      connectionIds: requestedConnectionIds,
+      enabled: workflow.enabled,
+      status: workflow.status,
+    },
+  });
+
+  return NextResponse.json(
+    { id: workflow.id, name: workflow.name, enabled: workflow.enabled, status: workflow.status },
+    { status: 201 }
+  );
+});

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -95,6 +95,7 @@ export type AuditEventType =
   | "integration.auth_recovered"
   | "integration.credentials_tested"
   | "integration.credentials_updated"
+  | "email_workflow.created"
   | "file.upload.staged"
   | "file.upload.attached"
   | "file.upload.expired"

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -28,7 +28,18 @@ export type MembershipDetail = {
 };
 
 export type AuditResource =
-  "agent" | "group" | "user" | "settings" | "config" | "channel" | "chat" | "integration";
+  | "agent"
+  | "group"
+  | "user"
+  | "settings"
+  | "config"
+  | "channel"
+  | "chat"
+  | "integration"
+  // Inbox Agent email workflows (design §5). Durable noun matching the
+  // email_workflows table; yields email_workflow.created/.updated/.deleted for
+  // the whole Automations CRUD lifecycle (the create path lands first).
+  | "email_workflow";
 
 export type AuditEventType =
   | `tool.${string}`

--- a/packages/web/src/lib/schemas/automations.test.ts
+++ b/packages/web/src/lib/schemas/automations.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+
+import { createAutomationSchema } from "@/lib/schemas/automations";
+
+// The shared request schema for POST /api/automations. Both the route handler
+// (parseRequestBody) and — later — the client form / the conversational
+// create tool (#705) import it, so a drift between what a caller sends and what
+// the route accepts is a compile-time error, not a runtime 400 (AGENTS.md,
+// "Shared Schemas And Typed Client").
+describe("createAutomationSchema", () => {
+  const valid = {
+    agentId: "agent-1",
+    name: "File supplier invoices",
+    filter: { hasAttachment: true, attachmentType: "application/pdf" },
+    action: "Draft a supplier bill in Odoo from the attached invoice.",
+    connectionIds: ["conn-1"],
+    sweepWindowDays: 30,
+  };
+
+  it("parses a fully specified workflow", () => {
+    const parsed = createAutomationSchema.parse(valid);
+    expect(parsed).toMatchObject(valid);
+  });
+
+  it("defaults filter to an empty matcher and sweepWindowDays to 14", () => {
+    // A caller may omit the filter (watch a whole mailbox) and the cadence knob;
+    // the route must still receive concrete values to write, so the defaults
+    // live in the schema, not scattered across callers.
+    const parsed = createAutomationSchema.parse({
+      agentId: "agent-1",
+      name: "Watch the invoices mailbox",
+      action: "File whatever lands here.",
+      connectionIds: ["conn-1"],
+    });
+    expect(parsed.filter).toEqual({});
+    expect(parsed.sweepWindowDays).toBe(14);
+  });
+
+  it("requires at least one connection — a workflow with no mailbox is inert", () => {
+    const result = createAutomationSchema.safeParse({ ...valid, connectionIds: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a blank or whitespace-only name", () => {
+    expect(createAutomationSchema.safeParse({ ...valid, name: "" }).success).toBe(false);
+    expect(createAutomationSchema.safeParse({ ...valid, name: "   " }).success).toBe(false);
+  });
+
+  it("requires an agent and a non-empty action", () => {
+    expect(createAutomationSchema.safeParse({ ...valid, agentId: "" }).success).toBe(false);
+    expect(createAutomationSchema.safeParse({ ...valid, action: "" }).success).toBe(false);
+  });
+
+  it("rejects a non-positive or non-integer sweep window", () => {
+    expect(createAutomationSchema.safeParse({ ...valid, sweepWindowDays: 0 }).success).toBe(false);
+    expect(createAutomationSchema.safeParse({ ...valid, sweepWindowDays: -1 }).success).toBe(false);
+    expect(createAutomationSchema.safeParse({ ...valid, sweepWindowDays: 2.5 }).success).toBe(
+      false
+    );
+  });
+});

--- a/packages/web/src/lib/schemas/automations.ts
+++ b/packages/web/src/lib/schemas/automations.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
+
+/**
+ * The deterministic trigger of an email workflow (design §5). Every field is
+ * optional and AND-combined by the matcher; an empty filter watches the whole
+ * mailbox. Structurally a subset of {@link EmailWorkflowFilter} — the parity
+ * guard below fails to compile if the two drift apart, so the request shape can
+ * never accept a field the dispatcher doesn't understand.
+ */
+export const automationFilterSchema = z.object({
+  from: z.array(z.string().min(1)).optional(),
+  toDomain: z.array(z.string().min(1)).optional(),
+  subjectContains: z.array(z.string().min(1)).optional(),
+  hasAttachment: z.boolean().optional(),
+  attachmentType: z.string().min(1).optional(),
+  folder: z.string().min(1).optional(),
+});
+
+// Compile-time guard (type-only, no runtime effect): the parsed filter must be
+// assignable to the type the dispatcher reads. If the two drift, the constraint
+// `T extends EmailWorkflowFilter` fails and this alias stops compiling. Exported
+// so it counts as used — its whole job is to make `tsc` fail on drift.
+export type AssertAssignable<T extends U, U> = T;
+export type FilterParity = AssertAssignable<
+  z.infer<typeof automationFilterSchema>,
+  EmailWorkflowFilter
+>;
+
+/** Upper bound on the workflow name — a label, not prose. */
+export const AUTOMATION_NAME_MAX_LENGTH = 200;
+
+/**
+ * Request schema for POST /api/automations — the single write path for the
+ * Inbox Agent's email workflows (design §5). Both the Automations form (#139)
+ * and the conversational create tool (#705) send this exact shape, so the
+ * route, the client, and the tool share one contract (AGENTS.md, "Shared
+ * Schemas And Typed Client").
+ *
+ * The route always writes the workflow `pending` + `disabled` regardless of
+ * this payload — activation is a separate, human-gated step (propose, don't
+ * self-activate), so enablement is deliberately NOT a field here.
+ */
+export const createAutomationSchema = z.object({
+  agentId: z.string().min(1),
+  name: z
+    .string()
+    .min(1)
+    .max(AUTOMATION_NAME_MAX_LENGTH)
+    .refine((v) => v.trim().length > 0, "Name is required"),
+  filter: automationFilterSchema.default({}),
+  action: z.string().min(1),
+  // At least one mailbox: a workflow with no connection is never dispatched
+  // (the loader inner-joins email_workflow_connections), so it would be inert.
+  connectionIds: z.array(z.string().min(1)).min(1),
+  // How far back the reconciliation sweep re-lists (design §5). Bounded so a
+  // typo can't make one workflow re-hydrate years of mail every pass.
+  sweepWindowDays: z.number().int().positive().max(365).default(14),
+});
+
+export type CreateAutomationInput = z.infer<typeof createAutomationSchema>;

--- a/packages/web/src/lib/schemas/automations.ts
+++ b/packages/web/src/lib/schemas/automations.ts
@@ -32,6 +32,13 @@ export type FilterParity = AssertAssignable<
 export const AUTOMATION_NAME_MAX_LENGTH = 200;
 
 /**
+ * Upper bound on mailboxes per workflow. Far above any real setup, but keeps
+ * an absurd request from ballooning the 400-error echo and the audit
+ * `detail.connectionIds` list (AGENTS.md: keep audit detail under 2048 bytes).
+ */
+export const AUTOMATION_MAX_CONNECTIONS = 50;
+
+/**
  * Request schema for POST /api/automations — the single write path for the
  * Inbox Agent's email workflows (design §5). Both the Automations form (#139)
  * and the conversational create tool (#705) send this exact shape, so the
@@ -53,7 +60,7 @@ export const createAutomationSchema = z.object({
   action: z.string().min(1),
   // At least one mailbox: a workflow with no connection is never dispatched
   // (the loader inner-joins email_workflow_connections), so it would be inert.
-  connectionIds: z.array(z.string().min(1)).min(1),
+  connectionIds: z.array(z.string().min(1)).min(1).max(AUTOMATION_MAX_CONNECTIONS),
   // How far back the reconciliation sweep re-lists (design §5). Bounded so a
   // typo can't make one workflow re-hydrate years of mail every pass.
   sweepWindowDays: z.number().int().positive().max(365).default(14),

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -310,6 +310,14 @@ export const EMAIL_OPERATIONS = ["read", "draft", "send"] as const;
 export type EmailOperation = (typeof EMAIL_OPERATIONS)[number];
 
 /**
+ * Every operation value that grants READ access to a mailbox: the canonical
+ * "read" plus the legacy "search"/"list" aliases described above. Use this
+ * wherever a gate asks "may this agent read this mailbox?" (e.g. the
+ * Automations write-API) so legacy rows keep working — never for draft/send.
+ */
+export const EMAIL_READ_OPERATIONS = ["read", "search", "list"] as const;
+
+/**
  * Display order for rendering granted operations (TOOLS.md mailbox context).
  * Superset of EMAIL_OPERATIONS: includes the legacy "search" and "list" slots
  * so old permission rows still render in a stable position.
@@ -343,7 +351,7 @@ const EMAIL_SEND_TOOLS = ["email_send"] as const;
 export function getEmailToolsForOperations(operations: string[]): string[] {
   const tools: string[] = [];
   const ops = new Set(operations);
-  if (ops.has("read") || ops.has("search") || ops.has("list")) tools.push(...EMAIL_READ_TOOLS);
+  if (EMAIL_READ_OPERATIONS.some((op) => ops.has(op))) tools.push(...EMAIL_READ_TOOLS);
   if (ops.has("draft")) tools.push(...EMAIL_DRAFT_TOOLS);
   if (ops.has("send")) tools.push(...EMAIL_SEND_TOOLS);
   return tools;


### PR DESCRIPTION
## What

The **Automations write-API** — the single write path the Inbox Agent (#139) has been missing. On `main` today, `email_workflows` rows are inserted **only in tests**; there is no production create path, no shared schema, no `*.created` audit. This adds all three.

`POST /api/automations` maps one shared Zod schema (`lib/schemas/automations.ts`) to a transactional two-table write (`email_workflows` + `email_workflow_connections`). Both the Automations form (#139) and — after #517 — the conversational create tool (#705) write this exact shape, so every way a workflow is born shares **one contract, one RBAC gate, one audit event** ("same object, one system").

## Why this, and why now

#705 (conversational create) sits on top of a stack of unbuilt bricks: it needs #517 (tool-call confirmation, still open), a review UI, **and** this write-API. This is the unblocked foundation both #139's form and #705's tool depend on, and it's independent of #517.

## Design

- **Scope-based RBAC** (design §7, #705): a member may create a workflow on a **personal agent they own**; a **shared agent** requires an **admin**. "Own connections" maps to the connections the agent is permitted to read (`agent_connection_permissions`) — `integration_connections` has no per-user owner, so agent-scoped permission is the real, code-backed boundary. An unknown connection id has no permission row either, so one check rejects both "no access" and "no such connection".
- **Propose, don't self-activate:** always written `pending` + `disabled`. Each connection is attached with a **now-watermark** (`since_ts = now`) so a fresh workflow never retroactively processes historical mail (design §8). Enablement is a separate, human-gated step — deliberately **not** a request field.
- **Audit:** new `AuditResource` value `email_workflow` → `email_workflow.created` (covers `.updated`/`.deleted` for the coming UI lifecycle too). `deferAuditLog` (rows committed, non-rollbackable). **IDs only** in `detail` — connection names can carry addresses.

## Naming note

The issue sketch says `workflow.created`; this uses **`email_workflow.created`** to match the `email_workflows` table + `lib/email-workflows` exactly (`workflow` alone is ambiguous).

## Tests (TDD, RED-first)

- **Schema unit** (`automations.test.ts`): defaults, ≥1 connection, blank-name/agent/action rejection, sweep-window bounds.
- **Real-DB route integration** (`automations-create.integration.test.ts`): member-on-own-personal-agent → 201 pending+disabled with now-watermark + `email_workflow.created` payload; member-on-shared → 403; member-on-others-personal → 403; admin-on-shared → 201; unpermitted/unknown connection → 400 **with no partial write**; unknown agent → 404; unauthenticated → 401.

## Gates

`typecheck` ✅ · `eslint` ✅ (0 errors) · `prettier --check` ✅ · schema unit ✅ (6) · route integration ✅ (8) · full web unit suite: 9101 passed. One unrelated flake (`openclaw-config.test.ts` flush-disable resolver) fails only under full-suite load and **passes 216/216 in isolation** — not touched by this diff (audit union + new automations files; the unit suite doesn't load `*.integration.test.ts`).

## Docs

No user-facing docs yet: the Automations feature has no UI surface (that arrives with #139's form / the Automations tab). The design of record lives in `docs/plans/2026-07-12-inbox-agent-design.md`. Docs land with the UI PR.

## Out of scope / follow-ups

- Automations tab UI (list / review / enable-disable) — #139.
- Conversational create tool — #705 (needs #517 first).
- `email_workflow.updated` / `.deleted` routes — land with the management UI.