### PR TITLE
feat(automations): create form — author email workflows in the UI (#139)

### DIFF
--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -7,14 +7,15 @@ import { Aside, Badge } from "@astrojs/starlight/components";
 
 Every agent in Pinchy is configured through a settings page. To open it, navigate to an agent's chat and click the **gear icon** in the top bar. Which tabs you see depends on your role and the agent type.
 
-| Tab                                                   | What it controls                     | Who can see it             |
-| ----------------------------------------------------- | ------------------------------------ | -------------------------- |
-| **General**                                           | Name, tagline, model, agent type     | Everyone who can edit      |
-| **Personality**                                       | Avatar, personality preset, SOUL.md  | Everyone who can edit      |
-| **Instructions**                                      | AGENTS.md operating instructions     | Everyone who can edit      |
-| **Permissions**                                       | Tool allow-list, directory access    | Admins only, shared agents |
-| **Access** <Badge text="Enterprise" variant="note" /> | Visibility mode, group assignment    | Admins only, shared agents |
-| **Telegram**                                          | Connect a Telegram bot to this agent | Admins only                |
+| Tab                                                   | What it controls                      | Who can see it                      |
+| ----------------------------------------------------- | ------------------------------------- | ----------------------------------- |
+| **General**                                           | Name, tagline, model, agent type      | Everyone who can edit               |
+| **Personality**                                       | Avatar, personality preset, SOUL.md   | Everyone who can edit               |
+| **Instructions**                                      | AGENTS.md operating instructions      | Everyone who can edit               |
+| **Permissions**                                       | Tool allow-list, directory access     | Admins only, shared agents          |
+| **Access** <Badge text="Enterprise" variant="note" /> | Visibility mode, group assignment     | Admins only, shared agents          |
+| **Telegram**                                          | Connect a Telegram bot to this agent  | Admins only                         |
+| **Automations**                                       | Email workflows the agent runs itself | Owner (personal) or admins (shared) |
 
 The Permissions and Access tabs exist only for shared agents. Personal agents (the auto-created Smithers each user gets) don't show them because there's nothing to share. Admins still see the Telegram tab on Smithers, but the main Smithers bot is managed centrally via **Settings → Telegram** rather than per-agent.
 
@@ -141,6 +142,36 @@ The Telegram tab lets admins connect a Telegram bot directly to this agent, so u
 The main Pinchy bot must be set up first via **Settings → Telegram** — users link their Telegram accounts once via the main bot and can then message any bot they have permission to use. For Smithers, this tab shows the shared main bot status; to remove it, use "Remove Telegram for everyone" in **Settings → Telegram**. For other agents, the tab shows a token field and a Connect button.
 
 For the full flow including BotFather setup and account linking, see [Set Up Telegram](/guides/telegram-setup/).
+
+## Automations tab
+
+The Automations tab is where an agent's **email workflows** live — standing rules that let the agent act on incoming mail on its own, without anyone opening a chat. A workflow pairs a deterministic **trigger** (which mail it fires on) with an **instruction** (what the agent does with each matching message). Pinchy checks the connected mailboxes on a schedule and runs the instruction once per new matching mail, tracking exactly which messages it has already handled so nothing is processed twice — and it never relies on the read/unread state you see in your own inbox.
+
+You'll see this tab on your personal Smithers and, as an admin, on shared agents that can read email. It's gated the same way the underlying API is: you can manage automations on a personal agent you own, and admins manage them on shared agents.
+
+### Create an automation
+
+Click **New automation** and fill in:
+
+- **Name** — a short label so you can recognize the workflow later.
+- **Instruction** — what the agent should do with each matching mail, in plain words (for example, "Draft a supplier bill in Odoo from the attached invoice"). It runs with this agent's permissions and tools, so it can only do what the agent is already allowed to do.
+- **Trigger** — optional filters that narrow which mail fires the workflow: sender addresses, recipient domain, words in the subject, whether it has an attachment (and of what type), and a folder. Only mail matching **every** filled-in field runs the automation; leave them all blank to watch the entire mailbox.
+- **Mailboxes** — which connected mailboxes to watch. The list only offers mailboxes this agent is permitted to read, so you can't point a workflow at a mailbox the agent can't open.
+- **Look back (days)** — how far back each pass re-checks for mail it may have missed.
+
+:::note[Created paused]
+A new automation is always created **disabled**. Pinchy proposes the workflow; it never activates one on its own. This is deliberate — an agent (or a form) should never grant itself standing autonomous authority. Nothing runs until a person reviews the workflow and switches it on.
+:::
+
+### Review, enable, and remove
+
+The tab lists every workflow on the agent with its trigger (in plain words, not raw filters), its instruction, the mailboxes it watches, and its status:
+
+- **Pending** — proposed but never yet run.
+- **Active** — enabled and running on its schedule.
+- **Error** — the last run hit a problem.
+
+Use **Enable** / **Disable** to turn a workflow on or off, and **Delete** to remove one for good. Enabling is the human-gated step that turns a proposal into a live automation; disabling pauses it without deleting it.
 
 ## Creating agents
 

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -7,15 +7,15 @@ import { Aside, Badge } from "@astrojs/starlight/components";
 
 Every agent in Pinchy is configured through a settings page. To open it, navigate to an agent's chat and click the **gear icon** in the top bar. Which tabs you see depends on your role and the agent type.
 
-| Tab                                                   | What it controls                      | Who can see it                      |
-| ----------------------------------------------------- | ------------------------------------- | ----------------------------------- |
-| **General**                                           | Name, tagline, model, agent type      | Everyone who can edit               |
-| **Personality**                                       | Avatar, personality preset, SOUL.md   | Everyone who can edit               |
-| **Instructions**                                      | AGENTS.md operating instructions      | Everyone who can edit               |
-| **Permissions**                                       | Tool allow-list, directory access     | Admins only, shared agents          |
-| **Access** <Badge text="Enterprise" variant="note" /> | Visibility mode, group assignment     | Admins only, shared agents          |
-| **Telegram**                                          | Connect a Telegram bot to this agent  | Admins only                         |
-| **Automations**                                       | Email workflows the agent runs itself | Owner (personal) or admins (shared) |
+| Tab                                                   | What it controls                      | Who can see it             |
+| ----------------------------------------------------- | ------------------------------------- | -------------------------- |
+| **General**                                           | Name, tagline, model, agent type      | Everyone who can edit      |
+| **Personality**                                       | Avatar, personality preset, SOUL.md   | Everyone who can edit      |
+| **Instructions**                                      | AGENTS.md operating instructions      | Everyone who can edit      |
+| **Permissions**                                       | Tool allow-list, directory access     | Admins only, shared agents |
+| **Access** <Badge text="Enterprise" variant="note" /> | Visibility mode, group assignment     | Admins only, shared agents |
+| **Telegram**                                          | Connect a Telegram bot to this agent  | Admins only                |
+| **Automations**                                       | Email workflows the agent runs itself | Owner (personal) or admins |
 
 The Permissions and Access tabs exist only for shared agents. Personal agents (the auto-created Smithers each user gets) don't show them because there's nothing to share. Admins still see the Telegram tab on Smithers, but the main Smithers bot is managed centrally via **Settings → Telegram** rather than per-agent.
 
@@ -147,7 +147,7 @@ For the full flow including BotFather setup and account linking, see [Set Up Tel
 
 The Automations tab is where an agent's **email workflows** live — standing rules that let the agent act on incoming mail on its own, without anyone opening a chat. A workflow pairs a deterministic **trigger** (which mail it fires on) with an **instruction** (what the agent does with each matching message). Pinchy checks the connected mailboxes on a schedule and runs the instruction once per new matching mail, tracking exactly which messages it has already handled so nothing is processed twice — and it never relies on the read/unread state you see in your own inbox.
 
-You'll see this tab on your personal Smithers and, as an admin, on shared agents that can read email. It's gated the same way the underlying API is: you can manage automations on a personal agent you own, and admins manage them on shared agents.
+You'll see this tab on your personal Smithers and, as an admin, on shared agents that can read email. It's gated the same way the underlying API is: you can manage automations on a personal agent you own; admins can manage them on any agent, shared or personal.
 
 ### Create an automation
 

--- a/packages/web/src/__tests__/api/automations-connections.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-connections.integration.test.ts
@@ -1,0 +1,158 @@
+// Real-DB integration tests for GET /api/automations/connections?agentId= — the
+// mailbox choices the Automations create form (#139) renders in its picker.
+//
+// Why real DB, not mocked chains: the load-bearing behavior is the SAME
+// permission resolution the create route enforces (agent_connection_permissions
+// where model="email" and operation ∈ EMAIL_READ_OPERATIONS), plus scope-based
+// RBAC. If the picker offered a connection the create route rejects — or hid one
+// it accepts — a user could only fail. So the two must resolve identically, and
+// only a real query proves that. @/lib/auth is mocked to drive the scope
+// branches deterministically.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { db } from "@/db";
+import { agents, users, agentConnectionPermissions, integrationConnections } from "@/db/schema";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
+
+const { getSessionMock } = vi.hoisted(() => ({ getSessionMock: vi.fn() }));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+  auth: { api: { getSession: getSessionMock } },
+}));
+
+const { GET } = await import("@/app/api/automations/connections/route");
+
+const OWNER = "user-owner";
+const OTHER = "user-other";
+const ADMIN = "user-admin";
+
+function asMember(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "member" } });
+}
+function asAdmin(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "admin" } });
+}
+
+async function seedUser(id: string, role: "member" | "admin" = "member") {
+  await db.insert(users).values({ id, name: id, email: `${id}@test.com`, role });
+}
+async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) {
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Smithers",
+      model: "ollama-cloud/gemini-3-flash",
+      greetingMessage: "Hi",
+      isPersonal: opts.isPersonal,
+      ownerId: opts.ownerId,
+    })
+    .returning();
+  return row;
+}
+async function seedConnection(id: string, name: string) {
+  await db
+    .insert(integrationConnections)
+    .values({ id, type: "imap", name, credentials: "enc:placeholder" });
+}
+async function grantEmailPermission(agentId: string, connectionId: string, operation = "read") {
+  await db
+    .insert(agentConnectionPermissions)
+    .values({ agentId, connectionId, model: "email", operation });
+}
+
+function req(agentId?: string) {
+  const url = agentId
+    ? `http://localhost/api/automations/connections?agentId=${agentId}`
+    : `http://localhost/api/automations/connections`;
+  return makeNextRequest(url, { method: "GET" });
+}
+
+describe("GET /api/automations/connections", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await seedUser(OWNER);
+    await seedUser(OTHER);
+    await seedUser(ADMIN, "admin");
+  });
+
+  it("returns the email-readable connections (id + name) for a member's own personal agent", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-a", "Invoices mailbox");
+    await grantEmailPermission(agent.id, "conn-a", "read");
+
+    const res = await GET(req(agent.id), routeContext());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([{ id: "conn-a", name: "Invoices mailbox" }]);
+  });
+
+  it("excludes a connection whose only email grant is send — the picker must match the create gate", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-read", "Readable");
+    await seedConnection("conn-send", "Send only");
+    await grantEmailPermission(agent.id, "conn-read", "read");
+    await grantEmailPermission(agent.id, "conn-send", "send");
+
+    const res = await GET(req(agent.id), routeContext());
+    const body = await res.json();
+    expect(body).toEqual([{ id: "conn-read", name: "Readable" }]);
+  });
+
+  it("treats legacy search/list operations as read and returns each connection once", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-legacy", "Legacy mailbox");
+    // Same connection granted under two read-alias operations — must not double up.
+    await grantEmailPermission(agent.id, "conn-legacy", "search");
+    await grantEmailPermission(agent.id, "conn-legacy", "list");
+
+    const res = await GET(req(agent.id), routeContext());
+    const body = await res.json();
+    expect(body).toEqual([{ id: "conn-legacy", name: "Legacy mailbox" }]);
+  });
+
+  it("returns an empty list when the agent has no email-readable connection", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    // Agent exists and is manageable, but holds no email read grant at all.
+    const res = await GET(req(agent.id), routeContext());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("forbids a member from listing a shared agent's connections", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const res = await GET(req(agent.id), routeContext());
+    expect(res.status).toBe(403);
+  });
+
+  it("lets an admin list a shared agent's connections", async () => {
+    asAdmin(ADMIN);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    await seedConnection("conn-shared", "Shared mailbox");
+    await grantEmailPermission(agent.id, "conn-shared", "read");
+
+    const res = await GET(req(agent.id), routeContext());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([{ id: "conn-shared", name: "Shared mailbox" }]);
+  });
+
+  it("requires an agentId query parameter", async () => {
+    asMember(OWNER);
+    const res = await GET(req(), routeContext());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown agent", async () => {
+    asMember(OWNER);
+    const res = await GET(req("ghost"), routeContext());
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/web/src/__tests__/api/automations-connections.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-connections.integration.test.ts
@@ -126,9 +126,34 @@ describe("GET /api/automations/connections", () => {
     expect(await res.json()).toEqual([]);
   });
 
+  it("returns connections sorted by name so the picker order is stable", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    // Insert deliberately out of alphabetical order — the route must sort.
+    await seedConnection("conn-z", "Zebra mailbox");
+    await seedConnection("conn-a", "Alpha mailbox");
+    await grantEmailPermission(agent.id, "conn-z", "read");
+    await grantEmailPermission(agent.id, "conn-a", "read");
+
+    const res = await GET(req(agent.id), routeContext());
+    expect(await res.json()).toEqual([
+      { id: "conn-a", name: "Alpha mailbox" },
+      { id: "conn-z", name: "Zebra mailbox" },
+    ]);
+  });
+
   it("forbids a member from listing a shared agent's connections", async () => {
     asMember(OWNER);
     const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const res = await GET(req(agent.id), routeContext());
+    expect(res.status).toBe(403);
+  });
+
+  it("forbids a member from listing another user's personal agent's connections", async () => {
+    // Coverage for the ownerId leg of canManageAgentWorkflows: personal, but
+    // owned by someone else — a member must not see its mailboxes.
+    asMember(OTHER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
     const res = await GET(req(agent.id), routeContext());
     expect(res.status).toBe(403);
   });

--- a/packages/web/src/__tests__/components/agent-settings-automation-create-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automation-create-dialog.test.tsx
@@ -1,0 +1,225 @@
+// Component tests for the Automations create dialog — the form that finally
+// gives a human a way to author an email workflow in the UI (#139). Until this,
+// the only create path was the raw POST API; the tab could review/enable/delete
+// but never create. Both this form and the conversational tool (#705) write the
+// SAME object through POST /api/automations ("same object, one system").
+//
+// The dialog GETs the agent's email-readable mailboxes (the picker options) and
+// POSTs a CreateAutomationInput. We mock global.fetch (the api-client helpers
+// read the body via text()+JSON.parse), so each Response exposes json() + text().
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { toast } from "sonner";
+import { AgentSettingsAutomationCreateDialog } from "@/components/agent-settings-automation-create-dialog";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const AGENT_ID = "agent-1";
+const CONNECTIONS = [
+  { id: "conn-a", name: "Invoices mailbox" },
+  { id: "conn-b", name: "Newsletters" },
+];
+
+describe("AgentSettingsAutomationCreateDialog", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+    const text = JSON.stringify(body);
+    return {
+      ok: init.ok ?? true,
+      status: init.status ?? 200,
+      json: async () => body,
+      text: async () => text,
+    } as unknown as Response;
+  }
+
+  /** GET connections → options; POST create → 201. Override per test as needed. */
+  function mockHappyPath(connections: unknown[] = CONNECTIONS) {
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations/connections")) return jsonResponse(connections);
+      if (url === "/api/automations" && (init as RequestInit)?.method === "POST") {
+        return jsonResponse(
+          { id: "wf-new", name: "x", enabled: false, status: "pending" },
+          {
+            status: 201,
+          }
+        );
+      }
+      return jsonResponse({});
+    });
+  }
+
+  function findPost() {
+    return fetchSpy.mock.calls.find(
+      (c: unknown[]) =>
+        String(c[0]) === "/api/automations" && (c[1] as RequestInit)?.method === "POST"
+    );
+  }
+
+  it("loads the agent's mailboxes scoped to the agent and offers them as options", async () => {
+    mockHappyPath();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+    expect(screen.getByRole("checkbox", { name: /Newsletters/i })).toBeInTheDocument();
+    expect(String(fetchSpy.mock.calls[0][0])).toBe(
+      `/api/automations/connections?agentId=${AGENT_ID}`
+    );
+  });
+
+  it("POSTs a well-formed create payload and then reports success", async () => {
+    mockHappyPath();
+    const onCreated = vi.fn();
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={onOpenChange}
+        onCreated={onCreated}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+
+    await user.type(screen.getByLabelText(/^Name/i), "File supplier invoices");
+    await user.type(screen.getByLabelText(/Instruction/i), "Draft a supplier bill in Odoo.");
+    await user.type(screen.getByLabelText(/^From/i), "billing@acme.com, ap@acme.com");
+    await user.click(screen.getByRole("checkbox", { name: /has an attachment/i }));
+    await user.type(screen.getByLabelText(/Attachment type/i), "application/pdf");
+    await user.click(screen.getByRole("checkbox", { name: /Invoices mailbox/i }));
+
+    await user.click(screen.getByRole("button", { name: /create automation/i }));
+
+    await waitFor(() => expect(findPost()).toBeTruthy());
+    const body = JSON.parse((findPost()![1] as RequestInit).body as string);
+    expect(body).toEqual({
+      agentId: AGENT_ID,
+      name: "File supplier invoices",
+      action: "Draft a supplier bill in Odoo.",
+      filter: {
+        from: ["billing@acme.com", "ap@acme.com"],
+        hasAttachment: true,
+        attachmentType: "application/pdf",
+      },
+      connectionIds: ["conn-a"],
+      sweepWindowDays: 14,
+    });
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("omits empty filter fields — an all-blank filter posts an empty filter object", async () => {
+    mockHappyPath();
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+
+    await user.type(screen.getByLabelText(/^Name/i), "Watch everything");
+    await user.type(screen.getByLabelText(/Instruction/i), "Summarize each mail.");
+    await user.click(screen.getByRole("checkbox", { name: /Newsletters/i }));
+    await user.click(screen.getByRole("button", { name: /create automation/i }));
+
+    await waitFor(() => expect(findPost()).toBeTruthy());
+    const body = JSON.parse((findPost()![1] as RequestInit).body as string);
+    expect(body.filter).toEqual({});
+    expect(body.connectionIds).toEqual(["conn-b"]);
+  });
+
+  it("keeps Create disabled until name, instruction, and at least one mailbox are set", async () => {
+    mockHappyPath();
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+
+    const createBtn = screen.getByRole("button", { name: /create automation/i });
+    expect(createBtn).toBeDisabled();
+
+    // Name + instruction alone is not enough — a workflow with no mailbox is
+    // never dispatched (the loader inner-joins connections), so the server 400s.
+    await user.type(screen.getByLabelText(/^Name/i), "No mailbox yet");
+    await user.type(screen.getByLabelText(/Instruction/i), "Do a thing.");
+    expect(createBtn).toBeDisabled();
+
+    await user.click(screen.getByRole("checkbox", { name: /Invoices mailbox/i }));
+    expect(createBtn).toBeEnabled();
+  });
+
+  it("surfaces the API error and stays open when the create fails", async () => {
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations/connections")) return jsonResponse(CONNECTIONS);
+      if (url === "/api/automations" && (init as RequestInit)?.method === "POST") {
+        return jsonResponse({ error: "The agent has no email access" }, { ok: false, status: 400 });
+      }
+      return jsonResponse({});
+    });
+    const onCreated = vi.fn();
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={onOpenChange}
+        onCreated={onCreated}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+
+    await user.type(screen.getByLabelText(/^Name/i), "Doomed");
+    await user.type(screen.getByLabelText(/Instruction/i), "Try it.");
+    await user.click(screen.getByRole("checkbox", { name: /Invoices mailbox/i }));
+    await user.click(screen.getByRole("button", { name: /create automation/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("The agent has no email access"));
+    expect(onCreated).not.toHaveBeenCalled();
+    // The dialog is never asked to close on failure — the user can fix and retry.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/web/src/__tests__/components/agent-settings-automation-create-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automation-create-dialog.test.tsx
@@ -222,4 +222,132 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     // The dialog is never asked to close on failure — the user can fix and retry.
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
+
+  it("keeps Create disabled and shows a hint when the look-back is out of range", async () => {
+    mockHappyPath();
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+
+    await user.type(screen.getByLabelText(/^Name/i), "Range check");
+    await user.type(screen.getByLabelText(/Instruction/i), "Do a thing.");
+    await user.click(screen.getByRole("checkbox", { name: /Invoices mailbox/i }));
+    const createBtn = screen.getByRole("button", { name: /create automation/i });
+    expect(createBtn).toBeEnabled();
+
+    // Above the server's 365-day cap: the form must refuse instead of letting
+    // the server 400 with a raw validation message.
+    const sweepInput = screen.getByLabelText(/Look back/i);
+    await user.clear(sweepInput);
+    await user.type(sweepInput, "9999");
+    expect(createBtn).toBeDisabled();
+    expect(screen.getByText(/between 1 and 365/i)).toBeInTheDocument();
+
+    // Back in range → submittable again, hint gone.
+    await user.clear(sweepInput);
+    await user.type(sweepInput, "30");
+    expect(createBtn).toBeEnabled();
+    expect(screen.queryByText(/between 1 and 365/i)).not.toBeInTheDocument();
+  });
+
+  it("treats a blank look-back as the default sweep window", async () => {
+    mockHappyPath();
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+
+    await user.type(screen.getByLabelText(/^Name/i), "Blank look-back");
+    await user.type(screen.getByLabelText(/Instruction/i), "Do a thing.");
+    await user.click(screen.getByRole("checkbox", { name: /Invoices mailbox/i }));
+    await user.clear(screen.getByLabelText(/Look back/i));
+    await user.click(screen.getByRole("button", { name: /create automation/i }));
+
+    await waitFor(() => expect(findPost()).toBeTruthy());
+    const body = JSON.parse((findPost()![1] as RequestInit).body as string);
+    expect(body.sweepWindowDays).toBe(14);
+  });
+
+  it("shows a load error with retry instead of the empty-mailbox message when the fetch fails", async () => {
+    let connectionCalls = 0;
+    vi.mocked(global.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations/connections")) {
+        connectionCalls++;
+        if (connectionCalls === 1) {
+          return jsonResponse({ error: "Session expired" }, { ok: false, status: 500 });
+        }
+        return jsonResponse(CONNECTIONS);
+      }
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+    render(
+      <AgentSettingsAutomationCreateDialog
+        agentId={AGENT_ID}
+        open={true}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />
+    );
+
+    // A failed load must NOT masquerade as "this agent has no mailboxes".
+    await waitFor(() => expect(screen.getByText(/Session expired/i)).toBeInTheDocument());
+    expect(screen.queryByText(/no readable email connection/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+  });
+
+  it("ignores a stale connections response from a previous open", async () => {
+    let resolveFirst!: (value: Response) => void;
+    const firstResponse = new Promise<Response>((resolve) => (resolveFirst = resolve));
+    let connectionCalls = 0;
+    vi.mocked(global.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations/connections")) {
+        connectionCalls++;
+        if (connectionCalls === 1) return firstResponse;
+        return jsonResponse([{ id: "conn-fresh", name: "Fresh mailbox" }]);
+      }
+      return jsonResponse({});
+    });
+    const props = { agentId: AGENT_ID, onOpenChange: vi.fn(), onCreated: vi.fn() };
+    const { rerender } = render(<AgentSettingsAutomationCreateDialog {...props} open={true} />);
+    // Make sure the first open's request is actually in flight before closing —
+    // the load is deferred to a microtask, so closing too early would cancel it.
+    await waitFor(() => expect(connectionCalls).toBe(1));
+
+    // Close and reopen while the first request is still in flight.
+    rerender(<AgentSettingsAutomationCreateDialog {...props} open={false} />);
+    rerender(<AgentSettingsAutomationCreateDialog {...props} open={true} />);
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Fresh mailbox/i })).toBeInTheDocument()
+    );
+
+    // The first open's response lands late — it must not clobber the fresh list.
+    resolveFirst(jsonResponse([{ id: "conn-stale", name: "Stale mailbox" }]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByText(/Stale mailbox/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /Fresh mailbox/i })).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
@@ -212,4 +212,46 @@ describe("AgentSettingsAutomations", () => {
     });
     expect(toast.success).toHaveBeenCalled();
   });
+
+  it("opens the create dialog and reloads the list after a workflow is created", async () => {
+    let listCalls = 0;
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = (init as RequestInit)?.method ?? "GET";
+      if (url.startsWith("/api/automations/connections")) {
+        return jsonResponse([{ id: "conn-a", name: "Invoices mailbox" }]);
+      }
+      if (url.startsWith("/api/automations?")) {
+        listCalls++;
+        return jsonResponse(mockAutomations);
+      }
+      if (url === "/api/automations" && method === "POST") {
+        return jsonResponse(
+          { id: "wf-new", name: "New one", enabled: false, status: "pending" },
+          { status: 201 }
+        );
+      }
+      return jsonResponse({ ok: true });
+    });
+
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+    await waitFor(() => expect(screen.getByText("File supplier invoices")).toBeInTheDocument());
+    const listCallsAfterLoad = listCalls;
+
+    await user.click(screen.getByRole("button", { name: /new automation/i }));
+
+    // Dialog opened → mailbox picker populated from the connections endpoint.
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+    );
+
+    await user.type(screen.getByLabelText(/^Name/i), "New one");
+    await user.type(screen.getByLabelText(/Instruction/i), "Do it.");
+    await user.click(screen.getByRole("checkbox", { name: /Invoices mailbox/i }));
+    await user.click(screen.getByRole("button", { name: /create automation/i }));
+
+    // onCreated → load(): the list is re-fetched after a successful create.
+    await waitFor(() => expect(listCalls).toBeGreaterThan(listCallsAfterLoad));
+  });
 });

--- a/packages/web/src/app/api/automations/connections/route.ts
+++ b/packages/web/src/app/api/automations/connections/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { db } from "@/db";
+import { agents, agentConnectionPermissions, integrationConnections } from "@/db/schema";
+import { withAuth } from "@/lib/api-auth";
+import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
+import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+
+/**
+ * GET /api/automations/connections?agentId=<id> — the mailbox choices the
+ * Automations create form (#139) renders in its picker.
+ *
+ * The connections a workflow may point at are EXACTLY those the create route
+ * (POST /api/automations) accepts: the ones the agent is permitted to READ
+ * (agent_connection_permissions, model="email", operation ∈
+ * EMAIL_READ_OPERATIONS). A workflow's trigger lists and reads mail, so a
+ * draft/send-only grant does not qualify. Resolving the picker through the same
+ * gate keeps it from ever offering a connection the create route would reject —
+ * or hiding one it accepts.
+ *
+ * Same scope gate as list/create (canManageAgentWorkflows): a member sees their
+ * own personal agent's connections; a shared agent is admin-only.
+ *
+ * audit-exempt: read-only; returns nothing state-changing and writes nothing.
+ */
+export const GET = withAuth(async (request, _ctx, session) => {
+  const agentId = new URL(request.url).searchParams.get("agentId");
+  if (!agentId) {
+    return NextResponse.json({ error: "agentId is required" }, { status: 400 });
+  }
+
+  const [agent] = await db
+    .select({ isPersonal: agents.isPersonal, ownerId: agents.ownerId })
+    .from(agents)
+    .where(eq(agents.id, agentId));
+  if (!agent) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+  if (!canManageAgentWorkflows(agent, { id: session.user.id!, role: session.user.role })) {
+    return NextResponse.json({ error: "You do not have access to this agent" }, { status: 403 });
+  }
+
+  // selectDistinct: an agent can hold several read-operation rows (read, and the
+  // legacy "search"/"list" aliases) for one connection — collapse them to one id.
+  const permitted = await db
+    .selectDistinct({ connectionId: agentConnectionPermissions.connectionId })
+    .from(agentConnectionPermissions)
+    .where(
+      and(
+        eq(agentConnectionPermissions.agentId, agentId),
+        eq(agentConnectionPermissions.model, "email"),
+        inArray(agentConnectionPermissions.operation, [...EMAIL_READ_OPERATIONS])
+      )
+    );
+  const ids = permitted.map((r) => r.connectionId);
+
+  // Resolve names in one query, keyed off the already-deduped ids (a join on the
+  // permission rows would repeat a connection once per read-alias operation).
+  const connections = ids.length
+    ? await db
+        .select({ id: integrationConnections.id, name: integrationConnections.name })
+        .from(integrationConnections)
+        .where(inArray(integrationConnections.id, ids))
+    : [];
+
+  return NextResponse.json(connections);
+});

--- a/packages/web/src/app/api/automations/connections/route.ts
+++ b/packages/web/src/app/api/automations/connections/route.ts
@@ -57,11 +57,13 @@ export const GET = withAuth(async (request, _ctx, session) => {
 
   // Resolve names in one query, keyed off the already-deduped ids (a join on the
   // permission rows would repeat a connection once per read-alias operation).
+  // Ordered by name so the picker renders a stable order across opens.
   const connections = ids.length
     ? await db
         .select({ id: integrationConnections.id, name: integrationConnections.name })
         .from(integrationConnections)
         .where(inArray(integrationConnections.id, ids))
+        .orderBy(integrationConnections.name)
     : [];
 
   return NextResponse.json(connections);

--- a/packages/web/src/components/agent-settings-automation-create-dialog.tsx
+++ b/packages/web/src/components/agent-settings-automation-create-dialog.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import type { AutomationConnectionOption, CreateAutomationInput } from "@/lib/schemas/automations";
+import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+
+/** Default sweep window (days) — mirrors the schema default so the form and the
+ * server agree on what "leave it blank" means. */
+const DEFAULT_SWEEP_WINDOW_DAYS = 14;
+
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof ApiError ? e.message : fallback;
+}
+
+/** Split a comma-separated input into trimmed, non-empty tokens. */
+function parseList(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * The create dialog for an Inbox Agent email workflow (#139) — the first UI path
+ * to author one. It resolves the same object POST /api/automations writes, so it
+ * shares the {@link CreateAutomationInput} contract with the route and the future
+ * conversational tool (#705).
+ *
+ * The mailbox picker is populated from GET /api/automations/connections, which
+ * resolves choices through the same email-read permission gate the create route
+ * enforces — so the form can only offer mailboxes the server will accept.
+ *
+ * Propose, don't self-activate: the route always writes the workflow
+ * pending + disabled, so there is no "enable now" control here — activation is
+ * the reviewer's separate step in the tab.
+ */
+export function AgentSettingsAutomationCreateDialog({
+  agentId,
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  agentId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
+}) {
+  const [connections, setConnections] = useState<AutomationConnectionOption[]>([]);
+  const [loadingConnections, setLoadingConnections] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [name, setName] = useState("");
+  const [action, setAction] = useState("");
+  const [from, setFrom] = useState("");
+  const [toDomain, setToDomain] = useState("");
+  const [subjectContains, setSubjectContains] = useState("");
+  const [hasAttachment, setHasAttachment] = useState(false);
+  const [attachmentType, setAttachmentType] = useState("");
+  const [folder, setFolder] = useState("");
+  const [sweepWindowDays, setSweepWindowDays] = useState(String(DEFAULT_SWEEP_WINDOW_DAYS));
+  const [selectedConnectionIds, setSelectedConnectionIds] = useState<string[]>([]);
+
+  // Fresh form on each open (React-recommended "adjust state during render"
+  // instead of an effect). Also clears the picker and re-arms the loading state
+  // so a reopen re-fetches rather than showing a stale mailbox list.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (prevOpen !== open) {
+    setPrevOpen(open);
+    if (open) {
+      setName("");
+      setAction("");
+      setFrom("");
+      setToDomain("");
+      setSubjectContains("");
+      setHasAttachment(false);
+      setAttachmentType("");
+      setFolder("");
+      setSweepWindowDays(String(DEFAULT_SWEEP_WINDOW_DAYS));
+      setSelectedConnectionIds([]);
+      setConnections([]);
+      setLoadingConnections(true);
+    }
+  }
+
+  const load = useCallback(async () => {
+    setLoadingConnections(true);
+    try {
+      const data = await apiGet<AutomationConnectionOption[]>(
+        `/api/automations/connections?agentId=${encodeURIComponent(agentId)}`
+      );
+      setConnections(Array.isArray(data) ? data : []);
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to load mailboxes"));
+      setConnections([]);
+    } finally {
+      setLoadingConnections(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    if (!open) return;
+    // Deferred past the effect body so the setState in `load` runs in a
+    // microtask, not synchronously inside the effect (react-hooks/
+    // set-state-in-effect) — same pattern as connected-apps.tsx.
+    let cancelled = false;
+    void Promise.resolve().then(() => {
+      if (!cancelled) void load();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, load]);
+
+  function toggleConnection(id: string, checked: boolean) {
+    setSelectedConnectionIds((prev) => (checked ? [...prev, id] : prev.filter((c) => c !== id)));
+  }
+
+  function buildFilter(): EmailWorkflowFilter {
+    const filter: EmailWorkflowFilter = {};
+    const fromList = parseList(from);
+    if (fromList.length) filter.from = fromList;
+    const toDomainList = parseList(toDomain);
+    if (toDomainList.length) filter.toDomain = toDomainList;
+    const subjectList = parseList(subjectContains);
+    if (subjectList.length) filter.subjectContains = subjectList;
+    if (hasAttachment) filter.hasAttachment = true;
+    if (attachmentType.trim()) filter.attachmentType = attachmentType.trim();
+    if (folder.trim()) filter.folder = folder.trim();
+    return filter;
+  }
+
+  const canSubmit =
+    name.trim().length > 0 &&
+    action.trim().length > 0 &&
+    selectedConnectionIds.length > 0 &&
+    !submitting;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    const parsedDays = Number.parseInt(sweepWindowDays, 10);
+    const payload: CreateAutomationInput = {
+      agentId,
+      name: name.trim(),
+      action: action.trim(),
+      filter: buildFilter(),
+      connectionIds: selectedConnectionIds,
+      sweepWindowDays:
+        Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : DEFAULT_SWEEP_WINDOW_DAYS,
+    };
+    setSubmitting(true);
+    try {
+      await apiPost("/api/automations", payload);
+      toast.success("Automation created — review and enable it below.");
+      onCreated();
+      onOpenChange(false);
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to create automation"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New automation</DialogTitle>
+          <DialogDescription>
+            Describe which mail this agent should act on and what to do. It&apos;s created paused —
+            you review and enable it afterwards.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} method="post" noValidate className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="automation-name">Name</Label>
+            <Input
+              id="automation-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="File supplier invoices"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="automation-action">Instruction</Label>
+            <Textarea
+              id="automation-action"
+              value={action}
+              onChange={(e) => setAction(e.target.value)}
+              placeholder="Draft a supplier bill in Odoo from the attached invoice."
+              rows={3}
+            />
+            <p className="text-xs text-muted-foreground">
+              What the agent should do with each matching mail, in plain words. It runs with this
+              agent&apos;s permissions and tools.
+            </p>
+          </div>
+
+          <fieldset className="space-y-3 rounded-lg border p-3">
+            <legend className="px-1 text-sm font-medium">Trigger</legend>
+            <p className="text-xs text-muted-foreground">
+              Only mail matching every filled-in field runs the automation. Leave all blank to watch
+              the entire mailbox.
+            </p>
+            <div className="space-y-2">
+              <Label htmlFor="automation-from">From</Label>
+              <Input
+                id="automation-from"
+                value={from}
+                onChange={(e) => setFrom(e.target.value)}
+                placeholder="billing@acme.com, ap@acme.com"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="automation-to-domain">To domain</Label>
+              <Input
+                id="automation-to-domain"
+                value={toDomain}
+                onChange={(e) => setToDomain(e.target.value)}
+                placeholder="acme.com"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="automation-subject">Subject contains</Label>
+              <Input
+                id="automation-subject"
+                value={subjectContains}
+                onChange={(e) => setSubjectContains(e.target.value)}
+                placeholder="invoice, receipt"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="automation-has-attachment"
+                checked={hasAttachment}
+                onCheckedChange={(c) => setHasAttachment(c === true)}
+              />
+              <Label htmlFor="automation-has-attachment" className="font-normal">
+                Has an attachment
+              </Label>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="automation-attachment-type">Attachment type</Label>
+              <Input
+                id="automation-attachment-type"
+                value={attachmentType}
+                onChange={(e) => setAttachmentType(e.target.value)}
+                placeholder="application/pdf"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="automation-folder">Folder</Label>
+              <Input
+                id="automation-folder"
+                value={folder}
+                onChange={(e) => setFolder(e.target.value)}
+                placeholder="Inbox"
+              />
+            </div>
+          </fieldset>
+
+          <div className="space-y-2">
+            <Label>Mailboxes</Label>
+            <p className="text-xs text-muted-foreground">
+              Which connected mailboxes this automation watches. Only mailboxes this agent may read
+              are listed.
+            </p>
+            {loadingConnections ? (
+              <div className="space-y-2">
+                <Skeleton className="h-6 w-full" />
+                <Skeleton className="h-6 w-2/3" />
+              </div>
+            ) : connections.length === 0 ? (
+              <p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+                This agent has no readable email connection yet. Give it email read access to a
+                connection first.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {connections.map((conn) => (
+                  <div key={conn.id} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`automation-conn-${conn.id}`}
+                      checked={selectedConnectionIds.includes(conn.id)}
+                      onCheckedChange={(c) => toggleConnection(conn.id, c === true)}
+                    />
+                    <Label htmlFor={`automation-conn-${conn.id}`} className="font-normal">
+                      {conn.name}
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="automation-sweep-window">Look back (days)</Label>
+            <Input
+              id="automation-sweep-window"
+              type="number"
+              min={1}
+              max={365}
+              value={sweepWindowDays}
+              onChange={(e) => setSweepWindowDays(e.target.value)}
+              className="w-28"
+            />
+            <p className="text-xs text-muted-foreground">
+              How far back each pass re-checks for mail it may have missed.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              Create automation
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/agent-settings-automation-create-dialog.tsx
+++ b/packages/web/src/components/agent-settings-automation-create-dialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { AUTOMATION_MAX_SWEEP_WINDOW_DAYS } from "@/lib/schemas/automations";
 import type { AutomationConnectionOption, CreateAutomationInput } from "@/lib/schemas/automations";
 import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
 import { Button } from "@/components/ui/button";
@@ -64,7 +65,12 @@ export function AgentSettingsAutomationCreateDialog({
 }) {
   const [connections, setConnections] = useState<AutomationConnectionOption[]>([]);
   const [loadingConnections, setLoadingConnections] = useState(true);
+  const [connectionsError, setConnectionsError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // Monotonic sequence for connection loads: a response only lands if it still
+  // belongs to the latest load, so a slow response from a previous open can
+  // never clobber the picker a reopen just refreshed.
+  const loadSeqRef = useRef(0);
 
   const [name, setName] = useState("");
   const [action, setAction] = useState("");
@@ -95,22 +101,29 @@ export function AgentSettingsAutomationCreateDialog({
       setSweepWindowDays(String(DEFAULT_SWEEP_WINDOW_DAYS));
       setSelectedConnectionIds([]);
       setConnections([]);
+      setConnectionsError(null);
       setLoadingConnections(true);
     }
   }
 
   const load = useCallback(async () => {
+    const seq = ++loadSeqRef.current;
     setLoadingConnections(true);
+    setConnectionsError(null);
     try {
       const data = await apiGet<AutomationConnectionOption[]>(
         `/api/automations/connections?agentId=${encodeURIComponent(agentId)}`
       );
+      if (seq !== loadSeqRef.current) return;
       setConnections(Array.isArray(data) ? data : []);
     } catch (e) {
-      toast.error(errorMessage(e, "Failed to load mailboxes"));
+      if (seq !== loadSeqRef.current) return;
       setConnections([]);
+      // Rendered inline (with a retry) instead of a toast: an empty picker after
+      // a failed load must not look like "this agent has no mailboxes".
+      setConnectionsError(errorMessage(e, "Failed to load mailboxes"));
     } finally {
-      setLoadingConnections(false);
+      if (seq === loadSeqRef.current) setLoadingConnections(false);
     }
   }, [agentId]);
 
@@ -146,24 +159,34 @@ export function AgentSettingsAutomationCreateDialog({
     return filter;
   }
 
+  // Validated against the exact bounds the server schema enforces
+  // (1..AUTOMATION_MAX_SWEEP_WINDOW_DAYS): out-of-range input blocks the submit
+  // with a hint instead of a server 400, and is never silently replaced by the
+  // default. Only a genuinely blank field means "use the default".
+  const sweepTrimmed = sweepWindowDays.trim();
+  const parsedSweepDays = sweepTrimmed === "" ? DEFAULT_SWEEP_WINDOW_DAYS : Number(sweepTrimmed);
+  const sweepWindowValid =
+    Number.isInteger(parsedSweepDays) &&
+    parsedSweepDays >= 1 &&
+    parsedSweepDays <= AUTOMATION_MAX_SWEEP_WINDOW_DAYS;
+
   const canSubmit =
     name.trim().length > 0 &&
     action.trim().length > 0 &&
     selectedConnectionIds.length > 0 &&
+    sweepWindowValid &&
     !submitting;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!canSubmit) return;
-    const parsedDays = Number.parseInt(sweepWindowDays, 10);
     const payload: CreateAutomationInput = {
       agentId,
       name: name.trim(),
       action: action.trim(),
       filter: buildFilter(),
       connectionIds: selectedConnectionIds,
-      sweepWindowDays:
-        Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : DEFAULT_SWEEP_WINDOW_DAYS,
+      sweepWindowDays: parsedSweepDays,
     };
     setSubmitting(true);
     try {
@@ -289,6 +312,13 @@ export function AgentSettingsAutomationCreateDialog({
                 <Skeleton className="h-6 w-full" />
                 <Skeleton className="h-6 w-2/3" />
               </div>
+            ) : connectionsError ? (
+              <div className="space-y-2 rounded-md border border-destructive/50 p-3">
+                <p className="text-sm text-destructive">{connectionsError}</p>
+                <Button type="button" variant="outline" size="sm" onClick={() => void load()}>
+                  Try again
+                </Button>
+              </div>
             ) : connections.length === 0 ? (
               <p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
                 This agent has no readable email connection yet. Give it email read access to a
@@ -318,11 +348,16 @@ export function AgentSettingsAutomationCreateDialog({
               id="automation-sweep-window"
               type="number"
               min={1}
-              max={365}
+              max={AUTOMATION_MAX_SWEEP_WINDOW_DAYS}
               value={sweepWindowDays}
               onChange={(e) => setSweepWindowDays(e.target.value)}
               className="w-28"
             />
+            {!sweepWindowValid && (
+              <p className="text-xs text-destructive">
+                Enter a whole number of days between 1 and {AUTOMATION_MAX_SWEEP_WINDOW_DAYS}.
+              </p>
+            )}
             <p className="text-xs text-muted-foreground">
               How far back each pass re-checks for mail it may have missed.
             </p>

--- a/packages/web/src/components/agent-settings-automations.tsx
+++ b/packages/web/src/components/agent-settings-automations.tsx
@@ -7,6 +7,7 @@ import { apiGet, apiPatch, apiDelete, ApiError } from "@/lib/api-client";
 import type { AutomationListItem } from "@/lib/schemas/automations";
 import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
 import type { EmailWorkflowStatus } from "@/db/enums";
+import { AgentSettingsAutomationCreateDialog } from "@/components/agent-settings-automation-create-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -79,6 +80,7 @@ export function AgentSettingsAutomations({ agentId }: { agentId: string }) {
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<AutomationListItem | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
 
   // No synchronous setState here: `loading` starts true and the `finally`
   // clears it, so the effect that calls this never sets state before its first
@@ -143,13 +145,25 @@ export function AgentSettingsAutomations({ agentId }: { agentId: string }) {
 
   return (
     <div className="space-y-4">
-      <div>
-        <h2 className="text-lg font-semibold">Automations</h2>
-        <p className="text-sm text-muted-foreground">
-          Email workflows this agent can run on its own. Review each proposal and switch it on when
-          you&apos;re ready — nothing runs until you enable it.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold">Automations</h2>
+          <p className="text-sm text-muted-foreground">
+            Email workflows this agent can run on its own. Review each proposal and switch it on
+            when you&apos;re ready — nothing runs until you enable it.
+          </p>
+        </div>
+        <Button size="sm" className="shrink-0" onClick={() => setCreateOpen(true)}>
+          New automation
+        </Button>
       </div>
+
+      <AgentSettingsAutomationCreateDialog
+        agentId={agentId}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={load}
+      />
 
       {loading ? (
         <div className="space-y-2">

--- a/packages/web/src/lib/schemas/automations.ts
+++ b/packages/web/src/lib/schemas/automations.ts
@@ -102,3 +102,14 @@ export interface AutomationListItem {
   createdAt: string;
   connectionIds: string[];
 }
+
+/**
+ * Client-side contract for one mailbox choice in the Automations create form's
+ * picker — GET /api/automations/connections?agentId. The endpoint resolves these
+ * through the same email-read permission gate the create route (POST) enforces,
+ * so the picker can never offer a connection the create route would reject.
+ */
+export interface AutomationConnectionOption {
+  id: string;
+  name: string;
+}

--- a/packages/web/src/lib/schemas/automations.ts
+++ b/packages/web/src/lib/schemas/automations.ts
@@ -33,6 +33,13 @@ export type FilterParity = AssertAssignable<
 export const AUTOMATION_NAME_MAX_LENGTH = 200;
 
 /**
+ * Upper bound on the reconciliation sweep window (design §5) — shared with the
+ * create form so the client validates against the exact limit the server
+ * enforces instead of hard-coding its own copy.
+ */
+export const AUTOMATION_MAX_SWEEP_WINDOW_DAYS = 365;
+
+/**
  * Upper bound on mailboxes per workflow. Far above any real setup, but keeps
  * an absurd request from ballooning the 400-error echo and the audit
  * `detail.connectionIds` list (AGENTS.md: keep audit detail under 2048 bytes).
@@ -64,7 +71,7 @@ export const createAutomationSchema = z.object({
   connectionIds: z.array(z.string().min(1)).min(1).max(AUTOMATION_MAX_CONNECTIONS),
   // How far back the reconciliation sweep re-lists (design §5). Bounded so a
   // typo can't make one workflow re-hydrate years of mail every pass.
-  sweepWindowDays: z.number().int().positive().max(365).default(14),
+  sweepWindowDays: z.number().int().positive().max(AUTOMATION_MAX_SWEEP_WINDOW_DAYS).default(14),
 });
 
 export type CreateAutomationInput = z.infer<typeof createAutomationSchema>;


### PR DESCRIPTION
## What & why

The missing keystone of the Inbox Agent (#139). The write API (#864), management API (#873), and the review/enable/delete tab (#896) all shipped — but **no path a real user can reach ever created a workflow**. Only the raw `POST /api/automations` (which nothing called) and integration tests did. So the whole feature was unreachable end-to-end. This PR is the create surface that closes `create → review → enable → sweep`.

Per design §5, "CRUD in the Automations tab" is the primary create path; the conversational tool (#705) is an explicit **fast-follow**. Both write the same object through the same route — this form just puts a human at the keyboard.

## Changes

- **`GET /api/automations/connections?agentId`** — the mailbox picker's options, resolved through the **same** email-read permission gate the create route (`POST`) enforces (`agent_connection_permissions`, `model="email"`, `operation ∈ EMAIL_READ_OPERATIONS`). So the form can never offer a connection the create route would reject, nor hide one it accepts. Same `canManageAgentWorkflows` scope gate as list/create. Read-only → `// audit-exempt`.
- **`AgentSettingsAutomationCreateDialog`** — name, trigger filters (from / to-domain / subject-contains as comma lists, has-attachment, attachment-type, folder), instruction, mailbox multi-select, look-back window. Posts the shared `CreateAutomationInput` contract. **Propose, don't self-activate:** no "enable now" control — the route always writes `pending`+`disabled`, and the reviewer enables it in the tab.
- **Wiring** — a "New automation" button in the Automations tab header; the list reloads on create.
- **Docs** — the review→enable flow is now end-to-end reachable, so the Automations-tab documentation deferred in #896 lands here (`concepts/agent-settings`).

## Scope — deliberately narrow

Create only. Field-editing (name/filter/action of an existing workflow) needs a PATCH-schema extension (`updateAutomationSchema` is `{enabled}` only) and is a separate brick. Enable/disable/delete already cover the lifecycle; a mistyped filter is delete + recreate for now.

## Tests (TDD, RED→GREEN)

- **Connections endpoint** (real-DB integration, 8): the create-gate parity (send-only excluded, legacy search/list treated as read + deduped), scope RBAC (member own-personal vs shared→admin), empty list, 400/404.
- **Create dialog** (component, 5): loads mailboxes scoped to the agent, posts a well-formed payload (comma-split filter arrays, empty fields omitted), all-blank filter → `{}`, Create disabled until name+instruction+≥1 mailbox, API-error toast + stays open.
- **Tab wiring** (component, +1): "New automation" opens the dialog and a successful create reloads the list.

## Gates

- Affected unit **12/12**, automations integration **31/31** (connections + create + manage), typecheck **0**, eslint **0**, prettier clean, docs build ok.
- Full unit suite **9302 pass**; the one failure — `knowledge-reindex-section` "slow status read" — is the **known load-flake** (documented on #873/#896): **12/12 green in isolation**, untouched by this diff. Not rerun-to-green.

## Follow-ups

- Edit-in-place form (needs PATCH-schema extension).
- #517 (tool-call confirmation) → #705 (conversational create; writes the same object through the same route).