### PR TITLE
fix(openclaw-config): surface a frozen secrets-volume config regen instead of failing silently (#878, #879)

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -112,6 +112,32 @@ You don't need to worry about these — Pinchy handles them on every startup:
 - **New environment variables** — Check the release notes for any new variables. Pinchy won't crash if they're missing (features may just be disabled), but review them in your `.env` file.
 - **Docker Compose changes** — Most releases reuse the existing `docker-compose.yml` and only require bumping `PINCHY_VERSION` in `.env`. When a release does need a new compose file (new services or volumes), the release notes spell out the extra `curl` step. New volumes and services are then created automatically on first start.
 
+<Aside type="caution" title="Pulling images is not the same as pulling the compose file">
+  `docker compose pull` only fetches new **images** — it never touches your
+  `docker-compose.yml`. When a release adds a volume or service, keeping the old
+  compose file leaves that mount missing, and the new image can silently fail
+  against it. The clearest symptom of this is the `openclaw-secrets` volume
+  going missing: config regeneration then throws `EACCES: permission denied,
+  mkdir '/openclaw-secrets'` on every startup, so `openclaw.json` freezes at its
+  pre-upgrade content — **newly-created agents return `unknown agent id`, new
+  providers never activate, and model changes never take effect**, even though
+  the app otherwise looks healthy.
+
+If you see this, `docker compose logs pinchy` shows a `FATAL: OpenClaw secrets
+  volume is not writable` line pointing you here. Re-fetch the compose file for
+your pinned version and restart:
+
+```bash
+cd /opt/pinchy
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
+docker compose up -d
+```
+
+Re-apply any custom `volumes:` mounts afterwards (or keep them in a
+`docker-compose.override.yml` so upgrades stay hands-off).
+
+</Aside>
+
 ## Restoring from backup
 
 If you need to roll back after an upgrade:

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -28,11 +28,14 @@ Service health check. **Public — no authentication required.** Suitable for lo
     "audit_hmac_secret": "envvar",
     "db_password": "default"
   },
-  "openclaw": { "connected": true }
+  "openclaw": { "connected": true },
+  "configRegeneration": { "ok": true }
 }
 ```
 
 `openclaw.connected` reflects whether the web process currently has a live WebSocket connection to the OpenClaw gateway — the dependency chat relies on. Top-level `status` deliberately stays `"ok"` even when `openclaw.connected` is `false`: brief disconnects during OpenClaw restarts (for example while applying a config change) are expected and self-heal, and flipping `status` would make the Docker healthcheck restart-loop the container during normal operation. Monitor `openclaw.connected` directly (or poll `/api/health/openclaw`) if you need alerting on gateway reachability specifically.
+
+`configRegeneration` reports the outcome of the most recent boot-time OpenClaw config regeneration. It is `{ "ok": true }` in normal operation. When a startup regeneration fails — most commonly because an image-only upgrade dropped the `openclaw-secrets` volume (see [Upgrading Pinchy](/guides/upgrading/)) — it becomes `{ "ok": false, "error": "<actionable message>", "at": "<ISO timestamp>" }`. This is the one signal that catches a **frozen config**: Pinchy still marks itself healthy so the OpenClaw container can start and hot-reload a fixed config later, so `status` stays `"ok"` and `openclaw.connected` can be `true` while new providers, agents, and model changes silently never take effect. `error` carries operator guidance only — never secret material. Alert on `configRegeneration.ok == false`. A later successful regeneration (for example after you fix the compose file and restart) clears it back to `{ "ok": true }`.
 
 ### `GET /api/health/openclaw`
 

--- a/packages/web/src/__tests__/api/health.test.ts
+++ b/packages/web/src/__tests__/api/health.test.ts
@@ -1,17 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "@/app/api/health/route";
 import { openClawConnectionState } from "@/server/openclaw-connection-state";
+import { recordConfigRegenSuccess, recordConfigRegenFailure } from "@/lib/openclaw-config-health";
+
+const REGEN_STATE_KEY = "__pinchyOpenClawConfigRegenState";
 
 describe("GET /api/health", () => {
   const originalConnected = openClawConnectionState.connected;
 
   beforeEach(() => {
     openClawConnectionState.connected = false;
+    delete (globalThis as Record<string, unknown>)[REGEN_STATE_KEY];
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     openClawConnectionState.connected = originalConnected;
+    delete (globalThis as Record<string, unknown>)[REGEN_STATE_KEY];
   });
 
   it("should return 200 with status ok", async () => {
@@ -85,6 +90,53 @@ describe("GET /api/health", () => {
 
       expect(response.status).toBe(200);
       expect(data.status).toBe("ok");
+    });
+  });
+
+  // Issue #879: readiness is marked even when the boot regenerate throws, so
+  // /api/health must expose the regeneration outcome — otherwise a frozen
+  // config (e.g. #878 missing-secrets-volume EACCES) is completely invisible
+  // to monitoring while the instance reports healthy.
+  describe("config regeneration outcome (#879)", () => {
+    it("reports configRegeneration ok when nothing has failed", async () => {
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.configRegeneration).toMatchObject({ ok: true });
+    });
+
+    it("surfaces a recorded regeneration failure with its actionable message", async () => {
+      recordConfigRegenFailure("your docker-compose.yml is missing the openclaw-secrets volume");
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.configRegeneration.ok).toBe(false);
+      expect(data.configRegeneration.error).toMatch(/openclaw-secrets volume/);
+    });
+
+    it("clears the failure once a later regeneration succeeds", async () => {
+      recordConfigRegenFailure("broken");
+      recordConfigRegenSuccess();
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(data.configRegeneration.ok).toBe(true);
+      expect(data.configRegeneration.error).toBeUndefined();
+    });
+
+    it("keeps top-level status 'ok' and HTTP 200 even when regeneration failed", async () => {
+      // Same rationale as the gateway-disconnect case: the boolean is for
+      // monitoring, not for flipping the Docker healthcheck into a restart loop.
+      recordConfigRegenFailure("broken");
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("ok");
+      expect(data.configRegeneration.ok).toBe(false);
     });
   });
 });

--- a/packages/web/src/__tests__/lib/boot-inits.test.ts
+++ b/packages/web/src/__tests__/lib/boot-inits.test.ts
@@ -11,6 +11,9 @@ const mocks = vi.hoisted(() => ({
   migrateSmithersSoul: vi.fn().mockResolvedValue(undefined),
   regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
   markOpenClawConfigReady: vi.fn(),
+  checkSecretsVolumeWritable: vi.fn().mockReturnValue({ ok: true }),
+  recordConfigRegenSuccess: vi.fn(),
+  recordConfigRegenFailure: vi.fn(),
 }));
 
 vi.mock("@/lib/session-migration", () => ({ migrateSessionKeys: mocks.migrateSessionKeys }));
@@ -33,6 +36,13 @@ vi.mock("@/lib/migrate-smithers-soul", () => ({
 vi.mock("@/lib/openclaw-config-ready", () => ({
   markOpenClawConfigReady: mocks.markOpenClawConfigReady,
 }));
+vi.mock("@/lib/openclaw-secrets", () => ({
+  checkSecretsVolumeWritable: mocks.checkSecretsVolumeWritable,
+}));
+vi.mock("@/lib/openclaw-config-health", () => ({
+  recordConfigRegenSuccess: mocks.recordConfigRegenSuccess,
+  recordConfigRegenFailure: mocks.recordConfigRegenFailure,
+}));
 
 describe("bootInits", () => {
   beforeEach(() => {
@@ -44,6 +54,7 @@ describe("bootInits", () => {
     mocks.migrateExistingSmithers.mockResolvedValue(undefined);
     mocks.migrateSmithersSoul.mockResolvedValue(undefined);
     mocks.regenerateOpenClawConfig.mockResolvedValue(undefined);
+    mocks.checkSecretsVolumeWritable.mockReturnValue({ ok: true });
   });
 
   it("runs all boot inits when setup is complete", async () => {
@@ -130,6 +141,88 @@ describe("bootInits", () => {
 
     expect(result).toBe(false);
     expect(mocks.markOpenClawConfigReady).toHaveBeenCalledOnce();
+  });
+
+  // #879: readiness is marked even when the boot regenerate throws (OpenClaw
+  // must be able to start), so the failure must be recorded separately for
+  // /api/health — otherwise the instance reports healthy while its config
+  // generation is broken.
+  it("records a config-regeneration failure when regenerate throws, without blocking readiness", async () => {
+    mocks.regenerateOpenClawConfig.mockRejectedValue(new Error("EACCES: permission denied"));
+
+    const { bootInits } = await import("@/lib/boot-inits");
+    await bootInits();
+
+    expect(mocks.recordConfigRegenFailure).toHaveBeenCalledWith(
+      expect.stringContaining("EACCES: permission denied")
+    );
+    expect(mocks.recordConfigRegenSuccess).not.toHaveBeenCalled();
+    expect(mocks.markOpenClawConfigReady).toHaveBeenCalledOnce();
+  });
+
+  it("records a config-regeneration success when the boot regenerate completes", async () => {
+    const { bootInits } = await import("@/lib/boot-inits");
+    await bootInits();
+
+    expect(mocks.recordConfigRegenSuccess).toHaveBeenCalledOnce();
+    expect(mocks.recordConfigRegenFailure).not.toHaveBeenCalled();
+  });
+
+  it("records a config-regeneration failure when the secrets-volume preflight fails", async () => {
+    // Even with setup incomplete (regenerate skipped), a broken volume must
+    // surface in health — the preflight records it directly.
+    mocks.isSetupComplete.mockResolvedValue(false);
+    mocks.checkSecretsVolumeWritable.mockReturnValue({
+      ok: false,
+      message: "docker-compose.yml is missing the openclaw-secrets volume",
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { bootInits } = await import("@/lib/boot-inits");
+    await bootInits();
+
+    expect(mocks.recordConfigRegenFailure).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw-secrets volume")
+    );
+    expect(mocks.regenerateOpenClawConfig).not.toHaveBeenCalled();
+    expect(mocks.recordConfigRegenSuccess).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it("logs the actionable secrets-volume message loudly when the volume is not writable", async () => {
+    // #878: an image-only upgrade drops the openclaw-secrets mount. The preflight
+    // must surface the actionable cause, not let the bare EACCES hide inside the
+    // generic "Failed to regenerate" catch.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.checkSecretsVolumeWritable.mockReturnValue({
+      ok: false,
+      message: "your docker-compose.yml is missing the openclaw-secrets volume",
+    });
+
+    const { bootInits } = await import("@/lib/boot-inits");
+    await bootInits();
+
+    const logged = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toMatch(/OpenClaw secrets volume is not writable/);
+    expect(logged).toMatch(/docker-compose\.yml is missing the openclaw-secrets volume/);
+    // Preflight is a loud warning, not a boot-blocker: the instance still comes
+    // up so the operator can fix the compose file and OpenClaw can start.
+    expect(mocks.markOpenClawConfigReady).toHaveBeenCalledOnce();
+
+    errorSpy.mockRestore();
+  });
+
+  it("does not log the secrets-volume error when the volume is writable", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { bootInits } = await import("@/lib/boot-inits");
+    await bootInits();
+
+    const logged = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).not.toMatch(/OpenClaw secrets volume is not writable/);
+
+    errorSpy.mockRestore();
   });
 
   it("still runs non-critical migrations when setup is incomplete", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config-health.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-health.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordConfigRegenSuccess,
+  recordConfigRegenFailure,
+  getConfigRegenState,
+} from "@/lib/openclaw-config-health";
+
+describe("openclaw-config-health", () => {
+  beforeEach(() => {
+    // The state lives on globalThis (shared across module scopes); clear it so
+    // each test starts from the never-recorded default.
+    delete (globalThis as Record<string, unknown>)["__pinchyOpenClawConfigRegenState"];
+  });
+
+  it("defaults to ok when nothing has been recorded (fresh boot / setup incomplete)", () => {
+    // A never-yet-regenerated instance must not be flagged as broken — #879 is
+    // about surfacing *failures*, not treating "hasn't run" as failure.
+    expect(getConfigRegenState()).toEqual({ ok: true });
+  });
+
+  it("records a failure with its actionable message", () => {
+    recordConfigRegenFailure("docker-compose.yml is missing the openclaw-secrets volume");
+    const state = getConfigRegenState();
+    expect(state.ok).toBe(false);
+    expect(state.error).toMatch(/openclaw-secrets volume/);
+    expect(state.at).toEqual(expect.any(String));
+  });
+
+  it("records a success and clears any prior error (self-heal on later good regen)", () => {
+    recordConfigRegenFailure("something broke");
+    recordConfigRegenSuccess();
+    const state = getConfigRegenState();
+    expect(state.ok).toBe(true);
+    expect(state.error).toBeUndefined();
+    expect(state.at).toEqual(expect.any(String));
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { secretRef, writeSecretsFile, readSecretsFile } from "@/lib/openclaw-secrets";
-import { readFileSync, existsSync, statSync } from "fs";
+import {
+  secretRef,
+  writeSecretsFile,
+  readSecretsFile,
+  checkSecretsVolumeWritable,
+} from "@/lib/openclaw-secrets";
+import { readFileSync, existsSync, statSync, writeFileSync } from "fs";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -75,6 +80,52 @@ describe("writeSecretsFile", () => {
     writeSecretsFile({ providers: { openai: { apiKey: "sk-different" } } });
     const content = JSON.parse(readFileSync(process.env.OPENCLAW_SECRETS_PATH!, "utf-8"));
     expect(content.providers.openai.apiKey).toBe("sk-different");
+  });
+
+  it("throws an actionable error when the secrets directory cannot be created (missing volume mount)", () => {
+    // Reproduce the #878 failure shape: the `openclaw-secrets` volume is not
+    // mounted, so the directory Pinchy expects to write into cannot be created.
+    // We simulate an un-creatable directory by pointing the path *under a
+    // regular file* — mkdir of a directory whose parent component is a file
+    // fails the same way an EACCES at the container root does. The bare fs
+    // error (EACCES/ENOTDIR) must be replaced by a message that tells the
+    // operator their docker-compose.yml is missing the volume.
+    const blocker = join(dir, "not-a-directory");
+    writeFileSync(blocker, "x");
+    process.env.OPENCLAW_SECRETS_PATH = join(blocker, "secrets.json");
+
+    expect(() => writeSecretsFile(bundle)).toThrow(/docker-compose\.yml/);
+    expect(() => writeSecretsFile(bundle)).toThrow(/openclaw-secrets/);
+  });
+});
+
+describe("checkSecretsVolumeWritable", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pinchy-secrets-"));
+    process.env.OPENCLAW_SECRETS_PATH = join(dir, "secrets.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.OPENCLAW_SECRETS_PATH;
+  });
+
+  it("returns ok when the secrets directory is writable", () => {
+    expect(checkSecretsVolumeWritable()).toEqual({ ok: true });
+  });
+
+  it("returns not-ok with an actionable message when the directory cannot be created", () => {
+    const blocker = join(dir, "not-a-directory");
+    writeFileSync(blocker, "x");
+    process.env.OPENCLAW_SECRETS_PATH = join(blocker, "secrets.json");
+
+    const result = checkSecretsVolumeWritable();
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected not-ok");
+    expect(result.message).toMatch(/docker-compose\.yml/);
+    expect(result.message).toMatch(/openclaw-secrets/);
   });
 });
 

--- a/packages/web/src/app/api/health/route.ts
+++ b/packages/web/src/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSecretsProvenance } from "@/lib/secret-source";
 import { openClawConnectionState } from "@/server/openclaw-connection-state";
+import { getConfigRegenState } from "@/lib/openclaw-config-health";
 
 export async function GET() {
   return NextResponse.json({
@@ -24,5 +25,13 @@ export async function GET() {
     openclaw: {
       connected: openClawConnectionState.connected,
     },
+    // Issue #879: the boot-time config regeneration can throw (e.g. the #878
+    // missing-secrets-volume EACCES) while readiness is still marked so
+    // OpenClaw can start — top-level `status` stays "ok" for the same reason it
+    // does for gateway disconnects. Surface the regeneration outcome here so
+    // monitoring and the admin UI can catch a frozen config even though the
+    // instance otherwise reports healthy. `error` is operator-facing guidance
+    // only — never secret material.
+    configRegeneration: getConfigRegenState(),
   });
 }

--- a/packages/web/src/lib/boot-inits.ts
+++ b/packages/web/src/lib/boot-inits.ts
@@ -14,6 +14,8 @@ import { migrateSmithersSoul } from "@/lib/migrate-smithers-soul";
 import { markOpenClawConfigReady } from "@/lib/openclaw-config-ready";
 import { seedBuiltinModels } from "@/lib/model-capabilities/seed";
 import { loadModelCapabilityCache } from "@/lib/model-capabilities/cache";
+import { checkSecretsVolumeWritable } from "@/lib/openclaw-secrets";
+import { recordConfigRegenSuccess, recordConfigRegenFailure } from "@/lib/openclaw-config-health";
 
 /**
  * Runs all one-time boot initializations in the correct order and performs
@@ -137,6 +139,27 @@ export async function bootInits(): Promise<boolean> {
     );
   }
 
+  // Preflight the secrets volume BEFORE regenerateOpenClawConfig() reaches its
+  // writeSecretsFile() step. On an instance upgraded image-only (docker compose
+  // pull, keeping a pre-existing docker-compose.yml), the `openclaw-secrets`
+  // volume is absent and every regenerate throws EACCES mid-flight — freezing
+  // openclaw.json so new providers/agents/models never reach OpenClaw (#878).
+  // The generic "Failed to regenerate" catch below would only log a bare
+  // EACCES; surface the actionable cause loudly and early instead.
+  const secretsCheck = checkSecretsVolumeWritable();
+  if (!secretsCheck.ok) {
+    console.error(
+      "[pinchy] FATAL: OpenClaw secrets volume is not writable — config " +
+        "regeneration will fail and this instance will not pick up new " +
+        "providers, agents, or model changes until it is fixed.\n" +
+        secretsCheck.message
+    );
+    // Record it so /api/health flags the broken state even if setup is
+    // incomplete (regenerate is skipped below) — a successful regenerate
+    // clears it again. See recordConfigRegenSuccess/Failure (#879).
+    recordConfigRegenFailure(secretsCheck.message);
+  }
+
   let setupWasComplete = false;
   try {
     if (await isSetupComplete()) {
@@ -156,20 +179,28 @@ export async function bootInits(): Promise<boolean> {
 
       await regenerateOpenClawConfig();
       console.log("[pinchy] OpenClaw config regenerated from DB state");
+      // Clear any preflight-recorded failure: the boot regenerate completed.
+      recordConfigRegenSuccess();
       setupWasComplete = true;
     }
   } catch (err) {
-    console.error(
-      "[pinchy] Failed to regenerate OpenClaw config on startup:",
-      err instanceof Error ? err.message : err
-    );
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[pinchy] Failed to regenerate OpenClaw config on startup:", message);
+    // #879: readiness is marked below regardless (OpenClaw must be able to
+    // start), so record the failure separately. Without this, /api/health
+    // reports a perfectly healthy instance while config generation is broken —
+    // exactly the silent state observed on the apsa v0.8.0 box.
+    recordConfigRegenFailure(message);
   }
 
   // Signal the Docker Compose healthcheck that Pinchy has finished its startup
   // sequence. OpenClaw depends on this to start. Called unconditionally so the
   // healthcheck passes even on fresh installs (no setup yet) or when config
   // regeneration fails — OpenClaw will start with whatever config is on disk
-  // and hot-reload via inotify when the setup wizard writes a new one.
+  // and hot-reload via inotify when the setup wizard writes a new one. The
+  // regeneration OUTCOME is tracked separately via recordConfigRegen* above and
+  // surfaced through /api/health, so a green healthcheck no longer hides a
+  // broken config generation (#879).
   console.log("[pinchy] boot complete: OpenClaw container may now start");
   markOpenClawConfigReady();
 

--- a/packages/web/src/lib/openclaw-config-health.ts
+++ b/packages/web/src/lib/openclaw-config-health.ts
@@ -1,0 +1,55 @@
+// Tracks the outcome of the most recent boot-time OpenClaw config regeneration,
+// kept deliberately SEPARATE from the OpenClaw-startup readiness gate in
+// openclaw-config-ready.ts.
+//
+// Why separate (issue #879): markOpenClawConfigReady() MUST fire unconditionally
+// so the OpenClaw container — which waits on `depends_on: pinchy service_healthy`
+// — can start and hot-reload a fixed config later, even when the boot-time
+// regenerate throws. That is correct for startup ordering but made readiness
+// *lie*: the healthcheck went green and OpenClaw started while config generation
+// was fundamentally broken (e.g. the #878 missing-secrets-volume EACCES), with
+// nothing external signalling the broken state. This module records that
+// outcome so /api/health can surface the failure to monitoring and the admin UI
+// WITHOUT gating OpenClaw's startup on it.
+//
+// globalThis-backed for the same reason as the ready flag: the state is written
+// from server.ts (tsx module scope, via bootInits) and read from a Next.js API
+// route (webpack module scope); a module-level `let` is not shared between them.
+
+const KEY = "__pinchyOpenClawConfigRegenState";
+
+export type ConfigRegenState = {
+  /** false only when the most recent boot-time regeneration attempt failed. */
+  ok: boolean;
+  /**
+   * Operator-facing message when `ok` is false. Carries the actionable cause
+   * (e.g. the missing-volume guidance from checkSecretsVolumeWritable). Never
+   * contains secret material — it is safe to expose via /api/health.
+   */
+  error?: string;
+  /** ISO timestamp of the most recent recorded attempt. */
+  at?: string;
+};
+
+export function recordConfigRegenSuccess(): void {
+  (globalThis as Record<string, unknown>)[KEY] = {
+    ok: true,
+    at: new Date().toISOString(),
+  } satisfies ConfigRegenState;
+}
+
+export function recordConfigRegenFailure(error: string): void {
+  (globalThis as Record<string, unknown>)[KEY] = {
+    ok: false,
+    error,
+    at: new Date().toISOString(),
+  } satisfies ConfigRegenState;
+}
+
+export function getConfigRegenState(): ConfigRegenState {
+  const state = (globalThis as Record<string, unknown>)[KEY] as ConfigRegenState | undefined;
+  // Default: no failure recorded. Either boot hasn't reached regeneration yet,
+  // or setup isn't complete so no regenerate has run. Report ok so a
+  // never-yet-regenerated instance isn't falsely flagged as broken.
+  return state ?? { ok: true };
+}

--- a/packages/web/src/lib/openclaw-secrets.ts
+++ b/packages/web/src/lib/openclaw-secrets.ts
@@ -1,4 +1,13 @@
-import { writeFileSync, readFileSync, renameSync, mkdirSync, existsSync, chmodSync } from "fs";
+import {
+  writeFileSync,
+  readFileSync,
+  renameSync,
+  mkdirSync,
+  existsSync,
+  chmodSync,
+  accessSync,
+  constants,
+} from "fs";
 import { dirname } from "path";
 
 export type SecretRef = {
@@ -28,6 +37,52 @@ export type SecretsBundle = {
   plugins?: Record<string, Record<string, string>>;
 };
 
+/**
+ * Actionable message for the #878 failure: the `openclaw-secrets` volume that
+ * this Pinchy version requires is not mounted, so the secrets directory cannot
+ * be created or written. The bare `EACCES: permission denied, mkdir
+ * '/openclaw-secrets'` that Node throws is useless to a self-hoster — it gives
+ * no hint that the cause is a stale `docker-compose.yml` left behind by an
+ * image-only upgrade (`docker compose pull` never re-fetches the compose file).
+ */
+function secretsVolumeErrorMessage(dir: string, cause: unknown): string {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return (
+    `[openclaw-config] Cannot create or write the OpenClaw secrets directory at ${dir}. ` +
+    `Pinchy stores provider API keys and other runtime secrets here, so OpenClaw config ` +
+    `generation cannot proceed.\n\n` +
+    `The most likely cause: your docker-compose.yml is missing the \`openclaw-secrets\` ` +
+    `volume mount that this Pinchy version requires. An image-only upgrade ` +
+    `(\`docker compose pull\`) does NOT update docker-compose.yml — re-fetch the compose ` +
+    `file for your release, then run \`docker compose up -d\` again.\n\n` +
+    `See https://docs.heypinchy.com/guides/upgrading/ for the upgrade steps.\n\n` +
+    `Underlying error: ${detail}`
+  );
+}
+
+/**
+ * Boot/preflight check: verify the secrets directory can be created and is
+ * writable, WITHOUT writing any content. Returns an actionable message instead
+ * of throwing so callers (e.g. bootInits) can surface the problem loudly and
+ * early — before a deep `writeSecretsFile` EACCES aborts `regenerateOpenClawConfig`
+ * and freezes the whole instance (#878).
+ */
+export function checkSecretsVolumeWritable(): { ok: true } | { ok: false; message: string } {
+  const path = process.env.OPENCLAW_SECRETS_PATH || DEFAULT_SECRETS_PATH;
+  const dir = dirname(path);
+  try {
+    // `recursive: true` is a no-op when `dir` already exists as a directory
+    // (the correctly-mounted case) and throws otherwise — EACCES when the
+    // parent isn't writable (missing mount), EEXIST/ENOTDIR when a non-dir
+    // sits in the path. Any of those means we can't write secrets here.
+    mkdirSync(dir, { recursive: true });
+    accessSync(dir, constants.W_OK);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, message: secretsVolumeErrorMessage(dir, err) };
+  }
+}
+
 export function writeSecretsFile(bundle: SecretsBundle): void {
   const path = process.env.OPENCLAW_SECRETS_PATH || DEFAULT_SECRETS_PATH;
   const newContent = JSON.stringify(bundle, null, 2);
@@ -44,15 +99,23 @@ export function writeSecretsFile(bundle: SecretsBundle): void {
   }
 
   const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  const tmp = `${path}.tmp`;
-  // Mode 0600: owner-only read/write. The tmpfs directory mode (0770) already
-  // restricts access to uid 999 (the pinchy user), but file-level 0600 is
-  // cheap defense-in-depth against same-uid local processes (e.g. shells
-  // inside docker exec).
-  writeFileSync(tmp, newContent, { mode: 0o600 });
-  chmodSync(tmp, 0o600); // enforce regardless of umask
-  renameSync(tmp, path);
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const tmp = `${path}.tmp`;
+    // Mode 0600: owner-only read/write. The tmpfs directory mode (0770) already
+    // restricts access to uid 999 (the pinchy user), but file-level 0600 is
+    // cheap defense-in-depth against same-uid local processes (e.g. shells
+    // inside docker exec).
+    writeFileSync(tmp, newContent, { mode: 0o600 });
+    chmodSync(tmp, 0o600); // enforce regardless of umask
+    renameSync(tmp, path);
+  } catch (err) {
+    // Replace the bare EACCES/ENOTDIR with an actionable message. This is the
+    // single choke point every regenerateOpenClawConfig() flows through, so both
+    // boot (bootInits catch) and every state-changing API route surface the same
+    // guidance instead of a stack trace buried in logs (#878).
+    throw new Error(secretsVolumeErrorMessage(dir, err));
+  }
 }
 
 export function readSecretsFile(): SecretsBundle {


### PR DESCRIPTION
## What does this PR do?

Fixes two compounding failures seen on a customer's self-hosted v0.8.0 box (apsa). An **image-only upgrade** (`docker compose pull`, keeping a pre-existing `docker-compose.yml`) drops the `openclaw-secrets` volume mount. Pinchy runs as uid 999 and cannot `mkdir` at the container root, so `writeSecretsFile()` throws `EACCES`, `regenerateOpenClawConfig()` aborts mid-flight, and `openclaw.json` freezes at its pre-upgrade content — **new providers, agents, and model changes never reach OpenClaw**.

- **#878** — the cause was a bare `EACCES` buried in logs.
- **#879** — boot marked readiness anyway, so `/api/health` stayed green while config generation was fundamentally broken. Nothing external signalled the frozen state.

### #878 — make the cause visible and actionable
- **`checkSecretsVolumeWritable()`** — boot preflight that verifies the secrets directory can be created/written *without* writing content.
- **`writeSecretsFile()`** now replaces the bare `EACCES`/`ENOTDIR` with an actionable message (missing volume → re-fetch the compose file → docs link). This is the single choke point every regenerate flows through, so **boot and every state-changing API route** surface the same guidance.
- **`bootInits()`** runs the preflight before regenerate and logs a loud, early `FATAL` line instead of the generic "Failed to regenerate" wrapper. **Not a boot-blocker** — the instance still comes up so the operator can fix compose and OpenClaw can start.
- Upgrading guide gains a troubleshooting note on the symptom (`unknown agent id`, providers not activating) and recovery.

### #879 — make the failure observable to monitoring
- **`openclaw-config-health.ts`** records the outcome of the boot-time regenerate, kept **deliberately separate** from the OpenClaw-startup readiness gate (which must fire unconditionally so OpenClaw — `depends_on: pinchy service_healthy` — can start and hot-reload a fixed config later).
- **`/api/health`** exposes `configRegeneration: { ok, error?, at? }`. Top-level `status` stays `"ok"` for the same reason it does for gateway disconnects (#651); the boolean is the monitoring signal. `error` is operator guidance only — **never secret material**. A later successful regenerate self-heals it.
- API reference documents the new field.

**Synergy:** the #879 failure field carries exactly the actionable #878 message.

Closes #878
Closes #879

## Type of change

- [x] 🐛 Bug fix
- [x] 📝 Documentation

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

### Tests & gates
- New/updated: `openclaw-secrets.test.ts`, `openclaw-config-health.test.ts` (new), `boot-inits.test.ts`, `health.test.ts` — 39 tests green across affected files; `openclaw-config.test.ts` (216) unchanged green.
- `pnpm -C packages/web typecheck` ✓ · `pnpm format:check` ✓ · lint 0 errors.
- No test deletions, no skips — drift guards untouched.

### Reviewer notes
- `markOpenClawConfigReady()` stays **unconditional** by design — gating it on regenerate success would stop OpenClaw from ever starting on fresh installs / broken-volume instances. #879 is solved by a *separate* observable signal, not by gating readiness.
- The two fixes are intertwined in `boot-inits.ts` (same incident, same lines), hence one PR rather than a stacked pair.