### PR TITLE
chore(deps): bump OpenClaw 2026.7.1 → 2026.7.1-2

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # `npm install -g openclaw@<version>` line to keep the runtime version in
 # lockstep with packages/web/package.json (which feeds /api/version). Keep the
 # literal form unchanged.
-RUN npm install -g openclaw@2026.7.1
+RUN npm install -g openclaw@2026.7.1-2
 
 # Bundle the external llama.cpp embedding provider (manifest id `llama-cpp`) plus
 # the EmbeddingGemma GGUF it serves. Together they give memory-core a key-less,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -104,7 +104,7 @@
     "eslint-config-next": "16.2.11",
     "eslint-plugin-security": "^4.0.1",
     "jsdom": "^29.1.1",
-    "openclaw": "2026.7.1",
+    "openclaw": "2026.7.1-2",
     "tailwindcss": "^4.3.2",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,8 +435,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
       openclaw:
-        specifier: 2026.7.1
-        version: 2026.7.1(@aws-sdk/credential-provider-node@3.972.60)(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1)
+        specifier: 2026.7.1-2
+        version: 2026.7.1-2(@aws-sdk/credential-provider-node@3.972.60)(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -1798,8 +1798,8 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@openclaw/ai@2026.7.1':
-    resolution: {integrity: sha512-FsKy5DXSHf4qyN8Huoz/10HZRgoEwLF4uk8UWaCafaIler+q5Fsl51HcrIqIrEe0S38OT7LOaxnR++MOshAlmw==}
+  '@openclaw/ai@2026.7.1-2':
+    resolution: {integrity: sha512-st+NH0cxlQqdbEur//yYqM7WlYBjeEBnop3cztJTSCONKjv6LNoGguI9cH65asZG94FdM/39z857isRGPnZvEw==}
     engines: {node: '>=22.19.0'}
 
   '@openclaw/fs-safe@0.4.1':
@@ -6052,8 +6052,8 @@ packages:
     resolution: {integrity: sha512-cLaeV44fWHrCILGLocG2cFH3uNlgj8TCXyLerzOHKOJhDp1PF6lideYL7aFHtb/zmey3C+tbO6nWQ0c3j3TVZw==}
     engines: {node: '>=20.0.0'}
 
-  openclaw@2026.7.1:
-    resolution: {integrity: sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==}
+  openclaw@2026.7.1-2:
+    resolution: {integrity: sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==}
     engines: {node: '>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0'}
     hasBin: true
 
@@ -7067,10 +7067,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -8864,7 +8860,7 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@openclaw/ai@2026.7.1(@aws-sdk/credential-provider-node@3.972.60)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1)(ws@8.21.0)(zod@4.4.3)':
+  '@openclaw/ai@2026.7.1-2(@aws-sdk/credential-provider-node@3.972.60)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
       '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
@@ -11795,7 +11791,7 @@ snapshots:
       send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13478,7 +13474,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  openclaw@2026.7.1(@aws-sdk/credential-provider-node@3.972.60)(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1):
+  openclaw@2026.7.1-2(@aws-sdk/credential-provider-node@3.972.60)(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1):
     dependencies:
       '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
       '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
@@ -13493,7 +13489,7 @@ snapshots:
       '@mistralai/mistralai': 2.4.0(@opentelemetry/api@1.9.1)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
-      '@openclaw/ai': 2026.7.1(@aws-sdk/credential-provider-node@3.972.60)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1)(ws@8.21.0)(zod@4.4.3)
+      '@openclaw/ai': 2026.7.1-2(@aws-sdk/credential-provider-node@3.972.60)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@opentelemetry/api@1.9.1)(@smithy/hash-node@4.4.5)(@smithy/signature-v4@5.6.1)(ws@8.21.0)(zod@4.4.3)
       '@openclaw/fs-safe': 0.4.1
       '@openclaw/proxyline': 0.3.3(undici@8.5.0)
       '@silvia-odwyer/photon-node': 0.3.4
@@ -14745,12 +14741,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.2
 
   type-is@2.1.0:
     dependencies:


### PR DESCRIPTION
## What

Bumps the pinned OpenClaw core runtime from `2026.7.1` to `2026.7.1-2` in both lockstep locations (`packages/web/package.json`, `Dockerfile.openclaw`), plus the lockfile.

## Why it's safe

`2026.7.1-2` is an npm **correction-release** carrying the npm `latest` dist-tag (there is no GitHub release / git tag for `-1`/`-2` — they exist only on npm). I compared the actual tarballs:

- **370 stable runtime dist files, 0 logic differences** — the dist changes are purely content-hash rebuilds from the embedded version string.
- Sole substantive delta (from the `-2` changelog): **#108336** — "accept singleton-array metadata from newer npm clients so tracked official plugins can install and update to correction releases." Pinchy does **not** use OpenClaw's npm/ClawHub plugin-tracking (our plugins ship via `Dockerfile.openclaw` copy), so this is functionally irrelevant but harmless.

### Four-question upgrade review

- **(a) Incompatibility risk — empty.** No change to session keys, `tools.allow`, `config.apply` timing, plugin/manifest resolution, provider `baseUrl`, or the `agent:bootstrap` hook contract. Runtime is byte-identical to the `2026.7.1` we already run.
- **(b) Workarounds — none affected.** #108881 (bootstrap-memory-group-filter), #47458 (Telegram allowFrom), #75534 (config.apply normalize / #215), #42172 (stop-button) all remain valid — a byte-identical runtime can't obsolete or break any of them.
- **(c)/(d)** — nothing new to adopt or surface.

`openclaw-node` stays at `0.14.0` (already latest). Transitive: `type-is 2.0.1 → 2.1.0` via `@openclaw/ai`'s shrinkwrap.

## Verification

- `openclaw-version-pin-drift` guard ✅ (both pins in lockstep)
- `bootstrap-memory-group-filter` hook-contract test ✅ (10/10)
- `pnpm build` ✅ · `pnpm test` ✅ (two component flakes surfaced under load were unrelated and are fixed separately in #897)

## Notes for reviewer

The `-2` prerelease-style suffix is upstream's chosen form for correction releases; both pins are exact, so there's no semver-range resolution concern.