### PR TITLE
fix(pinchy-odoo): bound odoo_read results below OpenClaw's tool-result cap

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -51,6 +51,9 @@ import plugin, {
   findInvalidSelectionValues,
   formatInvalidSelectionError,
   PRODUCT_REF_DISAMBIGUATION_HINT,
+  enforceReadResultBudget,
+  ODOO_READ_RESULT_BUDGET_CHARS,
+  ODOO_READ_TRUNCATION_HINT,
 } from "../index";
 
 const MOVE_FIELDS: OdooField[] = [
@@ -1250,6 +1253,76 @@ describe("PRODUCT_REF_DISAMBIGUATION_HINT (issue #377)", () => {
   });
 });
 
+// OpenClaw's runtime caps every tool result at maxChars=64000 and the whole
+// prompt history at aggregateBudgetChars=256000, replacing the overflow with a
+// literal "[... N more characters truncated …]" marker MID-JSON. A `crm.lead`
+// read of real production data reached ~509,000 chars — ~8× the per-result cap
+// — so the model received corrupt JSON plus the marker and narrated "the
+// results are truncated" in an unbreakable retry loop (pinchy production, Piper
+// agent, 2026-07-22). `enforceReadResultBudget` pre-empts that blind cut with a
+// Pinchy-side budget so odoo_read always returns valid, self-describing JSON.
+describe("enforceReadResultBudget", () => {
+  const bigRecords = (n: number, descLen = 1000) =>
+    Array.from({ length: n }, (_, i) => ({
+      id: i + 1,
+      name: `Lead ${i + 1}`,
+      description: "x".repeat(descLen),
+    }));
+
+  it("returns the input unchanged when it already fits the budget", () => {
+    const result = { records: [{ id: 1, name: "SO001" }], total: 1, limit: 100, offset: 0 };
+    const out = enforceReadResultBudget(result);
+    expect(out).toBe(result);
+    expect(out).not.toHaveProperty("truncated");
+  });
+
+  it("trims the record set to fit and reports the truncation honestly", () => {
+    const result = { records: bigRecords(200), total: 200, limit: 200, offset: 0 };
+    const out = enforceReadResultBudget(result) as {
+      records: unknown[];
+      total: number;
+      returned: number;
+      truncated: boolean;
+      hint: string;
+    };
+    expect(out.truncated).toBe(true);
+    expect(out.records.length).toBeLessThan(200);
+    expect(out.records.length).toBeGreaterThan(0);
+    expect(out.returned).toBe(out.records.length);
+    // `total` still reports the full Odoo match count so the model knows there is more.
+    expect(out.total).toBe(200);
+    expect(out.hint).toBe(ODOO_READ_TRUNCATION_HINT);
+    // The whole point: the serialized result stays under the budget (and thus
+    // comfortably under OpenClaw's 64000 per-result cap), so it is never cut.
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(ODOO_READ_RESULT_BUDGET_CHARS);
+  });
+
+  it("always keeps at least one record, even if that record alone exceeds the budget", () => {
+    const result = {
+      records: bigRecords(3, ODOO_READ_RESULT_BUDGET_CHARS * 2),
+      total: 3,
+      limit: 3,
+      offset: 0,
+    };
+    const out = enforceReadResultBudget(result) as { records: unknown[]; truncated: boolean };
+    expect(out.records).toHaveLength(1);
+    expect(out.truncated).toBe(true);
+  });
+
+  it("wraps a bare oversized array into a self-describing object", () => {
+    const out = enforceReadResultBudget(bigRecords(200)) as {
+      records: unknown[];
+      total: number;
+      returned: number;
+      truncated: boolean;
+    };
+    expect(out.truncated).toBe(true);
+    expect(out.total).toBe(200);
+    expect(out.returned).toBe(out.records.length);
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(ODOO_READ_RESULT_BUDGET_CHARS);
+  });
+});
+
 describe("odoo_read", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1334,6 +1407,41 @@ describe("odoo_read", () => {
       offset: 0,
       order: "date_order desc",
     });
+  });
+
+  // Regression (pinchy production, 2026-07-22): a real crm.lead read produced a
+  // ~509,000-char result that OpenClaw cut mid-JSON, so Piper looped on "the
+  // results are truncated". odoo_read must bound its own output so the returned
+  // JSON never approaches OpenClaw's 64000 per-result cap.
+  it("bounds an oversized result below OpenClaw's per-result cap", async () => {
+    const OPENCLAW_TOOL_RESULT_CAP = 64000;
+    mockSearchRead.mockResolvedValue({
+      records: Array.from({ length: 200 }, (_, i) => ({
+        id: i + 1,
+        name: `Lead ${i + 1}`,
+        description: "x".repeat(1000),
+      })),
+      total: 200,
+      limit: 200,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-big", {
+      model: "sale.order",
+      fields: ["name", "description"],
+      limit: 200,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text.length).toBeLessThan(OPENCLAW_TOOL_RESULT_CAP);
+    const data = JSON.parse(result.content[0].text);
+    expect(data.truncated).toBe(true);
+    expect(data.total).toBe(200);
+    expect(data.records.length).toBeLessThan(200);
+    expect(data.returned).toBe(data.records.length);
   });
 
   // The read side of the same trap: the tool prompt teaches `_pinchy_ref`,

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1297,6 +1297,22 @@ describe("enforceReadResultBudget", () => {
     expect(JSON.stringify(out).length).toBeLessThanOrEqual(ODOO_READ_RESULT_BUDGET_CHARS);
   });
 
+  // The kept records MUST be the leading prefix of the Odoo page, in order.
+  // The truncation hint tells the model to fetch the rest with
+  // `offset = offset + returned`; that only lands on the next unseen record if
+  // what we keep are records 0..returned-1. A future refactor that dropped, say,
+  // the *largest* records instead would still pass every size assertion above
+  // while silently making paging skip rows — this pins the invariant.
+  it("keeps the leading prefix in order so `offset + returned` pages correctly", () => {
+    const result = { records: bigRecords(200), total: 200, limit: 200, offset: 0 };
+    const out = enforceReadResultBudget(result) as {
+      records: Array<{ id: number }>;
+      returned: number;
+    };
+    const expectedIds = Array.from({ length: out.returned }, (_, i) => i + 1);
+    expect(out.records.map((r) => r.id)).toEqual(expectedIds);
+  });
+
   it("always keeps at least one record, even if that record alone exceeds the budget", () => {
     const result = {
       records: bigRecords(3, ODOO_READ_RESULT_BUDGET_CHARS * 2),

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2048,6 +2048,80 @@ function wrapReadResult(
   return result;
 }
 
+/**
+ * Serialized-size ceiling for an `odoo_read` result, in characters.
+ *
+ * OpenClaw's runtime caps every tool result at `maxChars=64000` and the whole
+ * prompt history at `aggregateBudgetChars=256000`, replacing the overflow with a
+ * literal `[... N more characters truncated …]` marker spliced MID-JSON. A real
+ * `crm.lead` read on production reached ~509,000 chars — ~8× the per-result cap
+ * and ~2× the entire aggregate budget — so the model received corrupt JSON plus
+ * the marker and looped on "the results are truncated" (pinchy production, Piper
+ * agent, 2026-07-22). We bound the result well under 64000 so (a) our JSON is
+ * never cut mid-structure, and (b) several reads still fit inside the 256000
+ * aggregate before OpenClaw has to intervene. This mirrors the pre-emptive
+ * ceiling `openclaw-config/bootstrap-caps.ts` applies to instruction files.
+ */
+export const ODOO_READ_RESULT_BUDGET_CHARS = 30000;
+
+export const ODOO_READ_TRUNCATION_HINT =
+  "Result truncated to fit the model's context budget: `returned` of `total` " +
+  "matching records are included. Narrow the query with more specific `filters`, " +
+  "request fewer `fields`, or page through the rest with `offset`.";
+
+/**
+ * Bound an `odoo_read` result to {@link ODOO_READ_RESULT_BUDGET_CHARS} so it can
+ * never trip OpenClaw's blind mid-JSON truncation. A result that already fits is
+ * returned verbatim (same reference, no added keys — existing callers/tests see
+ * no change). An oversized result keeps the largest prefix of records that fits
+ * and returns a self-describing object: the original `total` (full Odoo match
+ * count) is preserved, `returned` gives the included count, `truncated: true`
+ * flags the cut, and `hint` tells the model how to get the rest. At least one
+ * record is always kept, even if that single record alone exceeds the budget, so
+ * the model can still make progress (and see the hint to drop heavy `fields`).
+ */
+export function enforceReadResultBudget(
+  result: unknown,
+  budget: number = ODOO_READ_RESULT_BUDGET_CHARS
+): unknown {
+  const records = getSearchReadRecords(result);
+  if (records.length === 0) return result;
+  if (JSON.stringify(result).length <= budget) return result;
+
+  const isObjectShape = isRecord(result) && Array.isArray(result.records);
+  const base: Record<string, unknown> = isObjectShape
+    ? { ...(result as Record<string, unknown>) }
+    : {};
+  delete base.records;
+  const total =
+    isObjectShape && typeof (result as Record<string, unknown>).total === "number"
+      ? ((result as Record<string, unknown>).total as number)
+      : records.length;
+
+  const build = (kept: OdooRecord[]) => ({
+    ...base,
+    records: kept,
+    total,
+    returned: kept.length,
+    truncated: true,
+    hint: ODOO_READ_TRUNCATION_HINT,
+  });
+
+  // Grow the kept set while the *actual* serialized length stays within budget
+  // (measuring the real output, not an estimate, so the result is provably under
+  // the ceiling). At least one record is always kept — even a lone record that
+  // busts the budget beats returning nothing, and the hint tells the model to
+  // drop heavy `fields`. We only reach this branch when the full result already
+  // exceeds the budget, so the loop always breaks before exhausting `records`.
+  const kept: OdooRecord[] = [];
+  for (const record of records) {
+    if (kept.length > 0 && JSON.stringify(build([...kept, record])).length > budget) break;
+    kept.push(record);
+  }
+
+  return build(kept);
+}
+
 async function reportAuthFailure(
   apiBaseUrl: string,
   connectionId: string,
@@ -2472,7 +2546,7 @@ const plugin = {
         return {
           name: "odoo_read",
           label: "Odoo Read",
-          description: `Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data. ${PRODUCT_REF_DISAMBIGUATION_HINT}`,
+          description: `Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data. If a result is too large for the context, it is trimmed to fit and flagged with { truncated: true, returned } — read \`returned\` of \`total\`, then narrow \`fields\`, tighten \`filters\`, or page with \`offset\` to get the rest rather than re-issuing the same broad read. ${PRODUCT_REF_DISAMBIGUATION_HINT}`,
           parameters: {
             type: "object",
             properties: {
@@ -2542,7 +2616,7 @@ const plugin = {
               });
 
               return {
-                content: [{ type: "text", text: JSON.stringify(result) }],
+                content: [{ type: "text", text: JSON.stringify(enforceReadResultBudget(result)) }],
               };
             } catch (error) {
               return errorResult(error, {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2065,9 +2065,11 @@ function wrapReadResult(
 export const ODOO_READ_RESULT_BUDGET_CHARS = 30000;
 
 export const ODOO_READ_TRUNCATION_HINT =
-  "Result truncated to fit the model's context budget: `returned` of `total` " +
-  "matching records are included. Narrow the query with more specific `filters`, " +
-  "request fewer `fields`, or page through the rest with `offset`.";
+  "Result truncated to fit the model's context budget: the first `returned` of " +
+  "`total` matching records (in order) are included. To make the result smaller, " +
+  "request fewer `fields` (drop heavy ones like `description`) or narrow `filters`. " +
+  "To get the next page, re-read with `offset` set to this request's `offset` plus " +
+  "`returned`.";
 
 /**
  * Bound an `odoo_read` result to {@link ODOO_READ_RESULT_BUDGET_CHARS} so it can


### PR DESCRIPTION
## Problem

On **production**, Piper looped on *"Die Ergebnisse sind abgeschnitten"* (the results are truncated) whenever it read from Odoo, retrying with ever-narrower queries that all still failed.

Root cause, confirmed read-only on the production host (OpenClaw runtime log + session store + audit trail):

- OpenClaw 2026.7.1 caps **every tool result at `maxChars=64000`** and the whole prompt history at `aggregateBudgetChars=256000`, replacing the overflow with a literal `[... N more characters truncated …]` marker spliced **mid-JSON**.
- Pinchy's `odoo_read` did a bare `JSON.stringify(result)` with **no size guard** — a `crm.lead` read including the large HTML `description` field at `limit: 200`, each record further inflated by `_pinchy_ref` tokens + wrapped relational fields, reached **~509,000 chars** — ~8× the per-result cap and ~2× the entire aggregate budget.
- Piper received corrupt JSON + the marker, narrated "truncated", and retried. Because the shared session had already spent the 256k aggregate on earlier big reads, even narrower follow-ups got cut — the loop in the report.
- Only reproduces on production: dev/test seed data never approaches the cap.

## Fix

A Pinchy-side byte-budget guard, mirroring the pre-emptive ceiling `openclaw-config/bootstrap-caps.ts` already applies to instruction files:

- New pure function **`enforceReadResultBudget`** (`ODOO_READ_RESULT_BUDGET_CHARS = 30000`, headroom under 64k and room for several reads under the 256k aggregate), wired into `odoo_read`.
- A result that **fits** is returned **verbatim** (same reference, no added keys — existing behaviour/tests unchanged).
- An **oversized** result keeps the largest prefix of records that fits and reports it honestly as valid JSON: `{ records, total (full Odoo match count), returned, truncated: true, hint }`. **Always keeps ≥1 record** so the model can still make progress.
- The `odoo_read` tool description now teaches the model to page/narrow on `truncated` instead of re-issuing the same broad read.

## Tests

- Unit tests for the guard: fits-unchanged, trims-and-flags, always-keeps-one (even a lone over-budget record), bare-array wrapping.
- Regression through `odoo_read.execute`: a 200-record oversized read now serializes **< 64000** chars with `truncated: true`.
- `pnpm test` (plugin, 419) green · `tsc --noEmit` green · Prettier clean.

## Reviewer notes

- Approach chosen deliberately over "just lower the default limit": the guard holds even when the model explicitly requests a heavy field (`description`) across many records — exactly what happened here.
- **Operational:** the fix ships in a release (prod runs v0.8.0). It does not un-corrupt an *existing* shared session whose history already contains truncated results — new reads are clean; starting a fresh Piper conversation unsticks the current one immediately.
- No new tool, no test deletions/skips → CI drift guards unaffected.