### PR TITLE
fix(kb-eval): make the Layer-3 groundedness sweep actually run (#869)

### DIFF
--- a/packages/web/eval/kb/getRawAssistantMessage.ts
+++ b/packages/web/eval/kb/getRawAssistantMessage.ts
@@ -125,8 +125,17 @@ export async function getRawAssistantMessage(
     );
   }
 
+  // The CSRF gate (src/server/csrf-check.ts) rejects any mutating /api/ POST
+  // that carries neither an Origin nor a Referer header — reason
+  // "missing-origin-and-referer", surfaced as 403. Playwright's
+  // page.request.post sends neither by default (it is an API request context,
+  // not a browser fetch from page JS), so this capture was the one mutating
+  // eval call that bypassed run-eval.ts's `mutatingHeaders` helper (which sets
+  // `Origin: PINCHY_URL` on every pinchyPost/Patch/Delete). Send an Origin that
+  // matches the page's own host so the gate's Origin===Host check passes.
   const exportRes = await page.request.post("/api/diagnostics/export", {
     data: { agentId, sessionId: match.sessionId },
+    headers: { Origin: new URL(page.url()).origin },
   });
   if (!exportRes.ok()) {
     throw new Error(

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -124,9 +124,14 @@ async function seedSyntheticCorpus(dbUrl: string): Promise<void> {
   const sql = postgres(dbUrl);
   try {
     for (const doc of KB_EVAL_CORPUS) {
+      // kb_documents.id / kb_chunks.id are `text` with NO database default —
+      // the app supplies them via Drizzle's `$defaultFn(() => crypto.randomUUID())`,
+      // so a raw INSERT that omits `id` hits a NOT NULL violation. Mint one in
+      // SQL (gen_random_uuid() is built into Postgres 13+, no extension) to
+      // mirror the app's uuid-shaped text id.
       const [dbDoc] = await sql<{ id: string }[]>`
-        INSERT INTO kb_documents (org_id, content_hash, source_path, status)
-        VALUES (${DEFAULT_ORG_ID}, ${`hash-${doc.sourcePath}`}, ${doc.sourcePath}, 'active')
+        INSERT INTO kb_documents (id, org_id, content_hash, source_path, status)
+        VALUES (gen_random_uuid()::text, ${DEFAULT_ORG_ID}, ${`hash-${doc.sourcePath}`}, ${doc.sourcePath}, 'active')
         ON CONFLICT DO NOTHING
         RETURNING id
       `;
@@ -157,8 +162,8 @@ async function seedSyntheticCorpus(dbUrl: string): Promise<void> {
         // produces for a number array — see src/lib/knowledge/retrieve.ts's
         // identical `${queryVectorLiteral}::vector` pattern.
         await sql`
-          INSERT INTO kb_chunks (document_id, org_id, source_path, chunk_text, page, embedding)
-          VALUES (${dbDocId}, ${DEFAULT_ORG_ID}, ${doc.sourcePath}, ${chunk.text}, ${chunk.page}, ${JSON.stringify(embedding)}::vector)
+          INSERT INTO kb_chunks (id, document_id, org_id, source_path, chunk_text, page, embedding)
+          VALUES (gen_random_uuid()::text, ${dbDocId}, ${DEFAULT_ORG_ID}, ${doc.sourcePath}, ${chunk.text}, ${chunk.page}, ${JSON.stringify(embedding)}::vector)
         `;
       }
     }


### PR DESCRIPTION
Fixes the two latent bugs that stopped the KB Layer-3 groundedness sweep from ever running against a real stack — see #869 for the full findings.

## What this fixes
1. **id-less corpus INSERTs** — `seedSyntheticCorpus` omitted `id` on `kb_documents`/`kb_chunks` (both `text`, no DB default; app-generated via Drizzle `$defaultFn`), hitting a NOT NULL violation on the first insert. Now mints the id via `gen_random_uuid()::text`.
2. **CSRF-export 403** — `getRawAssistantMessage` POSTed to `/api/diagnostics/export` via `page.request.post` with no Origin/Referer → CSRF gate 403 → every capture failed as `run-infra-error`. Now sends `Origin` matching the page host, like `run-eval.ts`'s `mutatingHeaders`.

With both applied the pipeline runs end-to-end and grades for the first time.

## What this does NOT fix (tracked in #869)
- A `PostgresError: op ANY/ALL requires array` on some runs.
- **Methodology:** the sweep uses a bare `custom` agent with no cite-then-answer instructions, so capable models score passRate 0 (ungrounded/uncited) — a setup artifact, not a measurement. Needs a design decision (KB template vs. injected instructions).

## Test plan
- [x] `eval:selftest` green on the rebuilt stack.
- [x] `kb-eval:models` (kimi-k2.6 + qwen3.5:397b) now runs end-to-end and produces graded output (no id-violation, no export 403).
- [ ] A trustworthy groundedness number is blocked on the #869 methodology decision.

No product-code change — harness-only.