### PR TITLE
fix(test): raise timeouts on two load-sensitive heavy unit tests

### DIFF
--- a/packages/web/src/__tests__/components/timezone-settings.test.tsx
+++ b/packages/web/src/__tests__/components/timezone-settings.test.tsx
@@ -9,7 +9,10 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-describe("TimezoneSettings", () => {
+// 30s timeout: the Select renders ~418 Intl.supportedValuesOf timezones, so
+// opening it and querying options by role in jsdom takes ~3.5s of real CPU per
+// interaction test — over the 5s default when the full suite contends for CPU.
+describe("TimezoneSettings", { timeout: 30_000 }, () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1371,27 +1371,34 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.agents.defaults.compaction.memoryFlush.enabled).toBe(false);
   });
 
-  it("emits a flush-disable that OpenClaw's own resolver actually honors", async () => {
-    // Behavior guard against the REAL dependency: feed Pinchy's emitted config to
-    // OpenClaw's actual buildMemoryFlushPlan. A non-null plan is what spawned the
-    // tool-less flush run that dropped the production Telegram receipt; null means
-    // the flush never runs. Key-agnostic: if a future OpenClaw bump changes how the
-    // flag is read, this goes red even though our unit assertion above stays green.
-    const resolveFlushPlan = await loadOpenClawFlushResolver();
+  // 30s timeout: loadOpenClawFlushResolver cold-imports OpenClaw's real dist
+  // module graph (~95MB), which takes ~4.7s on an idle machine — over the 5s
+  // default whenever the full suite contends for CPU.
+  it(
+    "emits a flush-disable that OpenClaw's own resolver actually honors",
+    { timeout: 30_000 },
+    async () => {
+      // Behavior guard against the REAL dependency: feed Pinchy's emitted config to
+      // OpenClaw's actual buildMemoryFlushPlan. A non-null plan is what spawned the
+      // tool-less flush run that dropped the production Telegram receipt; null means
+      // the flush never runs. Key-agnostic: if a future OpenClaw bump changes how the
+      // flag is read, this goes red even though our unit assertion above stays green.
+      const resolveFlushPlan = await loadOpenClawFlushResolver();
 
-    await regenerateOpenClawConfig();
-    const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
+      await regenerateOpenClawConfig();
+      const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
 
-    // Pinchy's emitted config disables the flush.
-    expect(resolveFlushPlan({ cfg: config })).toBeNull();
+      // Pinchy's emitted config disables the flush.
+      expect(resolveFlushPlan({ cfg: config })).toBeNull();
 
-    // Baseline that prevents a false green: the SAME config with our flag removed
-    // must still produce a plan, proving the null above is caused by our flag and
-    // not by some unrelated reason the resolver bailed out.
-    const withoutFlag = structuredClone(config);
-    delete withoutFlag.agents.defaults.compaction;
-    expect(resolveFlushPlan({ cfg: withoutFlag })).not.toBeNull();
-  });
+      // Baseline that prevents a false green: the SAME config with our flag removed
+      // must still produce a plan, proving the null above is caused by our flag and
+      // not by some unrelated reason the resolver bailed out.
+      const withoutFlag = structuredClone(config);
+      delete withoutFlag.agents.defaults.compaction;
+      expect(resolveFlushPlan({ cfg: withoutFlag })).not.toBeNull();
+    }
+  );
 
   it("pins memory-search to the bundled local embedding provider (no API key, offline)", async () => {
     // memory_search / memory_get ride on memory-core's embedding index.

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -135,13 +135,15 @@ vi.mock("@/lib/openclaw-secrets", async (importOriginal) => {
 });
 
 vi.mock("@/lib/provider-models", () => {
-  const defaults: Record<string, string> = {
-    anthropic: "anthropic/claude-haiku-4-5-20251001",
-    openai: "openai/gpt-5.4-mini",
-    google: "google/gemini-2.5-flash",
-    "ollama-cloud": "ollama-cloud/minimax-m3",
-    "ollama-local": "",
-  };
+  // Map instead of a Record so the lookup below is not a
+  // security/detect-object-injection sink (Map#get is not one).
+  const defaults = new Map<string, string>([
+    ["anthropic", "anthropic/claude-haiku-4-5-20251001"],
+    ["openai", "openai/gpt-5.4-mini"],
+    ["google", "google/gemini-2.5-flash"],
+    ["ollama-cloud", "ollama-cloud/minimax-m3"],
+    ["ollama-local", ""],
+  ]);
   // Default "live" catalog: all three ollama-cloud image-preference models are
   // present. Individual tests override this to simulate an upstream retirement
   // (a model dropping out of /v1/models).
@@ -157,7 +159,7 @@ vi.mock("@/lib/provider-models", () => {
     },
   ]);
   return {
-    getDefaultModel: vi.fn(async (provider: string) => defaults[provider] ?? ""),
+    getDefaultModel: vi.fn(async (provider: string) => defaults.get(provider) ?? ""),
     fetchProviderModels,
     fetchOllamaLocalModelsFromUrl: vi.fn().mockResolvedValue([]),
   };
@@ -173,7 +175,7 @@ vi.mock("@/server/openclaw-client", () => ({
   getOpenClawClient: () => mockGetClient(),
 }));
 
-import { writeFileSync, readFileSync, existsSync, mkdirSync } from "fs";
+import { writeFileSync, readFileSync, existsSync } from "fs";
 import {
   writtenOpenClawConfig,
   findOpenClawConfigWrite,
@@ -200,7 +202,6 @@ const mockedFetchProviderModels = vi.mocked(fetchProviderModels);
 const mockedWriteFileSync = vi.mocked(writeFileSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedExistsSync = vi.mocked(existsSync);
-const mockedMkdirSync = vi.mocked(mkdirSync);
 
 const mockedDb = vi.mocked(db);
 const mockedGetSetting = vi.mocked(getSetting);
@@ -1038,6 +1039,8 @@ describe("regenerateOpenClawConfig", () => {
     const providers = config?.models?.providers ?? {};
 
     for (const providerName of ["anthropic", "openai"]) {
+      // Keys come from the literal list above, not from input.
+      // eslint-disable-next-line security/detect-object-injection
       const models = providers[providerName]?.models ?? [];
       expect(models.length, `${providerName} has models`).toBeGreaterThan(0);
       for (const m of models) {
@@ -1264,7 +1267,10 @@ describe("regenerateOpenClawConfig", () => {
         keyValue,
         expectedBaseUrl
       ) => {
+        // Env keys come from the literal it.each table above, not from input.
+        // eslint-disable-next-line security/detect-object-injection
         process.env[sdkEnv] = sdkValue;
+        // eslint-disable-next-line security/detect-object-injection
         process.env[pinchyEnv] = pinchyValue;
         mockedGetSetting.mockImplementation(async (key: string) => {
           if (key === settingKey) return keyValue;
@@ -1274,6 +1280,7 @@ describe("regenerateOpenClawConfig", () => {
         await regenerateOpenClawConfig();
         const written = writtenOpenClawConfig(mockedWriteFileSync);
         const config = JSON.parse(written);
+        // eslint-disable-next-line security/detect-object-injection
         expect(config?.models?.providers?.[provider]?.baseUrl).toBe(expectedBaseUrl);
       }
     );
@@ -2263,6 +2270,7 @@ describe("regenerateOpenClawConfig", () => {
       "mistral-large-3:675b",
     ];
     for (const id of visionModels) {
+      // eslint-disable-next-line security/detect-object-injection
       expect(byId[id].input).toEqual(["text", "image"]);
     }
     // Spot-check that text-only models stay text-only (gemma4 was the
@@ -2303,6 +2311,7 @@ describe("regenerateOpenClawConfig", () => {
       "qwen3.5:397b",
     ];
     for (const id of reasoningModels) {
+      // eslint-disable-next-line security/detect-object-injection
       expect(byId[id].reasoning).toBe(true);
     }
     // Non-reasoning — qwen3-coder-next explicitly "Non-thinking mode only",
@@ -2310,6 +2319,7 @@ describe("regenerateOpenClawConfig", () => {
     // minimax-m2.1 absent from Ollama's thinking tag list.
     const nonReasoningModels = ["mistral-large-3:675b"];
     for (const id of nonReasoningModels) {
+      // eslint-disable-next-line security/detect-object-injection
       expect(byId[id].reasoning).toBe(false);
     }
 
@@ -6967,8 +6977,6 @@ describe("pinchy-* plugin gatewayToken as SecretRef", () => {
     } as never);
     mockedGetSetting.mockResolvedValue(null);
   });
-
-  const GW_TOKEN_REF = { source: "file", provider: "pinchy", id: "/gateway/token" };
 
   it("preserves gateway.auth.token as plain string, keeps mode and bind", async () => {
     const existingConfig = {


### PR DESCRIPTION
## What does this PR do?

Fixes two unit tests that reproducibly failed only under full-suite load (`pnpm -C packages/web test`, ~9100 tests) while passing 227/227 in isolation — one of them already documented as a known full-suite flake in #864.

Root cause for both: genuinely heavy, **bounded** work sitting just under vitest's 5s default test timeout on an idle machine, pushed over it by full-suite CPU contention (~2× slowdown measured). No hang, no timer leak, no wrong assertion:

- **`openclaw-config.test.ts` › "emits a flush-disable that OpenClaw's own resolver actually honors"**: `loadOpenClawFlushResolver()` deliberately cold-imports OpenClaw's *real* dist module graph (~95MB; the `memory-search` chunk alone evals in ~2s). Measured **4.73s in isolation on an idle machine** — 271ms of headroom to the 5000ms limit. The real-dependency import is intentional (behavior guard against the installed openclaw) and stays untouched.
- **`timezone-settings.test.tsx` › Save-POST test**: opens a Radix Select rendering ~418 real `Intl.supportedValuesOf` timezones in jsdom, plus userEvent pointer simulation and `byRole` queries with accessible-name computation across all options — **3.5s under moderate load**.

Fix: explicit `{ timeout: 30_000 }` with an explanatory comment, following the existing pattern for deliberately heavy tests (`fake-ollama-usage.test.ts` 20s, `watcher-real-fs.test.ts` 15s, `vitest.integration.config.ts` 30s global):

- on the flush test individually (the file's other 215 tests run in ~300ms), and
- on the `TimezoneSettings` describe as a whole, because the sibling dropdown tests (2.2s each) share the same mechanism and are the next flake candidates.

No assertion changed, no query weakened, no skip — a genuine hang still fails, at 30s instead of 5s. The larger diff in `openclaw-config.test.ts` is pure prettier re-indentation from the added options argument.

**Verification:** two consecutive full-suite runs green (9115 passed each), both edited files green in isolation, web typecheck (incl. tests) clean.

## Type of change

- [x] 🧪 Tests

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [ ] I've added tests for new functionality (if applicable)
- [ ] I've updated the documentation (if applicable)
- [x] All existing tests pass

## Follow-up: lint cleanup (second commit)

Review follow-up: `openclaw-config.test.ts` carried 10 pre-existing ESLint warnings (all pre-dating this branch). The second commit clears them — the file is now at 0 warnings:

- Removed two dead consts (`mockedMkdirSync` + its now-unused `mkdirSync` import, `GW_TOKEN_REF`).
- The `getDefaultModel` mock's `defaults` lookup now uses a `Map`, so the dynamic access is no longer a `security/detect-object-injection` sink (same approach as `imap-providers.ts`).
- The six remaining `detect-object-injection` hits are documented false positives (every dynamic key comes from a literal test-local list or `it.each` table) and are suppressed with the file's established `eslint-disable-next-line` pattern.

No test added, removed, or behaviorally changed; test file green (216/216), typecheck + format clean.
