### PR TITLE
fix(openclaw-config): same-provider fallback chain for the chat model (#881)

### DIFF
--- a/packages/web/src/__tests__/lib/chat-model-fallback.test.ts
+++ b/packages/web/src/__tests__/lib/chat-model-fallback.test.ts
@@ -4,7 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // three edges (is the provider configured? what is its LIVE default? is that
 // default blocked?), so we mock the edges and assert the chain.
 const getSetting = vi.fn<(key: string) => Promise<string | null>>();
-const getDefaultModel = vi.fn<(provider: string) => Promise<string | null>>();
+// getDefaultModel's real contract is Promise<string> — it never resolves null,
+// falling back to PROVIDERS[provider].defaultModel. Mock the true shape.
+const getDefaultModel = vi.fn<(provider: string) => Promise<string>>();
 const getAgentModelBlockReason = vi.fn<(model: string) => string | null>();
 
 vi.mock("@/lib/settings", () => ({ getSetting: (k: string) => getSetting(k) }));
@@ -42,7 +44,7 @@ describe("resolveChatModelFallbackChain", () => {
       key === "ollama_local_url" ? "http://host.docker.internal:11434" : null
     );
     getDefaultModel.mockImplementation(async (provider) =>
-      provider === "ollama-local" ? "ollama/qwen3" : null
+      provider === "ollama-local" ? "ollama/qwen3" : "unused/other-provider-default"
     );
     getAgentModelBlockReason.mockReturnValue(null);
 

--- a/packages/web/src/__tests__/lib/chat-model-fallback.test.ts
+++ b/packages/web/src/__tests__/lib/chat-model-fallback.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Same-provider chat-model fallback resolver. It is pure preference logic over
+// three edges (is the provider configured? what is its LIVE default? is that
+// default blocked?), so we mock the edges and assert the chain.
+const getSetting = vi.fn<(key: string) => Promise<string | null>>();
+const getDefaultModel = vi.fn<(provider: string) => Promise<string | null>>();
+const getAgentModelBlockReason = vi.fn<(model: string) => string | null>();
+
+vi.mock("@/lib/settings", () => ({ getSetting: (k: string) => getSetting(k) }));
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: (p: string) => getDefaultModel(p),
+}));
+vi.mock("@/lib/model-resolver/blocklist", () => ({
+  getAgentModelBlockReason: (m: string) => getAgentModelBlockReason(m),
+}));
+
+import { resolveChatModelFallbackChain } from "@/lib/openclaw-config/chat-model-fallback";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveChatModelFallbackChain", () => {
+  it("falls back to the same provider's LIVE default when the primary is retired", async () => {
+    // apsa scenario: an agent pinned to a retired ollama-cloud model. The live
+    // catalog no longer lists it, but getDefaultModel resolves the balanced
+    // live pick — that is the fallback OpenClaw retries so the run recovers.
+    getSetting.mockImplementation(async (key) =>
+      key === "ollama_cloud_api_key" ? "sk-present" : null
+    );
+    getDefaultModel.mockResolvedValue("ollama-cloud/kimi-k2.6");
+    getAgentModelBlockReason.mockReturnValue(null);
+
+    const chain = await resolveChatModelFallbackChain("ollama-cloud/gemini-3-flash-preview");
+
+    expect(chain).toEqual(["ollama-cloud/kimi-k2.6"]);
+  });
+
+  it("maps the bare `ollama/` prefix to the ollama-local provider", async () => {
+    getSetting.mockImplementation(async (key) =>
+      key === "ollama_local_url" ? "http://host.docker.internal:11434" : null
+    );
+    getDefaultModel.mockImplementation(async (provider) =>
+      provider === "ollama-local" ? "ollama/qwen3" : null
+    );
+    getAgentModelBlockReason.mockReturnValue(null);
+
+    const chain = await resolveChatModelFallbackChain("ollama/some-retired-model");
+
+    expect(chain).toEqual(["ollama/qwen3"]);
+  });
+
+  it("returns no fallback when the same live default equals the primary", async () => {
+    // The primary is still live, so its provider default resolves to itself —
+    // emitting it as a fallback would be a useless duplicate.
+    getSetting.mockResolvedValue("sk-present");
+    getDefaultModel.mockResolvedValue("anthropic/claude-sonnet-4-6");
+    getAgentModelBlockReason.mockReturnValue(null);
+
+    const chain = await resolveChatModelFallbackChain("anthropic/claude-sonnet-4-6");
+
+    expect(chain).toEqual([]);
+  });
+
+  it("returns no fallback when the primary's provider is not configured", async () => {
+    // No key → the same-provider default would 401 at runtime, so it is not a
+    // usable fallback. (Also the state every unit test with null settings hits,
+    // keeping the emitted agent shape a bare string there.)
+    getSetting.mockResolvedValue(null);
+    getDefaultModel.mockResolvedValue("ollama-cloud/kimi-k2.6");
+    getAgentModelBlockReason.mockReturnValue(null);
+
+    const chain = await resolveChatModelFallbackChain("ollama-cloud/gemini-3-flash-preview");
+
+    expect(chain).toEqual([]);
+  });
+
+  it("drops a same-provider default that the tools blocklist rejects", async () => {
+    // Chat fallbacks drive tool loops, so a blocklisted default (e.g. one that
+    // mangles nested tool arguments) must not be handed out — unlike the vision
+    // chain, which describes images and applies no blocklist.
+    getSetting.mockResolvedValue("sk-present");
+    getDefaultModel.mockResolvedValue("ollama-cloud/minimax-m3");
+    getAgentModelBlockReason.mockImplementation((m) =>
+      m === "ollama-cloud/minimax-m3" ? "mangles nested tool arguments" : null
+    );
+
+    const chain = await resolveChatModelFallbackChain("ollama-cloud/gemini-3-flash-preview");
+
+    expect(chain).toEqual([]);
+  });
+
+  it.each([null, undefined, ""])(
+    "returns no fallback for a missing primary model (%s)",
+    async (primary) => {
+      // agents.model is nullable in the DB; the resolver must not throw on it.
+      getSetting.mockResolvedValue("sk-present");
+      getAgentModelBlockReason.mockReturnValue(null);
+
+      const chain = await resolveChatModelFallbackChain(primary as unknown as string);
+
+      expect(chain).toEqual([]);
+      expect(getDefaultModel).not.toHaveBeenCalled();
+    }
+  );
+
+  it("returns no fallback for an unprefixed / unknown model id", async () => {
+    getSetting.mockResolvedValue("sk-present");
+    getDefaultModel.mockResolvedValue("anthropic/claude-sonnet-4-6");
+    getAgentModelBlockReason.mockReturnValue(null);
+
+    const chain = await resolveChatModelFallbackChain("just-a-name-no-provider");
+
+    expect(chain).toEqual([]);
+    // An unknown prefix must never trigger a provider lookup — it has no provider.
+    expect(getDefaultModel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -866,6 +866,76 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.agents.list[0].model).toBe("anthropic/claude-haiku-4-5-20251001");
   });
 
+  it("keys the chat fallback per agent id — one agent gets a chain, another a bare string (#881)", async () => {
+    // The resolver runs once per agent into a Map keyed by agent id; a mis-keyed
+    // lookup would hand agent B's chain to agent A. First agent's model has a
+    // live-default sibling (opus → haiku) so it gets { primary, fallbacks };
+    // second agent already IS the live default so it stays a bare string.
+    const agentsData = [
+      {
+        id: "uuid-agent-chain",
+        name: "Smithers",
+        model: "anthropic/claude-opus-4-7",
+        createdAt: new Date(),
+      },
+      {
+        id: "uuid-agent-bare",
+        name: "Penny",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        createdAt: new Date(),
+      },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: mockFrom(agentsData),
+    } as never);
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "anthropic_api_key" ? "sk-ant-decrypted" : null
+    );
+
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
+    const byId = Object.fromEntries(
+      config.agents.list.map((a: { id: string; model: unknown }) => [a.id, a.model])
+    );
+
+    expect(byId["uuid-agent-chain"]).toEqual({
+      primary: "anthropic/claude-opus-4-7",
+      fallbacks: ["anthropic/claude-haiku-4-5-20251001"],
+    });
+    expect(byId["uuid-agent-bare"]).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+
+  it("keeps a retired chat model a bare string when the provider's live default is tools-blocklisted (#881)", async () => {
+    // apsa-shaped: a retired ollama-cloud primary whose provider's live default
+    // (minimax-m3) is itself tools-blocklisted. The resolver deliberately emits
+    // NO fallback rather than hand a tool loop a model that mangles nested tool
+    // args — so the agent keeps its bare string and does not silently recover
+    // onto a broken model. This exercises the real blocklist (not mocked here).
+    const agentsData = [
+      {
+        id: "uuid-agent-1",
+        name: "Smithers",
+        model: "ollama-cloud/gemini-3-flash-preview",
+        createdAt: new Date(),
+      },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: mockFrom(agentsData),
+    } as never);
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "ollama_cloud_api_key" ? "sk-oc-decrypted" : null
+    );
+
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
+
+    // getDefaultModel("ollama-cloud") → minimax-m3 (mock), which the tools
+    // blocklist rejects → no fallback → bare string kept.
+    expect(config.agents.list[0].model).toBe("ollama-cloud/gemini-3-flash-preview");
+  });
+
   it("excludes soft-deleted (tombstoned) agents from agents.list", async () => {
     const agentsData = [
       {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -810,6 +810,62 @@ describe("regenerateOpenClawConfig", () => {
     });
   });
 
+  it("emits a same-provider { primary, fallbacks } chain for the chat model when its provider is configured (#881)", async () => {
+    // A retired chat model was written verbatim into agents.*.model with no
+    // fallback, so an Ollama 410 killed every run permanently. We now emit the
+    // provider's LIVE default (getDefaultModel mock → haiku) as a fallback
+    // OpenClaw retries — same provider only, no silent cross-provider switch.
+    const agentsData = [
+      {
+        id: "uuid-agent-1",
+        name: "Smithers",
+        model: "anthropic/claude-opus-4-7",
+        createdAt: new Date(),
+      },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: mockFrom(agentsData),
+    } as never);
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "anthropic_api_key" ? "sk-ant-decrypted" : null
+    );
+
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
+
+    expect(config.agents.list[0].model).toEqual({
+      primary: "anthropic/claude-opus-4-7",
+      fallbacks: ["anthropic/claude-haiku-4-5-20251001"],
+    });
+  });
+
+  it("keeps the chat model a bare string when no same-provider fallback resolves (#881)", async () => {
+    // The primary is already the provider's live default, so there is nothing
+    // useful to add — the emitted shape must stay a bare string, not a
+    // single-entry chain that just repeats the primary.
+    const agentsData = [
+      {
+        id: "uuid-agent-1",
+        name: "Smithers",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        createdAt: new Date(),
+      },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: mockFrom(agentsData),
+    } as never);
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "anthropic_api_key" ? "sk-ant-decrypted" : null
+    );
+
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(writtenOpenClawConfig(mockedWriteFileSync));
+
+    expect(config.agents.list[0].model).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+
   it("excludes soft-deleted (tombstoned) agents from agents.list", async () => {
     const agentsData = [
       {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -55,6 +55,7 @@ import {
   BUILTIN_PROVIDER_API,
 } from "./provider-defaults";
 import { resolveDefaultVisionModelChain } from "./default-media-models";
+import { resolveChatModelFallbackChain } from "./chat-model-fallback";
 import { deepMerge } from "./deep-merge";
 import { buildGatewayBlock } from "./gateway";
 import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
@@ -507,11 +508,27 @@ export async function regenerateOpenClawConfig() {
   // agents map.
   let knowledgePluginAgents: Record<string, Record<string, never>> | undefined;
 
+  // Same-provider fallback chain for each agent's chat model (#881). A retired
+  // primary (Ollama 410) otherwise 410s forever with next=none because the
+  // model is written verbatim with no fallback and regeneration writes the same
+  // dead model back. Resolved ONCE per agent up front (the resolver is async;
+  // the map below is sync), keyed by agent id. Emitted as { primary, fallbacks }
+  // only when a usable fallback exists — otherwise the bare string is kept.
+  const chatModelFallbacks = new Map<string, string[]>(
+    await Promise.all(
+      liveAgents.map(
+        async (agent) =>
+          [agent.id, await resolveChatModelFallbackChain(agent.model)] as [string, string[]]
+      )
+    )
+  );
+
   const agentsList = liveAgents.map((agent) => {
+    const fallbacks = chatModelFallbacks.get(agent.id) ?? [];
     const agentEntry: Record<string, unknown> = {
       id: agent.id,
       name: agent.name,
-      model: agent.model,
+      model: fallbacks.length > 0 ? { primary: agent.model, fallbacks } : agent.model,
       workspace: getOpenClawWorkspacePath(agent.id),
       // Disable heartbeat by default: it fires LLM calls in the background
       // and racks up tokens even for idle agents. Set per-agent (NOT in

--- a/packages/web/src/lib/openclaw-config/chat-model-fallback.ts
+++ b/packages/web/src/lib/openclaw-config/chat-model-fallback.ts
@@ -66,13 +66,24 @@ export async function resolveChatModelFallbackChain(
   if (!key) return [];
 
   const liveDefault = await getDefaultModel(provider);
-  // No default, or the primary is still live and resolves to itself → nothing
-  // useful to add (emitting the primary as its own fallback is a dead entry).
+  // `getDefaultModel` contractually returns a non-empty string (it falls back to
+  // PROVIDERS[provider].defaultModel), so `!liveDefault` is a defensive guard
+  // against future contract drift. The load-bearing check is the equality: if the
+  // primary is still live it resolves to itself, and emitting the primary as its
+  // own fallback is a dead entry.
   if (!liveDefault || liveDefault === primaryModel) return [];
 
   // Chat fallbacks drive tool loops, so a blocklisted default (e.g. one that
   // mangles nested tool arguments) must never be handed out — unlike the vision
   // chain, whose slot only describes images and applies no blocklist.
+  //
+  // DELIBERATE non-recovery: if the provider's live default is itself
+  // blocklisted we return [] and the agent keeps its retired bare-string primary
+  // — so it stays dead rather than fall back to a tool-mangling model. A
+  // permanently-failing agent is the lesser evil versus one that silently
+  // corrupts tool calls, and this only bites when the balanced default itself is
+  // blocklisted (rare). The root fix for a stale catalog that still offers
+  // retired models as selectable defaults is tracked separately in #883.
   if (getAgentModelBlockReason(liveDefault)) return [];
 
   return [liveDefault];

--- a/packages/web/src/lib/openclaw-config/chat-model-fallback.ts
+++ b/packages/web/src/lib/openclaw-config/chat-model-fallback.ts
@@ -1,0 +1,79 @@
+import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { getSetting } from "@/lib/settings";
+import { getDefaultModel } from "@/lib/provider-models";
+import { getAgentModelBlockReason } from "@/lib/model-resolver/blocklist";
+
+/**
+ * Map a qualified model id's leading path segment to its ProviderName.
+ *
+ * The prefix is NOT always the ProviderName: ollama-local models are minted as
+ * `ollama/<model>` (see PROVIDERS["ollama-local"].defaultModel). This mapping
+ * is deterministic and — unlike a live-catalog lookup — resolves the provider
+ * even for a RETIRED model that has already dropped out of `/v1/models`, which
+ * is precisely the state the fallback resolver runs in.
+ */
+const MODEL_PREFIX_TO_PROVIDER: Record<string, ProviderName> = {
+  anthropic: "anthropic",
+  openai: "openai",
+  google: "google",
+  "ollama-cloud": "ollama-cloud",
+  ollama: "ollama-local",
+};
+
+function providerOfModel(model: string): ProviderName | null {
+  const prefix = model.split("/")[0];
+  // `prefix` is a runtime string from a nullable DB column, so this is a genuine
+  // dynamic key lookup — but the map is a finite whitelist that returns
+  // undefined for anything unrecognized, so no prototype key can leak through.
+  // eslint-disable-next-line security/detect-object-injection
+  return MODEL_PREFIX_TO_PROVIDER[prefix] ?? null;
+}
+
+/**
+ * Resolve a SAME-PROVIDER fallback chain for an agent's chat model.
+ *
+ * The chat model is written verbatim into `agents.*.model` with no fallback,
+ * so when a provider retires it upstream (Ollama HTTP 410 "retired") every run
+ * dies `410 → next=none → FailoverError/UNAVAILABLE` with nothing rendered, and
+ * stays dead because `regenerateOpenClawConfig` just writes the same dead model
+ * back (#881). We give OpenClaw a fallback to retry: the provider's LIVE default
+ * model, resolved against the current `/v1/models` catalog via `getDefaultModel`
+ * — so a retired primary hands off to a live sibling of the SAME provider.
+ *
+ * Same-provider only (deliberate): Pinchy is a governance product, so an agent
+ * must not silently switch to a different provider (cost / data-residency
+ * surprise). Cross-provider fallback — the shape the vision chain uses — is a
+ * separate, opt-in decision.
+ *
+ * Returns the fallbacks only (never the primary). Empty when there is no usable
+ * fallback; the caller then emits the bare `agent.model` string unchanged.
+ */
+export async function resolveChatModelFallbackChain(
+  primaryModel: string | null | undefined
+): Promise<string[]> {
+  // agents.model is nullable in the DB — a null/empty primary has no provider
+  // and needs no fallback (the caller keeps whatever bare value it had).
+  if (!primaryModel) return [];
+  const provider = providerOfModel(primaryModel);
+  if (!provider) return [];
+
+  // Unconfigured provider → its default would 401 at runtime, so it is not a
+  // usable fallback. This is also the state every unit test with null settings
+  // hits, which keeps the emitted agent `model` a bare string there.
+  // `provider` is a typed ProviderName from a finite map, never user input.
+  // eslint-disable-next-line security/detect-object-injection
+  const key = await getSetting(PROVIDERS[provider].settingsKey);
+  if (!key) return [];
+
+  const liveDefault = await getDefaultModel(provider);
+  // No default, or the primary is still live and resolves to itself → nothing
+  // useful to add (emitting the primary as its own fallback is a dead entry).
+  if (!liveDefault || liveDefault === primaryModel) return [];
+
+  // Chat fallbacks drive tool loops, so a blocklisted default (e.g. one that
+  // mangles nested tool arguments) must never be handed out — unlike the vision
+  // chain, whose slot only describes images and applies no blocklist.
+  if (getAgentModelBlockReason(liveDefault)) return [];
+
+  return [liveDefault];
+}

--- a/packages/web/src/server/model-self-heal.ts
+++ b/packages/web/src/server/model-self-heal.ts
@@ -5,10 +5,12 @@ import { resetCache } from "@/lib/provider-models";
 /**
  * Runtime self-heal: when a chat/tool dispatch fails because the configured
  * model was retired upstream (HTTP 410 / "Unknown model"), regenerate the
- * OpenClaw config. `regenerateOpenClawConfig` re-resolves media models against
- * the LIVE `/v1/models` catalog (see `default-media-models.ts`) and skips the
- * write when nothing changed — so a retired model is swapped for a live one
- * without waiting for the next Pinchy upgrade or restart.
+ * OpenClaw config. `regenerateOpenClawConfig` re-resolves against the LIVE
+ * `/v1/models` catalog — both the media models (see `default-media-models.ts`)
+ * AND each agent's chat-model fallback chain (see `chat-model-fallback.ts`, the
+ * `{ primary, fallbacks }` OpenClaw retries when the pinned model 410s, #881) —
+ * and skips the write when nothing changed. So a retired model is covered by a
+ * live one without waiting for the next Pinchy upgrade or restart.
  *
  * OpenClaw has no fallback resolver of its own, so this is Pinchy's job. The
  * regeneration is debounced: a retirement makes EVERY dispatch fail the same


### PR DESCRIPTION
Closes #881.

## Problem
If an agent's chat model is retired upstream (Ollama HTTP 410 "retired"), the agent produces **no response — permanently**, with no recovery. The chat model was written verbatim into `agents.*.model` with **no fallback chain** (`build.ts`), and the self-heal path re-resolved only the media models — so `regenerateOpenClawConfig()` wrote the same dead model back (`410 → next=none → FailoverError/UNAVAILABLE`, nothing rendered). apsa v0.8.0 saw ~13 of 31 configured Ollama models retired upstream, every run 410ing.

## Fix
Emit `{ primary, fallbacks }` for each per-agent chat model, mirroring the existing `pdfModel`/`imageModel` pattern.

- **New resolver** `chat-model-fallback.ts`: derives the provider deterministically from the model prefix (works even for a retired model already dropped from the live catalog; `ollama/` → `ollama-local`), then resolves the **same provider's** live default via `getDefaultModel`.
- **No fallback** when: provider unconfigured, live default equals the primary, default is tools-blocklisted (chat fallbacks drive tool loops), or the model is null/empty. In those cases the bare string is kept — so single-provider unit setups are unchanged.
- **Same-provider only**, deliberately: Pinchy is a governance product, so an agent must not silently switch to a different provider (cost / data-residency surprise). Cross-provider fallback would be a separate, opt-in decision.

Because self-heal already calls `regenerateOpenClawConfig()`, the chat fallback chain is now **re-resolved live on every heal** — so the chat path finally self-heals, not just the media models.

## Scope
The issue's second bullet ("surface the failure to the user") is explicitly delegated to a separate issue ("run failures not surfaced") and is not part of this PR. Follow-up #883 (stale builtin catalog offering retired models as selectable defaults) is a complementary but independent fix and will land as its own PR.

## Verification
- Confirmed OpenClaw 2026.7.1 honours per-agent `{ primary, fallbacks }` via `resolveAgentModelFallbacksOverride → raw.fallbacks` (not just `agents.defaults.model`).
- TDD: 9 new tests (7 resolver incl. null/blocklist/prefix cases + 2 build-emission), each seen red→green.
- `pnpm typecheck` ✓ · `pnpm lint` (0 errors) ✓ · `prettier --check` ✓ · affected suites (233 tests) ✓