### PR TITLE
fix(web): de-flake two component tests (reindex stale-read, name select-all)

### DIFF
--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -99,6 +99,20 @@ describe("KnowledgeReindexSection", () => {
     expect(screen.getByRole("button", { name: /reindex/i })).toBeDisabled();
   });
 
+  it("does not poll while no run is active", async () => {
+    // Idle state: the mount read answers "no job", so the poll effect must not
+    // register an interval at all. This pins the property the old
+    // `toHaveBeenCalledTimes(2)` in the stale-read test asserted by accident.
+    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} pollIntervalMs={20} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled());
+    // Give several would-be interval periods a chance to fire. Flake-safe as an
+    // absence assertion: with no interval registered the count can never grow,
+    // so load can only make a regression MORE visible, never a pass less so.
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(mockGet).toHaveBeenCalledTimes(1); // the mount read only
+  });
+
   it("summarizes the last successful run, emphasizing unsearchable and failed docs", async () => {
     mockGet.mockResolvedValue({
       job: job({

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -214,14 +214,22 @@ describe("KnowledgeReindexSection", () => {
       });
     mockPost.mockResolvedValue({ jobId: "job-9", status: "pending", pathCount: 2 });
 
-    render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} pollIntervalMs={20} />);
+    // This scenario is about the fetch-sequence guard dropping a stale mount
+    // read, NOT about polling. An effectively-idle poll interval keeps the test
+    // deterministic: the old `toHaveBeenCalledTimes(2)` assertion raced a live
+    // 20ms interval and flaked to a much higher count under load.
+    render(
+      <KnowledgeReindexSection agentId="a1" allowedPathCount={2} pollIntervalMs={1_000_000} />
+    );
     await user.click(screen.getByRole("button", { name: /reindex/i }));
     await waitFor(() => expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled());
 
     // The pre-click read finally answers "no job ever ran". It is stale — it
-    // must not clear the run the admin just started and is watching.
-    resolveMountGet({ job: null });
-    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+    // must not clear the run the admin just started and is watching. Flush its
+    // resolution so the guard's decision (drop it) is fully applied before we assert.
+    await act(async () => {
+      resolveMountGet({ job: null });
+    });
     expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled();
   });
 

--- a/packages/web/src/components/new-agent-form.tsx
+++ b/packages/web/src/components/new-agent-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -155,6 +155,21 @@ export function NewAgentForm() {
   });
 
   const nameInputRef = useRef<HTMLInputElement | null>(null);
+  // Set when a suggested name has just been applied; the layout effect below
+  // selects the field once, after the commit that puts the value in the DOM.
+  const selectNameAfterCommitRef = useRef(false);
+
+  // Select-all after the commit that applies a suggested name, so the user can
+  // overtype. A layout effect runs synchronously after the DOM mutation (unlike
+  // a `setTimeout`, which raced the template-switch re-renders and lost the
+  // selection under load). Later renders don't change the name value, so React
+  // won't reassign `node.value` and the selection survives.
+  useLayoutEffect(() => {
+    if (selectNameAfterCommitRef.current) {
+      selectNameAfterCommitRef.current = false;
+      nameInputRef.current?.select();
+    }
+  });
 
   const fetchData = useCallback(async () => {
     const templatesRes = await fetch("/api/templates");
@@ -338,9 +353,9 @@ export function NewAgentForm() {
           const suggested = pickSuggestedName(selectedTemplate, existingNames);
           if (suggested && !cancelled) {
             form.setValue("name", suggested);
-            // Select all text so users can overtype immediately.
-            // Defer past React's commit so the DOM reflects the new value.
-            setTimeout(() => nameInputRef.current?.select(), 0);
+            // Select all text so users can overtype immediately. The layout
+            // effect performs the selection after the value is committed.
+            selectNameAfterCommitRef.current = true;
           }
         } catch {
           // Ignore — user can still type a name manually


### PR DESCRIPTION
## Why

A full `pnpm test` run surfaced two flaky component tests that pass in isolation but fail under the parallel-suite load. Both have timing root causes; neither is a real product bug regressing, but each is a genuine fragility worth removing.

## Flake 1 — `new-agent-form` "selects all text in the name field" (component fix)

`selectionStart` came back `4` instead of `0`. Root cause: the suggested-name pre-fill selected the field with a fire-and-forget `setTimeout(() => nameInputRef.current?.select(), 0)`. A template-switch re-render can re-apply the controlled `value` **after** the timeout ran, clobbering the selection (caret lands at the end). With mocked `fetch` collapsing the natural timing, the race is easy to lose.

**Fix:** replace the `setTimeout` with a one-shot `useLayoutEffect` that selects synchronously after the commit which applies the name. Later renders don't change the name value, so React won't reassign `node.value` and the selection survives. This is also a real UX robustness improvement, not just a test fix.

## Flake 2 — `knowledge-reindex-section` "ignores a slow status read" (test fix)

`expected mockGet to be called 2 times, but got 47`. Root cause: the test asserted `toHaveBeenCalledTimes(2)` while the component polls every `20ms`. The exact count only holds in the sub-20ms window before the first poll tick; under load the interval fires first and `waitFor` can never see exactly 2 again → timeout. The test's real invariant — the `fetchSeq` guard dropping a **stale mount read** so it can't clear a running job — is poll-independent.

**Fix:** use an effectively-idle poll interval so no tick pollutes timing, flush the stale read's resolution with `act()`, and assert the running state held.

## Verification

- Both tests **mutation-tested** to confirm they still catch their regression:
  - Removing the `fetchSeq` guard → reindex test goes red.
  - Removing the `select()` call → name-select test goes red.
- Both files **stress-run 20×** → 0 failures.
- `format:check`, `eslint`, `tsc` (incl. tests) green.
- Full `pnpm test` run: my two targets pass. (One **unrelated, pre-existing** flake surfaced — `pinchy-files` "registers pinchy_ls and pinchy_read" times out at 5s under load; passes isolated. Tracked separately, not in this PR.)

Out of scope: the OpenClaw version bump these flakes surfaced under, and the third `pinchy-files` timeout flake.