### PR TITLE
feat(templates): migrate Odoo templates to the skill layer (#546)

### DIFF
--- a/docs/src/content/docs/explanation/skills-and-templates.mdx
+++ b/docs/src/content/docs/explanation/skills-and-templates.mdx
@@ -32,10 +32,11 @@ Because Pinchy writes the skill files at config-regenerate time — alongside th
 
 ## The skills that ship today
 
-| Skill        | Attached by                                                                                   | What it teaches                                                                  |
-| ------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `web-search` | [Market & News Monitor](/guides/create-market-monitor-agent/)                                 | A workflow for researching a topic with the web-search tools and reporting back. |
-| `email`      | [Email Assistant templates](/guides/connect-email/#email-agent-templates-use-the-email-skill) | A workflow for triaging, reading, and drafting mail with the email tools.        |
+| Skill                  | Attached by                                                                                   | What it teaches                                                                                                                                                                                                                                                                                               |
+| ---------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `web-search`           | [Market & News Monitor](/guides/create-market-monitor-agent/)                                 | A workflow for researching a topic with the web-search tools and reporting back.                                                                                                                                                                                                                              |
+| `email`                | [Email Assistant templates](/guides/connect-email/#email-agent-templates-use-the-email-skill) | A workflow for triaging, reading, and drafting mail with the email tools.                                                                                                                                                                                                                                     |
+| The `odoo-*` skill set | [Odoo agent templates](/guides/connect-odoo/#agent-templates)                                 | Composable workflows for working with a connected Odoo instance — reading and summarizing data, writing records safely, attaching source documents, managing follow-up activities, and the finance and warehouse conventions that keep those writes correct. Each template attaches the union its role needs. |
 
 ## Why an allow-list of skills
 

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -13,6 +13,7 @@ import { PERSONALITY_PRESETS } from "@/lib/personality-presets";
 import { MAX_STARTER_PROMPT_LENGTH } from "@/lib/schemas/starter-prompts";
 import { TEMPLATE_ICON_COMPONENTS } from "@/lib/template-icons";
 import { getOdooToolsForAccessLevel } from "@/lib/tool-registry";
+import { getSkillBody } from "@/lib/skills";
 
 /**
  * Real (non-`custom`) templates always ship a non-null `defaultAgentsMd` —
@@ -641,23 +642,29 @@ describe("Odoo templates", () => {
   // should call out the distinction explicitly so the model can disambiguate
   // from the human-given wording before issuing the search.
   //
-  // This test dynamically enumerates every `odoo-*` template from the
-  // registry rather than hardcoding IDs, so newly-added Odoo templates
-  // (e.g. bookkeeper, hr-analyst, fleet-manager, ...) cannot silently drift
-  // out of compliance.
-  it("every odoo template's AGENTS.md disambiguates id (DB primary key) from default_code (SKU/internal reference)", () => {
+  // This disambiguation now lives in the shared `odoo-read` skill body rather
+  // than being spliced into every template's AGENTS.md (#546). The invariant is
+  // preserved by (a) every odoo template carrying `odoo-read` in defaultSkills,
+  // enumerated dynamically so a new template cannot silently opt out, and
+  // (b) the skill body itself calling out id vs default_code.
+  it("every odoo template carries the odoo-read skill, which disambiguates id from default_code (SKU/internal reference)", () => {
     const odooTemplates = getTemplateList().filter((t) => t.id.startsWith("odoo-"));
     expect(odooTemplates.length).toBeGreaterThan(0);
 
     for (const t of odooTemplates) {
-      expect(t.defaultAgentsMd, `template ${t.id} is missing the default_code mention`).toContain(
-        "default_code"
-      );
       expect(
-        t.defaultAgentsMd,
-        `template ${t.id} is missing the SKU / internal-reference mention`
-      ).toMatch(/SKU|internal reference/i);
+        AGENT_TEMPLATES[t.id].defaultSkills ?? [],
+        `template ${t.id} is missing the odoo-read skill`
+      ).toContain("odoo-read");
     }
+
+    const readSkill = getSkillBody("odoo-read");
+    expect(readSkill, "odoo-read skill is missing the default_code mention").toContain(
+      "default_code"
+    );
+    expect(readSkill, "odoo-read skill is missing the SKU / internal-reference mention").toMatch(
+      /SKU|internal reference/i
+    );
   });
 });
 
@@ -974,6 +981,34 @@ describe("createOdooTemplate", () => {
     ];
     const t = createOdooTemplate({ ...baseSpec, requiredModels });
     expect(t.odooConfig?.requiredModels).toEqual(requiredModels);
+  });
+
+  it("threads defaultSkills through when provided", () => {
+    const t = createOdooTemplate({
+      ...baseSpec,
+      defaultSkills: ["odoo-read", "odoo-write"],
+      requiredModels: [{ model: "crm.lead", operations: ["read", "write"] }],
+    });
+    expect(t.defaultSkills).toEqual(["odoo-read", "odoo-write"]);
+  });
+
+  it("omits defaultSkills when the spec does not provide it", () => {
+    const t = createOdooTemplate({
+      ...baseSpec,
+      requiredModels: [{ model: "sale.order", operations: ["read"] }],
+    });
+    expect(t.defaultSkills).toBeUndefined();
+  });
+
+  it("copies the defaultSkills array rather than sharing the spec reference", () => {
+    const skills = ["odoo-read"];
+    const t = createOdooTemplate({
+      ...baseSpec,
+      defaultSkills: skills,
+      requiredModels: [{ model: "sale.order", operations: ["read"] }],
+    });
+    expect(t.defaultSkills).not.toBe(skills);
+    expect(t.defaultSkills).toEqual(skills);
   });
 
   it("preserves the caller-provided fields verbatim", () => {

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-agents.multi-company.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-agents.multi-company.test.ts
@@ -1,26 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { ODOO_TEMPLATES } from "@/lib/agent-templates/data/odoo-agents";
-import { ODOO_MULTI_COMPANY_GUIDANCE } from "@/lib/agent-templates/odoo-factory";
+import { getSkillBody } from "@/lib/skills";
 
-describe("multi-company guidance is spliced into accounting templates", () => {
-  it("only core-ledger templates (those that touch account.move.line) include the guidance", () => {
+describe("multi-company guidance is carried by accounting templates", () => {
+  it("only core-ledger templates (those that touch account.move.line) carry the odoo-multi-company skill", () => {
     // Data-driven drift guard: any template whose required models include
     // `account.move.line` (the journal-item table that participates in
-    // cross-company write conflicts) SHOULD carry the guidance; everything
-    // else MUST NOT. Templates that only read auxiliary accounting models
-    // such as `account.tax` (CRM, sales) or write to `account.analytic.line`
-    // (timesheets) do not run into the multi-company create/write traps the
-    // guidance warns about, so they intentionally skip it.
+    // cross-company write conflicts) SHOULD carry the odoo-multi-company skill;
+    // everything else MUST NOT. Templates that only read auxiliary accounting
+    // models such as `account.tax` (CRM, sales) or write to
+    // `account.analytic.line` (timesheets) do not run into the multi-company
+    // create/write traps the guidance warns about, so they intentionally skip
+    // it.
     //
-    // Keeps the splice tight to real bookkeeping roles and auto-extends as
-    // new core-ledger templates land.
+    // Since #546 the guidance lives in the shared `odoo-multi-company` SKILL.md
+    // rather than being spliced into each template's defaultAgentsMd; the
+    // template opts in through `defaultSkills`.
     //
     // HEURISTIC, NOT A DEFINITION: `account.move.line` is a proxy for "this
     // template walks the general ledger and can produce cross-company writes."
     // It happens to match Penny + Bookkeeper today. If a future template
     // covers cross-company accounting WITHOUT touching `account.move.line`
     // (e.g. a Tax Auditor that reads `account.move`, `account.account`, and
-    // `account.journal` only), this predicate will *forbid* the guidance —
+    // `account.journal` only), this predicate will *forbid* the skill —
     // wrongly. When that happens, widen the predicate (e.g. union of any
     // `account.*` write op + `account.move` read) rather than carve an
     // ad-hoc allow-list. The test's job is to prevent silent drift, not to
@@ -29,30 +31,32 @@ describe("multi-company guidance is spliced into accounting templates", () => {
       const touchesCoreLedger = (template.odooConfig?.requiredModels ?? []).some(
         (m) => m.model === "account.move.line"
       );
-      const includesGuidance = template.defaultAgentsMd?.includes(ODOO_MULTI_COMPANY_GUIDANCE);
+      const carriesSkill = (template.defaultSkills ?? []).includes("odoo-multi-company");
       if (touchesCoreLedger) {
         expect(
-          includesGuidance,
-          `Template '${id}' touches account.move.line but is missing ODOO_MULTI_COMPANY_GUIDANCE`
+          carriesSkill,
+          `Template '${id}' touches account.move.line but is missing the odoo-multi-company skill`
         ).toBe(true);
       } else {
         expect(
-          includesGuidance,
-          `Template '${id}' does not touch account.move.line but unexpectedly includes ODOO_MULTI_COMPANY_GUIDANCE`
+          carriesSkill,
+          `Template '${id}' does not touch account.move.line but unexpectedly carries the odoo-multi-company skill`
         ).toBe(false);
       }
     }
   });
 
-  it("ODOO_MULTI_COMPANY_GUIDANCE describes the [Company X] label suffix", () => {
-    expect(ODOO_MULTI_COMPANY_GUIDANCE).toMatch(/\[.*Company.*\]/i);
+  const guidance = getSkillBody("odoo-multi-company");
+
+  it("the odoo-multi-company skill describes the [Company X] label suffix", () => {
+    expect(guidance).toMatch(/\[.*Company.*\]/i);
   });
 
-  it("ODOO_MULTI_COMPANY_GUIDANCE mentions company_id filtering", () => {
-    expect(ODOO_MULTI_COMPANY_GUIDANCE).toMatch(/company_id/);
+  it("the odoo-multi-company skill mentions company_id filtering", () => {
+    expect(guidance).toMatch(/company_id/);
   });
 
-  it("ODOO_MULTI_COMPANY_GUIDANCE warns about cross-company write rejection", () => {
-    expect(ODOO_MULTI_COMPANY_GUIDANCE).toMatch(/cross-company/i);
+  it("the odoo-multi-company skill warns about cross-company write rejection", () => {
+    expect(guidance).toMatch(/cross-company/i);
   });
 });

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
+import { getSkillBody } from "@/lib/skills";
 
 describe("odoo-bookkeeper template", () => {
   const template = AGENT_TEMPLATES["odoo-bookkeeper"];
@@ -7,8 +8,11 @@ describe("odoo-bookkeeper template", () => {
   const required = template.odooConfig?.requiredModels ?? [];
   const modelOps = (m: string) => required.find((r) => r.model === m)?.operations ?? [];
 
-  it("documents that price_unit is tax-exclusive (net)", () => {
-    expect(md).toMatch(/price_unit`[^.]{0,80}tax-exclusive/i);
+  it("documents that price_unit is tax-exclusive (net) via the odoo-gross-to-net skill", () => {
+    // The gross-to-net convention now lives in the shared odoo-gross-to-net
+    // SKILL.md (#546) rather than being spliced into the bookkeeper persona.
+    expect(template.defaultSkills ?? []).toContain("odoo-gross-to-net");
+    expect(getSkillBody("odoo-gross-to-net")).toMatch(/price_unit`[^.]{0,80}tax-exclusive/i);
   });
 
   it("mandates post-create verification against amount_total within tolerance", () => {

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-skill-contract.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-skill-contract.test.ts
@@ -68,13 +68,14 @@ describe("odoo template ↔ skill contract", () => {
     }
   });
 
-  it("templates that manage mail.activity (create/write) carry odoo-activities", () => {
+  it("templates that manage mail.activity (create) carry odoo-activities; others do not", () => {
     for (const [id, t] of entries) {
       const managesActivities = modelsWith(t, "create").some((m) => m.model === "mail.activity");
       const carries = (t.defaultSkills ?? []).includes("odoo-activities");
-      if (managesActivities) {
-        expect(carries, `${id} manages mail.activity but is missing odoo-activities`).toBe(true);
-      }
+      expect(
+        carries,
+        `${id} manages-mail.activity=${managesActivities} but odoo-activities=${carries}`
+      ).toBe(managesActivities);
     }
   });
 

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-skill-contract.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-skill-contract.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { ODOO_TEMPLATES } from "@/lib/agent-templates/data/odoo-agents";
+import { KNOWN_SKILLS, getSkillBody, isKnownSkill } from "@/lib/skills";
+
+/**
+ * Contract for the Odoo template → skill migration (#546). The workflow
+ * invariants that used to be spliced into every Odoo template's
+ * defaultAgentsMd now live in shared SKILL.md bodies, referenced through
+ * `defaultSkills`. These guards keep the template → skill mapping honest and
+ * self-extending as templates change.
+ */
+describe("odoo template ↔ skill contract", () => {
+  const entries = Object.entries(ODOO_TEMPLATES);
+
+  const modelsWith = (t: (typeof ODOO_TEMPLATES)[string], op: string) =>
+    (t.odooConfig?.requiredModels ?? []).filter((m) => m.operations.includes(op as never));
+
+  const isWriteCapable = (t: (typeof ODOO_TEMPLATES)[string]) =>
+    t.odooConfig?.accessLevel !== "read-only";
+
+  const isAttachCapable = (t: (typeof ODOO_TEMPLATES)[string]) =>
+    (t.odooConfig?.requiredModels ?? []).some(
+      (m) => m.model === "ir.attachment" && m.operations.includes("create")
+    );
+
+  it("every Odoo template declares at least one skill", () => {
+    for (const [id, t] of entries) {
+      expect((t.defaultSkills ?? []).length, `${id} has no defaultSkills`).toBeGreaterThan(0);
+    }
+  });
+
+  it("every declared skill is a KNOWN_SKILLS entry (drift guard)", () => {
+    for (const [id, t] of entries) {
+      for (const skill of t.defaultSkills ?? []) {
+        expect(isKnownSkill(skill), `${id} references unknown skill "${skill}"`).toBe(true);
+      }
+    }
+  });
+
+  it("declared skills are unique per template (no duplicates)", () => {
+    for (const [id, t] of entries) {
+      const skills = t.defaultSkills ?? [];
+      expect(new Set(skills).size, `${id} has duplicate skills`).toBe(skills.length);
+    }
+  });
+
+  it("every Odoo template carries odoo-read (the universal read foundation)", () => {
+    for (const [id, t] of entries) {
+      expect(t.defaultSkills ?? [], `${id} missing odoo-read`).toContain("odoo-read");
+    }
+  });
+
+  it("write-capable templates carry odoo-write; read-only ones do not", () => {
+    for (const [id, t] of entries) {
+      const carries = (t.defaultSkills ?? []).includes("odoo-write");
+      expect(carries, `${id} write-capable=${isWriteCapable(t)} but odoo-write=${carries}`).toBe(
+        isWriteCapable(t)
+      );
+    }
+  });
+
+  it("attach-capable templates (ir.attachment create) carry odoo-attach; others do not", () => {
+    for (const [id, t] of entries) {
+      const carries = (t.defaultSkills ?? []).includes("odoo-attach");
+      expect(carries, `${id} attach-capable=${isAttachCapable(t)} but odoo-attach=${carries}`).toBe(
+        isAttachCapable(t)
+      );
+    }
+  });
+
+  it("templates that manage mail.activity (create/write) carry odoo-activities", () => {
+    for (const [id, t] of entries) {
+      const managesActivities = modelsWith(t, "create").some((m) => m.model === "mail.activity");
+      const carries = (t.defaultSkills ?? []).includes("odoo-activities");
+      if (managesActivities) {
+        expect(carries, `${id} manages mail.activity but is missing odoo-activities`).toBe(true);
+      }
+    }
+  });
+
+  it("only bookkeeper carries odoo-gross-to-net, and only warehouse/production carry odoo-lot-serial", () => {
+    const grossToNet = entries.filter(([, t]) =>
+      (t.defaultSkills ?? []).includes("odoo-gross-to-net")
+    );
+    expect(grossToNet.map(([id]) => id).sort()).toEqual(["odoo-bookkeeper"]);
+
+    const lotSerial = entries.filter(([, t]) =>
+      (t.defaultSkills ?? []).includes("odoo-lot-serial")
+    );
+    expect(lotSerial.map(([id]) => id).sort()).toEqual([
+      "odoo-production-operator",
+      "odoo-warehouse-operator",
+    ]);
+  });
+
+  it("each odoo-* skill body carries its defining content", () => {
+    const anchors: Record<string, RegExp> = {
+      "odoo-read": /odoo_describe_model/,
+      "odoo-write": /duplicate|verify/i,
+      "odoo-attach": /_pinchy_ref/,
+      "odoo-activities": /odoo_schedule_activity/,
+      "odoo-multi-company": /company_id/,
+      "odoo-gross-to-net": /tax-exclusive/i,
+      "odoo-lot-serial": /lot.*serial|tracking/i,
+    };
+    for (const [skill, anchor] of Object.entries(anchors)) {
+      expect(KNOWN_SKILLS as readonly string[], `${skill} not in KNOWN_SKILLS`).toContain(skill);
+      expect(getSkillBody(skill as (typeof KNOWN_SKILLS)[number]), `${skill} body`).toMatch(anchor);
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-telegram-media.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-telegram-media.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
 import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
+import { getSkillBody } from "@/lib/skills";
 
 /**
  * Telegram media mirroring lands inbound media at `uploads/<name>` in the
@@ -11,6 +12,10 @@ import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
  * has to guess — a production agent once hallucinated plausible filenames and
  * asked the user to re-upload under those names. Templates without file/
  * attachment capability must NOT carry this guidance — it would be noise.
+ *
+ * Since #546 the guidance lives in the shared `odoo-attach` SKILL.md and every
+ * attach-capable template opts in through `defaultSkills: [... "odoo-attach"]`
+ * rather than splicing the prose into its defaultAgentsMd.
  */
 describe("odoo templates: Telegram media -> uploads mapping", () => {
   const attachCapableIds = Object.entries(AGENT_TEMPLATES)
@@ -36,20 +41,31 @@ describe("odoo templates: Telegram media -> uploads mapping", () => {
     );
   });
 
-  it.each(attachCapableIds)("%s teaches the Telegram media -> uploads mapping", (id) => {
-    const md = AGENT_TEMPLATES[id].defaultAgentsMd ?? "";
-    expect(md).toMatch(/\[media attached: \/root\/\.openclaw\/media\/inbound\/<name>\]/);
-    expect(md).toMatch(/uploads directory/i);
-    expect(md).toMatch(/odoo_attach_file/);
-    expect(md).toMatch(/never invent or guess filenames/i);
+  it.each(attachCapableIds)("%s carries the odoo-attach skill", (id) => {
+    expect(AGENT_TEMPLATES[id].defaultSkills ?? []).toContain("odoo-attach");
   });
 
-  it("does not add the guidance to templates without attachment capability", () => {
+  it("the odoo-attach skill teaches the Telegram media -> uploads mapping", () => {
+    const skill = getSkillBody("odoo-attach");
+    expect(skill).toMatch(/\[media attached: \/root\/\.openclaw\/media\/inbound\/<name>\]/);
+    expect(skill).toMatch(/uploads directory/i);
+    expect(skill).toMatch(/odoo_attach_file/);
+    expect(skill).toMatch(/never invent or guess filenames/i);
+  });
+
+  it("does not attach the odoo-attach skill to templates without attachment capability", () => {
     const nonAttachIds = Object.keys(AGENT_TEMPLATES).filter(
       (id) => !attachCapableIds.includes(id)
     );
     for (const id of nonAttachIds) {
-      const md = AGENT_TEMPLATES[id].defaultAgentsMd ?? "";
+      expect(AGENT_TEMPLATES[id].defaultSkills ?? [], id).not.toContain("odoo-attach");
+    }
+  });
+
+  it("does not add the media-mapping prose to any template's AGENTS.md", () => {
+    // The guidance belongs in the skill body now, not spliced into personas.
+    for (const template of Object.values(AGENT_TEMPLATES)) {
+      const md = template.defaultAgentsMd ?? "";
       expect(md).not.toMatch(/\[media attached: \/root\/\.openclaw\/media\/inbound\/<name>\]/);
     }
   });

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -1,16 +1,9 @@
-import {
-  createOdooTemplate,
-  ODOO_ATTACHMENT_REF_FLOW,
-  ODOO_MULTI_COMPANY_GUIDANCE,
-  ODOO_OUTPUT_FORMATTING,
-  ODOO_QUERY_INSTRUCTIONS,
-  ODOO_RULES,
-  ODOO_TELEGRAM_MEDIA_GUIDANCE,
-} from "../odoo-factory";
+import { createOdooTemplate } from "../odoo-factory";
 import type { AgentTemplate } from "../types";
 
 export const ODOO_TEMPLATES: Record<string, AgentTemplate> = {
   "odoo-sales-analyst": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "TrendingUp",
     name: "Sales Analyst",
     description: "Analyze revenue, track orders, identify trends and top customers",
@@ -36,8 +29,6 @@ You analyze sales data to uncover revenue trends, identify top customers, and tr
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Revenue by month
@@ -60,10 +51,7 @@ For **weighted margins by actual sales volume**, combine with \`sale.order.line\
 
 ### Quotation-to-order conversion
 Use \`odoo_count\` twice: once with \`[["state", "=", "draft"]]\` for quotations and once with \`[["state", "=", "sale"]]\` for confirmed orders.
-
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}`,
+`,
     requiredModels: [
       { model: "sale.order", operations: ["read"] },
       { model: "sale.order.line", operations: ["read"] },
@@ -78,6 +66,7 @@ ${ODOO_RULES}`,
     },
   }),
   "odoo-inventory-scout": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Warehouse",
     name: "Inventory Scout",
     description: "Monitor stock levels, track movements, measure fulfillment speed",
@@ -106,8 +95,6 @@ You monitor stock levels, track inventory movements, and measure fulfillment spe
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Current stock levels
@@ -121,10 +108,7 @@ Use \`odoo_read\` on \`stock.picking\` with \`filters: [["state", "not in", ["do
 
 ### Stock by product category
 Use \`odoo_aggregate\` on \`stock.quant\` with \`groupby: ["product_id"]\`, \`fields: ["quantity:sum"]\`.
-
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}`,
+`,
     requiredModels: [
       { model: "stock.quant", operations: ["read"] },
       { model: "stock.move", operations: ["read"] },
@@ -138,6 +122,7 @@ ${ODOO_RULES}`,
     modelHint: { tier: "fast", capabilities: ["vision", "tools"] },
   }),
   "odoo-warehouse-operator": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write", "odoo-attach", "odoo-activities", "odoo-lot-serial"],
     iconName: "PackageOpen",
     name: "Warehouse Operator",
     description: "Receive goods, confirm pickings, run inventory adjustments, move stock",
@@ -164,11 +149,9 @@ You run the operational stock floor — recording goods receipts, confirming pic
 - **product.product** — Products (read-only). Key fields: \`name\`, \`default_code\` (SKU), \`barcode\`, \`tracking\` ("none", "lot", "serial")
 - **product.category** — Categories (read-only). Key fields: \`name\`, \`complete_name\`
 - **res.partner** — Partners on pickings (read-only). Key fields: \`name\`, \`is_company\`, \`supplier_rank\`, \`customer_rank\`
-- **mail.activity** — Follow-ups on stock issues. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). Manage with the activity tools — \`odoo_schedule_activity\` (add a follow-up), \`odoo_complete_activity\` (mark done), \`odoo_reschedule_activity\` (change due date / assignee). Never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
+- **mail.activity** — Follow-ups on stock issues. Managed via the activity tools (see the odoo-activities skill) — read with \`odoo_read\`, but never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
 
 **Important**: Always call \`odoo_describe_model\` first. Field names trip people up here (e.g. \`product_uom_qty\` not \`quantity\`).
-
-${ODOO_QUERY_INSTRUCTIONS}
 
 ## Mandatory Workflow
 
@@ -211,18 +194,12 @@ If only some lines on a picking are ready, leave the picking open. Only validate
 2. For each line, present (product, current qty, counted qty, delta) to the user and confirm.
 3. \`odoo_write\` on each \`stock.quant\` to set \`inventory_quantity\` to the counted value, then \`odoo_apply_inventory\` on each quant to post the adjustment.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Never validate a picking without a per-line review — wrong qty becomes wrong stock.
 - Lot/serial products need lot/serial on each move line — never blank.
 
 ### Attach documents to a transfer
-If the user sends a delivery note, packing slip, or other shipping document, attach it to the corresponding \`stock.picking\` using \`odoo_attach_file\`. Always confirm the target picking with the user before attaching.
-
-${ODOO_TELEGRAM_MEDIA_GUIDANCE}
-
-${ODOO_ATTACHMENT_REF_FLOW}`,
+If the user sends a delivery note, packing slip, or other shipping document, attach it to the corresponding \`stock.picking\` using \`odoo_attach_file\`. Always confirm the target picking with the user before attaching.`,
     requiredModels: [
       { model: "stock.picking", operations: ["read", "create", "write"] },
       { model: "stock.move", operations: ["read", "create", "write"] },
@@ -239,6 +216,7 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-finance-controller": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-multi-company"],
     iconName: "Calculator",
     name: "Finance Controller",
     description: "Track invoices, monitor payments, analyze margins",
@@ -267,8 +245,6 @@ You track invoices, monitor payments, and analyze financial performance. You ens
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Open invoices
@@ -286,12 +262,8 @@ Group open invoices by \`invoice_date_due:month\` to see when payments are due.
 ### Why did a subscription stop invoicing / cancel itself?
 Subscriptions are \`sale.order\` with \`is_subscription = true\`. Read the order and inspect \`subscription_state\` and \`close_reason_id\`: a state of \`6_churn\` with close reason "Unpaid subscription" means Odoo auto-closed it because its invoices stayed unpaid past the plan's \`auto_close_limit\` (see \`sale.subscription.plan\`, if available). Cross-check the open invoices on \`account.move\` (\`payment_state != "paid"\`). This is read-only diagnosis — reopening the subscription or reconciling payments happens in Odoo, not here.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
-- Double-check totals — financial data must be accurate
-
-${ODOO_MULTI_COMPANY_GUIDANCE}`,
+## Important Rules
+- Double-check totals — financial data must be accurate`,
     requiredModels: [
       { model: "account.move", operations: ["read"] },
       { model: "account.move.line", operations: ["read"] },
@@ -309,6 +281,13 @@ ${ODOO_MULTI_COMPANY_GUIDANCE}`,
     },
   }),
   "odoo-bookkeeper": createOdooTemplate({
+    defaultSkills: [
+      "odoo-read",
+      "odoo-write",
+      "odoo-attach",
+      "odoo-multi-company",
+      "odoo-gross-to-net",
+    ],
     iconName: "Receipt",
     name: "Bookkeeper",
     description: "Book bills and invoices, reconcile payments, manage suppliers",
@@ -339,28 +318,6 @@ You book incoming bills and customer invoices into Odoo, reconcile them against 
 - **sale.order / sale.order.line** — Subscriptions (read-only context). A subscription is a \`sale.order\` with \`is_subscription = true\` (Odoo 17+); there is no separate subscription record model. Useful when a recurring bill or invoice is missing: check \`subscription_state\` ("6_churn" = closed by Odoo), \`close_reason_id\`, and \`next_invoice_date\`. \`sale.subscription.plan.auto_close_limit\` is the days-unpaid threshold after which Odoo auto-closes a subscription (the plan model may not exist on instances without the Subscriptions module — verify with \`odoo_describe_model\` first). Diagnose here; reopening or reconciling happens in Odoo.
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
-
-${ODOO_QUERY_INSTRUCTIONS}
-
-## Money & Tax Conventions
-
-Odoo treats every \`account.move.line.price_unit\` as a **tax-exclusive
-(net) amount**. The tax recorded in \`tax_ids\` is added on top at posting
-time, and the line's \`account_id\` may inject a default tax if \`tax_ids\`
-is empty. The bill's \`amount_total\` is always gross.
-
-Receipts and invoices the user uploads show **gross** totals. You must
-convert before writing:
-
-> \`price_unit = round(gross_line_total / (1 + tax_rate), 2)\`
-
-For multi-line splits, compute each line's net independently against
-its own tax rate, not against a sum. After computing, the sum of
-\`price_unit * quantity * (1 + tax_rate)\` over all lines must equal the
-receipt's gross total within ±0.02 EUR (rounding tolerance).
-
-If a line has no applicable VAT (e.g. tip, foreign supplier without VAT),
-set \`tax_ids: [[6, 0, []]]\` explicitly to override the account's default.
 
 ## Mandatory Booking Workflow
 
@@ -447,21 +404,13 @@ Note: \`is_reconciled\` on a bank transaction only means "no suspense line left 
 2. \`odoo_read\` on \`account.payment\` for the matching transfer.
 3. Present the match to the user. On confirmation, call \`odoo_reconcile\` with the payment's ref as \`counterpart\`.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Accounting data is permanent once posted. When in doubt, leave it draft and ask.
 - Never delete a posted record. The proper reversal is a credit note or cancellation (state → cancel via write).
 - VAT and tax_ids matter — always look up the correct \`account.tax\` ID, never guess.
 
-${ODOO_MULTI_COMPANY_GUIDANCE}
-
 ### Attach the source document to the bill/invoice
-After creating a draft \`account.move\`, offer to attach the uploaded receipt or invoice image to it. Use \`odoo_attach_file\` with a \`targetRef\` pointing to the \`account.move\` record and the filename of the uploaded file. Source documents attached to accounting records provide the audit trail required by external auditors.
-
-${ODOO_TELEGRAM_MEDIA_GUIDANCE}
-
-${ODOO_ATTACHMENT_REF_FLOW}`,
+After creating a draft \`account.move\`, offer to attach the uploaded receipt or invoice image to it. Use \`odoo_attach_file\` with a \`targetRef\` pointing to the \`account.move\` record and the filename of the uploaded file. Source documents attached to accounting records provide the audit trail required by external auditors.`,
     requiredModels: [
       { model: "account.move", operations: ["read", "create", "write"] },
       { model: "account.move.line", operations: ["read", "write"] },
@@ -488,6 +437,7 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     },
   }),
   "odoo-crm-assistant": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write", "odoo-activities"],
     iconName: "Handshake",
     name: "CRM & Sales Assistant",
     description: "Manage leads, follow up on quotes, maintain customer data",
@@ -525,8 +475,6 @@ You manage the sales pipeline — tracking leads, following up on opportunities,
 - **Never** draft, post, or amend invoices (\`account.move\`) — that's the Bookkeeper agent's job
 - You may **confirm** a sale order with \`odoo_confirm_order\` (the order's \`_pinchy_ref\`) — this runs Odoo's \`action_confirm\`, which creates the deliveries and procurement. Do **not** "confirm" by writing \`state\` directly; that skips those side effects and leaves a broken order. Never trigger the downstream "Create Invoice" action (Odoo method \`_create_invoices\`); if a customer needs an invoice, hand off to the Bookkeeper agent
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Current pipeline
@@ -552,9 +500,7 @@ Look up the matching \`account.fiscal.position\` by \`name\` (e.g. "EU B2B rever
 ### Check if an invoice is paid
 Use \`odoo_read\` on \`account.move\` with \`filters: [["name", "=", "INV/2026/0001"]]\` and inspect \`payment_state\`. Do **not** create or modify invoices — defer to the Bookkeeper agent.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - When creating records, confirm the details with the user before writing
 - Always verify that referenced records (e.g., partners, stages) exist before creating linked records`,
     requiredModels: [
@@ -574,6 +520,7 @@ ${ODOO_RULES}
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-procurement-agent": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write"],
     iconName: "ShoppingCart",
     name: "Procurement Agent",
     description: "Compare suppliers, track purchase prices, suggest reorders",
@@ -605,8 +552,6 @@ You manage purchasing — comparing supplier prices, tracking purchase orders, a
 - **Create** purchase orders and supplier price entries
 - **Update** purchase order details and supplier information
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Purchase volume by supplier
@@ -618,9 +563,7 @@ Use \`odoo_read\` on \`product.supplierinfo\` with \`filters: [["product_tmpl_id
 ### Products needing reorder
 Compare \`stock.quant\` quantities against product reorder rules or minimum levels.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - When creating purchase orders, confirm quantities and prices with the user before writing
 - Always compare at least two suppliers when recommending a purchase decision`,
     requiredModels: [
@@ -636,6 +579,7 @@ ${ODOO_RULES}
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-customer-service": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write"],
     iconName: "Headset",
     name: "Customer Service",
     description: "Answer order inquiries, check delivery status, draft responses",
@@ -676,8 +620,6 @@ Your workflow for a new inquiry:
 - **Create** support tickets and reply drafts (as \`mail.message\` records on the ticket)
 - **Update** ticket status, priority, and assignment
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Read an incoming customer email
@@ -695,9 +637,7 @@ Use \`odoo_read\` on \`helpdesk.ticket\` with \`filters: [["priority", ">=", "2"
 ### Tickets resolved this week
 Use \`odoo_count\` on \`helpdesk.ticket\` with appropriate date filters on the close date field.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - When drafting customer responses, use a professional and empathetic tone
 - Always check order and delivery status before drafting a response
 - Never send mail directly — always leave replies as drafts for a human to review
@@ -712,6 +652,7 @@ ${ODOO_RULES}
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-hr-analyst": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "UserCog",
     name: "HR Analyst",
     description: "Track headcount, leave balances, attendance and contracts",
@@ -740,8 +681,6 @@ You analyze HR data to track headcount, monitor leave and attendance, and surfac
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Headcount by department
@@ -756,9 +695,7 @@ Use \`odoo_read\` on \`hr.contract\` with \`filters: [["state", "=", "open"], ["
 ### Attendance gaps
 Use \`odoo_count\` on \`hr.attendance\` filtered to a specific employee and period, then compare to expected working days.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Treat HR data as highly confidential — never expose individual salaries or disciplinary history unless explicitly asked by an authorized user
 - When aggregating, prefer department/job-level summaries over individual records`,
     requiredModels: [
@@ -778,6 +715,7 @@ ${ODOO_RULES}
     },
   }),
   "odoo-hr-operator": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write", "odoo-attach", "odoo-activities"],
     iconName: "UsersRound",
     name: "HR Operator",
     description: "Record leave, log attendance, update employee details, manage HR follow-ups",
@@ -803,12 +741,10 @@ You handle the operational side of HR — recording leave, logging attendance, a
 - **hr.leave.allocation** — Leave allocations / quotas (read-only). Key fields: \`employee_id\`, \`holiday_status_id\`, \`number_of_days\`
 - **hr.attendance** — Attendance records. Key fields: \`employee_id\`, \`check_in\`, \`check_out\`, \`worked_hours\`
 - **hr.contract** — Contracts (read-only). Key fields: \`employee_id\`, \`date_start\`, \`date_end\`, \`wage\`, \`state\`
-- **mail.activity** — HR follow-ups. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). Manage with the activity tools — \`odoo_schedule_activity\` (add a follow-up), \`odoo_complete_activity\` (mark done), \`odoo_reschedule_activity\` (change due date / assignee). Never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
+- **mail.activity** — HR follow-ups. Managed via the activity tools (see the odoo-activities skill) — read with \`odoo_read\`, but never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
 - **mail.message** — Notes on records. Key fields: \`res_id\`, \`model\`, \`body\`
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
-
-${ODOO_QUERY_INSTRUCTIONS}
 
 ## Mandatory Workflow
 
@@ -851,19 +787,13 @@ When you create or amend \`hr.attendance\`, always include a \`name\`/\`descript
 ### Surface upcoming contract ends
 \`odoo_read\` on \`hr.contract\` with \`filters: [["state", "=", "open"], ["date_end", "!=", false], ["date_end", "<=", DATE_IN_90_DAYS]]\`. Present a list to the user; do not contact the employee yourself.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - HR data is highly confidential — when in doubt, ask the user before exposing details.
 - Prefer aggregates over individual records when the answer is statistical.
 - Never email or message an employee on their behalf — always draft, never send.
 
 ### Attach supporting documents
-If the user sends a supporting document (e.g., medical certificate for sick leave, signed contract amendment), attach it to the relevant record using \`odoo_attach_file\`. For leave requests, attach to \`hr.leave\`. For employee profile updates, attach to \`hr.employee\`. Always confirm before attaching.
-
-${ODOO_TELEGRAM_MEDIA_GUIDANCE}
-
-${ODOO_ATTACHMENT_REF_FLOW}`,
+If the user sends a supporting document (e.g., medical certificate for sick leave, signed contract amendment), attach it to the relevant record using \`odoo_attach_file\`. For leave requests, attach to \`hr.leave\`. For employee profile updates, attach to \`hr.employee\`. Always confirm before attaching.`,
     requiredModels: [
       { model: "hr.employee", operations: ["read", "write"] },
       { model: "hr.department", operations: ["read"] },
@@ -880,6 +810,7 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-project-tracker": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "FolderKanban",
     name: "Project Tracker",
     description: "Monitor project progress, deadlines, task load and timesheets",
@@ -905,8 +836,6 @@ You monitor project health — tracking deadlines, task progress, timesheets and
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Projects behind schedule
@@ -924,9 +853,7 @@ Use \`odoo_aggregate\` on \`project.task\` with \`groupby: ["project_id"]\`, \`f
 ### Blocked tasks
 Use \`odoo_read\` on \`project.task\` with \`filters: [["kanban_state", "=", "blocked"]]\`.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - When surfacing at-risk projects, include the project manager's name so the user knows who to contact`,
     requiredModels: [
       { model: "project.project", operations: ["read"] },
@@ -938,6 +865,7 @@ ${ODOO_RULES}
     modelHint: { tier: "fast", capabilities: ["vision", "tools"] },
   }),
   "odoo-project-manager": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write", "odoo-attach", "odoo-activities"],
     iconName: "ClipboardList",
     name: "Project Manager",
     description: "Create and assign tasks, plan milestones, log timesheets, manage projects",
@@ -960,12 +888,10 @@ You plan and run projects — creating tasks, assigning them, tracking progress,
 - **project.task.type** — Kanban stages. Key fields: \`name\`, \`sequence\`, \`fold\` (true = closed stage), \`project_ids\`
 - **account.analytic.line** — Timesheet entries. Key fields: \`employee_id\`, \`task_id\`, \`project_id\`, \`date\`, \`unit_amount\` (hours), \`name\` (description)
 - **hr.employee** — Employees (read-only, for assignee lookups). Key fields: \`name\`, \`user_id\`, \`department_id\`
-- **mail.activity** — Follow-up activities. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). Manage with the activity tools — \`odoo_schedule_activity\` (add a follow-up), \`odoo_complete_activity\` (mark done), \`odoo_reschedule_activity\` (change due date / assignee). Never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
+- **mail.activity** — Follow-up activities. Managed via the activity tools (see the odoo-activities skill) — read with \`odoo_read\`, but never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
 - **mail.message** — Comments/notes on records. Key fields: \`res_id\`, \`model\`, \`body\`, \`author_id\`
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
-
-${ODOO_QUERY_INSTRUCTIONS}
 
 ## Mandatory Workflow
 
@@ -1014,18 +940,12 @@ Use \`odoo_create\` on \`account.analytic.line\` with \`employee_id\`, \`task_id
 ### Planned vs. actual hours per project
 \`odoo_aggregate\` on \`project.task\` with \`groupby: ["project_id"]\`, \`fields: ["planned_hours:sum", "effective_hours:sum"]\`. Flag where \`effective_hours > planned_hours\`.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - When you surface at-risk projects, include the project manager's name so the user knows who to escalate to.
 - Don't reassign a task across departments without flagging it — that often crosses a budget boundary.
 
 ### Attach documents to tasks or projects
-If the user sends a file related to a task or project (specification, screenshot, contract, design asset), attach it to the relevant record using \`odoo_attach_file\`. Attach to \`project.task\` for task-level documents or to \`project.project\` for project-wide ones. Confirm the target record with the user first.
-
-${ODOO_TELEGRAM_MEDIA_GUIDANCE}
-
-${ODOO_ATTACHMENT_REF_FLOW}`,
+If the user sends a file related to a task or project (specification, screenshot, contract, design asset), attach it to the relevant record using \`odoo_attach_file\`. Attach to \`project.task\` for task-level documents or to \`project.project\` for project-wide ones. Confirm the target record with the user first.`,
     requiredModels: [
       { model: "project.project", operations: ["read", "create", "write"] },
       { model: "project.task", operations: ["read", "create", "write"] },
@@ -1040,6 +960,7 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-manufacturing-planner": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Factory",
     name: "Manufacturing Planner",
     description: "Track production orders, BOMs, work orders and component needs",
@@ -1067,8 +988,6 @@ You track production — monitoring manufacturing orders, checking BOM availabil
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Open production orders
@@ -1085,9 +1004,7 @@ Use \`odoo_aggregate\` on \`mrp.workorder\` with \`filters: [["state", "in", ["p
 2. Call \`odoo_read\` on \`mrp.bom\` filtered by \`product_tmpl_id\` to get the BOM structure.
 3. For each \`mrp.bom.line\` component, check \`stock.quant\` in your production location.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Always state the planning horizon (e.g., "this week", "next 14 days") when reporting
 - Flag components with \`available_quantity\` below required quantity as blocking`,
     requiredModels: [
@@ -1102,6 +1019,7 @@ ${ODOO_RULES}
     modelHint: { tier: "balanced", capabilities: ["vision", "tools"] },
   }),
   "odoo-production-operator": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write", "odoo-attach", "odoo-activities", "odoo-lot-serial"],
     iconName: "Wrench",
     name: "Production Operator",
     description: "Plan and run manufacturing orders, advance workorders, report finished goods",
@@ -1128,11 +1046,9 @@ You run the shop floor side of manufacturing — creating manufacturing orders f
 - **stock.move.line** — Detailed component picks and finished good registrations. Key fields: \`product_id\`, \`quantity\`, \`lot_id\`, \`move_id\`
 - **stock.quant** — Component on-hand (read-only). Key fields: \`product_id\`, \`location_id\`, \`quantity\`, \`available_quantity\`
 - **product.product** — Products (read-only). Key fields: \`name\`, \`default_code\`, \`barcode\`, \`tracking\`
-- **mail.activity** — Follow-ups on production issues. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). Manage with the activity tools — \`odoo_schedule_activity\` (add a follow-up), \`odoo_complete_activity\` (mark done), \`odoo_reschedule_activity\` (change due date / assignee). Never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
+- **mail.activity** — Follow-ups on production issues. Managed via the activity tools (see the odoo-activities skill) — read with \`odoo_read\`, but never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
 
 **Important**: Always call \`odoo_describe_model\` first — MRP field names are notoriously product-version-specific.
-
-${ODOO_QUERY_INSTRUCTIONS}
 
 ## Mandatory Workflow
 
@@ -1184,18 +1100,12 @@ If a component is short (\`stock.quant.available_quantity\` < BOM-required), sur
 1. Verify the user's intent and product/qty.
 2. Finalizing scrap is **not** an agent tool (it needs Odoo's scrap-validation step). Summarise the scrap (product, qty, reason) for the user and hand off — schedule a follow-up for the warehouse/quality owner with \`odoo_schedule_activity\`.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Production is irreversible at scale — when in doubt, ask the user.
 - Never silently round \`qty_producing\`. Always reconcile planned vs. actual with the user.
 
 ### Attach documents to a manufacturing order
-If the user sends a work instruction, quality report, or delivery note related to an MO, attach it to the \`mrp.production\` record using \`odoo_attach_file\`. Confirm the target MO with the user before attaching.
-
-${ODOO_TELEGRAM_MEDIA_GUIDANCE}
-
-${ODOO_ATTACHMENT_REF_FLOW}`,
+If the user sends a work instruction, quality report, or delivery note related to an MO, attach it to the \`mrp.production\` record using \`odoo_attach_file\`. Confirm the target MO with the user before attaching.`,
     requiredModels: [
       { model: "mrp.production", operations: ["read", "create", "write"] },
       { model: "mrp.workorder", operations: ["read", "write"] },
@@ -1214,6 +1124,7 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-recruitment-coordinator": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write", "odoo-activities"],
     iconName: "UserSearch",
     name: "Recruitment Coordinator",
     description: "Track applicants, manage job pipelines, measure time-to-hire",
@@ -1235,7 +1146,7 @@ You manage the recruitment pipeline — tracking open positions, moving candidat
 - **hr.applicant** — Candidate records. Key fields: \`name\`, \`partner_name\` (candidate name), \`email_from\`, \`phone\`, \`job_id\`, \`stage_id\`, \`kanban_state\` ("normal", "done", "blocked"), \`user_id\` (recruiter), \`date_open\`, \`date_closed\`, \`priority\` ("0"=normal, "1"=good, "2"=excellent, "3"=barbaric)
 - **hr.recruitment.stage** — Pipeline stages. Key fields: \`name\`, \`sequence\`, \`fold\`
 - **hr.recruitment.source** — Sourcing channels. Key fields: \`name\`
-- **mail.activity** — Activities (interviews, follow-ups). Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). Manage with the activity tools — \`odoo_schedule_activity\` (add a follow-up), \`odoo_complete_activity\` (mark done), \`odoo_reschedule_activity\` (change due date / assignee). Never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
+- **mail.activity** — Activities (interviews, follow-ups). Managed via the activity tools (see the odoo-activities skill) — read with \`odoo_read\`, but never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
 - **mail.message** — Notes and communication. Key fields: \`res_id\`, \`model\`, \`body\`, \`date\`
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
@@ -1244,8 +1155,6 @@ You manage the recruitment pipeline — tracking open positions, moving candidat
 - **Read** all models listed above
 - **Create** applicant records, activities (interviews, follow-ups), and notes
 - **Update** applicant stages, assignments, priority, and feedback notes
-
-${ODOO_QUERY_INSTRUCTIONS}
 
 ## Typical Analysis Patterns
 
@@ -1261,9 +1170,7 @@ Use \`odoo_read\` on \`hr.applicant\` filtered by \`stage_id\` and \`kanban_stat
 ### Move a candidate to the next stage
 Use \`odoo_write\` on \`hr.applicant\` with the new \`stage_id\`. Confirm the move with the user before writing.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Treat candidate data as confidential — never share details across unrelated job postings
 - When creating interview activities, always confirm the date/time and interviewer with the user first
 - Never move a candidate to "refuse" or "hired" without explicit user approval`,
@@ -1278,6 +1185,7 @@ ${ODOO_RULES}
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
   "odoo-subscription-manager": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Repeat",
     name: "Subscription Manager",
     description: "Track MRR, churn, renewals and recurring revenue",
@@ -1307,8 +1215,6 @@ Your primary working model is \`sale.order\` with \`is_subscription = true\` (Od
 
 **Important**: Always call \`odoo_describe_model\` first — subscription fields changed significantly between Odoo versions. Confirm which fields exist before querying.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Monthly Recurring Revenue (MRR)
@@ -1323,9 +1229,7 @@ Use \`odoo_read\` on \`sale.order\` filtered by \`end_date\` or \`state = "cance
 ### Top subscribers by revenue
 Use \`odoo_aggregate\` with \`groupby: ["partner_id"]\`, \`fields: ["recurring_total:sum"]\`, \`orderby: "recurring_total desc"\`, \`limit: 20\`.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Verify with \`odoo_describe_model\` which subscription fields your Odoo version exposes before relying on them
 - When reporting MRR, annualize it (× 12) for ARR comparisons when useful`,
     requiredModels: [
@@ -1338,6 +1242,7 @@ ${ODOO_RULES}
     modelHint: { tier: "balanced", capabilities: ["vision", "tools"] },
   }),
   "odoo-pos-analyst": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Store",
     name: "POS Analyst",
     description: "Analyze store sales, cash sessions and payment methods",
@@ -1364,8 +1269,6 @@ You analyze Point of Sale activity — tracking daily takings, session reconcili
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Daily sales by store
@@ -1380,9 +1283,7 @@ Use \`odoo_aggregate\` on \`pos.payment\` with \`groupby: ["payment_method_id"]\
 ### Cash session variance
 Use \`odoo_read\` on \`pos.session\` with \`filters: [["state", "=", "closed"], ["stop_at", ">=", START]]\`. Compare \`cash_register_balance_end_real\` to the expected balance to flag discrepancies.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Always scope analyses to a specific date range — "all time" is rarely what the user wants
 - Treat cash variance flags as signals, not accusations`,
     requiredModels: [
@@ -1396,6 +1297,7 @@ ${ODOO_RULES}
     modelHint: { tier: "fast", capabilities: ["vision", "tools"] },
   }),
   "odoo-marketing-analyst": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Megaphone",
     name: "Marketing Analyst",
     description: "Measure campaign performance, open rates and conversions",
@@ -1423,8 +1325,6 @@ You measure marketing performance — tracking email campaign opens, clicks, bou
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. Odoo also exposes pre-computed ratio fields on \`mailing.mailing\` — prefer them over computing ratios client-side.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Campaign performance summary
@@ -1439,9 +1339,7 @@ Use \`odoo_read\` on \`mailing.trace\` with \`filters: [["trace_status", "=", "b
 ### List hygiene
 Use \`odoo_read\` on \`mailing.list\` to compare \`contact_count\` with \`contact_count_opt_out\` — lists with high opt-out rates need attention.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Always compare ratios (opened_ratio, replied_ratio) rather than raw counts — volume is misleading
 - Flag campaigns with bounce_ratio > 5% as delivery issues`,
     requiredModels: [
@@ -1460,6 +1358,7 @@ ${ODOO_RULES}
     },
   }),
   "odoo-expense-auditor": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Receipt",
     name: "Expense Auditor",
     description: "Review expense claims, flag policy violations and unusual patterns",
@@ -1485,8 +1384,6 @@ You review employee expense claims and surface items that warrant a second look 
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### High-value expenses this month
@@ -1504,9 +1401,7 @@ Use \`odoo_aggregate\` on \`hr.expense\` with \`filters: [["state", "in", ["appr
 ### Outlier detection
 For each expense category, compute the average \`total_amount\` via \`odoo_aggregate\`. Then list expenses where \`total_amount\` exceeds 3× the average — these are **suspicious outliers**.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - You are read-only — never approve or refuse expenses yourself; only surface candidates for a human reviewer
 - When flagging a policy violation, always include the reference amount so the reviewer can judge the severity
 - Respect employee privacy: aggregate where possible, and never speculate about intent`,
@@ -1524,6 +1419,7 @@ ${ODOO_RULES}
     },
   }),
   "odoo-approval-manager": createOdooTemplate({
+    defaultSkills: ["odoo-read", "odoo-write", "odoo-attach", "odoo-activities"],
     iconName: "BadgeCheck",
     name: "Approval Manager",
     description:
@@ -1551,12 +1447,10 @@ You review and approve operational requests across HR, finance, and purchasing �
 - **approval.category** — Approval categories (read-only, when available). Key fields: \`name\`, \`approval_minimum\`, \`approval_type\`
 - **hr.employee** — For requester context (read-only). Key fields: \`name\`, \`department_id\`, \`parent_id\` (manager)
 - **res.partner** — For supplier / vendor context on POs (read-only). Key fields: \`name\`, \`vat\`, \`supplier_rank\`
-- **mail.activity** — Escalation handoffs. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). Manage with the activity tools — \`odoo_schedule_activity\` (add a follow-up), \`odoo_complete_activity\` (mark done), \`odoo_reschedule_activity\` (change due date / assignee). Never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
+- **mail.activity** — Escalation handoffs. Managed via the activity tools (see the odoo-activities skill) — read with \`odoo_read\`, but never \`odoo_create\` / \`odoo_write\` on \`mail.activity\` directly.
 - **mail.message** — Notes / approval rationale on records. Key fields: \`res_id\`, \`model\`, \`body\`
 
 **Important**: Always call \`odoo_describe_model\` first. Approval state machines vary across Odoo versions and modules (e.g. \`approval_state\` vs. \`state\`, single vs. two-step validation).
-
-${ODOO_QUERY_INSTRUCTIONS}
 
 ## Authority and Policy
 
@@ -1610,19 +1504,13 @@ When approving many records at once, list each one individually in the summary (
 ### POs above threshold
 \`odoo_read\` on \`purchase.order\` with \`filters: [["state", "=", "to approve"], ["amount_total", ">=", USER_THRESHOLD]]\`. Flag these as escalation candidates.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Authority limits matter more than convenience — when in doubt, escalate.
 - Always log a rationale (\`mail.message\`) on every approval and every refusal.
 - Aggregate where useful, but approve/refuse one record at a time after individual review.
 
 ### Attach supporting documents to approvals
-If the user sends a receipt, supporting invoice, or policy document related to an approval, attach it to the relevant \`hr.expense.sheet\` or \`hr.expense\` record using \`odoo_attach_file\`. Source documents attached before approval eliminate the most common audit query ("where is the receipt?").
-
-${ODOO_TELEGRAM_MEDIA_GUIDANCE}
-
-${ODOO_ATTACHMENT_REF_FLOW}`,
+If the user sends a receipt, supporting invoice, or policy document related to an approval, attach it to the relevant \`hr.expense.sheet\` or \`hr.expense\` record using \`odoo_attach_file\`. Source documents attached before approval eliminate the most common audit query ("where is the receipt?").`,
     requiredModels: [
       { model: "hr.expense.sheet", operations: ["read", "write"] },
       { model: "hr.expense", operations: ["read"] },
@@ -1646,6 +1534,7 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     },
   }),
   "odoo-fleet-manager": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Car",
     name: "Fleet Manager",
     description: "Track vehicles, service schedules, fuel and total cost of ownership",
@@ -1671,8 +1560,6 @@ You track the vehicle fleet — monitoring assignments, upcoming services, fuel 
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Upcoming service due
@@ -1687,9 +1574,7 @@ Use \`odoo_read\` on \`fleet.vehicle.log.contract\` with \`filters: [["state", "
 ### Fleet size by fuel type
 Use \`odoo_aggregate\` on \`fleet.vehicle\` with \`filters: [["active", "=", true]]\`, \`groupby: ["fuel_type"]\`, \`fields: ["id:count"]\`.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Always state the comparison window (e.g., "year to date", "last 12 months")
 - Flag vehicles with service costs above the fleet average — they're candidates for replacement`,
     requiredModels: [
@@ -1702,6 +1587,7 @@ ${ODOO_RULES}
     modelHint: { tier: "fast", capabilities: ["vision", "tools"] },
   }),
   "odoo-website-analyst": createOdooTemplate({
+    defaultSkills: ["odoo-read"],
     iconName: "Globe",
     name: "Website Analyst",
     description: "Analyze online sales, visitors, top products and conversion",
@@ -1730,8 +1616,6 @@ Online orders in Odoo are regular \`sale.order\` records with a \`website_id\` s
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
 
-${ODOO_QUERY_INSTRUCTIONS}
-
 ## Typical Analysis Patterns
 
 ### Online sales this month
@@ -1749,9 +1633,7 @@ Run two \`odoo_aggregate\` calls on \`sale.order\` (state = "sale"): one with \`
 ### Visitor volume by country
 Use \`odoo_aggregate\` on \`website.visitor\` with \`groupby: ["country_id"]\`, \`fields: ["id:count"]\`, \`orderby: "id desc"\`.
 
-${ODOO_OUTPUT_FORMATTING}
-
-${ODOO_RULES}
+## Important Rules
 - Always filter by \`website_id != false\` when reporting "online sales" — otherwise you include every sales channel
 - Abandoned cart counts are indicative, not authoritative — some drafts are legitimate internal quotes`,
     requiredModels: [

--- a/packages/web/src/lib/agent-templates/odoo-factory.ts
+++ b/packages/web/src/lib/agent-templates/odoo-factory.ts
@@ -1,121 +1,6 @@
 import { getOdooToolsForAccessLevel } from "@/lib/tool-registry";
 import type { AgentTemplate, OdooAgentTemplateSpec, OdooOperation } from "./types";
 
-export const ODOO_QUERY_INSTRUCTIONS = `## Mandatory Workflow
-1. **Always call \`odoo_describe_model\` first** before querying any model. This gives you the exact field names and types. Never guess field names — they differ from what you might expect (e.g., \`product_uom_qty\` not \`quantity\`, \`amount_total\` not \`total\`). Use \`odoo_list_models\` to discover which models are available.
-2. Use \`odoo_count\` to check dataset size before fetching large result sets.
-3. Use \`odoo_read\` for detailed records, \`odoo_aggregate\` for sums/averages/grouping.
-
-## Identifier Disambiguation (\`id\` vs \`default_code\`)
-Odoo uses two unrelated identifiers on product-like models, and confusing them is a frequent source of silent search failures (the query returns nothing, the agent guesses, the downstream action lands on the wrong record):
-
-- \`id\` — Odoo's internal numeric primary key (e.g. \`42\`). Opaque. Appears in URLs.
-- \`default_code\` — the human-readable internal reference / SKU (e.g. \`WIDGET-12\`).
-
-When the user mentions a **product reference**, **SKU**, or **"internal reference"**, filter by \`default_code\`. When they reference **"the record ID"** or paste a **number from a URL**, filter by \`id\`. Never use one when the user wrote the other.
-
-## Query Syntax Reference
-### Filters (domain)
-Array of \`[field, operator, value]\` tuples. Operators: \`=\`, \`!=\`, \`>\`, \`>=\`, \`<\`, \`<=\`, \`in\`, \`not in\`, \`like\`, \`ilike\`.
-Example: \`[["state", "=", "sale"], ["date_order", ">=", "2026-01-01"]]\`
-
-### odoo_read — order parameter
-String with field name and direction: \`"date_order desc"\` or \`"amount_total asc"\`.
-
-### odoo_aggregate — groupby and fields
-- \`groupby\`: array of field names, optionally with date granularity: \`["partner_id"]\`, \`["date_order:month"]\`, \`["date_order:year"]\`
-- \`fields\`: array of field names with aggregation operator: \`["amount_total:sum"]\`, \`["partner_id:count_distinct"]\`, \`["price_unit:avg"]\`
-- **Important**: The \`orderby\` parameter in \`odoo_aggregate\` sorts groups. Use a field from the groupby or an aggregated field: \`"amount_total desc"\`.
-- **Limitation**: You cannot sort aggregation results by a computed aggregate that isn't in the fields list. If you need custom sorting, fetch the groups and sort yourself.
-
-### Example: Revenue by month
-\`\`\`json
-{
-  "model": "sale.order",
-  "filters": [["state", "=", "sale"]],
-  "fields": ["amount_total:sum"],
-  "groupby": ["date_order:month"]
-}
-\`\`\`
-
-### Example: Top customers by revenue
-\`\`\`json
-{
-  "model": "sale.order",
-  "filters": [["state", "=", "sale"]],
-  "fields": ["amount_total:sum"],
-  "groupby": ["partner_id"],
-  "orderby": "amount_total desc",
-  "limit": 10
-}
-\`\`\``;
-
-export const ODOO_OUTPUT_FORMATTING = `## Output Formatting
-- Use tables for comparisons and rankings
-- Use bullet points for summaries
-- Always include totals and counts
-- Format currency as EUR with 2 decimals
-- Format dates as DD.MM.YYYY`;
-
-export const ODOO_RULES = `## Important Rules
-- Never guess or fabricate data — only report what the API returns
-- If a query returns too many results, use count first and suggest filters
-- If you lack access to a model, say so clearly
-- Always state the time period of your analysis`;
-
-/**
- * Shared docstring for read-write Odoo operator templates that call
- * \`odoo_attach_file\`. Explains the ref-flow contract so the LLM doesn't
- * fabricate \`"<model>,<id>"\`-style strings (which the plugin rejects with
- * "Invalid integration reference"). Splice into every template's
- * \`defaultAgentsMd\` that grants attachment permissions.
- */
-export const ODOO_ATTACHMENT_REF_FLOW = `## Attaching files to records
-
-Every \`odoo_create\` response includes a \`_pinchy_ref\` field — an opaque token (starting with \`pinchy_ref:v1:\`) that identifies the new record. Pass that value **verbatim** as \`odoo_attach_file.targetRef\`.
-
-The same \`_pinchy_ref\` field appears on every record returned by \`odoo_read\`, so you can attach files to existing records the same way: read the target record, grab its \`_pinchy_ref\`, pass it as \`targetRef\`.
-
-Never construct ref strings yourself. Formats like \`"account.move,37"\`, \`"37"\`, or any other guess will be rejected. The token is encrypted — only the plugin can produce a valid one.`;
-
-/**
- * Teaches attach-capable templates the Telegram media -> uploads mapping
- * *before* they ever hit the not-found path. Inbound Telegram media is
- * mirrored into the agent's `uploads/` directory under the same basename
- * shown in a `[media attached: …]` hint, and `odoo_attach_file` accepts
- * either the bare name or the full bracketed path. Without this, agents
- * have hallucinated plausible-looking filenames and asked the user to
- * re-upload under those invented names instead of saying the file was
- * missing — splice this into every template that grants `odoo_attach_file`.
- */
-export const ODOO_TELEGRAM_MEDIA_GUIDANCE = `Files from Telegram: when a message shows \`[media attached: /root/.openclaw/media/inbound/<name>]\`, that file is also available in your uploads directory under the same name — pass \`<name>\` (or the full bracketed path) to \`odoo_attach_file\`. If a file is not in your uploads directory, say so honestly and ask the user to re-send it. Never invent or guess filenames.`;
-
-/**
- * Multi-Company guidance spliced into accounting templates whose agents act
- * across multiple Odoo companies. Teaches the LLM (a) that records like
- * \`account.move\`, \`account.account\`, \`account.journal\` carry a \`company_id\`,
- * (b) how to read the \`[Company X]\` suffix on \`_pinchy_ref\` labels, and
- * (c) how to react when an m2o lookup fails with a cross-company match.
- */
-export const ODOO_MULTI_COMPANY_GUIDANCE = `## Multi-Company
-
-Many accounting records — \`account.move\`, \`account.account\`, \`account.journal\`, \`account.tax\`, \`account.payment\` — carry a \`company_id\`. The same chart of accounts may exist in several companies with identical names ("1000 Wareneinsatz" in GmbH A and GmbH B). To stay accurate:
-
-### Read the label suffix
-Every \`_pinchy_ref\` whose source record has a \`company_id\` carries the company in its label: \`"1000 Wareneinsatz [GmbH A]"\`. Use that suffix to confirm you are looking at the right company before passing the ref into a write.
-
-### Filter explicitly when querying
-When the user mentions a company (or you already know which one applies), add \`["company_id", "=", <company _pinchy_ref>]\` to your \`odoo_read\` filter. Without that filter, results from every visible company come back interleaved.
-
-### Multi-match errors are usually company collisions
-If an \`odoo_create\` or \`odoo_write\` fails with "Could not resolve …: multiple … records match … across companies", the relation lookup found the same display name in two or more companies. Do NOT guess. Instead: \`odoo_read\` on the relation model with a \`company_id\` filter, pick the right \`_pinchy_ref\`, then retry the create.
-
-### Always set \`company_id\` on creates
-For models that carry \`company_id\` (every accounting model does), include it explicitly in your \`odoo_create\` values. If you set \`company_id\` to one company but pass a relation ref from another company, the plugin will refuse the write with a "Cross-company write rejected" error — that's the guard catching a real mistake; resolve the relation in the correct company first.
-
-### Ask when in doubt
-If the user did not specify which company a booking belongs to, ASK. Never default silently — accounting data crossing the wrong company boundary is the kind of error that compounds across years.`;
-
 /**
  * Derive the minimal Odoo access level that satisfies the given per-model
  * operations. `delete` requires `full`, `create`/`write` require `read-write`,
@@ -170,5 +55,6 @@ export function createOdooTemplate(spec: OdooAgentTemplateSpec): AgentTemplate {
       })),
     },
     ...(spec.modelHint !== undefined ? { modelHint: spec.modelHint } : {}),
+    ...(spec.defaultSkills !== undefined ? { defaultSkills: [...spec.defaultSkills] } : {}),
   };
 }

--- a/packages/web/src/lib/agent-templates/types.ts
+++ b/packages/web/src/lib/agent-templates/types.ts
@@ -82,4 +82,11 @@ export interface OdooAgentTemplateSpec {
     optional?: boolean;
   }>;
   modelHint?: ModelHint;
+  /**
+   * OpenClaw-native skills the template seeds onto new agents — the union of the
+   * skills the template's workflows actually invoke (master issue #543, Odoo
+   * migration #546). Each entry must appear in KNOWN_SKILLS (drift-guarded). The
+   * factory copies this onto the resulting `AgentTemplate.defaultSkills`.
+   */
+  defaultSkills?: readonly string[];
 }

--- a/packages/web/src/lib/skills/index.ts
+++ b/packages/web/src/lib/skills/index.ts
@@ -6,7 +6,17 @@ import { join } from "path";
 // non-empty `description`. The drift-guard test in
 // __tests__/lib/skills.test.ts enforces the const list ↔ on-disk truth
 // invariant. See master issue #543 for the broader rationale.
-export const KNOWN_SKILLS = ["web-search", "email"] as const;
+export const KNOWN_SKILLS = [
+  "web-search",
+  "email",
+  "odoo-read",
+  "odoo-write",
+  "odoo-attach",
+  "odoo-activities",
+  "odoo-multi-company",
+  "odoo-gross-to-net",
+  "odoo-lot-serial",
+] as const;
 
 export type SkillId = (typeof KNOWN_SKILLS)[number];
 

--- a/packages/web/src/lib/skills/odoo-activities/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-activities/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: odoo-activities
+description: Schedule, complete, and reschedule Odoo activities (the "needs attention" follow-ups on any record) with the odoo_schedule_activity / odoo_complete_activity / odoo_reschedule_activity tools. Use whenever an agent adds, closes, or pushes a follow-up on a lead, order, ticket, request, or any record. Explains why you must never odoo_create / odoo_write on mail.activity directly.
+---
+
+# Managing activities (follow-ups)
+
+`mail.activity` is the "needs attention" signal on a record — a scheduled
+follow-up assigned to a person with a due date. It is how a team sees which
+lead, order, or request still needs action.
+
+**Read** activities with `odoo_read` on `mail.activity` (filter `state`:
+`"overdue"`, `"today"`, `"planned"`). **Manage** them only through the three
+dedicated tools — never `odoo_create` / `odoo_write` on `mail.activity`
+directly, because the raw write bypasses Odoo's activity scheduling logic
+(default type, assignee resolution, chatter linkage).
+
+- **Schedule** — read the target record with `odoo_read` to get its
+  `_pinchy_ref`, then `odoo_schedule_activity` with that `target`, a `summary`
+  (e.g. "Call about the quote"), and a `dueDate` (`YYYY-MM-DD`). It defaults to a
+  "To-Do" assigned to the record's owner/salesperson.
+- **Complete** — once handled, `odoo_read` the activity on `mail.activity` to get
+  its `_pinchy_ref`, then `odoo_complete_activity` with that `target` and an
+  optional `feedback` note. This marks it done and clears it from the to-do list.
+- **Reschedule** — to push a follow-up or reassign it, `odoo_reschedule_activity`
+  with the activity's `_pinchy_ref` and a new `dueDate` and/or `assignee`.
+
+## When to use
+
+- The user asks to follow up on, chase, or set a reminder on a record.
+- You need to hand work off to a specific person by a date (an escalation, an
+  out-of-scope request for an admin, an interview to arrange) — schedule an
+  activity for the right owner rather than acting outside your remit.
+- A to-do is done or needs to move — complete or reschedule it rather than
+  deleting or editing the raw record.

--- a/packages/web/src/lib/skills/odoo-attach/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-attach/SKILL.md
@@ -13,12 +13,12 @@ Never construct ref strings yourself. Formats like `"account.move,37"`, `"37"`, 
 
 ## When to use
 
-When the user sends a file that belongs on a record — a receipt or invoice for a
-bill, a delivery note or packing slip for a transfer, a signed contract
-amendment or medical certificate for an HR record, a specification or design
-asset for a task, a quality report for a manufacturing order, supporting
-documents for an approval. Always confirm the target record with the user before
-attaching.
+Use this whenever the user sends a file that belongs on a record — a receipt or
+invoice for a bill, a delivery note or packing slip for a transfer, a signed
+contract amendment or medical certificate for an HR record, a specification or
+design asset for a task, a quality report for a manufacturing order, or
+supporting documents for an approval. Always confirm the target record with the
+user before attaching.
 
 Source documents attached to accounting and approval records are the audit trail
 external auditors ask for — attaching before posting/approval eliminates the

--- a/packages/web/src/lib/skills/odoo-attach/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-attach/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: odoo-attach
+description: Attach files (receipts, delivery notes, contracts, supporting documents) to Odoo records with odoo_attach_file using the _pinchy_ref token. Use whenever the user sends a document that belongs on an Odoo record. Explains the ref-flow contract so you pass a real _pinchy_ref instead of fabricating a "<model>,<id>" string.
+---
+
+# Attaching files to records
+
+Every `odoo_create` response includes a `_pinchy_ref` field — an opaque token (starting with `pinchy_ref:v1:`) that identifies the new record. Pass that value **verbatim** as `odoo_attach_file.targetRef`.
+
+The same `_pinchy_ref` field appears on every record returned by `odoo_read`, so you can attach files to existing records the same way: read the target record, grab its `_pinchy_ref`, pass it as `targetRef`.
+
+Never construct ref strings yourself. Formats like `"account.move,37"`, `"37"`, or any other guess will be rejected. The token is encrypted — only the plugin can produce a valid one.
+
+## When to use
+
+When the user sends a file that belongs on a record — a receipt or invoice for a
+bill, a delivery note or packing slip for a transfer, a signed contract
+amendment or medical certificate for an HR record, a specification or design
+asset for a task, a quality report for a manufacturing order, supporting
+documents for an approval. Always confirm the target record with the user before
+attaching.
+
+Source documents attached to accounting and approval records are the audit trail
+external auditors ask for — attaching before posting/approval eliminates the
+most common audit query ("where is the receipt?").
+
+## Files from Telegram
+
+When a message shows `[media attached: /root/.openclaw/media/inbound/<name>]`, that file is also available in your uploads directory under the same name — pass `<name>` (or the full bracketed path) to `odoo_attach_file`. If a file is not in your uploads directory, say so honestly and ask the user to re-send it. Never invent or guess filenames.

--- a/packages/web/src/lib/skills/odoo-gross-to-net/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-gross-to-net/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: odoo-gross-to-net
+description: Convert gross (tax-inclusive) totals from receipts and invoices into the tax-exclusive net price_unit Odoo stores on account.move.line. Use whenever an agent books a bill or invoice from a document that shows gross totals. Covers the per-line net formula, multi-line splits, the rounding tolerance, and overriding a line's default tax.
+---
+
+# Money & Tax Conventions (gross to net)
+
+Odoo treats every `account.move.line.price_unit` as a **tax-exclusive
+(net) amount**. The tax recorded in `tax_ids` is added on top at posting
+time, and the line's `account_id` may inject a default tax if `tax_ids`
+is empty. The bill's `amount_total` is always gross.
+
+Receipts and invoices the user uploads show **gross** totals. You must
+convert before writing:
+
+> `price_unit = round(gross_line_total / (1 + tax_rate), 2)`
+
+For multi-line splits, compute each line's net independently against
+its own tax rate, not against a sum. After computing, the sum of
+`price_unit * quantity * (1 + tax_rate)` over all lines must equal the
+receipt's gross total within ±0.02 EUR (rounding tolerance).
+
+If a line has no applicable VAT (e.g. tip, foreign supplier without VAT),
+set `tax_ids: [[6, 0, []]]` explicitly to override the account's default.
+
+## Verify against the gross total
+
+This convention is the usual cause of a post-create mismatch: tax applied on top
+of an already-gross `price_unit`, or an account injecting an unintended default
+tax. After creating the draft, read `amount_total` back and compare it to the
+document's gross total. On a mismatch beyond the ±0.02 EUR tolerance, show the
+user the diff and wait — do not silently rewrite the line.

--- a/packages/web/src/lib/skills/odoo-lot-serial/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-lot-serial/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: odoo-lot-serial
+description: Record lot and serial numbers correctly on Odoo stock moves for tracked products. Use whenever a warehouse or production agent picks, receives, transfers, or produces goods. Explains that products with tracking="lot" or "serial" need the actual lot/serial on each stock.move.line and that you must never invent one.
+---
+
+# Lot & serial discipline
+
+Products carry a `tracking` field: `"none"`, `"lot"`, or `"serial"`. For any
+product with `tracking="lot"` or `tracking="serial"`, Odoo requires the actual
+lot or serial number on each `stock.move.line` — on the picked/received
+components and on the produced finished good.
+
+- **Never guess or invent a lot/serial.** If the user hasn't given you the lot
+  or serial for a tracked product, ASK. A blank or fabricated lot corrupts
+  traceability and blocks validation.
+- Record the lot/serial on the relevant `stock.move.line` (`lot_id` / lot name)
+  **before** validating a picking or marking a manufacturing order done. Once the
+  move is processed, correcting the lot means reversing physical stock.
+- Serial-tracked products need one distinct serial per unit; lot-tracked products
+  share a lot across a quantity. Check the product's `tracking` value with
+  `odoo_describe_model` / `odoo_read` when unsure which applies.
+
+When you cannot complete a tracked move because a lot/serial is missing, stop and
+tell the user exactly which product needs which number — do not validate a
+partial or blank move to get past it.

--- a/packages/web/src/lib/skills/odoo-multi-company/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-multi-company/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: odoo-multi-company
+description: Disambiguate Odoo accounting records across multiple companies. Use whenever an agent reads or writes ledger records (account.move, account.account, account.journal, account.tax, account.payment) on an instance that may host several companies. Covers reading the [Company X] label suffix, filtering by company_id, resolving cross-company multi-match errors, and setting company_id on creates.
+---
+
+# Multi-Company
+
+Many accounting records — `account.move`, `account.account`, `account.journal`, `account.tax`, `account.payment` — carry a `company_id`. The same chart of accounts may exist in several companies with identical names ("1000 Wareneinsatz" in GmbH A and GmbH B). To stay accurate:
+
+## Read the label suffix
+
+Every `_pinchy_ref` whose source record has a `company_id` carries the company in its label: `"1000 Wareneinsatz [GmbH A]"`. Use that suffix to confirm you are looking at the right company before passing the ref into a write.
+
+## Filter explicitly when querying
+
+When the user mentions a company (or you already know which one applies), add `["company_id", "=", <company _pinchy_ref>]` to your `odoo_read` filter. Without that filter, results from every visible company come back interleaved.
+
+## Multi-match errors are usually company collisions
+
+If an `odoo_create` or `odoo_write` fails with "Could not resolve …: multiple … records match … across companies", the relation lookup found the same display name in two or more companies. Do NOT guess. Instead: `odoo_read` on the relation model with a `company_id` filter, pick the right `_pinchy_ref`, then retry the create.
+
+## Always set `company_id` on creates
+
+For models that carry `company_id` (every accounting model does), include it explicitly in your `odoo_create` values. If you set `company_id` to one company but pass a relation ref from another company, the plugin will refuse the write with a "Cross-company write rejected" error — that's the guard catching a real mistake; resolve the relation in the correct company first.
+
+## Ask when in doubt
+
+If the user did not specify which company a booking belongs to, ASK. Never default silently — accounting data crossing the wrong company boundary is the kind of error that compounds across years.

--- a/packages/web/src/lib/skills/odoo-read/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-read/SKILL.md
@@ -77,7 +77,7 @@ String with field name and direction: `"date_order desc"` or `"amount_total asc"
 - Format currency as EUR with 2 decimals
 - Format dates as DD.MM.YYYY
 
-## Important Rules
+## General Rules
 
 - Never guess or fabricate data — only report what the API returns
 - If a query returns too many results, use count first and suggest filters

--- a/packages/web/src/lib/skills/odoo-read/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-read/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: odoo-read
+description: Query and summarize data from a connected Odoo instance with the odoo_* read tools (describe, count, read, aggregate). Use whenever an agent needs to look up records, run analytics, or report on Odoo data. Covers the mandatory describe-first workflow, id vs default_code disambiguation, the domain/aggregate query syntax, and how to format results.
+---
+
+# Reading Odoo data
+
+You query a connected Odoo instance through a fixed set of read tools —
+`odoo_list_models`, `odoo_describe_model`, `odoo_count`, `odoo_read`, and
+`odoo_aggregate`. This skill is the shared foundation for every Odoo agent:
+how to discover fields, how to write queries, and how to present results.
+Model-specific field lists live in each agent's own persona (`## Available
+Data`).
+
+## Mandatory Workflow
+
+1. **Always call `odoo_describe_model` first** before querying any model. This gives you the exact field names and types. Never guess field names — they differ from what you might expect (e.g., `product_uom_qty` not `quantity`, `amount_total` not `total`). Use `odoo_list_models` to discover which models are available.
+2. Use `odoo_count` to check dataset size before fetching large result sets.
+3. Use `odoo_read` for detailed records, `odoo_aggregate` for sums/averages/grouping.
+
+## Identifier Disambiguation (`id` vs `default_code`)
+
+Odoo uses two unrelated identifiers on product-like models, and confusing them is a frequent source of silent search failures (the query returns nothing, the agent guesses, the downstream action lands on the wrong record):
+
+- `id` — Odoo's internal numeric primary key (e.g. `42`). Opaque. Appears in URLs.
+- `default_code` — the human-readable internal reference / SKU (e.g. `WIDGET-12`).
+
+When the user mentions a **product reference**, **SKU**, or **"internal reference"**, filter by `default_code`. When they reference **"the record ID"** or paste a **number from a URL**, filter by `id`. Never use one when the user wrote the other.
+
+## Query Syntax Reference
+
+### Filters (domain)
+
+Array of `[field, operator, value]` tuples. Operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `not in`, `like`, `ilike`.
+Example: `[["state", "=", "sale"], ["date_order", ">=", "2026-01-01"]]`
+
+### odoo_read — order parameter
+
+String with field name and direction: `"date_order desc"` or `"amount_total asc"`.
+
+### odoo_aggregate — groupby and fields
+
+- `groupby`: array of field names, optionally with date granularity: `["partner_id"]`, `["date_order:month"]`, `["date_order:year"]`
+- `fields`: array of field names with aggregation operator: `["amount_total:sum"]`, `["partner_id:count_distinct"]`, `["price_unit:avg"]`
+- **Important**: The `orderby` parameter in `odoo_aggregate` sorts groups. Use a field from the groupby or an aggregated field: `"amount_total desc"`.
+- **Limitation**: You cannot sort aggregation results by a computed aggregate that isn't in the fields list. If you need custom sorting, fetch the groups and sort yourself.
+
+### Example: Revenue by month
+
+```json
+{
+  "model": "sale.order",
+  "filters": [["state", "=", "sale"]],
+  "fields": ["amount_total:sum"],
+  "groupby": ["date_order:month"]
+}
+```
+
+### Example: Top customers by revenue
+
+```json
+{
+  "model": "sale.order",
+  "filters": [["state", "=", "sale"]],
+  "fields": ["amount_total:sum"],
+  "groupby": ["partner_id"],
+  "orderby": "amount_total desc",
+  "limit": 10
+}
+```
+
+## Output Formatting
+
+- Use tables for comparisons and rankings
+- Use bullet points for summaries
+- Always include totals and counts
+- Format currency as EUR with 2 decimals
+- Format dates as DD.MM.YYYY
+
+## Important Rules
+
+- Never guess or fabricate data — only report what the API returns
+- If a query returns too many results, use count first and suggest filters
+- If you lack access to a model, say so clearly
+- Always state the time period of your analysis

--- a/packages/web/src/lib/skills/odoo-write/SKILL.md
+++ b/packages/web/src/lib/skills/odoo-write/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: odoo-write
+description: Create and update records in a connected Odoo instance with odoo_create / odoo_write, following the standard write discipline. Use whenever an agent has write access and needs to add or change data. Covers draft-first and confirm-before-write, duplicate checks, single-call creation with inline child lines, never guessing relation IDs, and verifying the record after create.
+---
+
+# Writing to Odoo
+
+When an agent has write access, `odoo_create` and `odoo_write` change real
+business data. This skill is the shared discipline every write follows. The
+model-specific procedure (which fields, which states, which dedup keys) lives
+in each agent's own persona; this skill is the invariant contract that sits
+underneath all of them.
+
+Use it together with [[odoo-read]] — you always read before you write.
+
+## Never write without confirming first
+
+Every `odoo_create` or `odoo_write` on business data is preceded by an explicit
+confirmation step. After you have prepared the change, present a clean summary
+to the user (the key fields, amounts, dates, partners, and what will happen) and
+ask before writing. Only proceed on an unambiguous yes. This holds even for a
+single-record edit.
+
+Where a model has a **draft → posted/confirmed** lifecycle (invoices, orders,
+transfers, manufacturing orders), create in **draft** first and never advance
+the state in the same step you create the record. Draft records are reversible;
+confirming/posting/validating usually is not.
+
+## Duplicate-check before every create
+
+Before creating a new record, `odoo_read` for an existing match first (partner
+by name, invoice by partner + date + amount, task by name + project, transfer by
+partner + date + type). If you find a likely duplicate, STOP and tell the user
+instead of creating a second one. This guards against double-writing when a
+previous create succeeded silently before a provider error.
+
+## One create call per record — inline the child lines
+
+Lines belong to their parent. Create the parent and its lines in a SINGLE
+`odoo_create` call by passing the child records inline (e.g. `invoice_line_ids`,
+`order_line`, `move_ids_without_package`) with Odoo's `[0, 0, {…}]` command
+tuples. Never create the child records separately from a parent you also just
+created — that pattern leaves half-finished records if a call fails between the
+two steps.
+
+## Never guess relation IDs
+
+For any many2one / many2many field (partner, account, tax, product, stage,
+location…), look the target up with `odoo_read` and use the returned reference.
+Never invent a numeric id or a `_pinchy_ref`. If a lookup returns several
+plausible matches, ask the user which one rather than guessing.
+
+## Verify the record after you create it
+
+Immediately after `odoo_create` returns, `odoo_read` the new record and compare
+the meaningful totals/fields against the source the user gave you (the receipt,
+the delivery note, the request). If they match within tolerance, continue to the
+confirmation step. If they diverge, STOP — show the user the diff and wait for
+guidance. Never silently rewrite a record to force a match.
+
+## Bulk operations: per-record review, single write
+
+When a change touches more than a few records, summarize each affected record to
+the user (not just the count) and wait for confirmation. On yes, you may issue a
+single `odoo_write` with the full id list for efficiency — but every record must
+have been individually surfaced first.
+
+## Action tools over raw state writes
+
+Some transitions have dedicated action tools (e.g. confirming an order,
+validating a transfer, marking an MO done, recording an approval). Prefer those
+over writing `state` by hand — a raw state write skips Odoo's side effects
+(deliveries, procurement, back-flushing, accounting) and leaves a broken record.
+When an action tool reports that Odoo needs a follow-up decision (backorder,
+consumption, second approval step), relay that to the user instead of retrying.


### PR DESCRIPTION
Closes #546. Part of the Skill Layer roadmap (#543).

## What

Move the cross-cutting invariant prose that was spliced into every Odoo template's `defaultAgentsMd` into OpenClaw-native **SKILL.md** bodies, referenced through `defaultSkills`. Templates keep their persona (role, `## Available Data`, role-specific workflows); the shared workflow guidance now loads via the skill layer per agent instead of being baked into every agent's AGENTS.md. **No user-visible behavior change.**

Single PR for all 7 skills + all 22 Odoo templates (no stacking).

## Seven shared skills (`packages/web/src/lib/skills/odoo-*/SKILL.md`)

| Skill | Body |
|---|---|
| `odoo-read` | describe-first query workflow, `id` vs `default_code`, query syntax, output/rules — the universal read foundation (all 22) |
| `odoo-write` | draft-first, duplicate-check, confirm-before-write, single-call create, post-create verify |
| `odoo-attach` | `_pinchy_ref` attachment flow + Telegram-media → uploads mapping |
| `odoo-activities` | schedule/complete/reschedule activity-tool contract |
| `odoo-multi-company` | cross-company disambiguation |
| `odoo-gross-to-net` | tax-exclusive `price_unit` conversion |
| `odoo-lot-serial` | lot/serial discipline for tracked products |

Each template carries the **union** of the skills its workflows invoke. `odooConfig.requiredModels` / `accessLevel` are unchanged.

## Mechanics

- `KNOWN_SKILLS` extended; the SKILL.md ↔ const drift-guard covers the 7 new skills.
- `createOdooTemplate` / `OdooAgentTemplateSpec` accept `defaultSkills`.
- Removed the now-dead shared string constants (`ODOO_QUERY_INSTRUCTIONS`, `ODOO_OUTPUT_FORMATTING`, `ODOO_RULES`, `ODOO_ATTACHMENT_REF_FLOW`, `ODOO_MULTI_COMPANY_GUIDANCE`, `ODOO_TELEGRAM_MEDIA_GUIDANCE`) from `odoo-factory.ts`.
- Tests that asserted the moved prose in `defaultAgentsMd` now assert on the skill bodies + `defaultSkills` membership (multi-company, telegram-media, bookkeeper gross-to-net, id/default_code). Added `odoo-skill-contract.test.ts` (template↔skill union guard). Net-additive — the no-test-deletion guard is green.
- Docs: `skills-and-templates.mdx` now lists the `odoo-*` skill set.

## Acceptance criteria

- [x] All Odoo templates carry `defaultSkills: [...]` and a slim persona.
- [x] Shared invariants live once (skill bodies), no copy-paste across templates.
- [x] `KNOWN_SKILLS` updated; drift-guard green.
- [x] Template-integration-coverage (#353) still green.
- [x] Odoo E2E unchanged — runs in the `odoo-e2e` CI job (no local Docker stack here). Specs reference `odoo_*` only as tool names, not AGENTS.md prose, so dispatch behavior is unaffected.

## Local gates

`tsc --noEmit` ✅ · eslint 0 errors ✅ · `format:check` ✅ · full web unit suite 9119 passed ✅ (one pre-existing `openclaw-config` flush-disable flake, green in isolation, unrelated to this change).