### PR TITLE
feat(pinchy-odoo): deterministic vendor-bill duplicate guard (#721)

### DIFF
--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -152,6 +152,16 @@ If your Odoo database hosts more than one `res.company`, Pinchy adds two layers 
 
 The stock **Finance Controller** and **Bookkeeper** templates also include guidance that teaches the agent to disambiguate multi-company records up front. (Finance Controller suggests **Penny** as one of its agent names, so you may see this agent under that name.) Newly-created agents pick this up automatically; existing agents keep their stored `AGENTS.md` until you recreate them, but the runtime cross-company guard applies regardless.
 
+## Duplicate vendor bills
+
+Filing the same supplier invoice twice is double payment — one of the failure modes teams fear most from an autonomous agent. So before an agent creates a vendor bill or vendor credit note (`account.move` with `move_type` `in_invoice` or `in_refund`), the `pinchy-odoo` plugin checks whether a bill with the same reference (`ref` — the supplier's invoice number) is already on file, scoped to the company and partner when the create supplies them.
+
+**On a match, the create is blocked.** The agent receives a structured refusal naming the existing bill — its id, name, state, total, and date — so it relays that back to you instead of writing a second copy. The blocked attempt is recorded in the [audit trail](/concepts/audit-trail/) as a failed `tool.odoo_create` entry, which is exactly what the audit should show.
+
+This mirrors how Odoo itself keys duplicate detection for vendor documents — on the reference number — and never applies to customer invoices or journal entries, where a shared reference is legitimate.
+
+**Deliberate re-filings have an escape hatch.** If a second entry really is intended, the agent can repeat the create with `allow_duplicate: true`. The bill is then created and the audit entry records the override alongside the bill it duplicated, so the decision stays traceable.
+
 ## Re-syncing when Odoo permissions change
 
 If the Odoo admin changes the API user's permissions after you've set up the connection, agents may lose access to certain models. When this happens, the agent gets a clear error message explaining that access was denied.

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -38,6 +38,7 @@ interface AgentTool {
   ) => Promise<{
     content: Array<{ type: string; text: string }>;
     isError?: boolean;
+    details?: unknown;
   }>;
 }
 
@@ -744,14 +745,36 @@ describe("pinchy-odoo multi-company journal resolution (bare ref + scoped lookup
       values,
     });
     expect(second.isError).toBe(true);
-    expect(second.content[0].text).toContain("already exists");
+    // Structured, retry-safe block (pinchy#721): names the existing bill and
+    // points at the explicit override rather than inviting a blind retry.
+    expect(second.content[0].text).toContain("blocked");
     expect(second.content[0].text).toContain("DUP-INV-777");
+    expect(second.content[0].text).toContain("allow_duplicate");
 
     // Exactly one move with that ref exists — no duplicate was written.
     const moves = (await fetch(
       `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`
     ).then((res) => res.json())) as Array<Record<string, unknown>>;
     expect(moves.filter((m) => m.ref === "DUP-INV-777")).toHaveLength(1);
+
+    // The explicit override re-files the bill deliberately: the create proceeds
+    // and the result carries a traceable override detail naming the bill it
+    // duplicated (the tool-use audit route lifts result.details).
+    const overridden = await createTool.execute("create-dup-override", {
+      model: "account.move",
+      values,
+      allow_duplicate: true,
+    });
+    expect(overridden.isError).toBeFalsy();
+    const overrideDetails = overridden.details as Record<string, unknown>;
+    expect(overrideDetails.duplicateOverride).toBe(true);
+    expect((overrideDetails.existingBill as { id: number }).id).toBeGreaterThan(0);
+
+    // Now two moves with that ref exist — the deliberate second entry landed.
+    const movesAfter = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(movesAfter.filter((m) => m.ref === "DUP-INV-777")).toHaveLength(2);
   });
 
   it("#3: allows the same ref in a DIFFERENT company (dedup is company-scoped, not global)", async () => {

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -2442,6 +2442,250 @@ describe("odoo_create", () => {
   });
 });
 
+// pinchy#721: deterministic vendor-bill duplicate guard. Before an odoo_create on
+// account.move for a VENDOR document (move_type in_invoice / in_refund), the plugin
+// searches for an existing bill with the same partner + ref and, on a hit, blocks
+// the create and returns a structured snapshot of the existing bill so the model
+// relays it to the user instead of double-booking (a double-payment risk). An
+// explicit `allow_duplicate: true` override exists for deliberate re-filings.
+//
+// Scope is intentionally the two VENDOR move types only — matching Odoo's own
+// _fetch_duplicate_reference, which keys vendor docs on `ref` and never
+// ref-dedups customer invoices (out_invoice) or journal entries (entry).
+describe("odoo_create vendor-bill duplicate guard (#721)", () => {
+  const dupConfig = {
+    connectionId: "conn-test-1",
+    permissions: { "account.move": ["read", "create"] },
+    modelNames: { "account.move": "Journal Entry" },
+  };
+  // Odoo account.move fields the guard's normalization + selection validation see.
+  const MOVE_SCHEMA_FIELDS = [
+    {
+      name: "move_type",
+      string: "Type",
+      type: "selection",
+      selection: [
+        ["entry", "Journal Entry"],
+        ["out_invoice", "Customer Invoice"],
+        ["out_refund", "Customer Credit Note"],
+        ["in_invoice", "Vendor Bill"],
+        ["in_refund", "Vendor Credit Note"],
+      ],
+    },
+    { name: "ref", string: "Reference", type: "char" },
+    { name: "partner_id", string: "Partner", type: "many2one", relation: "res.partner" },
+  ];
+
+  // The vendor bill already on file that a hit must snapshot.
+  const EXISTING_BILL = {
+    id: 39,
+    name: "BILL/2026/0039",
+    state: "posted",
+    amount_total: 1234.56,
+    invoice_date: "2026-06-01",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+    mockFields.mockResolvedValue(MOVE_SCHEMA_FIELDS);
+  });
+
+  it("blocks a vendor-bill create when a bill with the same ref already exists, snapshotting id/name/state/amount_total/date", async () => {
+    mockSearchRead.mockResolvedValue({
+      records: [EXISTING_BILL],
+      total: 1,
+      limit: 1,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: dupConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-dup", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "083000981540" },
+    });
+
+    // Blocked: failure outcome, no write reached Odoo.
+    expect(result.isError).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+
+    // Structured snapshot naming the existing bill (issue: id, name, state,
+    // amount_total, date) so the model can relay it instead of writing.
+    const text = result.content[0].text;
+    expect(text).toContain("083000981540"); // the ref
+    expect(text).toContain("39"); // existing bill id
+    expect(text).toContain("BILL/2026/0039"); // existing bill name
+    expect(text).toContain("posted"); // existing bill state
+    expect(text).toContain("1234.56"); // amount_total
+    expect(text).toContain("2026-06-01"); // date
+    // Retry-safe: point the model at the override rather than a blind retry.
+    expect(text).toMatch(/allow_duplicate/);
+  });
+
+  it("blocks a vendor CREDIT NOTE (in_refund) duplicate too — Odoo treats it with vendor bills", async () => {
+    mockSearchRead.mockResolvedValue({
+      records: [{ ...EXISTING_BILL, id: 41, name: "RBILL/2026/0041" }],
+      total: 1,
+      limit: 1,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: dupConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-refund-dup", {
+      model: "account.move",
+      values: { move_type: "in_refund", ref: "CN-9001" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain("41");
+  });
+
+  it("lets a first-time vendor bill through when no duplicate is on file", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 1, offset: 0 });
+    mockCreate.mockResolvedValue(1002);
+
+    const tools = createApi({ [agentId]: dupConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-first", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "NEW-0001" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("account.move", {
+      move_type: "in_invoice",
+      ref: "NEW-0001",
+    });
+    expect(JSON.parse(result.content[0].text).id).toBe(1002);
+  });
+
+  it("does NOT guard a customer invoice (out_invoice) — Odoo never ref-dedups those", async () => {
+    // A same-ref customer invoice is a legitimate second entry: out-document refs
+    // are not vendor document numbers. The guard must not run its search, so the
+    // create proceeds even though a record with this ref exists.
+    mockSearchRead.mockResolvedValue({
+      records: [EXISTING_BILL],
+      total: 1,
+      limit: 1,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(2002);
+
+    const tools = createApi({ [agentId]: dupConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-out", {
+      model: "account.move",
+      values: { move_type: "out_invoice", ref: "083000981540" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("does NOT guard a plain journal entry (no move_type) — Odoo never dedups those", async () => {
+    mockCreate.mockResolvedValue(3003);
+
+    const tools = createApi({ [agentId]: dupConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-entry", {
+      model: "account.move",
+      values: { ref: "JE-0001" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("proceeds and records a traceable override when allow_duplicate is true", async () => {
+    mockSearchRead.mockResolvedValue({
+      records: [EXISTING_BILL],
+      total: 1,
+      limit: 1,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(1003);
+
+    const tools = createApi({ [agentId]: dupConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-override", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "083000981540" },
+      allow_duplicate: true,
+    });
+
+    // The create proceeds despite the on-file duplicate.
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("account.move", {
+      move_type: "in_invoice",
+      ref: "083000981540",
+    });
+    expect(JSON.parse(result.content[0].text).id).toBe(1003);
+
+    // The override decision is captured in a curated audit detail (the tool-use
+    // audit route lifts result.details) naming the bill that was overridden, so
+    // the deliberate double-booking is traceable.
+    const details = result.details as Record<string, unknown>;
+    expect(details.duplicateOverride).toBe(true);
+    expect((details.existingBill as { id: number }).id).toBe(39);
+    // The audit row describes the deliberate double-booking inline: what was
+    // booked (ref + move type + new id) alongside the bill it duplicated.
+    expect(details.bookedRef).toBe("083000981540");
+    expect(details.bookedMoveType).toBe("in_invoice");
+    expect(details.createdId).toBe(1003);
+  });
+
+  it("allow_duplicate on a bill with NO on-file duplicate is a normal create (no override detail)", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 1, offset: 0 });
+    mockCreate.mockResolvedValue(1004);
+
+    const tools = createApi({ [agentId]: dupConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-override-noop", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "NEW-0002" },
+      allow_duplicate: true,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+    // No duplicate existed, so nothing was overridden — no override audit detail.
+    expect(result.details).toBeUndefined();
+  });
+
+  it("skips the guard when the agent lacks read on account.move (cannot verify, so cannot block)", async () => {
+    const createOnly = {
+      connectionId: "conn-test-1",
+      permissions: { "account.move": ["create"] },
+      modelNames: { "account.move": "Journal Entry" },
+    };
+    mockCreate.mockResolvedValue(4004);
+
+    const tools = createApi({ [agentId]: createOnly });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-noread", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "083000981540" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+});
+
 describe("odoo_write", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2132,6 +2132,72 @@ function errorResult(
   return toolError(`Error: ${message}`);
 }
 
+/**
+ * A snapshot of the vendor bill that already carries a given `ref`, surfaced by
+ * the deterministic duplicate guard (pinchy#721) so the model can relay it to
+ * the user instead of double-booking (a double-payment risk).
+ */
+interface ExistingBillSnapshot {
+  id: number;
+  name: string | null;
+  state: string | null;
+  amount_total: number | null;
+  date: string | null;
+}
+
+// Odoo's own duplicate detection (`_fetch_duplicate_reference`, account 19)
+// keys VENDOR documents on their `ref` — the supplier's invoice number. Customer
+// invoices (out_invoice/out_refund) are deduped on amount+date, NEVER on ref, and
+// journal entries are never deduped at all. So a ref-based guard scopes to exactly
+// these two vendor move types; guarding out_* on ref would falsely reject a
+// legitimately re-used customer-document reference.
+const VENDOR_DOCUMENT_MOVE_TYPES = new Set(["in_invoice", "in_refund"]);
+
+function vendorDocumentLabel(moveType: string): string {
+  return moveType === "in_refund" ? "vendor credit note" : "vendor bill";
+}
+
+function toBillSnapshot(record: Record<string, unknown>): ExistingBillSnapshot {
+  return {
+    id: record.id as number,
+    name: typeof record.name === "string" ? record.name : null,
+    state: typeof record.state === "string" ? record.state : null,
+    amount_total: typeof record.amount_total === "number" ? record.amount_total : null,
+    // Odoo returns `false` for an unset invoice_date; normalize to null.
+    date: typeof record.invoice_date === "string" ? record.invoice_date : null,
+  };
+}
+
+function formatExistingBillSnapshot(s: ExistingBillSnapshot): string {
+  const parts = [`id ${s.id}`];
+  if (s.name) parts.push(`"${s.name}"`);
+  if (s.state) parts.push(`state ${s.state}`);
+  if (s.amount_total !== null) parts.push(`total ${s.amount_total}`);
+  if (s.date) parts.push(`dated ${s.date}`);
+  return parts.join(", ");
+}
+
+/**
+ * The block message. Deliberately phrased to make the model RELAY the existing
+ * bill rather than loop against the refusal (the eval's hard-rejection scenario
+ * showed some models retry a refused create). It names the bill, states it was
+ * not created, and points at the explicit `allow_duplicate` override.
+ */
+function duplicateBillBlockMessage(
+  moveType: string,
+  ref: string,
+  snapshot: ExistingBillSnapshot
+): string {
+  const label = vendorDocumentLabel(moveType);
+  return (
+    `Duplicate ${label} blocked. A ${label} with reference "${ref}" is already on file ` +
+    `in Odoo: ${formatExistingBillSnapshot(snapshot)}. It was NOT created again — booking ` +
+    `it twice risks a double payment. Do not retry this create; relay the existing bill ` +
+    `above to the user. If this is a deliberate, confirmed re-filing, call odoo_create ` +
+    `again with allow_duplicate: true.`
+  );
+}
+
 const plugin = {
   id: "pinchy-odoo",
   name: "Pinchy Odoo",
@@ -2645,7 +2711,7 @@ const plugin = {
           name: "odoo_create",
           label: "Odoo Create",
           description:
-            'Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.',
+            'Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing. Vendor bills and vendor credit notes (account.move `in_invoice` / `in_refund`) are duplicate-guarded: a create whose `ref` already exists on file is BLOCKED and the existing bill returned so you can relay it to the user instead of double-booking. Set `allow_duplicate: true` only to deliberately re-file a bill you have confirmed should exist twice.',
           parameters: {
             type: "object",
             properties: {
@@ -2654,6 +2720,11 @@ const plugin = {
                 type: "object",
                 description:
                   "Field values for the new record. Many2one text values must be exact names or supported codes, not partial/fuzzy matches.",
+              },
+              allow_duplicate: {
+                type: "boolean",
+                description:
+                  "Set true ONLY to deliberately re-file a vendor bill/credit note (account.move in_invoice/in_refund) whose reference already exists in Odoo. Normally leave unset: the plugin blocks a duplicate vendor-bill create and returns the existing bill so you relay it to the user instead of double-booking (a double-payment risk).",
               },
             },
             required: ["model", "values"],
@@ -2671,94 +2742,140 @@ const plugin = {
                 throw itemWrappedError("values");
               }
 
-              const id = await withAuthRetry(agentId, config, async (client) => {
-                let values: Record<string, unknown>;
-                // The model's field schema, fetched once during many2one
-                // normalization and reused for #5 selection validation below
-                // (avoids a second client.fields round-trip on every create).
-                let modelFields: OdooField[] | null = null;
-                if (isRecord(params.values)) {
-                  const cleaned = unquoteFieldKeys(params.values);
-                  assertNoCrossCompanyRefs(cleaned);
-                  const normalized = await normalizeMany2OneValues(
-                    client,
-                    config.connectionId,
-                    model,
-                    cleaned,
-                    config.permissions
-                  );
-                  values = normalized.values;
-                  modelFields = normalized.fields;
-                  values = await ensureActivityResModelId(client, model, values);
-                } else {
-                  values = params.values as Record<string, unknown>;
-                }
+              // Explicit override for a deliberate re-filing of a bill that
+              // already exists (pinchy#721). Read from the raw params: it is a
+              // tool-level flag, not an Odoo field, so it never enters `values`.
+              const allowDuplicate = params.allow_duplicate === true;
 
-                // #5: reject out-of-set selection values (e.g. move_type
-                // "in_bill", which is not a real Odoo move_type) with the valid
-                // options, instead of forwarding a bad enum to Odoo where it
-                // surfaces as an opaque server error the agent has to guess at.
-                if (modelFields) {
-                  const invalidSelections = findInvalidSelectionValues(modelFields, values);
-                  if (invalidSelections.length > 0) {
-                    throw new Error(formatInvalidSelectionError(model, invalidSelections));
-                  }
-                }
-
-                // #3: duplicate-invoice guard. An account.move (vendor/customer
-                // invoice) is keyed by its `ref` — the supplier's invoice
-                // number. Agents that fail to find an existing bill (e.g. a
-                // search with an invalid move_type returns empty) otherwise book
-                // a DUPLICATE: on staging the agent created move_id 40 duplicating
-                // move_id 39, both ref 083000981540. Before creating, surface any
-                // existing move that already carries the same ref (+ move_type +
-                // partner) so the agent updates it or confirms a deliberate
-                // second entry rather than silently double-booking.
-                if (
-                  model === "account.move" &&
-                  typeof values.ref === "string" &&
-                  values.ref.trim() &&
-                  checkPermission(config.permissions, model, "read")
-                ) {
-                  const dupDomain: OdooDomain = [["ref", "=", values.ref]];
-                  if (typeof values.move_type === "string") {
-                    dupDomain.push(["move_type", "=", values.move_type]);
-                  }
-                  // Scope by company: the same supplier invoice number can be
-                  // booked legitimately by two separate companies in one Odoo
-                  // instance, so a global ref match would falsely reject the
-                  // second company's entry. company_id is a resolved integer
-                  // here (normalizeMany2OneValues ran above).
-                  if (typeof values.company_id === "number") {
-                    dupDomain.push(["company_id", "=", values.company_id]);
-                  }
-                  if (typeof values.partner_id === "number") {
-                    dupDomain.push(["partner_id", "=", values.partner_id]);
-                  }
-                  const existing = getSearchReadRecords(
-                    await client.searchRead("account.move", dupDomain, {
-                      fields: ["id", "name", "state"],
-                      limit: 1,
-                    })
-                  );
-                  if (existing.length > 0) {
-                    const dup = existing[0] as { id: number; name?: string; state?: string };
-                    throw new Error(
-                      `A record already exists in account.move with ref "${values.ref}"` +
-                        (typeof values.move_type === "string"
-                          ? ` (move_type "${values.move_type}")`
-                          : "") +
-                        `: id ${dup.id}` +
-                        (dup.name ? ` "${dup.name}"` : "") +
-                        (dup.state ? `, state "${dup.state}"` : "") +
-                        `. To avoid a duplicate, update it with odoo_write, or confirm you ` +
-                        `intend a second entry before creating.`
+              const outcome = await withAuthRetry(
+                agentId,
+                config,
+                async (
+                  client
+                ): Promise<
+                  | {
+                      kind: "created";
+                      id: number;
+                      override: ExistingBillSnapshot | null;
+                      ref: string | null;
+                      moveType: string;
+                    }
+                  | {
+                      kind: "blocked";
+                      moveType: string;
+                      ref: string;
+                      snapshot: ExistingBillSnapshot;
+                    }
+                > => {
+                  let values: Record<string, unknown>;
+                  // The model's field schema, fetched once during many2one
+                  // normalization and reused for #5 selection validation below
+                  // (avoids a second client.fields round-trip on every create).
+                  let modelFields: OdooField[] | null = null;
+                  if (isRecord(params.values)) {
+                    const cleaned = unquoteFieldKeys(params.values);
+                    assertNoCrossCompanyRefs(cleaned);
+                    const normalized = await normalizeMany2OneValues(
+                      client,
+                      config.connectionId,
+                      model,
+                      cleaned,
+                      config.permissions
                     );
+                    values = normalized.values;
+                    modelFields = normalized.fields;
+                    values = await ensureActivityResModelId(client, model, values);
+                  } else {
+                    values = params.values as Record<string, unknown>;
                   }
-                }
 
-                return client.create(model, values);
-              });
+                  // #5: reject out-of-set selection values (e.g. move_type
+                  // "in_bill", which is not a real Odoo move_type) with the valid
+                  // options, instead of forwarding a bad enum to Odoo where it
+                  // surfaces as an opaque server error the agent has to guess at.
+                  if (modelFields) {
+                    const invalidSelections = findInvalidSelectionValues(modelFields, values);
+                    if (invalidSelections.length > 0) {
+                      throw new Error(formatInvalidSelectionError(model, invalidSelections));
+                    }
+                  }
+
+                  // #3: deterministic vendor-bill duplicate guard (pinchy#721).
+                  // A vendor bill/credit note is keyed by its `ref` — the
+                  // supplier's invoice number. On staging an agent created
+                  // move_id 40 duplicating move_id 39, both ref 083000981540; in
+                  // the eval, 13/14 models filed the duplicate anyway. Pinchy owns
+                  // the tool layer, so Pinchy owns the guarantee: before creating,
+                  // search for an existing bill with the same ref (+ move_type +
+                  // company + partner). On a hit, BLOCK and return the existing
+                  // bill so the model relays it; `allow_duplicate: true` is the
+                  // explicit escape hatch for a deliberate second entry. Scope is
+                  // in_invoice/in_refund only — matching Odoo's own ref-based
+                  // dedup, which never ref-dedups customer invoices or entries.
+                  let override: ExistingBillSnapshot | null = null;
+                  const moveType = typeof values.move_type === "string" ? values.move_type : "";
+                  if (
+                    model === "account.move" &&
+                    VENDOR_DOCUMENT_MOVE_TYPES.has(moveType) &&
+                    typeof values.ref === "string" &&
+                    values.ref.trim() &&
+                    checkPermission(config.permissions, model, "read")
+                  ) {
+                    const dupDomain: OdooDomain = [
+                      ["ref", "=", values.ref],
+                      ["move_type", "=", moveType],
+                    ];
+                    // Scope by company: the same supplier invoice number can be
+                    // booked legitimately by two separate companies in one Odoo
+                    // instance, so a global ref match would falsely reject the
+                    // second company's entry. company_id is a resolved integer
+                    // here (normalizeMany2OneValues ran above).
+                    if (typeof values.company_id === "number") {
+                      dupDomain.push(["company_id", "=", values.company_id]);
+                    }
+                    if (typeof values.partner_id === "number") {
+                      dupDomain.push(["partner_id", "=", values.partner_id]);
+                    }
+                    const existing = getSearchReadRecords(
+                      await client.searchRead("account.move", dupDomain, {
+                        fields: ["id", "name", "state", "amount_total", "invoice_date"],
+                        limit: 1,
+                      })
+                    );
+                    if (existing.length > 0) {
+                      const snapshot = toBillSnapshot(existing[0]);
+                      if (!allowDuplicate) {
+                        return { kind: "blocked", moveType, ref: values.ref, snapshot };
+                      }
+                      // Override authorized: remember what was overridden so the
+                      // deliberate double-booking is traceable in the audit trail.
+                      override = snapshot;
+                    }
+                  }
+
+                  const createdId = await client.create(model, values);
+                  return {
+                    kind: "created",
+                    id: createdId,
+                    override,
+                    ref: typeof values.ref === "string" ? values.ref : null,
+                    moveType,
+                  };
+                }
+              );
+
+              if (outcome.kind === "blocked") {
+                // isError:true → the pinchy-audit hook + tool-use route record
+                // outcome=failure with the snapshot lifted into detail.error.
+                // toolError emits an error-ONLY `details: { error }`, which the
+                // route deliberately does not treat as curation — so the blocked
+                // create's params survive in the audit row for forensics.
+                return toolError(
+                  duplicateBillBlockMessage(outcome.moveType, outcome.ref, outcome.snapshot)
+                );
+              }
+
+              const id = outcome.id;
 
               // Emit a self-ref so the LLM can chain into tools that consume
               // opaque references (most importantly odoo_attach_file). Without
@@ -2780,11 +2897,32 @@ const plugin = {
                 label,
               });
 
+              const body: Record<string, unknown> = { id, _pinchy_ref: selfRef };
+              if (outcome.override) {
+                body.duplicate_override = { existing_bill: outcome.override };
+                return {
+                  content: [{ type: "text", text: JSON.stringify(body) }],
+                  // Curated audit detail (the tool-use route lifts result.details
+                  // and, because it carries non-error fields, suppresses the raw
+                  // create params): the deliberate double-booking described inline
+                  // — what was booked (ref + move type + new id) AND the bill it
+                  // duplicated — so an auditor sees the full decision without a
+                  // second lookup, and without logging partner/amount PII.
+                  details: {
+                    duplicateOverride: true,
+                    bookedRef: outcome.ref,
+                    bookedMoveType: outcome.moveType,
+                    createdId: id,
+                    existingBill: outcome.override,
+                  },
+                };
+              }
+
               return {
                 content: [
                   {
                     type: "text",
-                    text: JSON.stringify({ id, _pinchy_ref: selfRef }),
+                    text: JSON.stringify(body),
                   },
                 ],
               };

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2907,7 +2907,9 @@ const plugin = {
                   // create params): the deliberate double-booking described inline
                   // — what was booked (ref + move type + new id) AND the bill it
                   // duplicated — so an auditor sees the full decision without a
-                  // second lookup, and without logging partner/amount PII.
+                  // second lookup. The snapshot deliberately carries the existing
+                  // bill's amount/date/state (auditor context, not PII) but no
+                  // partner identity, so no personal identifiers reach the log.
                   details: {
                     duplicateOverride: true,
                     bookedRef: outcome.ref,

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -30,6 +30,9 @@ import {
   FAKE_OLLAMA_ODOO_RECONCILE_REF_TRIGGER,
   FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_TRIGGER,
   FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_FILENAME,
+  FAKE_OLLAMA_ODOO_DUP_BILL_REF,
+  FAKE_OLLAMA_ODOO_CREATE_DUP_BLOCK_TRIGGER,
+  FAKE_OLLAMA_ODOO_CREATE_DUP_OVERRIDE_TRIGGER,
   FAKE_OLLAMA_PORT,
   startFakeOllama,
   stopFakeOllama,
@@ -406,6 +409,26 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
         company_id: [1, "Helmcraft GmbH"],
       },
     ]);
+    // Duplicate guard (pinchy#721): a POSTED vendor bill already on file. A
+    // second odoo_create with this same ref+move_type must be blocked; the
+    // override probe re-files it deliberately. It carries no lines, so the
+    // mock's amount-computation leaves it untouched. Crucially it is seeded
+    // AFTER the reconcile bill (9601): the reconcile probe's odoo_read passes no
+    // `order`, so the mock returns account.move in INSERTION order, keeping 9601
+    // first and the probe's `refs[0]` on the reconcile bill. The id (9801 > 9601)
+    // is a belt-and-suspenders in case a default id sort is ever introduced.
+    // Do not reorder these seeds.
+    await seedOdooRecords("account.move", [
+      {
+        id: 9801,
+        name: "BILL/E2E-DUP",
+        move_type: "in_invoice",
+        state: "posted",
+        ref: FAKE_OLLAMA_ODOO_DUP_BILL_REF,
+        company_id: [1, "Helmcraft GmbH"],
+        partner_id: [1, "Müller GmbH"],
+      },
+    ]);
     await seedOdooRecords("account.move.line", [
       {
         id: 9611,
@@ -451,6 +474,7 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
       { model: "purchase.order", operation: "read" },
       { model: "purchase.order", operation: "write" },
       { model: "account.move", operation: "read" },
+      { model: "account.move", operation: "create" },
       { model: "account.move.line", operation: "write" },
       { model: "account.payment", operation: "read" },
       { model: "ir.attachment", operation: "create" },
@@ -475,6 +499,7 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
           "odoo_set_approval",
           "odoo_reconcile",
           "odoo_attach_file",
+          "odoo_create",
         ],
       },
       dispatchCookie
@@ -801,5 +826,60 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
         await expect(readyChip).toBeVisible({ timeout: 20_000 });
       },
     });
+  });
+
+  // ── Deterministic vendor-bill duplicate guard (pinchy#721) ────────────────
+  // A vendor bill with ref ODOO_DUP_BILL_REF is already on file (seeded in
+  // beforeAll). These two probes dispatch odoo_create for the SAME ref and
+  // assert the AUDIT outcome end-to-end: a blind create is BLOCKED (failure),
+  // and the explicit allow_duplicate:true override proceeds (success). This is
+  // the audit half of the acceptance — the block/override logic itself is unit-
+  // and integration-tested against the same odoo-mock.
+  async function dispatchCreateAndGetAudit(page: Page, testInfo: TestInfo, trigger: string) {
+    testInfo.setTimeout(180_000);
+    await loginViaUI(page, getAdminEmail(), getAdminPassword());
+    await page.goto(`/chat/${dispatchAgentId}`);
+    await expect(page).toHaveURL(`/chat/${dispatchAgentId}`, { timeout: 10_000 });
+
+    const input = page.getByPlaceholder(/send a message/i);
+    await expect(input).toBeVisible({ timeout: 10_000 });
+
+    const since = new Date().toISOString();
+    await input.fill(`${trigger}: file the vendor bill`);
+    await input.press("Enter");
+
+    return pollAuditForEvent(page, {
+      eventType: "tool.odoo_create",
+      predicate: (e) => e.resource === `agent:${dispatchAgentId}`,
+      since,
+      deadlineMs: 160_000,
+    });
+  }
+
+  test("odoo_create is BLOCKED for a duplicate vendor bill (audited failure)", async ({
+    page,
+  }, testInfo) => {
+    const entry = await dispatchCreateAndGetAudit(
+      page,
+      testInfo,
+      FAKE_OLLAMA_ODOO_CREATE_DUP_BLOCK_TRIGGER
+    );
+    expect(entry.outcome, `audit detail: ${JSON.stringify(entry.detail)}`).toBe("failure");
+    // The blocked attempt is what the audit trail should show — with the
+    // structured refusal (naming the on-file bill) in the detail.
+    expect(JSON.stringify(entry.detail)).toContain("blocked");
+  });
+
+  test("odoo_create PROCEEDS for a duplicate when allow_duplicate is set (audited success)", async ({
+    page,
+  }, testInfo) => {
+    const entry = await dispatchCreateAndGetAudit(
+      page,
+      testInfo,
+      FAKE_OLLAMA_ODOO_CREATE_DUP_OVERRIDE_TRIGGER
+    );
+    expect(entry.outcome, `audit detail: ${JSON.stringify(entry.detail)}`).toBe("success");
+    // The deliberate override is traceable: the curated detail flags it.
+    expect(JSON.stringify(entry.detail)).toContain("duplicateOverride");
   });
 });

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -267,6 +267,17 @@ const ODOO_READ_DENIED_RESPONSE = "Read attempted: coverage probe complete.";
 // against a mock that now actually validates many2one write values.
 const ODOO_CREATE_NESTED_LINES_TRIGGER = "E2E_ODOO_CREATE_NESTED_LINES_TOOL";
 const ODOO_CREATE_NESTED_LINES_RESPONSE = "Move created: coverage probe complete.";
+// Deterministic vendor-bill duplicate guard (pinchy#721). The spec seeds a
+// posted vendor bill with ref ODOO_DUP_BILL_REF before dispatch. The BLOCK
+// trigger dispatches odoo_create for a second account.move with the SAME
+// ref+move_type: the plugin refuses it (audited failure). The OVERRIDE trigger
+// passes allow_duplicate:true, so the deliberate second entry proceeds (audited
+// success with a traceable override detail).
+const ODOO_DUP_BILL_REF = "E2E-DUP-777";
+const ODOO_CREATE_DUP_BLOCK_TRIGGER = "E2E_ODOO_CREATE_DUP_BLOCK_TOOL";
+const ODOO_CREATE_DUP_BLOCK_RESPONSE = "Duplicate blocked: coverage probe complete.";
+const ODOO_CREATE_DUP_OVERRIDE_TRIGGER = "E2E_ODOO_CREATE_DUP_OVERRIDE_TOOL";
+const ODOO_CREATE_DUP_OVERRIDE_RESPONSE = "Duplicate overridden: coverage probe complete.";
 // Inbox Agent (#139). Unlike every trigger around it, this one answers with
 // plain TEXT and no tool call: an inbox run's result channel IS the final
 // assistant text, ending in one fenced JSON report (see run-adapter.ts —
@@ -587,6 +598,27 @@ const TOOL_TRIGGERS: TriggerConfig[] = [
           [0, 0, { account_id: "Bank", credit: 100 }],
         ],
       },
+    },
+  },
+  {
+    trigger: ODOO_CREATE_DUP_BLOCK_TRIGGER,
+    response: ODOO_CREATE_DUP_BLOCK_RESPONSE,
+    toolName: "odoo_create",
+    // Same ref + move_type as the seeded bill → the guard blocks this create.
+    arguments: {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: ODOO_DUP_BILL_REF },
+    },
+  },
+  {
+    trigger: ODOO_CREATE_DUP_OVERRIDE_TRIGGER,
+    response: ODOO_CREATE_DUP_OVERRIDE_RESPONSE,
+    toolName: "odoo_create",
+    // allow_duplicate:true authorizes the deliberate second entry.
+    arguments: {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: ODOO_DUP_BILL_REF },
+      allow_duplicate: true,
     },
   },
   {
@@ -1943,6 +1975,9 @@ export const FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_TRIGGER = ODOO_ATTACH_FILE_REF_TRI
 export const FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_FILENAME = ODOO_ATTACH_FILE_REF_FILENAME;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_TRIGGER = ODOO_CREATE_NESTED_LINES_TRIGGER;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_RESPONSE = ODOO_CREATE_NESTED_LINES_RESPONSE;
+export const FAKE_OLLAMA_ODOO_DUP_BILL_REF = ODOO_DUP_BILL_REF;
+export const FAKE_OLLAMA_ODOO_CREATE_DUP_BLOCK_TRIGGER = ODOO_CREATE_DUP_BLOCK_TRIGGER;
+export const FAKE_OLLAMA_ODOO_CREATE_DUP_OVERRIDE_TRIGGER = ODOO_CREATE_DUP_OVERRIDE_TRIGGER;
 export const FAKE_OLLAMA_INBOX_SWEEP_TRIGGER = INBOX_SWEEP_TRIGGER;
 export const FAKE_OLLAMA_EMAIL_LIST_TOOL_TRIGGER = EMAIL_LIST_TRIGGER;
 export const FAKE_OLLAMA_EMAIL_LIST_TOOL_RESPONSE = EMAIL_LIST_RESPONSE;


### PR DESCRIPTION
Closes #721.

## What

Before an `odoo_create` on `account.move` for a **vendor document** (`move_type` `in_invoice`/`in_refund`), the `pinchy-odoo` plugin searches for an existing bill with the same `ref` (+ move_type + company + partner). On a hit it **blocks** the create and returns a structured, retry-safe refusal naming the existing bill (`id/name/state/amount_total/date`), so the model relays it to the user instead of double-booking. An explicit `allow_duplicate: true` override re-files a bill deliberately, with a traceable audit detail.

This is the double-payment failure mode Eval-v1 (#669) caught: **13/14 models filed the duplicate anyway**. Pinchy owns the tool layer, so Pinchy owns the guarantee — the read-side sibling of #720.

## How it maps to Odoo's own behavior

Grounded in Odoo 19's `_fetch_duplicate_reference`: it ref-dedups **vendor documents only** (customer invoices dedupe on amount+date, journal entries never), and surfaces duplicates as a *soft* warning that disables auto-post. In the agent context the agent **is** the automation — no human reads a banner — so the correct analog is: block the automated create, surface the duplicate, require an explicit override.

Scope was deliberately **narrowed** from the prior guard (which fired for any `account.move` with a `ref`) to `in_invoice`/`in_refund`, removing a latent false-positive on customer invoices/entries that legitimately re-use a reference.

## Audit

Automatic via the `pinchy-audit` `after_tool_call` hook + the tool-use route:
- **Blocked** → `outcome: failure`, snapshot lifted into `detail.error`, create params retained for forensics.
- **Overridden** → `outcome: success` with curated, PII-free `details` (`bookedRef`, `bookedMoveType`, `createdId`, `existingBill`).

## ⚠️ Note on the eval acceptance item

`gradeDuplicateAvoidance` (`graders.ts:806`) keys the `duplicate-created` tag on the `odoo_create` **attempt** — *"regardless of whether a downstream guard blocked it."* It deliberately grades the model's *check-first* behavior, not persisted state. **So this guard does not move the duplicate-scenario score** — eval and guard are the two halves of "governed writes": the eval measures behavior, the guard guarantees the outcome as the deterministic backstop. Happy-path is regression-free by construction (the guard only fires on a match) and by unit test. A full 14-model keep-or-revert sweep needs Docker + API keys and is a separate, user-run step (`run-model-eval`); the eval-gating unit tests (scorecard-triage-guard, oracle-solutions) pass unchanged.

## Tests

- **Unit** (`__tests__/tools.test.ts`, 8 new, TDD): block+snapshot, `in_refund`, first-time pass, `out_invoice`/no-`move_type` not-guarded, override, override no-op, no-read-permission skip.
- **Integration** (`__tests__/integration.test.ts`): block + override round-trip against the real odoo-mock over HTTP (two moves after override).
- **E2E** (`e2e/odoo/odoo-agent-chat.spec.ts`): block → audited `failure`, override → audited `success`, via new fake-ollama triggers.
- **Docs**: `docs/src/content/docs/guides/connect-odoo.mdx` — new "Duplicate vendor bills" section.

## Acceptance
- [x] TDD: failing plugin unit tests first (hit → block w/ snapshot, miss → proceeds, override, permission interaction)
- [x] Audit entries for blocked and overridden creates
- [x] E2E: odoo spec covers block + override round trips
- [ ] Eval re-run — see the note above; the guard is a backstop, not a score-mover (deferred to a user-run sweep)
- [x] Docs updated

## Related
#669 (Eval-v1) · #720 (read-back verification) · #124 (approval queue)