### PR TITLE
feat(automations): Automations tab — review, enable/disable, delete workflows (#139)

### DIFF
--- a/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
@@ -1,0 +1,215 @@
+// Component tests for the Automations tab — the "review & activate" surface for
+// Inbox Agent email workflows (#139). A workflow is created pending+disabled
+// (write API #864); the sweep dispatches only ENABLED workflows, so this tab is
+// where a human reviews the structured translation and flips it on — the
+// human-gated step "propose, don't self-activate" reserves for a person.
+//
+// The tab drives the management API (#873): GET /api/automations?agentId,
+// PATCH /api/automations/[id] {enabled}, DELETE /api/automations/[id]. We mock
+// global.fetch (the api-client helpers read the body via text()+JSON.parse), so
+// each Response mock exposes BOTH json() and text().
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { toast } from "sonner";
+import { AgentSettingsAutomations } from "@/components/agent-settings-automations";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const AGENT_ID = "agent-1";
+
+const mockAutomations = [
+  {
+    id: "wf-1",
+    name: "File supplier invoices",
+    filter: { hasAttachment: true, from: ["billing@acme.com"] },
+    action: "Draft a supplier bill in Odoo.",
+    enabled: false,
+    status: "pending",
+    sweepWindowDays: 14,
+    createdBy: "u1",
+    createdAt: "2026-07-20T10:00:00.000Z",
+    connectionIds: ["conn-a"],
+  },
+  {
+    id: "wf-2",
+    name: "Summarize newsletters",
+    filter: {},
+    action: "Post a one-line summary.",
+    enabled: true,
+    status: "active",
+    sweepWindowDays: 7,
+    createdBy: "u1",
+    createdAt: "2026-07-21T10:00:00.000Z",
+    connectionIds: ["conn-a", "conn-b"],
+  },
+];
+
+describe("AgentSettingsAutomations", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+    const text = JSON.stringify(body);
+    return {
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => body,
+      text: async () => text,
+    } as unknown as Response;
+  }
+
+  /** Route GET /api/automations to `list`; everything else (PATCH/DELETE) to ok. */
+  function mockList(list: unknown[] = mockAutomations) {
+    vi.mocked(global.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations?")) return jsonResponse(list);
+      // PATCH/DELETE on /api/automations/<id>
+      return jsonResponse({ ok: true });
+    });
+  }
+
+  it("lists the agent's workflows with filter summary, action, status and mailbox count", async () => {
+    mockList();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("File supplier invoices")).toBeInTheDocument();
+    });
+
+    // It fetches scoped to this agent.
+    expect(String(fetchSpy.mock.calls[0][0])).toBe(`/api/automations?agentId=${AGENT_ID}`);
+
+    const row1 = screen.getByRole("row", { name: /File supplier invoices/ });
+    const cells1 = within(row1);
+    expect(cells1.getByText("Draft a supplier bill in Odoo.")).toBeInTheDocument();
+    // A pending workflow shows a status badge.
+    expect(cells1.getByText(/pending/i)).toBeInTheDocument();
+    // Filter is rendered human-readable, not raw JSON.
+    expect(cells1.getByText(/has an attachment/i)).toBeInTheDocument();
+    expect(cells1.getByText(/billing@acme\.com/i)).toBeInTheDocument();
+    // One mailbox attached.
+    expect(cells1.getByText(/1 mailbox/i)).toBeInTheDocument();
+
+    const row2 = screen.getByRole("row", { name: /Summarize newsletters/ });
+    const cells2 = within(row2);
+    expect(cells2.getByText(/active/i)).toBeInTheDocument();
+    // An empty filter watches the whole mailbox.
+    expect(cells2.getByText(/entire mailbox/i)).toBeInTheDocument();
+    expect(cells2.getByText(/2 mailboxes/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the agent has no workflows", async () => {
+    mockList([]);
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no automations yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("enables a pending workflow via PATCH and flips its toggle", async () => {
+    mockList();
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => expect(screen.getByText("File supplier invoices")).toBeInTheDocument());
+
+    const row1 = screen.getByRole("row", { name: /File supplier invoices/ });
+    await user.click(within(row1).getByRole("button", { name: /enable/i }));
+
+    await waitFor(() => {
+      const patch = fetchSpy.mock.calls.find(
+        (c: unknown[]) =>
+          String(c[0]) === "/api/automations/wf-1" && (c[1] as RequestInit)?.method === "PATCH"
+      );
+      expect(patch).toBeTruthy();
+      expect(JSON.parse((patch![1] as RequestInit).body as string)).toEqual({ enabled: true });
+    });
+
+    // The toggle now offers to disable it (optimistic flip).
+    await waitFor(() => {
+      const r = screen.getByRole("row", { name: /File supplier invoices/ });
+      expect(within(r).getByRole("button", { name: /disable/i })).toBeInTheDocument();
+    });
+  });
+
+  it("disables an enabled workflow via PATCH { enabled: false }", async () => {
+    mockList();
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Summarize newsletters")).toBeInTheDocument());
+
+    const row2 = screen.getByRole("row", { name: /Summarize newsletters/ });
+    await user.click(within(row2).getByRole("button", { name: /disable/i }));
+
+    await waitFor(() => {
+      const patch = fetchSpy.mock.calls.find(
+        (c: unknown[]) =>
+          String(c[0]) === "/api/automations/wf-2" && (c[1] as RequestInit)?.method === "PATCH"
+      );
+      expect(patch).toBeTruthy();
+      expect(JSON.parse((patch![1] as RequestInit).body as string)).toEqual({ enabled: false });
+    });
+  });
+
+  it("surfaces a toast when the toggle fails and does not flip the button", async () => {
+    vi.mocked(global.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations?")) return jsonResponse(mockAutomations);
+      return jsonResponse({ error: "Boom" }, { ok: false, status: 500 });
+    });
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => expect(screen.getByText("File supplier invoices")).toBeInTheDocument());
+    const row1 = screen.getByRole("row", { name: /File supplier invoices/ });
+    await user.click(within(row1).getByRole("button", { name: /enable/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Boom"));
+    // Still offers to enable — the optimistic flip was rolled back.
+    expect(
+      within(screen.getByRole("row", { name: /File supplier invoices/ })).getByRole("button", {
+        name: /enable/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("deletes a workflow after confirmation and removes its row", async () => {
+    mockList();
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Summarize newsletters")).toBeInTheDocument());
+
+    const row2 = screen.getByRole("row", { name: /Summarize newsletters/ });
+    await user.click(within(row2).getByRole("button", { name: /delete/i }));
+
+    // Confirm in the dialog.
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      const del = fetchSpy.mock.calls.find(
+        (c: unknown[]) =>
+          String(c[0]) === "/api/automations/wf-2" && (c[1] as RequestInit)?.method === "DELETE"
+      );
+      expect(del).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Summarize newsletters")).not.toBeInTheDocument();
+    });
+    expect(toast.success).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
@@ -212,4 +212,79 @@ describe("AgentSettingsAutomations", () => {
     });
     expect(toast.success).toHaveBeenCalled();
   });
+
+  it("surfaces a toast and falls back to the empty state when the list fails to load", async () => {
+    vi.mocked(global.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations?"))
+        return jsonResponse({ error: "Nope" }, { ok: false, status: 500 });
+      return jsonResponse({ ok: true });
+    });
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Nope"));
+    // The load failed, so we clear the skeleton and show the honest empty state
+    // rather than a stuck spinner.
+    expect(screen.getByText(/no automations yet/i)).toBeInTheDocument();
+  });
+
+  it("keeps the row and toasts when the delete fails (non-optimistic removal)", async () => {
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations?")) return jsonResponse(mockAutomations);
+      if ((init as RequestInit)?.method === "DELETE")
+        return jsonResponse({ error: "Nope" }, { ok: false, status: 500 });
+      return jsonResponse({ ok: true });
+    });
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Summarize newsletters")).toBeInTheDocument());
+    const row2 = screen.getByRole("row", { name: /Summarize newsletters/ });
+    await user.click(within(row2).getByRole("button", { name: /delete/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Nope"));
+    // The row is removed only on a successful DELETE, so a failed one leaves it
+    // in place for the user to retry.
+    expect(screen.getByText("Summarize newsletters")).toBeInTheDocument();
+  });
+
+  it("disables the confirm button while a delete is in flight, guarding double-submit", async () => {
+    let releaseDelete: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    let deleteCount = 0;
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations?")) return jsonResponse(mockAutomations);
+      if ((init as RequestInit)?.method === "DELETE") {
+        deleteCount += 1;
+        await gate;
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ ok: true });
+    });
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+
+    await waitFor(() => expect(screen.getByText("Summarize newsletters")).toBeInTheDocument());
+    const row2 = screen.getByRole("row", { name: /Summarize newsletters/ });
+    await user.click(within(row2).getByRole("button", { name: /delete/i }));
+    const dialog = await screen.findByRole("alertdialog");
+    const confirm = within(dialog).getByRole("button", { name: /delete/i });
+    await user.click(confirm);
+
+    // While the DELETE is in flight the confirm button is disabled, so a second
+    // click cannot fire a second DELETE on the same (now-gone) id.
+    await waitFor(() => expect(confirm).toBeDisabled());
+    expect(deleteCount).toBe(1);
+
+    releaseDelete();
+    await waitFor(() =>
+      expect(screen.queryByText("Summarize newsletters")).not.toBeInTheDocument()
+    );
+  });
 });

--- a/packages/web/src/__tests__/components/agent-settings-page-content-automations-tab.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-page-content-automations-tab.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// The Automations tab (#139) is the review-and-activate surface for an agent's
+// email workflows. It carries the same scope as managing the agent itself: a
+// personal agent's owner (a non-admin) may manage it, and an admin may manage a
+// shared agent's — mirroring the Telegram tab's gate. (A non-admin on a shared
+// agent never reaches this page at all — canEdit is false and the page
+// redirects to chat — so there is no "visible page without the tab" case to
+// assert for them.)
+
+const mockSession = vi.fn();
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: () => mockSession() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ agentId: "agent-1" }),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/chat/agent-1/settings",
+}));
+
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ triggerRestart: vi.fn() }),
+}));
+
+// Stub the tab bodies — this test only exercises the page's tab wiring.
+vi.mock("@/components/agent-settings-general", () => ({ AgentSettingsGeneral: () => <div /> }));
+vi.mock("@/components/agent-settings-file", () => ({ AgentSettingsFile: () => <div /> }));
+vi.mock("@/components/agent-settings-personality", () => ({
+  AgentSettingsPersonality: () => <div />,
+}));
+vi.mock("@/components/agent-settings-permissions", () => ({
+  AgentSettingsPermissions: () => <div />,
+}));
+vi.mock("@/components/agent-settings-access", () => ({ AgentSettingsAccess: () => <div /> }));
+vi.mock("@/components/agent-settings-diagnostics", () => ({
+  AgentSettingsDiagnostics: () => <div />,
+}));
+vi.mock("@/components/agent-telegram-settings", () => ({
+  AgentTelegramSettings: () => <div />,
+}));
+vi.mock("@/components/agent-settings-automations", () => ({
+  AgentSettingsAutomations: () => <div data-testid="agent-settings-automations" />,
+}));
+
+import { AgentSettingsPageContent } from "@/components/agent-settings-page-content";
+
+const baseAgent = {
+  id: "agent-1",
+  name: "Smithers",
+  model: "anthropic/claude-haiku-4-5-20251001",
+  allowedTools: [],
+  pluginConfig: null,
+  tagline: null,
+  avatarSeed: null,
+  personalityPresetId: null,
+  visibility: "restricted",
+  groupIds: [],
+};
+
+function mockFetchReturning(agent: object) {
+  global.fetch = vi.fn().mockImplementation((url: unknown) => {
+    if (url === "/api/agents/agent-1") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(agent) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  }) as unknown as typeof fetch;
+}
+
+describe("AgentSettingsPageContent — Automations tab visibility (#139)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the Automations tab to a non-admin owner of a personal agent", async () => {
+    mockSession.mockReturnValue({
+      data: { user: { id: "u1", role: "member" } },
+      isPending: false,
+    });
+    mockFetchReturning({ ...baseAgent, isPersonal: true });
+
+    render(<AgentSettingsPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /automations/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows the Automations tab to an admin on a shared agent", async () => {
+    mockSession.mockReturnValue({
+      data: { user: { id: "admin-1", role: "admin" } },
+      isPending: false,
+    });
+    mockFetchReturning({ ...baseAgent, isPersonal: false });
+
+    render(<AgentSettingsPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /automations/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/components/agent-settings-automations.tsx
+++ b/packages/web/src/components/agent-settings-automations.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { apiGet, apiPatch, apiDelete, ApiError } from "@/lib/api-client";
+import type { AutomationListItem } from "@/lib/schemas/automations";
+import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
+import type { EmailWorkflowStatus } from "@/db/enums";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+/**
+ * Turn a deterministic workflow filter into human-readable clauses. The stored
+ * shape is machine data (design §5); a reviewer needs to see *what mail this
+ * triggers on* in plain words before switching it on. An all-empty filter
+ * watches everything, so we say so explicitly rather than render nothing.
+ */
+function summarizeFilter(filter: EmailWorkflowFilter): string[] {
+  const parts: string[] = [];
+  if (filter.from?.length) parts.push(`From ${filter.from.join(", ")}`);
+  if (filter.toDomain?.length) parts.push(`To domain ${filter.toDomain.join(", ")}`);
+  if (filter.subjectContains?.length)
+    parts.push(`Subject contains ${filter.subjectContains.join(", ")}`);
+  if (filter.hasAttachment) parts.push("Has an attachment");
+  if (filter.attachmentType) parts.push(`Attachment is ${filter.attachmentType}`);
+  if (filter.folder) parts.push(`In folder ${filter.folder}`);
+  return parts;
+}
+
+// Status is a health signal the dispatcher writes (pending → active/error), not
+// something this tab owns. We only render it so a reviewer can tell a proposal
+// (pending) from a running workflow (active) from one that hit trouble (error).
+const STATUS_VARIANT: Record<EmailWorkflowStatus, "default" | "secondary" | "destructive"> = {
+  active: "default",
+  pending: "secondary",
+  error: "destructive",
+};
+
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof ApiError ? e.message : fallback;
+}
+
+/**
+ * The Automations tab: the review-and-activate surface for an agent's Inbox
+ * Agent email workflows (#139). Workflows are created disabled (write API #864)
+ * and the sweep dispatches only enabled ones, so this is where a human vets the
+ * structured translation and flips it on — the human-gated step "propose, don't
+ * self-activate" reserves for a person. Editing a workflow's fields, and the
+ * conversational way to create one, live elsewhere (#705); this tab lists,
+ * enables/disables, and deletes.
+ *
+ * Self-contained (like the Telegram/Diagnostics tabs): it does its own GET and
+ * persists each toggle/delete immediately, outside the page's shared draft/Save
+ * flow. The management API enforces the same scope gate that hides this tab from
+ * users who cannot manage the agent.
+ */
+export function AgentSettingsAutomations({ agentId }: { agentId: string }) {
+  const [items, setItems] = useState<AutomationListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AutomationListItem | null>(null);
+
+  // No synchronous setState here: `loading` starts true and the `finally`
+  // clears it, so the effect that calls this never sets state before its first
+  // await (react-hooks/set-state-in-effect). The tab mounts once, so there is no
+  // re-fetch that would need to re-show the skeleton.
+  const load = useCallback(async () => {
+    try {
+      const data = await apiGet<AutomationListItem[]>(
+        `/api/automations?agentId=${encodeURIComponent(agentId)}`
+      );
+      setItems(Array.isArray(data) ? data : []);
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to load automations"));
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    // Deferred past the effect body so the initial setState happens in a
+    // microtask, not synchronously inside the effect (react-hooks/
+    // set-state-in-effect) — same pattern as connected-apps.tsx.
+    let cancelled = false;
+    void Promise.resolve().then(() => {
+      if (!cancelled) void load();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  async function handleToggle(item: AutomationListItem) {
+    const next = !item.enabled;
+    // Optimistic: flip immediately, roll back if the PATCH is rejected. We never
+    // touch `status` — the dispatcher flips pending → active on the next sweep.
+    setItems((prev) => prev.map((w) => (w.id === item.id ? { ...w, enabled: next } : w)));
+    setBusyId(item.id);
+    try {
+      await apiPatch(`/api/automations/${item.id}`, { enabled: next });
+    } catch (e) {
+      setItems((prev) => prev.map((w) => (w.id === item.id ? { ...w, enabled: item.enabled } : w)));
+      toast.error(errorMessage(e, "Failed to update automation"));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDelete(item: AutomationListItem) {
+    setBusyId(item.id);
+    try {
+      await apiDelete(`/api/automations/${item.id}`);
+      setItems((prev) => prev.filter((w) => w.id !== item.id));
+      toast.success("Automation deleted");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to delete automation"));
+    } finally {
+      setBusyId(null);
+      setDeleteTarget(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Automations</h2>
+        <p className="text-sm text-muted-foreground">
+          Email workflows this agent can run on its own. Review each proposal and switch it on when
+          you&apos;re ready — nothing runs until you enable it.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No automations yet. When this agent proposes an email workflow, it shows up here for you
+          to review and enable.
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Trigger</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>Mailboxes</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Manage</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.map((item) => {
+                const clauses = summarizeFilter(item.filter);
+                const mailboxCount = item.connectionIds.length;
+                return (
+                  <TableRow key={item.id}>
+                    <TableCell className="font-medium">{item.name}</TableCell>
+                    <TableCell>
+                      {clauses.length === 0 ? (
+                        <span className="text-muted-foreground">Entire mailbox</span>
+                      ) : (
+                        <div className="flex flex-wrap gap-1">
+                          {clauses.map((clause) => (
+                            <Badge key={clause} variant="outline" className="font-normal">
+                              {clause}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell className="max-w-xs truncate" title={item.action}>
+                      {item.action}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-muted-foreground">
+                      {mailboxCount} {mailboxCount === 1 ? "mailbox" : "mailboxes"}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={STATUS_VARIANT[item.status]}>{item.status}</Badge>
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      <Button
+                        size="sm"
+                        variant={item.enabled ? "outline" : "default"}
+                        disabled={busyId === item.id}
+                        onClick={() => handleToggle(item)}
+                      >
+                        {item.enabled ? "Disable" : "Enable"}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="ml-2 text-destructive hover:text-destructive"
+                        disabled={busyId === item.id}
+                        onClick={() => setDeleteTarget(item)}
+                      >
+                        Delete
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this automation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteTarget
+                ? `"${deleteTarget.name}" will be removed for good. This cannot be undone.`
+                : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                // Keep the dialog controlled: run the delete, close on our terms.
+                e.preventDefault();
+                if (deleteTarget) handleDelete(deleteTarget);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/packages/web/src/components/agent-settings-automations.tsx
+++ b/packages/web/src/components/agent-settings-automations.tsx
@@ -248,6 +248,10 @@ export function AgentSettingsAutomations({ agentId }: { agentId: string }) {
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
+              // Disabled while the DELETE is in flight: the dialog stays open
+              // during the await (we preventDefault its auto-close), so without
+              // this a second click would fire a second DELETE on the same id.
+              disabled={busyId !== null && busyId === deleteTarget?.id}
               onClick={(e) => {
                 // Keep the dialog controlled: run the delete, close on our terms.
                 e.preventDefault();

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -25,6 +25,7 @@ import { AgentSettingsPermissions } from "@/components/agent-settings-permission
 import { AgentSettingsAccess } from "@/components/agent-settings-access";
 import { AgentSettingsDiagnostics } from "@/components/agent-settings-diagnostics";
 import { AgentTelegramSettings } from "@/components/agent-telegram-settings";
+import { AgentSettingsAutomations } from "@/components/agent-settings-automations";
 import { useRestart } from "@/components/restart-provider";
 import { normalizeStarterPrompts } from "@/lib/schemas/starter-prompts";
 import type { AgentPluginConfig } from "@/db/schema";
@@ -96,7 +97,12 @@ type DirtyTabs = Set<"general" | "personality" | "instructions" | "permissions" 
 // Single source of truth for which agent-settings tabs require admin (or
 // personal-agent-owner) access. Non-admin visibility is derived from this
 // instead of being a second, hand-maintained tab list that could drift.
-const ADMIN_ONLY_TABS = new Set<AgentSettingsTab>(["permissions", "access", "telegram"]);
+const ADMIN_ONLY_TABS = new Set<AgentSettingsTab>([
+  "permissions",
+  "access",
+  "telegram",
+  "automations",
+]);
 
 function DirtyDot() {
   return (
@@ -119,11 +125,19 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
   // being an admin. The page is only viewable by the owner or an admin (see
   // `canEdit`), so `isPersonal` here implies the viewer owns it. (#476 gap 2)
   const canManageTelegram = isAdmin || agent?.isPersonal === true;
+  // Same scope as Telegram: a personal agent's owner (non-admin) manages its own
+  // automations; a shared agent's are admin-only. The management API enforces
+  // the exact same gate (canManageAgentWorkflows), so the tab and the routes
+  // never disagree.
+  const canManageAutomations = isAdmin || agent?.isPersonal === true;
   const visibleTabs: AgentSettingsTab[] =
     isPending || isAdmin
       ? [...AGENT_SETTINGS_TABS]
       : AGENT_SETTINGS_TABS.filter(
-          (tab) => !ADMIN_ONLY_TABS.has(tab) || (tab === "telegram" && canManageTelegram)
+          (tab) =>
+            !ADMIN_ONLY_TABS.has(tab) ||
+            (tab === "telegram" && canManageTelegram) ||
+            (tab === "automations" && canManageAutomations)
         );
   const [activeTab, setActiveTab] = useTabParam("general", visibleTabs, initialTab);
 
@@ -443,6 +457,7 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
               </TabsTrigger>
             )}
             {canManageTelegram && <TabsTrigger value="telegram">Telegram</TabsTrigger>}
+            {canManageAutomations && <TabsTrigger value="automations">Automations</TabsTrigger>}
             <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
           </TabsList>
 
@@ -507,6 +522,16 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
                 isSmithers={agent.isPersonal}
                 isAdmin={isAdmin}
               />
+            </TabsContent>
+          )}
+
+          {/* Self-contained and lazily mounted (no `keepMounted`), like Telegram
+              and Diagnostics: it does its own GET/PATCH/DELETE and persists each
+              toggle immediately, so it stays out of the shared draft/Save flow
+              and its list fetch only fires when the tab is actually opened. */}
+          {canManageAutomations && (
+            <TabsContent value="automations">
+              <AgentSettingsAutomations agentId={agentId} />
             </TabsContent>
           )}
 

--- a/packages/web/src/hooks/use-tab-param.ts
+++ b/packages/web/src/hooks/use-tab-param.ts
@@ -24,6 +24,7 @@ export const AGENT_SETTINGS_TABS = [
   "permissions",
   "access",
   "telegram",
+  "automations",
   "diagnostics",
 ] as const;
 

--- a/packages/web/src/lib/schemas/automations.ts
+++ b/packages/web/src/lib/schemas/automations.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
+import type { EmailWorkflowStatus } from "@/db/enums";
 
 /**
  * The deterministic trigger of an email workflow (design §5). Every field is
@@ -80,3 +81,24 @@ export const updateAutomationSchema = z.object({
 });
 
 export type UpdateAutomationInput = z.infer<typeof updateAutomationSchema>;
+
+/**
+ * Client-side contract for one row of GET /api/automations?agentId — the shape
+ * the Automations tab (#139) renders. `createdAt` is a string here (JSON has no
+ * Date), whereas the route works with a `Date` before serialization; that is the
+ * one deliberate divergence from the route's in-memory row type. Kept beside the
+ * request schemas so the tab, the tool, and any future consumer share one source
+ * of truth for the workflow's read shape.
+ */
+export interface AutomationListItem {
+  id: string;
+  name: string;
+  filter: EmailWorkflowFilter;
+  action: string;
+  enabled: boolean;
+  status: EmailWorkflowStatus;
+  sweepWindowDays: number;
+  createdBy: string | null;
+  createdAt: string;
+  connectionIds: string[];
+}


### PR DESCRIPTION
## What & why

The **review-and-activate surface** for Inbox Agent email workflows (#139). The write API (#864) creates every workflow `pending` + `disabled`, and the sweep dispatches only **enabled** ones — so without a UI to review and switch a proposal on, nothing a non-DB user gets ever runs. This tab is that human-gated step ("propose, don't self-activate").

Builds directly on the management API (#873): `GET /api/automations?agentId`, `PATCH /api/automations/[id] {enabled}`, `DELETE /api/automations/[id]`.

## What's in it

- **New tab component** `AgentSettingsAutomations` — self-contained like the Telegram/Diagnostics tabs (own GET, each toggle/delete persisted immediately, lazily mounted so its fetch never fires on unrelated Settings loads):
  - Lists the agent's workflows: name, **human-readable trigger summary** (not raw filter JSON; empty filter → "Entire mailbox"), action, mailbox count, and a status badge (`pending`/`active`/`error`).
  - **Enable/Disable** button → `PATCH {enabled}`, optimistic flip with rollback on error. **`status` is left untouched** — it's the dispatcher's health signal (flips `pending → active` on the next sweep), not something this tab owns.
  - **Delete** with an `AlertDialog` confirm → `DELETE`, row removed **on success only** (non-optimistic — a failed delete keeps the row and toasts). The confirm button is disabled while the request is in flight, so a second click can't fire a second `DELETE` on the same id. Success toast.
  - Errors surface via `toast.error(ApiError.message)`.
- **Tab wiring** in `use-tab-param.ts` + `agent-settings-page-content.tsx`, gated `isAdmin || agent.isPersonal` — the exact mirror of the Telegram tab and, crucially, of the API's own `canManageAgentWorkflows` gate, so the tab and the routes never disagree. (A non-admin on a shared agent never reaches this page at all — `canEdit` redirects them — so there's no partial-page case.)
- **Client-contract type** `AutomationListItem` in `lib/schemas/automations.ts`, beside the request schemas.

## Scope (deliberately narrow)

This brick is **list + review + enable/disable + delete**. Creating a workflow and editing its fields are **not** here: `updateAutomationSchema` is only `{enabled}` by design, and the primary create UX is the conversational tool (#705). Today no shipped path creates a workflow, so the tab renders its honest empty state for real users — the enable/delete logic is fully exercised via mocked GET.

## Docs

**Deliberately deferred.** A user-facing guide now would document an unreachable flow — there's no shipped way to *create* a workflow yet, so the review→enable loop isn't end-to-end. Docs land with the create path (#705), documenting the whole flow at once. Called out here so the deferral is a conscious, tracked decision, not an omission.

## TDD

RED → GREEN throughout:
- `agent-settings-automations.test.tsx` (9): list rendering incl. filter summary + status + mailbox count, empty state, enable PATCH + optimistic flip, disable PATCH, toggle-failure toast + rollback, delete-with-confirm + row removal, list-load-failure toast + empty-state fallback, delete-failure toast + row retained, in-flight delete disables confirm (double-submit guard).
- `agent-settings-page-content-automations-tab.test.tsx` (2): tab visible to a personal-agent owner (non-admin) and to an admin on a shared agent. (The "hidden" case is the page-level redirect, already enforced — noted in the test.)

## Gates

- Affected tests together: **53/53** (component 9, tab-visibility 2, existing page 14, tab-hook 17, schema 9, telegram-tab 2).
- typecheck 0 · eslint 0 · prettier clean.
- **Full web suite:** 2 files failed under load — `knowledge-reindex-section` ("slow status read" race) and `memory-audit-watcher` ("unhandledRejection resilience"), both **19/19 green in isolation**, both async-timing tests unrelated to this UI-only diff. Confirmed load-flakes, not reruns-to-green; documented here rather than hidden.

## Follow-ups (#139 → #705)

- Field editing (name / filter / action) — with a create/edit form.
- Conversational create tool (#705) — the primary way workflows are born; docs land with it.
