### PR TITLE
feat(automations): management API — list, enable/disable, delete workflows (#139)

### DIFF
--- a/packages/web/src/__tests__/api/automations-manage.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-manage.integration.test.ts
@@ -1,0 +1,304 @@
+// Real-DB integration tests for the Automations management API — the read +
+// enable/disable + delete surface that completes the create → review → enable
+// loop the write path (#864) opened. A created workflow lands pending+disabled;
+// the sweep dispatches only ENABLED workflows, so without an enable path nothing
+// a user creates ever runs. These routes are that path.
+//
+// Real DB (not mocked chains) for the same reason as the create route: the
+// load-bearing behavior is scope-based RBAC that queries agent ownership, plus
+// a cascading delete. @/lib/auth and @/lib/audit-deferred are mocked to drive
+// the scope branches and capture audit payloads.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+  agents,
+  users,
+  emailWorkflows,
+  emailWorkflowConnections,
+  integrationConnections,
+} from "@/db/schema";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
+
+const { getSessionMock, deferAuditLogMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  deferAuditLogMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+  auth: { api: { getSession: getSessionMock } },
+}));
+vi.mock("@/lib/audit-deferred", () => ({
+  deferAuditLog: (...args: unknown[]) => deferAuditLogMock(...args),
+}));
+
+const { GET } = await import("@/app/api/automations/route");
+const { PATCH, DELETE } = await import("@/app/api/automations/[id]/route");
+
+const OWNER = "user-owner";
+const OTHER = "user-other";
+const ADMIN = "user-admin";
+
+function asMember(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "member" } });
+}
+function asAdmin(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "admin" } });
+}
+
+async function seedUser(id: string, role: "member" | "admin" = "member") {
+  await db.insert(users).values({ id, name: id, email: `${id}@test.com`, role });
+}
+async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) {
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Smithers",
+      model: "ollama-cloud/gemini-3-flash",
+      greetingMessage: "Hi",
+      isPersonal: opts.isPersonal,
+      ownerId: opts.ownerId,
+    })
+    .returning();
+  return row;
+}
+async function seedConnection(id: string) {
+  await db
+    .insert(integrationConnections)
+    .values({ id, type: "imap", name: "Invoices mailbox", credentials: "enc:placeholder" });
+}
+async function seedWorkflow(
+  agentId: string,
+  opts: { enabled?: boolean; name?: string; createdBy?: string } = {}
+) {
+  const [wf] = await db
+    .insert(emailWorkflows)
+    .values({
+      agentId,
+      name: opts.name ?? "File supplier invoices",
+      filter: { hasAttachment: true },
+      action: "Draft a supplier bill.",
+      enabled: opts.enabled ?? false,
+      createdBy: opts.createdBy ?? null,
+    })
+    .returning();
+  return wf;
+}
+async function linkConnection(workflowId: string, connectionId: string) {
+  await db
+    .insert(emailWorkflowConnections)
+    .values({ workflowId, connectionId, sinceTs: new Date() });
+}
+
+function req(url: string, init?: { method?: string; body?: unknown }) {
+  return makeNextRequest(url, {
+    method: init?.method ?? "GET",
+    headers: init?.body ? { "content-type": "application/json" } : undefined,
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  });
+}
+
+async function loadWorkflow(id: string) {
+  const [row] = await db.select().from(emailWorkflows).where(eq(emailWorkflows.id, id));
+  return row;
+}
+
+describe("Automations management API", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await seedUser(OWNER);
+    await seedUser(OTHER);
+    await seedUser(ADMIN, "admin");
+  });
+
+  describe("GET /api/automations?agentId", () => {
+    it("lists a member's own personal-agent workflows with their connections", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      await seedConnection("conn-a");
+      const wf = await seedWorkflow(agent.id, { createdBy: OWNER });
+      await linkConnection(wf.id, "conn-a");
+
+      const res = await GET(
+        req(`http://localhost/api/automations?agentId=${agent.id}`),
+        routeContext()
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveLength(1);
+      expect(body[0]).toMatchObject({
+        id: wf.id,
+        name: "File supplier invoices",
+        enabled: false,
+        status: "pending",
+        connectionIds: ["conn-a"],
+      });
+    });
+
+    it("forbids a member from listing a shared agent's workflows", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: false, ownerId: null });
+      const res = await GET(
+        req(`http://localhost/api/automations?agentId=${agent.id}`),
+        routeContext()
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("requires an agentId query parameter", async () => {
+      asMember(OWNER);
+      const res = await GET(req(`http://localhost/api/automations`), routeContext());
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for an unknown agent", async () => {
+      asMember(OWNER);
+      const res = await GET(req(`http://localhost/api/automations?agentId=ghost`), routeContext());
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/automations/[id]", () => {
+    it("lets a member enable a pending workflow on their own personal agent", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      const wf = await seedWorkflow(agent.id, { enabled: false, createdBy: OWNER });
+
+      const res = await PATCH(
+        req(`http://localhost/api/automations/${wf.id}`, {
+          method: "PATCH",
+          body: { enabled: true },
+        }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(200);
+      expect((await loadWorkflow(wf.id)).enabled).toBe(true);
+
+      expect(deferAuditLogMock).toHaveBeenCalledTimes(1);
+      const entry = deferAuditLogMock.mock.calls[0][0];
+      expect(entry).toMatchObject({
+        eventType: "email_workflow.updated",
+        actorType: "user",
+        actorId: OWNER,
+        resource: `email_workflow:${wf.id}`,
+        outcome: "success",
+      });
+      expect(entry.detail.changes).toMatchObject({ enabled: { from: false, to: true } });
+    });
+
+    it("does not audit a no-op toggle", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      const wf = await seedWorkflow(agent.id, { enabled: false, createdBy: OWNER });
+
+      const res = await PATCH(
+        req(`http://localhost/api/automations/${wf.id}`, {
+          method: "PATCH",
+          body: { enabled: false },
+        }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(200);
+      expect(deferAuditLogMock).not.toHaveBeenCalled();
+    });
+
+    it("forbids a member from toggling a shared agent's workflow", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: false, ownerId: null });
+      const wf = await seedWorkflow(agent.id, { enabled: false });
+
+      const res = await PATCH(
+        req(`http://localhost/api/automations/${wf.id}`, {
+          method: "PATCH",
+          body: { enabled: true },
+        }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(403);
+      expect((await loadWorkflow(wf.id)).enabled).toBe(false);
+    });
+
+    it("returns 404 for an unknown workflow", async () => {
+      asMember(OWNER);
+      const res = await PATCH(
+        req(`http://localhost/api/automations/ghost`, { method: "PATCH", body: { enabled: true } }),
+        routeContext({ id: "ghost" })
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/automations/[id]", () => {
+    it("lets a member delete their own personal-agent workflow and cascades its connections", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      await seedConnection("conn-d");
+      const wf = await seedWorkflow(agent.id, { name: "Reject me", createdBy: OWNER });
+      await linkConnection(wf.id, "conn-d");
+
+      const res = await DELETE(
+        req(`http://localhost/api/automations/${wf.id}`, { method: "DELETE" }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(200);
+      expect(await loadWorkflow(wf.id)).toBeUndefined();
+      const conns = await db
+        .select()
+        .from(emailWorkflowConnections)
+        .where(eq(emailWorkflowConnections.workflowId, wf.id));
+      expect(conns).toHaveLength(0);
+
+      expect(deferAuditLogMock).toHaveBeenCalledTimes(1);
+      const entry = deferAuditLogMock.mock.calls[0][0];
+      expect(entry).toMatchObject({
+        eventType: "email_workflow.deleted",
+        actorId: OWNER,
+        resource: `email_workflow:${wf.id}`,
+        outcome: "success",
+      });
+      // DeleteDetail requires a name snapshot — the row is gone, so the trail
+      // must carry it (AGENTS.md: include resource names in delete events).
+      expect(entry.detail.name).toBe("Reject me");
+    });
+
+    it("forbids a member from deleting a shared agent's workflow", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: false, ownerId: null });
+      const wf = await seedWorkflow(agent.id);
+
+      const res = await DELETE(
+        req(`http://localhost/api/automations/${wf.id}`, { method: "DELETE" }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(403);
+      expect(await loadWorkflow(wf.id)).toBeDefined();
+    });
+
+    it("lets an admin delete a shared agent's workflow", async () => {
+      asAdmin(ADMIN);
+      const agent = await seedAgent({ isPersonal: false, ownerId: null });
+      const wf = await seedWorkflow(agent.id);
+
+      const res = await DELETE(
+        req(`http://localhost/api/automations/${wf.id}`, { method: "DELETE" }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(200);
+      expect(await loadWorkflow(wf.id)).toBeUndefined();
+    });
+
+    it("returns 404 for an unknown workflow", async () => {
+      asMember(OWNER);
+      const res = await DELETE(
+        req(`http://localhost/api/automations/ghost`, { method: "DELETE" }),
+        routeContext({ id: "ghost" })
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -53,6 +53,15 @@ describe("AuditLogEntry email_workflow.created (Inbox Agent, #139)", () => {
   });
 });
 
+describe("AuditLogEntry email_workflow.updated / .deleted (Automations management)", () => {
+  it("keeps the whole CRUD lifecycle in the curated union", () => {
+    // The management API (list / enable-disable / delete) rounds out the
+    // lifecycle; like agent.*, all three verbs are curated explicitly.
+    expectTypeOf<"email_workflow.updated">().toExtend<AuditEventType>();
+    expectTypeOf<"email_workflow.deleted">().toExtend<AuditEventType>();
+  });
+});
+
 describe("AuditEventType is a subset of AuditLogEntry['eventType']", () => {
   it("every curated event type is one appendAuditLog can record", () => {
     // Intentionally NOT equal (the entry type is strictly broader), but the

--- a/packages/web/src/__tests__/lib/email-workflows/authz.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/authz.test.ts
@@ -1,0 +1,58 @@
+// Unit tests for the workflow scope gate (design §7, #705) — the single source
+// of truth every workflow route (create / list / enable-disable / delete)
+// shares. The route integration tests exercise the wiring (own-personal allow,
+// shared forbid); this pins the full RBAC matrix at the one place the rule
+// lives, so the load-bearing `ownerId === actor.id` term can't silently drop
+// out. In particular a member acting on *someone else's* personal agent — the
+// branch the route suites don't cover — must be forbidden.
+import { describe, it, expect } from "vitest";
+
+import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+
+const OWNER = "user-owner";
+const OTHER = "user-other";
+
+describe("canManageAgentWorkflows", () => {
+  describe("member (non-admin)", () => {
+    const member = { id: OWNER, role: "member" as const };
+
+    it("may manage a personal agent they own", () => {
+      expect(canManageAgentWorkflows({ isPersonal: true, ownerId: OWNER }, member)).toBe(true);
+    });
+
+    it("may NOT manage another member's personal agent", () => {
+      expect(canManageAgentWorkflows({ isPersonal: true, ownerId: OTHER }, member)).toBe(false);
+    });
+
+    it("may NOT manage a shared agent", () => {
+      expect(canManageAgentWorkflows({ isPersonal: false, ownerId: null }, member)).toBe(false);
+    });
+
+    it("may NOT manage an ownerless personal agent", () => {
+      // Defensive: isPersonal with a null owner is not a shape the app writes,
+      // but the gate must still deny it rather than throw or coerce.
+      expect(canManageAgentWorkflows({ isPersonal: true, ownerId: null }, member)).toBe(false);
+    });
+  });
+
+  describe("admin", () => {
+    const admin = { id: OWNER, role: "admin" as const };
+
+    it("may manage any shared agent", () => {
+      expect(canManageAgentWorkflows({ isPersonal: false, ownerId: null }, admin)).toBe(true);
+    });
+
+    it("may manage another user's personal agent", () => {
+      expect(canManageAgentWorkflows({ isPersonal: true, ownerId: OTHER }, admin)).toBe(true);
+    });
+  });
+
+  it("treats a missing/null role as a non-admin member", () => {
+    expect(
+      canManageAgentWorkflows({ isPersonal: false, ownerId: null }, { id: OWNER, role: null })
+    ).toBe(false);
+    expect(
+      canManageAgentWorkflows({ isPersonal: true, ownerId: OWNER }, { id: OWNER, role: undefined })
+    ).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/schemas/automations.test.ts
+++ b/packages/web/src/__tests__/lib/schemas/automations.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-import { AUTOMATION_MAX_CONNECTIONS, createAutomationSchema } from "@/lib/schemas/automations";
+import {
+  AUTOMATION_MAX_CONNECTIONS,
+  createAutomationSchema,
+  updateAutomationSchema,
+} from "@/lib/schemas/automations";
 
 // The shared request schema for POST /api/automations. Both the route handler
 // (parseRequestBody) and — later — the client form / the conversational
@@ -73,5 +77,20 @@ describe("createAutomationSchema", () => {
     expect(createAutomationSchema.safeParse({ ...valid, sweepWindowDays: 2.5 }).success).toBe(
       false
     );
+  });
+});
+
+// PATCH /api/automations/[id]. The one mutable knob a reviewer flips to activate
+// (or pause) a proposed workflow — deliberately narrow: editing name/filter/
+// action is the form's job (#139), enabling is the human-gated activation step.
+describe("updateAutomationSchema", () => {
+  it("parses an enable/disable toggle", () => {
+    expect(updateAutomationSchema.parse({ enabled: true })).toEqual({ enabled: true });
+    expect(updateAutomationSchema.parse({ enabled: false })).toEqual({ enabled: false });
+  });
+
+  it("requires enabled to be a boolean", () => {
+    expect(updateAutomationSchema.safeParse({}).success).toBe(false);
+    expect(updateAutomationSchema.safeParse({ enabled: "yes" }).success).toBe(false);
   });
 });

--- a/packages/web/src/app/api/automations/[id]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { agents, emailWorkflows } from "@/db/schema";
+import { withAuth } from "@/lib/api-auth";
+import { parseRequestBody } from "@/lib/api-validation";
+import { updateAutomationSchema } from "@/lib/schemas/automations";
+import { scrubEmails } from "@/lib/audit";
+import { deferAuditLog } from "@/lib/audit-deferred";
+import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// email_workflows.id is a uuid column: a non-uuid path param (a typo, a probe)
+// would make the query throw a cast error (500) instead of resolving to
+// "nothing". Guarding here turns any malformed id into a clean 404 — it
+// definitionally matches no workflow.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Load a workflow together with the ownership fields of its agent — everything
+ * the scope gate and the audit snapshot need, in one round trip. Returns
+ * undefined when the id is malformed or matches nothing.
+ */
+async function loadWorkflowWithAgent(id: string) {
+  if (!UUID_RE.test(id)) return undefined;
+  const [row] = await db
+    .select({
+      id: emailWorkflows.id,
+      name: emailWorkflows.name,
+      enabled: emailWorkflows.enabled,
+      agentId: emailWorkflows.agentId,
+      agentName: agents.name,
+      isPersonal: agents.isPersonal,
+      ownerId: agents.ownerId,
+    })
+    .from(emailWorkflows)
+    .innerJoin(agents, eq(agents.id, emailWorkflows.agentId))
+    .where(eq(emailWorkflows.id, id));
+  return row;
+}
+
+/**
+ * PATCH /api/automations/[id] — flip a workflow's `enabled` state. This is the
+ * human-gated activation step "propose, don't self-activate" reserves for a
+ * person: a created workflow sits disabled until a reviewer turns it on here.
+ * Scope gate matches create (own personal agent → member; shared → admin).
+ *
+ * `status` is deliberately untouched — it is a health signal the dispatcher
+ * writes (pending→active/error), not a field this route owns; the loader gates
+ * dispatch on `enabled` alone, so the next clean sweep flips a freshly enabled
+ * workflow to `active` on its own.
+ */
+export const PATCH = withAuth<RouteContext>(async (request, { params }, session) => {
+  const { id } = await params;
+  const parsed = await parseRequestBody(updateAutomationSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { enabled } = parsed.data;
+
+  const workflow = await loadWorkflowWithAgent(id);
+  if (!workflow) {
+    return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+  }
+  if (!canManageAgentWorkflows(workflow, { id: session.user.id!, role: session.user.role })) {
+    return NextResponse.json(
+      { error: "You do not have permission to change this workflow" },
+      { status: 403 }
+    );
+  }
+
+  // No-op toggle: nothing changed, so nothing to record. Return 200 (idempotent)
+  // without an audit row — an unchanged state is not an event.
+  if (workflow.enabled === enabled) {
+    return NextResponse.json({ id, enabled });
+  }
+
+  await db
+    .update(emailWorkflows)
+    .set({ enabled, updatedAt: new Date() })
+    .where(eq(emailWorkflows.id, id));
+
+  deferAuditLog({
+    actorType: "user",
+    actorId: session.user.id!,
+    eventType: "email_workflow.updated",
+    resource: `email_workflow:${id}`,
+    outcome: "success",
+    detail: { changes: { enabled: { from: workflow.enabled, to: enabled } } },
+  });
+
+  return NextResponse.json({ id, enabled });
+});
+
+/**
+ * DELETE /api/automations/[id] — reject/remove a workflow. The FK cascade drops
+ * its connection rows and ledger entries with it. Scope gate matches create.
+ */
+export const DELETE = withAuth<RouteContext>(async (_request, { params }, session) => {
+  const { id } = await params;
+
+  const workflow = await loadWorkflowWithAgent(id);
+  if (!workflow) {
+    return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+  }
+  if (!canManageAgentWorkflows(workflow, { id: session.user.id!, role: session.user.role })) {
+    return NextResponse.json(
+      { error: "You do not have permission to delete this workflow" },
+      { status: 403 }
+    );
+  }
+
+  await db.delete(emailWorkflows).where(eq(emailWorkflows.id, id));
+
+  // The row is gone, so the trail must carry its name (AGENTS.md: include
+  // resource names in delete events). Scrubbed — a free-text name can hold an
+  // address, and the audit log is append-only + HMAC-signed.
+  const safeName = scrubEmails(workflow.name);
+  deferAuditLog({
+    actorType: "user",
+    actorId: session.user.id!,
+    eventType: "email_workflow.deleted",
+    resource: `email_workflow:${id}`,
+    outcome: "success",
+    detail: {
+      name: safeName,
+      workflow: { id, name: safeName },
+      agent: { id: workflow.agentId, name: workflow.agentName },
+    },
+  });
+
+  return NextResponse.json({ id });
+});

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
 import {
@@ -14,6 +14,70 @@ import { createAutomationSchema } from "@/lib/schemas/automations";
 import { scrubEmails } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
+import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+
+/**
+ * GET /api/automations?agentId=<id> — list an agent's email workflows for the
+ * Automations tab. Same scope gate as create: a member sees their own personal
+ * agent's workflows; a shared agent is admin-only. Each row carries its attached
+ * connection ids so the tab can render (and the reviewer can vet) the full
+ * structured translation before enabling it.
+ */
+export const GET = withAuth(async (request, _ctx, session) => {
+  const agentId = new URL(request.url).searchParams.get("agentId");
+  if (!agentId) {
+    return NextResponse.json({ error: "agentId is required" }, { status: 400 });
+  }
+
+  const [agent] = await db
+    .select({ isPersonal: agents.isPersonal, ownerId: agents.ownerId })
+    .from(agents)
+    .where(eq(agents.id, agentId));
+  if (!agent) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+  if (!canManageAgentWorkflows(agent, { id: session.user.id!, role: session.user.role })) {
+    return NextResponse.json({ error: "You do not have access to this agent" }, { status: 403 });
+  }
+
+  const workflows = await db
+    .select({
+      id: emailWorkflows.id,
+      name: emailWorkflows.name,
+      filter: emailWorkflows.filter,
+      action: emailWorkflows.action,
+      enabled: emailWorkflows.enabled,
+      status: emailWorkflows.status,
+      sweepWindowDays: emailWorkflows.sweepWindowDays,
+      createdBy: emailWorkflows.createdBy,
+      createdAt: emailWorkflows.createdAt,
+    })
+    .from(emailWorkflows)
+    .where(eq(emailWorkflows.agentId, agentId))
+    .orderBy(desc(emailWorkflows.createdAt));
+
+  // Fan the connection ids back onto each workflow in one query, not N.
+  const ids = workflows.map((w) => w.id);
+  const connRows = ids.length
+    ? await db
+        .select({
+          workflowId: emailWorkflowConnections.workflowId,
+          connectionId: emailWorkflowConnections.connectionId,
+        })
+        .from(emailWorkflowConnections)
+        .where(inArray(emailWorkflowConnections.workflowId, ids))
+    : [];
+  const byWorkflow = new Map<string, string[]>();
+  for (const row of connRows) {
+    const list = byWorkflow.get(row.workflowId) ?? [];
+    list.push(row.connectionId);
+    byWorkflow.set(row.workflowId, list);
+  }
+
+  return NextResponse.json(
+    workflows.map((w) => ({ ...w, connectionIds: byWorkflow.get(w.id) ?? [] }))
+  );
+});
 
 /**
  * POST /api/automations — create an Inbox Agent email workflow (design §5).
@@ -38,7 +102,6 @@ export const POST = withAuth(async (request, _ctx, session) => {
   const { agentId, name, filter, action, connectionIds, sweepWindowDays } = parsed.data;
 
   const userId = session.user.id!;
-  const isAdmin = session.user.role === "admin";
 
   const [agent] = await db
     .select({
@@ -53,10 +116,7 @@ export const POST = withAuth(async (request, _ctx, session) => {
     return NextResponse.json({ error: "Agent not found" }, { status: 404 });
   }
 
-  // A member may act only on a personal agent they own; a shared agent (or
-  // someone else's personal agent) is admin-only.
-  const isOwnPersonalAgent = agent.isPersonal && agent.ownerId === userId;
-  if (!isOwnPersonalAgent && !isAdmin) {
+  if (!canManageAgentWorkflows(agent, { id: userId, role: session.user.role })) {
     return NextResponse.json(
       { error: "You do not have permission to create a workflow on this agent" },
       { status: 403 }

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -96,6 +96,8 @@ export type AuditEventType =
   | "integration.credentials_tested"
   | "integration.credentials_updated"
   | "email_workflow.created"
+  | "email_workflow.updated"
+  | "email_workflow.deleted"
   | "file.upload.staged"
   | "file.upload.attached"
   | "file.upload.expired"

--- a/packages/web/src/lib/email-workflows/authz.ts
+++ b/packages/web/src/lib/email-workflows/authz.ts
@@ -1,0 +1,23 @@
+/**
+ * The scope rule for creating and managing an agent's email workflows
+ * (design §7, #705): a member may act only on a **personal agent they own**; a
+ * shared agent — or someone else's personal agent — is admin-only.
+ *
+ * Single source of truth for every workflow route (create, list, enable/disable,
+ * delete), so the boundary can't drift between them. A workflow is standing
+ * autonomous authority scoped to one agent, so "may I touch this agent" is the
+ * whole question — connection-level checks (create) sit on top of this, not
+ * instead of it.
+ */
+export interface WorkflowAgentScope {
+  isPersonal: boolean;
+  ownerId: string | null;
+}
+
+export function canManageAgentWorkflows(
+  agent: WorkflowAgentScope,
+  actor: { id: string; role: string | null | undefined }
+): boolean {
+  if (actor.role === "admin") return true;
+  return agent.isPersonal && agent.ownerId === actor.id;
+}

--- a/packages/web/src/lib/schemas/automations.ts
+++ b/packages/web/src/lib/schemas/automations.ts
@@ -67,3 +67,16 @@ export const createAutomationSchema = z.object({
 });
 
 export type CreateAutomationInput = z.infer<typeof createAutomationSchema>;
+
+/**
+ * Request schema for PATCH /api/automations/[id]. Deliberately narrow: `enabled`
+ * is the one knob a human flips to activate (or pause) a proposed workflow —
+ * the human-gated step that "propose, don't self-activate" reserves for a
+ * person. Editing name/filter/action belongs to the Automations form (#139), not
+ * this toggle.
+ */
+export const updateAutomationSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export type UpdateAutomationInput = z.infer<typeof updateAutomationSchema>;


### PR DESCRIPTION
## What

Completes the **create → review → enable** loop the write path ([#864](https://github.com/heypinchy/pinchy/pull/864)) opened. A created workflow lands `pending`+`disabled`, and the sweep dispatches **only ENABLED** workflows — so without an enable path, nothing a user creates ever runs. These routes are that path: the backend the Automations tab (#139) will render.

- **`GET /api/automations?agentId=…`** — list an agent's workflows with their attached connection ids, so the tab can render (and a reviewer can vet) the full structured translation before enabling it.
- **`PATCH /api/automations/[id]`** — flip `enabled` (the human-gated activation step "propose, don't self-activate" reserves for a person). `status` is left untouched — it's a dispatcher-written health signal, and the loader gates dispatch on `enabled` alone, so the next clean sweep flips a freshly enabled workflow to `active` itself. A **no-op toggle returns 200 without an audit row** (an unchanged state is not an event).
- **`DELETE /api/automations/[id]`** — reject/remove a workflow; the FK cascade drops its connections + ledger rows.

## Design

- **One scope boundary, shared.** Extracted `canManageAgentWorkflows` to `lib/email-workflows/authz.ts` and adopted it in the create route too, so create / list / enable-disable / delete can't drift: **member on own personal agent; shared agent → admin**.
- **Robust ids.** `email_workflows.id` is a uuid column — a non-uuid `[id]` path param (typo, probe) resolves to a clean **404**, not a cast-error 500.
- **Audit.** `email_workflow.updated` (a `{ enabled: {from,to} }` change diff) and `email_workflow.deleted` (scrubbed name snapshot — the row is gone, so the trail must carry it) added to the curated `AuditEventType` union, mirrored in `audit-types.test.ts`. `deferAuditLog`, ids/scrubbed-names only.

## Tests (TDD, RED-first)

- **Schema unit**: `updateAutomationSchema` (enable toggle; rejects non-boolean/missing).
- **Real-DB route integration** (`automations-manage.integration.test.ts`, 12): GET lists own-personal-agent workflows with connections / 403 shared / 400 no-agentId / 404 unknown-agent; PATCH enables with `email_workflow.updated` payload / no-op-no-audit / 403 shared / 404 unknown; DELETE cascades + `email_workflow.deleted` / 403 shared / admin-on-shared 201 / 404 unknown.

## Gates

`typecheck` ✅ · `eslint` ✅ (0 errors) · `prettier --check` ✅ · schema unit ✅ (9) · route integration ✅ (23, incl. create regression after the shared-helper refactor) · audit enumeration/type tests ✅ (29).

Full web unit suite: 9126–9127 pass. The 1–2 failures that appear **only under full-suite load are pre-existing flakes** — a *different* set each run (`openclaw-config.test.ts` flush-disable, `timezone-settings.test.tsx`), none touched by this diff, all green in isolation (216/216, 11/11). Same class #864 shipped through cleanly.

## Follow-ups

- **Automations tab UI** — renders these routes (#139).
- Conversational create tool — #705 (still needs #517).
- Field editing (name/filter/action) — with the form (#139); this PR intentionally scopes PATCH to the `enabled` toggle.