### PR TITLE
fix(pinchy-email): keep plaintext email body + recipient out of the immutable audit

### DIFF
--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -1428,6 +1428,129 @@ describe("audit PII curation for email_send / email_draft", () => {
     expect(JSON.stringify(details)).not.toContain("secret body text");
     expect(mockSend).not.toHaveBeenCalled();
   });
+
+  it("scrubs email addresses embedded in the audited subject", async () => {
+    // A subject like "Re: your mail to max@firma.de" carries an address —
+    // keeping the subject for governance must not keep the address.
+    mockSend.mockResolvedValue({ messageId: "sent-1" });
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Re: your mail to max@firma.de",
+      body: "body",
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(details.subject).toBe("Re: your mail to <email-redacted>");
+  });
+});
+
+describe("audit PII curation for email_search", () => {
+  // email_search params can carry email addresses too: `from`/`to` are
+  // address filters by schema, and `text`/`subject` are free-text terms a
+  // model may fill with an address. Same AGENTS.md rule as for send/draft —
+  // curate every return path so raw params never reach the audit.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCredentialResponse();
+  });
+
+  it("curates from/to filters (masked) and lists the filter names, dropping raw addresses", async () => {
+    mockSearch.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_search", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      from: "sender@test.com",
+      to: "recipient@test.com",
+      unread: true,
+      folder: "INBOX",
+      limit: 5,
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(details).toBeDefined();
+    expect(details.filters).toEqual(["from", "to", "unread", "folder", "limit"]);
+    expect(details.from).toBe(`s${"*".repeat("sender".length - 1)}@test.com`);
+    expect(details.to).toBe(`r${"*".repeat("recipient".length - 1)}@test.com`);
+    expect(details.folder).toBe("INBOX");
+    expect(details.unread).toBe(true);
+    expect(details.limit).toBe(5);
+    const serialized = JSON.stringify(details);
+    expect(serialized).not.toContain("sender@test.com");
+    expect(serialized).not.toContain("recipient@test.com");
+    // A non-error curated field is present, so the route drops raw params.
+    expect(Object.keys(details).some((k) => k !== "error")).toBe(true);
+  });
+
+  it("scrubs email addresses out of the free-text and subject terms", async () => {
+    mockSearch.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_search", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      text: "invoice from max@firma.de",
+      subject: "for anna@firma.de",
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(details.text).toBe("invoice from <email-redacted>");
+    expect(details.subject).toBe("for <email-redacted>");
+    const serialized = JSON.stringify(details);
+    expect(serialized).not.toContain("max@firma.de");
+    expect(serialized).not.toContain("anna@firma.de");
+  });
+
+  it("curates details on permission denial", async () => {
+    const configNoRead: PluginConfig = {
+      ...testConfig,
+      agents: {
+        "agent-1": {
+          connectionId: "conn-1",
+          permissions: { email: [] },
+        },
+      },
+    };
+    const tools = createApi(configNoRead);
+    const tool = findTool(tools, "email_search", agentId)!;
+
+    const result = await tool.execute("call-1", { from: "sender@test.com" });
+
+    expect(result.isError).toBe(true);
+    const details = result.details as Record<string, unknown>;
+    expect(details.from).toBe(`s${"*".repeat("sender".length - 1)}@test.com`);
+    expect(JSON.stringify(details)).not.toContain("sender@test.com");
+  });
+
+  it("curates details on the removed-`query` guard path without echoing the query value", async () => {
+    const tools = createApi();
+    const tool = findTool(tools, "email_search", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      query: "from:secret-person@firma.de",
+    });
+
+    expect(result.isError).toBe(true);
+    const details = result.details as Record<string, unknown>;
+    expect(JSON.stringify(details)).not.toContain("secret-person@firma.de");
+    expect(Object.keys(details).some((k) => k !== "error")).toBe(true);
+  });
+
+  it("curates details when the adapter throws", async () => {
+    mockSearch.mockRejectedValue(new Error("imap exploded"));
+    const tools = createApi();
+    const tool = findTool(tools, "email_search", agentId)!;
+
+    const result = await tool.execute("call-1", { to: "recipient@test.com" });
+
+    expect(result.isError).toBe(true);
+    const details = result.details as Record<string, unknown>;
+    expect(details.error).toBeDefined();
+    expect(details.to).toBe(`r${"*".repeat("recipient".length - 1)}@test.com`);
+    expect(JSON.stringify(details)).not.toContain("recipient@test.com");
+  });
 });
 
 describe("error handling", () => {

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -1250,6 +1250,112 @@ describe("email_send", () => {
   });
 });
 
+describe("audit PII curation for email_send / email_draft", () => {
+  // The tool-use audit route (packages/web/.../api/internal/audit/tool-use)
+  // logs raw tool params UNLESS a tool returns curated `details` carrying a
+  // non-error field — then it deletes detail.params (curatesNonErrorFields).
+  // email_send/email_draft params hold the recipient address and the full body:
+  // PII that must never land in the append-only, HMAC-signed audit in plaintext
+  // (AGENTS.md § Secret Handling: "Never write plaintext email addresses or
+  // other PII into audit detail"). These tests pin the curation — masked
+  // recipient, subject kept, body reduced to a byte count — on every return
+  // path so a regression re-exposes the leak loudly.
+  const configWithSend: PluginConfig = {
+    ...testConfig,
+    agents: {
+      "agent-1": {
+        connectionId: "conn-1",
+        permissions: { email: ["read", "draft", "send"] },
+      },
+    },
+  };
+  const maskedRecipient = `r${"*".repeat("recipient".length - 1)}@test.com`;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCredentialResponse();
+  });
+
+  it("email_send success returns curated details (masked recipient, subject, body byte length) and drops the raw body", async () => {
+    mockSend.mockResolvedValue({ messageId: "sent-1" });
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const body = "Grüße — a body with 2-byte chars";
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Sent Subject",
+      body,
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(details).toBeDefined();
+    expect(details.to).toBe(maskedRecipient);
+    expect(details.to).not.toBe("recipient@test.com");
+    expect(details.subject).toBe("Sent Subject");
+    expect(details.bodyBytes).toBe(Buffer.byteLength(body, "utf8"));
+    // The body content itself must be gone from the audit detail.
+    expect(JSON.stringify(details)).not.toContain("a body with 2-byte chars");
+    // A non-error curated field is present, so the route drops raw params.
+    expect(Object.keys(details).some((k) => k !== "error")).toBe(true);
+  });
+
+  it("email_send curates details on the failure path so the route still suppresses raw params when the send throws", async () => {
+    mockSend.mockRejectedValue(new Error("smtp exploded"));
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Sent Subject",
+      body: "secret body text",
+    });
+
+    expect(result.isError).toBe(true);
+    const details = result.details as Record<string, unknown>;
+    expect(details.error).toBeDefined();
+    // Non-error fields must also be present on failure — an error-only
+    // details:{error} does NOT suppress params (route curatesNonErrorFields).
+    expect(details.to).toBe(maskedRecipient);
+    expect(details.bodyBytes).toBe(Buffer.byteLength("secret body text", "utf8"));
+    expect(JSON.stringify(details)).not.toContain("secret body text");
+  });
+
+  it("email_send curates details on permission denial (raw recipient/body never reach the audit)", async () => {
+    const tools = createApi(); // testConfig agent-1 has no "send" grant
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Sent Subject",
+      body: "secret body text",
+    });
+
+    expect(result.isError).toBe(true);
+    const details = result.details as Record<string, unknown>;
+    expect(details.to).toBe(maskedRecipient);
+    expect(JSON.stringify(details)).not.toContain("secret body text");
+  });
+
+  it("email_draft success returns curated details and drops the raw body", async () => {
+    mockDraft.mockResolvedValue({ draftId: "draft-1" });
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_draft", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Draft Subject",
+      body: "draft secret body",
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(details.to).toBe(maskedRecipient);
+    expect(details.subject).toBe("Draft Subject");
+    expect(details.bodyBytes).toBe(Buffer.byteLength("draft secret body", "utf8"));
+    expect(JSON.stringify(details)).not.toContain("draft secret body");
+  });
+});
+
 describe("error handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -1354,6 +1354,80 @@ describe("audit PII curation for email_send / email_draft", () => {
     expect(details.bodyBytes).toBe(Buffer.byteLength("draft secret body", "utf8"));
     expect(JSON.stringify(details)).not.toContain("draft secret body");
   });
+
+  it("masks a single-character local part fully — `m@google.com` must never appear verbatim", async () => {
+    // With `local[0] + "*".repeat(local.length - 1)`, a one-char local part
+    // repeats zero stars and the full address survives verbatim — exactly the
+    // leak this curation exists to prevent.
+    mockSend.mockResolvedValue({ messageId: "sent-1" });
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "m@google.com",
+      subject: "Short local part",
+      body: "body",
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(details.to).toBe("*@google.com");
+    expect(JSON.stringify(details)).not.toContain("m@google.com");
+  });
+
+  it("caps the audited subject at 256 UTF-8 bytes so a flooded subject cannot smuggle content past the 2048-byte detail cap", async () => {
+    mockSend.mockResolvedValue({ messageId: "sent-1" });
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const longSubject = "S".repeat(1000);
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: longSubject,
+      body: "body",
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(details.subject).toBe("S".repeat(256));
+  });
+
+  it("subject truncation never splits a multi-byte character", async () => {
+    mockSend.mockResolvedValue({ messageId: "sent-1" });
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    // 200 × "ö" = 400 UTF-8 bytes; a naive byte slice at 256 would cut the
+    // 128th "ö" in half and emit a replacement char.
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "ö".repeat(200),
+      body: "body",
+    });
+
+    const details = result.details as Record<string, unknown>;
+    const subject = details.subject as string;
+    expect(Buffer.byteLength(subject, "utf8")).toBeLessThanOrEqual(256);
+    expect(subject).toBe("ö".repeat(128));
+    expect(subject).not.toContain("�");
+  });
+
+  it("email_send curates details on an unknown replyTo handle (the last uncovered return path)", async () => {
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Re: Hello",
+      body: "secret body text",
+      replyTo: "msg_unknownhandle",
+    });
+
+    expect(result.isError).toBe(true);
+    const details = result.details as Record<string, unknown>;
+    expect(details.to).toBe(maskedRecipient);
+    expect(details.bodyBytes).toBe(Buffer.byteLength("secret body text", "utf8"));
+    expect(JSON.stringify(details)).not.toContain("secret body text");
+    expect(mockSend).not.toHaveBeenCalled();
+  });
 });
 
 describe("error handling", () => {

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -308,6 +308,18 @@ function maskRecipientForAudit(value: unknown): string {
   return `${local[0]}${"*".repeat(local.length - 1)}@${domain}`;
 }
 
+// Scrub any email-shaped run out of a free-text audit field (subject line,
+// search term). A subject like "Re: your mail to max@firma.de" carries an
+// address; keeping the subject for governance value must not keep the address
+// in the append-only, un-redactable audit. Mirrors web audit.ts scrubEmails —
+// which this plugin cannot import across the package boundary. The TLD-required
+// / IP-literal branches match that source so a social `@handle` isn't mistaken
+// for an email; `u` flag + \p{L}/\p{N} covers internationalized domains.
+const EMAIL_LIKE_PATTERN = /[\p{L}\p{N}._%+-]+@(?:\[[^\]\s]+\]|[\p{L}\p{N}.-]+\.[\p{L}]{2,})/gu;
+function scrubEmailsForAudit(text: string): string {
+  return text.replace(EMAIL_LIKE_PATTERN, "<email-redacted>");
+}
+
 // Cap free-text audit fields so a flooded value can't blow the 2048-byte
 // detail cap (web audit.ts truncateDetail would then collapse the whole
 // curated detail into a `_truncated` summary blob, losing the governance
@@ -326,6 +338,14 @@ function truncateUtf8ForAudit(text: string, maxBytes: number): string {
   return buf.subarray(0, end).toString("utf8");
 }
 
+// Curate a free-text audit field: scrub email addresses first, then cap —
+// never the other way round, so a truncation can't leave a partial
+// `user@example` fragment behind (same ordering rule as web safeProviderError).
+function curateAuditText(value: unknown, maxBytes: number): string {
+  const text = typeof value === "string" ? value : "";
+  return truncateUtf8ForAudit(scrubEmailsForAudit(text), maxBytes);
+}
+
 /**
  * Curated audit details for email_send / email_draft. Returning these non-error
  * fields makes the audit route suppress the raw params (recipient + full body)
@@ -342,10 +362,7 @@ function emailWriteAuditDetails(params: Record<string, unknown>): {
 } {
   return {
     to: maskRecipientForAudit(params.to),
-    subject: truncateUtf8ForAudit(
-      typeof params.subject === "string" ? params.subject : "",
-      AUDIT_SUBJECT_MAX_BYTES
-    ),
+    subject: curateAuditText(params.subject, AUDIT_SUBJECT_MAX_BYTES),
     bodyBytes: Buffer.byteLength(typeof params.body === "string" ? params.body : "", "utf8"),
   };
 }
@@ -361,6 +378,69 @@ function withEmailAuditDetails(
   return {
     ...base,
     details: { ...emailWriteAuditDetails(params), error: base.details.error },
+  };
+}
+
+/**
+ * Curated audit details for email_search. Its params carry PII too: `from`/`to`
+ * are recipient addresses by schema, and `subject`/`text` are free-text terms a
+ * model may fill with an address. Same contract as emailWriteAuditDetails —
+ * returning a non-error field makes the audit route drop the raw params on every
+ * return path. Addresses are masked, free-text is scrubbed + capped, and the
+ * remaining structured filters (folder/unread/sinceDays/limit) are safe to keep
+ * verbatim for governance value. `filters` lists which fields the search used —
+ * always present, so the route suppresses raw params even for a filter-less call.
+ */
+function emailSearchAuditDetails(params: Record<string, unknown>): Record<string, unknown> {
+  const details: Record<string, unknown> = {};
+  const filters: string[] = [];
+  if (typeof params.from === "string") {
+    details.from = maskRecipientForAudit(params.from);
+    filters.push("from");
+  }
+  if (typeof params.to === "string") {
+    details.to = maskRecipientForAudit(params.to);
+    filters.push("to");
+  }
+  if (typeof params.subject === "string") {
+    details.subject = curateAuditText(params.subject, AUDIT_SUBJECT_MAX_BYTES);
+    filters.push("subject");
+  }
+  if (typeof params.text === "string") {
+    details.text = curateAuditText(params.text, AUDIT_SUBJECT_MAX_BYTES);
+    filters.push("text");
+  }
+  if (typeof params.unread === "boolean") {
+    details.unread = params.unread;
+    filters.push("unread");
+  }
+  if (typeof params.sinceDays === "number") {
+    details.sinceDays = params.sinceDays;
+    filters.push("sinceDays");
+  }
+  if (typeof params.folder === "string") {
+    details.folder = params.folder;
+    filters.push("folder");
+  }
+  if (typeof params.limit === "number") {
+    details.limit = params.limit;
+    filters.push("limit");
+  }
+  details.filters = filters;
+  return details;
+}
+
+/**
+ * Merge curated search audit details into an error result (see
+ * emailSearchAuditDetails) so the route suppresses raw params on failure paths.
+ */
+function withEmailSearchAuditDetails(
+  base: { content: ContentBlock[]; isError: true; details: { error: string } },
+  params: Record<string, unknown>
+): { content: ContentBlock[]; isError: true; details: Record<string, unknown> } {
+  return {
+    ...base,
+    details: { ...emailSearchAuditDetails(params), error: base.details.error },
   };
 }
 
@@ -993,7 +1073,7 @@ const plugin = {
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             try {
               if (!checkPermission(config.permissions, "email", "read")) {
-                return permissionDenied("read");
+                return withEmailSearchAuditDetails(permissionDenied("read"), params);
               }
 
               // email_search used to take a raw Gmail-style `query` string.
@@ -1007,12 +1087,15 @@ const plugin = {
               // valid DSL fields are both present, treat it as ambiguous
               // intent and reject rather than guess.
               if (typeof params.query === "string" && params.query.length > 0) {
-                return errorResult(
-                  new Error(
-                    "The `query` parameter was removed. email_search now uses structured " +
-                      "fields instead of a raw query string: from, to, subject, unread, " +
-                      "sinceDays, folder, limit. Re-issue the call using those fields."
-                  )
+                return withEmailSearchAuditDetails(
+                  errorResult(
+                    new Error(
+                      "The `query` parameter was removed. email_search now uses structured " +
+                        "fields instead of a raw query string: from, to, subject, unread, " +
+                        "sinceDays, folder, limit. Re-issue the call using those fields."
+                    )
+                  ),
+                  params
                 );
               }
 
@@ -1034,9 +1117,10 @@ const plugin = {
 
               return {
                 content: [{ type: "text", text: JSON.stringify(handleized, null, 2) }],
+                details: emailSearchAuditDetails(params),
               };
             } catch (error) {
-              return errorResult(error);
+              return withEmailSearchAuditDetails(errorResult(error), params);
             }
           },
         };

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -291,9 +291,10 @@ function errorResult(error: unknown): {
  *
  * We cannot call the web app's redactEmail() here — it keys an HMAC with a
  * server-only secret this OpenClaw process has no access to — so we mask
- * locally: keep the domain and the first local-part character, mask the rest.
- * Stricter than redactEmail's preview (which shows short local parts in full),
- * so no address is ever emitted verbatim.
+ * locally: keep the domain and the first local-part character, mask the rest
+ * (a one-char local part is masked entirely). Stricter than redactEmail's
+ * preview (which shows short local parts in full), so no address is ever
+ * emitted verbatim.
  */
 function maskRecipientForAudit(value: unknown): string {
   if (typeof value !== "string") return "<redacted>";
@@ -302,7 +303,27 @@ function maskRecipientForAudit(value: unknown): string {
   if (at <= 0 || at === email.length - 1) return "<redacted>";
   const local = email.slice(0, at);
   const domain = email.slice(at + 1);
+  // A one-char local part would survive verbatim as `local[0]` + zero stars.
+  if (local.length === 1) return `*@${domain}`;
   return `${local[0]}${"*".repeat(local.length - 1)}@${domain}`;
+}
+
+// Cap free-text audit fields so a flooded value can't blow the 2048-byte
+// detail cap (web audit.ts truncateDetail would then collapse the whole
+// curated detail into a `_truncated` summary blob, losing the governance
+// fields this curation exists to keep). Byte-measured with a back-off to the
+// nearest UTF-8 character boundary, mirroring web audit.ts truncateUtf8 —
+// which this plugin cannot import across the package boundary.
+const AUDIT_SUBJECT_MAX_BYTES = 256;
+function truncateUtf8ForAudit(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= maxBytes) return text;
+  let end = maxBytes;
+  // 0b10xxxxxx marks a UTF-8 continuation byte — step back off a split char.
+  while (end > 0 && (buf.readUInt8(end) & 0xc0) === 0x80) {
+    end--;
+  }
+  return buf.subarray(0, end).toString("utf8");
 }
 
 /**
@@ -311,7 +332,8 @@ function maskRecipientForAudit(value: unknown): string {
  * on EVERY return path — success and failure alike (route.ts: an error-only
  * `details: { error }` deliberately does NOT suppress params, so error paths
  * must carry a non-error field too). Body content is reduced to its byte length;
- * the recipient is masked; the subject is kept for governance value.
+ * the recipient is masked; the subject is kept for governance value, capped at
+ * AUDIT_SUBJECT_MAX_BYTES so it cannot smuggle content past the detail cap.
  */
 function emailWriteAuditDetails(params: Record<string, unknown>): {
   to: string;
@@ -320,7 +342,10 @@ function emailWriteAuditDetails(params: Record<string, unknown>): {
 } {
   return {
     to: maskRecipientForAudit(params.to),
-    subject: typeof params.subject === "string" ? params.subject : "",
+    subject: truncateUtf8ForAudit(
+      typeof params.subject === "string" ? params.subject : "",
+      AUDIT_SUBJECT_MAX_BYTES
+    ),
     bodyBytes: Buffer.byteLength(typeof params.body === "string" ? params.body : "", "utf8"),
   };
 }

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -177,7 +177,11 @@ interface AgentTool {
   ) => Promise<{
     content: ContentBlock[];
     isError?: boolean;
-    details?: { error: string };
+    // `error` stays a typed string for the isError-stripping contract (#404),
+    // but tools may curate additional non-error fields — email_send/email_draft
+    // return { to, subject, bodyBytes } so the audit route suppresses raw params
+    // (recipient + full body). The route reads details as Record<string, unknown>.
+    details?: { error?: string } & Record<string, unknown>;
   }>;
 }
 
@@ -274,6 +278,65 @@ function errorResult(error: unknown): {
 } {
   const message = error instanceof Error ? error.message : "Unknown error";
   return toolError(`Error: ${message}`);
+}
+
+/**
+ * Mask a recipient address for the tool-use audit. email_send / email_draft
+ * carry the recipient and the full body as tool params; the audit route logs
+ * raw params verbatim unless the tool returns curated `details` (route.ts:
+ * curatesNonErrorFields deletes detail.params). Those params are PII that would
+ * otherwise land in the append-only, HMAC-signed audit in plaintext (AGENTS.md
+ * § Secret Handling: "Never write plaintext email addresses or other PII into
+ * audit detail").
+ *
+ * We cannot call the web app's redactEmail() here — it keys an HMAC with a
+ * server-only secret this OpenClaw process has no access to — so we mask
+ * locally: keep the domain and the first local-part character, mask the rest.
+ * Stricter than redactEmail's preview (which shows short local parts in full),
+ * so no address is ever emitted verbatim.
+ */
+function maskRecipientForAudit(value: unknown): string {
+  if (typeof value !== "string") return "<redacted>";
+  const email = value.trim();
+  const at = email.lastIndexOf("@");
+  if (at <= 0 || at === email.length - 1) return "<redacted>";
+  const local = email.slice(0, at);
+  const domain = email.slice(at + 1);
+  return `${local[0]}${"*".repeat(local.length - 1)}@${domain}`;
+}
+
+/**
+ * Curated audit details for email_send / email_draft. Returning these non-error
+ * fields makes the audit route suppress the raw params (recipient + full body)
+ * on EVERY return path — success and failure alike (route.ts: an error-only
+ * `details: { error }` deliberately does NOT suppress params, so error paths
+ * must carry a non-error field too). Body content is reduced to its byte length;
+ * the recipient is masked; the subject is kept for governance value.
+ */
+function emailWriteAuditDetails(params: Record<string, unknown>): {
+  to: string;
+  subject: string;
+  bodyBytes: number;
+} {
+  return {
+    to: maskRecipientForAudit(params.to),
+    subject: typeof params.subject === "string" ? params.subject : "",
+    bodyBytes: Buffer.byteLength(typeof params.body === "string" ? params.body : "", "utf8"),
+  };
+}
+
+/**
+ * Merge curated email audit details into an error result so the audit route
+ * suppresses the raw params on the failure path too (see emailWriteAuditDetails).
+ */
+function withEmailAuditDetails(
+  base: { content: ContentBlock[]; isError: true; details: { error: string } },
+  params: Record<string, unknown>
+): { content: ContentBlock[]; isError: true; details: Record<string, unknown> } {
+  return {
+    ...base,
+    details: { ...emailWriteAuditDetails(params), error: base.details.error },
+  };
 }
 
 /**
@@ -988,13 +1051,13 @@ const plugin = {
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             try {
               if (!checkPermission(config.permissions, "email", "draft")) {
-                return permissionDenied("draft");
+                return withEmailAuditDetails(permissionDenied("draft"), params);
               }
 
               let replyTo: string | undefined = params.replyTo as string | undefined;
               if (replyTo != null) {
                 const resolved = resolveEmailReference(agentId, replyTo);
-                if (!resolved.ok) return resolved.result;
+                if (!resolved.ok) return withEmailAuditDetails(resolved.result, params);
                 replyTo = resolved.realId;
               }
 
@@ -1024,9 +1087,10 @@ const plugin = {
                     ),
                   },
                 ],
+                details: emailWriteAuditDetails(params),
               };
             } catch (error) {
-              return errorResult(error);
+              return withEmailAuditDetails(errorResult(error), params);
             }
           },
         };
@@ -1066,13 +1130,13 @@ const plugin = {
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             try {
               if (!checkPermission(config.permissions, "email", "send")) {
-                return permissionDenied("send");
+                return withEmailAuditDetails(permissionDenied("send"), params);
               }
 
               let replyTo: string | undefined = params.replyTo as string | undefined;
               if (replyTo != null) {
                 const resolved = resolveEmailReference(agentId, replyTo);
-                if (!resolved.ok) return resolved.result;
+                if (!resolved.ok) return withEmailAuditDetails(resolved.result, params);
                 replyTo = resolved.realId;
               }
 
@@ -1109,9 +1173,9 @@ const plugin = {
                 });
               }
 
-              return { content };
+              return { content, details: emailWriteAuditDetails(params) };
             } catch (error) {
-              return errorResult(error);
+              return withEmailAuditDetails(errorResult(error), params);
             }
           },
         };

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -939,4 +939,69 @@ describe("POST /api/internal/audit/tool-use", () => {
       expect(entry?.error?.message).toContain("<email-redacted>");
     });
   });
+
+  // Backstop for the transport-error path: when OpenClaw's hook reports a
+  // dispatch-level failure it forwards no plugin result, so the pinchy-email
+  // plugin's own detail-curation never runs and the raw params (recipient +
+  // full body) would be logged verbatim. The route must redact them itself.
+  describe("email-tool param PII backstop (no plugin-curated details)", () => {
+    it("redacts recipient and body from email_send params when the dispatch fails before curation", async () => {
+      await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "email_send",
+          agentId: "agent-1",
+          error: "dispatch timed out",
+          params: { to: "recipient@test.com", subject: "Hello", body: "secret body text" },
+        })
+      );
+
+      const entry = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+      const serialized = JSON.stringify(entry);
+      expect(serialized).not.toContain("recipient@test.com");
+      expect(serialized).not.toContain("secret body text");
+      const detail = entry?.detail as Record<string, unknown>;
+      const params = detail.params as Record<string, unknown>;
+      // Forensic value preserved: which fields were set, non-PII subject.
+      expect(params.subject).toBe("Hello");
+      expect(params.body).toBe(`<redacted ${Buffer.byteLength("secret body text", "utf8")} bytes>`);
+    });
+
+    it("redacts address filters from email_search params on the transport-error path", async () => {
+      await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "email_search",
+          agentId: "agent-1",
+          error: "imap connection reset",
+          params: { from: "sender@test.com", to: "recipient@test.com", folder: "INBOX" },
+        })
+      );
+
+      const entry = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+      const serialized = JSON.stringify(entry);
+      expect(serialized).not.toContain("sender@test.com");
+      expect(serialized).not.toContain("recipient@test.com");
+      const detail = entry?.detail as Record<string, unknown>;
+      const params = detail.params as Record<string, unknown>;
+      expect(params.folder).toBe("INBOX");
+    });
+
+    it("leaves non-email tool params untouched (scoped to email tools)", async () => {
+      await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "pinchy_read",
+          agentId: "agent-1",
+          error: "boom",
+          params: { path: "/data/kb/report.md" },
+        })
+      );
+
+      const entry = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+      const detail = entry?.detail as Record<string, unknown>;
+      const params = detail.params as Record<string, unknown>;
+      expect(params.path).toBe("/data/kb/report.md");
+    });
+  });
 });

--- a/packages/web/src/__tests__/lib/audit-tool-params.test.ts
+++ b/packages/web/src/__tests__/lib/audit-tool-params.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { redactEmailToolParamsForAudit } from "@/lib/audit-tool-params";
+
+describe("redactEmailToolParamsForAudit", () => {
+  it("reduces the email_send body to a byte-count marker and scrubs the recipient", () => {
+    const out = redactEmailToolParamsForAudit("email_send", {
+      to: "recipient@test.com",
+      subject: "Hello",
+      body: "secret body text",
+    }) as Record<string, unknown>;
+
+    expect(out.to).toBe("<email-redacted>");
+    expect(out.subject).toBe("Hello");
+    expect(out.body).toBe(`<redacted ${Buffer.byteLength("secret body text", "utf8")} bytes>`);
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("recipient@test.com");
+    expect(serialized).not.toContain("secret body text");
+  });
+
+  it("scrubs an address embedded in a free-text subject", () => {
+    const out = redactEmailToolParamsForAudit("email_draft", {
+      to: "a@b.com",
+      subject: "Re: your mail to max@firma.de",
+      body: "hi",
+    }) as Record<string, unknown>;
+
+    expect(out.subject).toBe("Re: your mail to <email-redacted>");
+    expect(JSON.stringify(out)).not.toContain("max@firma.de");
+  });
+
+  it("scrubs email_search address filters and free-text terms while keeping structured filters", () => {
+    const out = redactEmailToolParamsForAudit("email_search", {
+      from: "sender@test.com",
+      to: "recipient@test.com",
+      text: "invoice from max@firma.de",
+      folder: "INBOX",
+      unread: true,
+      limit: 5,
+    }) as Record<string, unknown>;
+
+    expect(out.from).toBe("<email-redacted>");
+    expect(out.to).toBe("<email-redacted>");
+    expect(out.text).toBe("invoice from <email-redacted>");
+    // Structured, non-PII filters stay verbatim for forensic value.
+    expect(out.folder).toBe("INBOX");
+    expect(out.unread).toBe(true);
+    expect(out.limit).toBe(5);
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("sender@test.com");
+    expect(serialized).not.toContain("recipient@test.com");
+    expect(serialized).not.toContain("max@firma.de");
+  });
+
+  it("leaves params of non-email tools untouched (scoped by tool name)", () => {
+    const params = { path: "/data/x.md", note: "reach me at a@b.com" };
+    const out = redactEmailToolParamsForAudit("pinchy_read", params);
+    expect(out).toBe(params);
+  });
+
+  it("preserves the params reference when there is nothing to redact", () => {
+    const params = { folder: "INBOX", unread: true };
+    const out = redactEmailToolParamsForAudit("email_search", params) as Record<string, unknown>;
+    // A shallow copy is returned; values are unchanged.
+    expect(out).toEqual(params);
+  });
+
+  it("returns non-object params unchanged", () => {
+    expect(redactEmailToolParamsForAudit("email_send", undefined)).toBeUndefined();
+    expect(redactEmailToolParamsForAudit("email_send", "raw")).toBe("raw");
+    const arr = ["a@b.com"];
+    expect(redactEmailToolParamsForAudit("email_send", arr)).toBe(arr);
+  });
+
+  it("does not mutate the input object", () => {
+    const params = { to: "recipient@test.com", body: "secret" };
+    redactEmailToolParamsForAudit("email_send", params);
+    expect(params.to).toBe("recipient@test.com");
+    expect(params.body).toBe("secret");
+  });
+});

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { appendAuditLog, safeProviderError } from "@/lib/audit";
 import { sanitizeDetail } from "@/lib/audit-sanitize";
+import { redactEmailToolParamsForAudit } from "@/lib/audit-tool-params";
 import { parseRequestBody } from "@/lib/api-validation";
 import { db } from "@/db";
 import { users } from "@/db/schema";
@@ -199,7 +200,15 @@ export async function POST(request: NextRequest) {
   };
 
   if (payload.toolCallId !== undefined) detail.toolCallId = payload.toolCallId;
-  if (payload.params !== undefined) detail.params = payload.params;
+  // Backstop for the transport-error path: the pinchy-email plugin curates its
+  // own details (masked recipient, body → bodyBytes) on every path it controls,
+  // but a dispatch-level failure forwards no plugin result, so those raw params
+  // (recipient + full body) would otherwise be logged verbatim. Redact them here
+  // before they land in the append-only, HMAC-signed audit. No-op for non-email
+  // tools; when the plugin DID curate, curatesNonErrorFields drops params below.
+  if (payload.params !== undefined) {
+    detail.params = redactEmailToolParamsForAudit(payload.toolName, payload.params);
+  }
   if (detailError !== undefined) detail.error = detailError;
   if (payload.durationMs !== undefined) detail.durationMs = payload.durationMs;
 

--- a/packages/web/src/lib/audit-tool-params.ts
+++ b/packages/web/src/lib/audit-tool-params.ts
@@ -1,0 +1,50 @@
+import { scrubEmails } from "@/lib/audit";
+
+// Defense-in-depth for the tool-use audit's transport-error path.
+//
+// On the normal path, the pinchy-email plugin curates its own `details` and the
+// route drops the raw params entirely (route.ts curatesNonErrorFields). But when
+// OpenClaw's tool-use hook reports a dispatch-level failure it forwards no plugin
+// result, so that curation never runs and the raw params — the recipient address
+// and the full message body — would land verbatim in the append-only, HMAC-signed
+// audit (AGENTS.md § Secret Handling: "Never write plaintext email addresses or
+// other PII into audit detail"). Because the row is HMAC-signed, GDPR Art. 17
+// erasure cannot remove it afterwards, so it must never be written.
+//
+// This backstop is deliberately scoped by tool name to the three email tools that
+// carry PII in their params. It keeps the forensic value of the params (which
+// fields were set, structured non-PII filters like folder/limit) while redacting
+// the PII values: addresses and free-text terms are scrubbed, and the large body
+// blob is reduced to a byte count (mirroring the plugin's `bodyBytes`).
+
+const PII_PARAM_TOOLS = new Set(["email_send", "email_draft", "email_search"]);
+
+// Params whose value is a message body — reduced to a byte count, never kept.
+const BODY_PARAM_KEYS = new Set(["body"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Redact PII from the params of the email tools before they are logged raw.
+ * No-op (returns the input unchanged) for any other tool or non-object params.
+ * Never mutates the input — returns a shallow copy when it redacts.
+ */
+export function redactEmailToolParamsForAudit(toolName: string, params: unknown): unknown {
+  if (!PII_PARAM_TOOLS.has(toolName)) return params;
+  if (!isPlainObject(params)) return params;
+
+  const out: Record<string, unknown> = { ...params };
+  for (const [key, value] of Object.entries(out)) {
+    if (typeof value !== "string") continue;
+    if (BODY_PARAM_KEYS.has(key)) {
+      out[key] = `<redacted ${Buffer.byteLength(value, "utf8")} bytes>`;
+    } else {
+      // Addresses (to/from/cc/bcc/replyTo) and free-text terms (subject/text)
+      // may both carry an address — scrubEmails handles both.
+      out[key] = scrubEmails(value);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Problem

Found while release-testing IMAP email end-to-end on `:rc-0.9` staging. The live `tool.email_send` audit row carried the recipient **and the full body in plaintext**:

```
detail.params = { to: "test@heypinchy.com", subject: "…",
                  body: "Automated … Grüße Ölfässer … ß." }
```

The tool-use audit route logs raw tool params **unless** a tool returns curated `details` with a non-error field (it then deletes `detail.params`, exactly as `pinchy_write` does for its `content` blob). `email_send` / `email_draft` never curated, so every sent/drafted email wrote its recipient address and full body verbatim into the **append-only, HMAC-signed** audit — plaintext PII that GDPR crypto-erasure can't remove from the HMAC chain, and a direct violation of the AGENTS.md rule *"Never write plaintext email addresses or other PII into audit detail."*

Pre-existing behaviour (v0.8.0 logged params the same way), but **0.9.0's IMAP-connect UI is what makes email reachable for self-hosted customers** — so this is the release where the leak becomes real. Since audit + GDPR governance is Pinchy's core differentiator, fixing it in 0.9.0.

## Fix

`email_send` and `email_draft` now return curated `details` on **every** return path — success, permission denial, bad `replyTo`, and send/draft failure:

- **recipient masked** (`r********@test.com`) — never verbatim
- **subject kept** for governance value
- **body reduced to a byte count** (`bodyBytes`), content dropped

The non-error fields are present on the **failure** paths too, so the route suppresses raw params even when a send throws (an error-only `details:{error}` deliberately does *not* suppress — forensics need failed params for other tools).

`redactEmail()` can't run in the plugin — it keys an HMAC with a server-only secret the OpenClaw process has no access to — so the recipient is masked locally, and more strictly than `redactEmail`'s preview (short local parts are masked, not shown in full).

## Tests

New `describe("audit PII curation for email_send / email_draft")` in `tools.test.ts` pins the curation on success, send-failure, permission-denial, and draft paths: masked recipient, subject kept, `bodyBytes` correct, and the raw body absent from the serialized detail. Full plugin suite green (350 tests); `typecheck:plugins` clean for pinchy-email.

## Scope note

`email_read`/`email_get_attachment` already use opaque handles (no PII in params); `email_list`/`email_search` log only folder + a search term. This PR targets the two tools that carry recipient + body.

---

## Follow-up hardening (review of this PR)

Four gaps surfaced reviewing the original curation; all fixed here with tests-first:

1. **One-char local part leaked verbatim** — `maskRecipientForAudit("m@google.com")` returned the full address (`local[0]` + zero stars). Now masked to `*@domain`.
2. **Subject was unbounded free text** — an address embedded in a subject (`Re: your mail to max@firma.de`) landed verbatim, and a flooded subject could blow the 2048-byte detail cap (collapsing the whole curated detail into a `_truncated` blob). Now scrubbed (email-shaped runs → `<email-redacted>`) and capped at 256 UTF-8 bytes on char boundaries.
3. **`email_search` curation** — its `from`/`to` filters are addresses and `subject`/`text` are free-text terms a model may fill with one, all logged raw. Now curated on every return path (masked addresses, scrubbed free-text, structured filters kept, filter names listed).
4. **Transport-error backstop** — the plugin can only curate paths where it returns a result; a dispatch-level failure (`payload.error`, no result) skips curation and the route logged raw params. New `redactEmailToolParamsForAudit` (scoped to the three email tools) scrubs addresses and reduces the body to a byte count, wired into the tool-use route.

Also pinned the previously-untested unknown-`replyTo` return path.

New/updated tests: pinchy-email `tools.test.ts` (360 green), web `internal-audit-tool-use.test.ts` + new `audit-tool-params.test.ts` (102 green in the audit slice). `typecheck` clean for web + all plugins.
