### PR TITLE
fix(api): make config regeneration best-effort on provider/agent save (#880)

### DIFF
--- a/packages/web/src/__tests__/api/agents-audit.test.ts
+++ b/packages/web/src/__tests__/api/agents-audit.test.ts
@@ -192,6 +192,33 @@ describe("POST /api/agents audit logging", () => {
       },
     });
   });
+
+  it("audits a runtime-apply failure event when regeneration fails, keeping create success (#880)", async () => {
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(
+      new Error("EACCES: permission denied, open '/config/openclaw.json'")
+    );
+
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "Test Agent", templateId: "custom" }),
+    });
+
+    const response = await POST(request, routeContext());
+    // The agent row committed, so the create still succeeds...
+    expect(response.status).toBe(201);
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "agent.created", outcome: "success" })
+    );
+    // ...but the trail also records that it never reached the runtime.
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "config.changed",
+        resource: "agent:new-agent-id",
+        outcome: "failure",
+        detail: expect.objectContaining({ action: "runtime_apply_failed" }),
+      })
+    );
+  });
 });
 
 // ── PATCH /api/agents/[agentId] — agent.updated audit ───────────────────

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -226,6 +226,39 @@ describe("POST /api/agents", () => {
     expect(waitInvocations[0]).toBeGreaterThan(regenInvocations[0]);
   });
 
+  it("still returns 201 with the created agent and a warning when config regeneration fails", async () => {
+    // Regression for #880: the agent row already committed, so a failed
+    // runtime apply must not surface as a hard 500 that implies nothing saved.
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(
+      new Error("EACCES: permission denied, open '/config/openclaw.json'")
+    );
+
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "Best Effort", templateId: "custom" }),
+    });
+
+    const response = await POST(request, routeContext());
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    // The persisted agent must still be returned so the UI can navigate to it.
+    expect(body.id).toBe("new-agent-id");
+    expect(typeof body.warning).toBe("string");
+    expect(body.warning.length).toBeGreaterThan(0);
+  });
+
+  it("does not include a warning when config regeneration succeeds", async () => {
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "Happy Path", templateId: "custom" }),
+    });
+
+    const response = await POST(request, routeContext());
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.warning).toBeUndefined();
+  });
+
   it("should return 403 for non-admin users", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(
       mockSession({ user: { id: "2", email: "user@test.com", role: "member" } })

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -239,6 +239,43 @@ describe("POST /api/setup/provider", () => {
     expect(regenerateOpenClawConfig).toHaveBeenCalled();
   });
 
+  it("should still return 200 with a warning when config regeneration fails", async () => {
+    // Regression for #880: the DB write already committed, so a failed
+    // runtime apply must not surface as a hard 500 that implies nothing saved.
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(
+      new Error("EACCES: permission denied, open '/config/openclaw.json'")
+    );
+
+    const response = await POST(
+      makeRequest({
+        provider: "anthropic",
+        apiKey: "sk-ant-key",
+      }) as any
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(typeof data.warning).toBe("string");
+    expect(data.warning.length).toBeGreaterThan(0);
+    // The persisted change must still have committed.
+    expect(setSetting).toHaveBeenCalledWith("anthropic_api_key", "sk-ant-key", true);
+  });
+
+  it("should not include a warning when config regeneration succeeds", async () => {
+    const response = await POST(
+      makeRequest({
+        provider: "anthropic",
+        apiKey: "sk-ant-key",
+      }) as any
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.warning).toBeUndefined();
+  });
+
   it("should reset model cache after saving provider", async () => {
     await POST(
       makeRequest({

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -260,6 +260,12 @@ describe("POST /api/setup/provider", () => {
     expect(data.warning.length).toBeGreaterThan(0);
     // The persisted change must still have committed.
     expect(setSetting).toHaveBeenCalledWith("anthropic_api_key", "sk-ant-key", true);
+    // ...and the audit trail records that it did not reach the runtime.
+    const auditDetail = vi.mocked(appendAuditLog).mock.calls[0][0].detail as Record<
+      string,
+      unknown
+    >;
+    expect(auditDetail.runtimeApplied).toBe(false);
   });
 
   it("should not include a warning when config regeneration succeeds", async () => {
@@ -637,6 +643,8 @@ describe("POST /api/setup/provider", () => {
     expect(call.detail).toMatchObject({
       provider: { id: "anthropic", name: "Anthropic" },
       authType: "api-key",
+      // On the happy path the setting also reached the runtime (#880).
+      runtimeApplied: true,
     });
   });
 

--- a/packages/web/src/__tests__/api/user-config-audit.test.ts
+++ b/packages/web/src/__tests__/api/user-config-audit.test.ts
@@ -300,6 +300,8 @@ describe("audit: POST /api/setup/provider", () => {
       detail: {
         provider: { id: "anthropic", name: "Anthropic" },
         authType: "api-key",
+        // Records whether the setting also reached the OpenClaw runtime (#880).
+        runtimeApplied: true,
       },
     });
   });

--- a/packages/web/src/__tests__/components/new-agent-form.test.tsx
+++ b/packages/web/src/__tests__/components/new-agent-form.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { NewAgentForm } from "@/components/new-agent-form";
+import { toast } from "sonner";
 
 const { mockPush, mockReplace, mockSearchParams } = vi.hoisted(() => {
   const searchParamsRef = { current: new URLSearchParams() };
@@ -29,6 +30,10 @@ vi.mock("next/navigation", () => ({
     replace: mockReplace,
   }),
   useSearchParams: () => mockSearchParams.current,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
 }));
 
 const mockTemplates = [
@@ -391,6 +396,50 @@ describe("NewAgentForm — tagline field", () => {
       const body = JSON.parse(postCall![1]!.body as string);
       expect(body.tagline).toBe("My custom tagline");
     });
+  });
+
+  it("navigates and shows a warning toast when creation reports a runtime warning (#880)", async () => {
+    fetchSpy.mockImplementation(async (url, init) => {
+      if (String(url) === "/api/templates") {
+        return {
+          ok: true,
+          json: async () => ({ templates: mockTemplates }),
+        } as Response;
+      }
+      if (String(url) === "/api/agents" && init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "new-agent-id",
+            warning: "Agent created. Applying it to the runtime failed.",
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({}) } as Response;
+    });
+
+    render(<NewAgentForm />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/start from scratch/i)).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText(/start from scratch/i));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    });
+    await userEvent.type(screen.getByLabelText(/name/i), "My Bot");
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    // Still a success flow: the user is navigated to the new agent's chat, and
+    // the warning surfaces non-blockingly (no inline error).
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/chat/new-agent-id");
+      expect(toast.warning).toHaveBeenCalledWith(
+        "Agent created. Applying it to the runtime failed."
+      );
+    });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/__tests__/components/provider-key-form.test.tsx
+++ b/packages/web/src/__tests__/components/provider-key-form.test.tsx
@@ -5,7 +5,9 @@ import "@testing-library/jest-dom";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { toast } from "sonner";
 
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
 
 vi.mock("@/lib/github-issue", () => ({
   buildGitHubIssueUrl: vi.fn().mockReturnValue("https://github.com/test"),
@@ -89,6 +91,32 @@ describe("ProviderKeyForm", () => {
       expect(onSuccess).toHaveBeenCalled();
       expect(toast.success).toHaveBeenCalledWith("API key saved");
     });
+  });
+
+  it("shows a warning toast (not success) when the save reports a runtime warning (#880)", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        warning: "Saved. Applying it to the agent runtime failed.",
+      }),
+    } as Response);
+
+    render(<ProviderKeyForm onSuccess={onSuccess} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+    fireEvent.change(screen.getByLabelText(/api key/i), {
+      target: { value: "sk-ant-valid-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      // Still a success flow — onSuccess fires and no error toast.
+      expect(onSuccess).toHaveBeenCalled();
+      expect(toast.warning).toHaveBeenCalledWith("Saved. Applying it to the agent runtime failed.");
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("should show inline error message on failed validation", async () => {

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -307,23 +307,35 @@ export const POST = withAdmin(async (request, _ctx, session) => {
   });
   writeWorkspaceFileInternal(agent.id, "USER.md", context);
 
-  await regenerateOpenClawConfig();
-
-  // Wait until OC's runtime has the new agent visible in `agents.list`.
-  // Pinchy's regenerate is fire-and-forget (`pushConfigInBackground`) and OC
-  // applies the hot reload asynchronously; without this gate the first
-  // dispatch after POST /api/agents can race the reload and fail with
-  // `invalid agent params: unknown agent id`. Best-effort with a 5 s cap so
-  // we don't block the interactive save flow if OC is restarting.
-  let client = null;
+  // Best-effort runtime apply: the agent row is already committed above, so a
+  // failed regeneration must NOT surface as a 500 that implies the agent
+  // wasn't created (#880) — the UI would show an error while a refresh reveals
+  // the agent exists. On failure we still return 201 with a non-blocking
+  // warning; OpenClaw reconciles on its next startup / config push.
+  let runtimeWarning: string | undefined;
   try {
-    client = getOpenClawClient();
-  } catch {
-    // OC client not initialised (rare in tests / pre-setup). Skip the wait.
+    await regenerateOpenClawConfig();
+
+    // Wait until OC's runtime has the new agent visible in `agents.list`.
+    // Pinchy's regenerate is fire-and-forget (`pushConfigInBackground`) and OC
+    // applies the hot reload asynchronously; without this gate the first
+    // dispatch after POST /api/agents can race the reload and fail with
+    // `invalid agent params: unknown agent id`. Best-effort with a 5 s cap so
+    // we don't block the interactive save flow if OC is restarting.
+    let client = null;
+    try {
+      client = getOpenClawClient();
+    } catch {
+      // OC client not initialised (rare in tests / pre-setup). Skip the wait.
+    }
+    await waitForAgentInRuntime(client, agent.id);
+  } catch (err) {
+    console.error("Failed to apply new agent config to the OpenClaw runtime:", err);
+    runtimeWarning =
+      "Agent created. Applying it to the runtime failed — this usually resolves on the next restart.";
   }
-  await waitForAgentInRuntime(client, agent.id);
 
   revalidatePath("/", "layout");
 
-  return NextResponse.json(agent, { status: 201 });
+  return NextResponse.json({ ...agent, warning: runtimeWarning }, { status: 201 });
 });

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -332,7 +332,25 @@ export const POST = withAdmin(async (request, _ctx, session) => {
   } catch (err) {
     console.error("Failed to apply new agent config to the OpenClaw runtime:", err);
     runtimeWarning =
-      "Agent created. Applying it to the runtime failed — this usually resolves on the next restart.";
+      "Agent created. Applying it to the runtime failed — check the server logs; it will retry on the next restart or config change.";
+    // The agent row is committed (the create is audited as success above), but
+    // it never reached the runtime. Record that as a distinct failure event so
+    // the trail shows "created but not applied" instead of silently implying a
+    // clean create (#880). deferAuditLog: the create already happened and must
+    // not be rolled back if this write fails.
+    deferAuditLog({
+      actorType: "user",
+      actorId: session.user.id!,
+      eventType: "config.changed",
+      resource: `agent:${agent.id}`,
+      detail: {
+        action: "runtime_apply_failed",
+        agentId: agent.id,
+        name: agent.name,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      outcome: "failure",
+    });
   }
 
   revalidatePath("/", "layout");

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -186,8 +186,22 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Regenerate full OpenClaw config (includes agent list, provider env, model defaults)
-  await regenerateOpenClawConfig();
+  // Regenerate full OpenClaw config (includes agent list, provider env, model
+  // defaults). This is best-effort: the provider key/URL is already committed
+  // above, so a failed runtime apply must NOT surface as a 500 that implies
+  // nothing saved (#880). apsa v0.8.0 saw this fire on every call (EACCES on
+  // openclaw.json) — the setting persisted, the wizard showed an error, and a
+  // refresh revealed it had actually saved. On failure we still return
+  // success with a non-blocking warning; OpenClaw reconciles on its next
+  // startup / config push.
+  let runtimeWarning: string | undefined;
+  try {
+    await regenerateOpenClawConfig();
+  } catch (err) {
+    console.error("Failed to apply provider config to the OpenClaw runtime:", err);
+    runtimeWarning =
+      "Saved. Applying it to the agent runtime failed — this usually resolves on the next restart.";
+  }
   resetCache();
 
   // Wait until OC's runtime has Smithers visible in `agents.list`. Same race
@@ -209,15 +223,19 @@ export async function POST(request: NextRequest) {
   // while still failing fast if OC is genuinely broken. PR #445 CI showed
   // 23 s pass / 1.7 m fail on the same commit on the 5 s default —
   // textbook timing flake.
-  const smithersForWait = await db.query.agents.findFirst();
-  if (smithersForWait) {
-    let client = null;
-    try {
-      client = getOpenClawClient();
-    } catch {
-      // OC client not initialised (rare in tests / pre-setup). Skip the wait.
+  // Only worth waiting when the config actually regenerated — if it threw,
+  // OC's runtime won't be reloading and the poll would just burn its budget.
+  if (!runtimeWarning) {
+    const smithersForWait = await db.query.agents.findFirst();
+    if (smithersForWait) {
+      let client = null;
+      try {
+        client = getOpenClawClient();
+      } catch {
+        // OC client not initialised (rare in tests / pre-setup). Skip the wait.
+      }
+      await waitForAgentInRuntime(client, smithersForWait.id, 30000);
     }
-    await waitForAgentInRuntime(client, smithersForWait.id, 30000);
   }
 
   // Build a CLAUDE.md-compliant audit detail: snapshot the human-readable
@@ -227,6 +245,9 @@ export async function POST(request: NextRequest) {
   const detail: Record<string, unknown> = {
     provider: { id: provider, name: PROVIDERS[provider].name },
     authType: config.authType,
+    // The setting is committed regardless; record whether it also reached the
+    // OpenClaw runtime so the trail distinguishes "saved" from "saved+applied".
+    runtimeApplied: !runtimeWarning,
   };
   if (config.authType === "url" && body.url) {
     try {
@@ -248,5 +269,5 @@ export async function POST(request: NextRequest) {
     })
   );
 
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true, warning: runtimeWarning });
 }

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -200,7 +200,7 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     console.error("Failed to apply provider config to the OpenClaw runtime:", err);
     runtimeWarning =
-      "Saved. Applying it to the agent runtime failed — this usually resolves on the next restart.";
+      "Saved. Applying it to the agent runtime failed — check the server logs; it will retry on the next restart or config change.";
   }
   resetCache();
 

--- a/packages/web/src/components/new-agent-form.tsx
+++ b/packages/web/src/components/new-agent-form.tsx
@@ -36,6 +36,7 @@ import { autoSelectConnection, type OdooConnection } from "@/lib/odoo-connection
 import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
 import { getPermissionPreviewItems } from "@/lib/template-grouping";
 import Link from "next/link";
+import { toast } from "sonner";
 
 const EMAIL_CONNECTION_TYPE_SET = new Set<string>(EMAIL_CONNECTION_TYPES);
 
@@ -391,6 +392,13 @@ export function NewAgentForm() {
       }
 
       const agent = await res.json();
+      // #880 — the route creates the agent even when applying it to the OC
+      // runtime fails, returning a non-blocking `warning` instead of a 500.
+      // Surface it as a warning toast (sonner persists across the navigation
+      // below) so the creation still reads as successful.
+      if (typeof agent?.warning === "string" && agent.warning.length > 0) {
+        toast.warning(agent.warning);
+      }
       triggerRestart();
       router.push(`/chat/${agent.id}`);
       router.refresh();

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -286,9 +286,26 @@ export function ProviderKeyForm({
         throw new Error(message);
       }
 
+      // #880 — the route persists the key even when applying it to the OC
+      // runtime fails, and returns a non-blocking `warning` instead of a 500.
+      // Surface it as a warning toast so the save still reads as successful.
+      let warning: string | undefined;
+      try {
+        const data = await res.json();
+        if (typeof data?.warning === "string" && data.warning.length > 0) {
+          warning = data.warning;
+        }
+      } catch {
+        // No/!JSON body — treat as a plain success.
+      }
+
       setValidationStatus("success");
       form.reset();
-      toast.success(isUrlProvider ? "URL saved" : "API key saved");
+      if (warning) {
+        toast.warning(warning);
+      } else {
+        toast.success(isUrlProvider ? "URL saved" : "API key saved");
+      }
       triggerRestart();
       onSaved?.(provider, VISION_CAPABLE_PROVIDERS.has(provider));
       onSuccess(provider);


### PR DESCRIPTION
Closes #880.

## Problem
`POST /api/setup/provider` and `POST /api/agents` both commit to the DB and then call `regenerateOpenClawConfig()` **unguarded**. If regeneration throws (e.g. `EACCES` on `openclaw.json`, as seen on apsa v0.8.0 where it fired on *every* call), the exception propagates to a hard HTTP 500 — but the row is already committed, so a refresh reveals the change actually saved. Confusing "did it save?" UX.

## Fix
Make the runtime apply best-effort in the request path — "runtime apply failed" must not equate to "save failed":

**Server**
- Wrap `regenerateOpenClawConfig()` (and the post-regenerate `waitForAgentInRuntime` gate) in `try/catch` in both routes.
- On failure, still return success (`200` / `201`) for the persisted change with a non-blocking `warning` field, instead of a `500`. OpenClaw reconciles on its next startup / config push.
- Provider route skips the wait gate on failure (no point polling for a reload that isn't happening) and records `runtimeApplied: true|false` in the audit `detail`, so the trail distinguishes "saved" from "saved + applied".

**Client**
- `provider-key-form` and `new-agent-form` surface the `warning` as `toast.warning(...)` instead of a success toast. The flow still reads as a success — navigation happens, no inline error.

## Tests
TDD (red → green). New regression tests at both layers cover the success path *and* the regeneration-failure path:
- `setup-provider.test.ts`, `agents-create.test.ts` — route returns success + warning while the write stays committed.
- `provider-key-form.test.tsx`, `new-agent-form.test.tsx` — warning toast (not success/error), flow completes.

## Verification
- 158 tests green across the four touched test files.
- `pnpm typecheck` clean, `pnpm lint` 0 errors, `pnpm format:check` green.

## Scope
Deliberately limited to the two POST routes named in the issue. `PATCH /api/agents` also regenerates but is out of scope here.