### PR TITLE
feat(kb): show elapsed time on the reindex progress

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -44,7 +44,7 @@ Click **Save** to apply the permissions.
 
 ## 6. Index the documents
 
-Granting a directory doesn't index it automatically — an admin has to trigger indexing. The simplest way is right where you granted the directories: in the agent's **Permissions** tab, the **Knowledge Base** section has an **Index** control. Click **Reindex now** and the section shows the run inline — discovery, a live progress bar, and the last run's outcome — so you never have to leave the page or read a log.
+Granting a directory doesn't index it automatically — an admin has to trigger indexing. The simplest way is right where you granted the directories: in the agent's **Permissions** tab, the **Knowledge Base** section has an **Index** control. Click **Reindex now** and the section shows the run inline — discovery, a live progress bar with how long the run has been going, and the last run's outcome — so you never have to leave the page or read a log. (It's an elapsed time, not an estimate to completion: on a real corpus a single large document can dominate the work, so any countdown would mislead more than it helps.)
 
 The same action is available over the API, which is what you'd script for scheduled re-indexing:
 

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -306,6 +306,27 @@ describe("KnowledgeReindexSection", () => {
       await waitFor(() => expect(screen.getByText(/discovering documents/i)).toBeInTheDocument());
       expect(screen.queryByText(/running/i)).not.toBeInTheDocument();
     });
+
+    it("ticks the readout forward on its own as wall-clock time passes", async () => {
+      // The whole point of the 1s clock (vs. computing only on each 3s poll) is
+      // that the age keeps moving between polls. Freeze at 12 min, then let a
+      // minute of wall clock elapse WITHOUT a new poll response and assert the
+      // readout advanced itself to 13 min.
+      vi.setSystemTime(new Date("2026-07-21T10:12:01.000Z"));
+      mockGet.mockResolvedValue({
+        job: job({ status: "running", processed: 5, total: 20 }),
+      });
+
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      await waitFor(() => expect(screen.getByText(/running 12 min/i)).toBeInTheDocument());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+
+      expect(screen.getByText(/running 13 min/i)).toBeInTheDocument();
+    });
   });
 
   describe("formatElapsed", () => {
@@ -329,6 +350,15 @@ describe("KnowledgeReindexSection", () => {
 
     it("clamps clock skew (now before start) to zero", () => {
       expect(formatElapsed(base, base - 5_000)).toBe("0 sec");
+    });
+
+    // An unparseable startedAt yields NaN from Date#getTime, and NaN survives
+    // both Math.max and Math.floor — so without a guard the UI would render
+    // "NaN h NaN min". Degrade to "0 sec", matching how formatWhen already
+    // guards its own NaN date.
+    it("degrades to zero rather than NaN on an unparseable timestamp", () => {
+      expect(formatElapsed(NaN, base)).toBe("0 sec");
+      expect(formatElapsed(base, NaN)).toBe("0 sec");
     });
   });
 });

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-import { KnowledgeReindexSection } from "@/components/knowledge-reindex-section";
+import { KnowledgeReindexSection, formatElapsed } from "@/components/knowledge-reindex-section";
 import { apiGet, apiPost, ApiError } from "@/lib/api-client";
 import { toast } from "sonner";
 
@@ -259,5 +259,76 @@ describe("KnowledgeReindexSection", () => {
     expect(toast.error).not.toHaveBeenCalled();
     // No phantom running state — the button stays usable.
     expect(screen.getByRole("button", { name: /reindex/i })).toBeEnabled();
+  });
+
+  // Elapsed-time readout: an honest "it's still moving" signal for a long index,
+  // deliberately NOT an ETA — per-document embedding cost varies too wildly
+  // (one compilation PDF can be 38% of all chunks) for a doc-count projection to
+  // be anything but a lie. Chunk-level progress + a real ETA is tracked in #907.
+  describe("elapsed time while a run is in flight", () => {
+    beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+    afterEach(() => vi.useRealTimers());
+
+    it("shows how long the running index has been going", async () => {
+      // startedAt is 10:00:01; freeze now 12 minutes later.
+      vi.setSystemTime(new Date("2026-07-21T10:12:01.000Z"));
+      mockGet.mockResolvedValue({
+        job: job({ status: "running", processed: 5, total: 20 }),
+      });
+
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      await waitFor(() => expect(screen.getByText(/running 12 min/i)).toBeInTheDocument());
+      // Still shows the document progress alongside it.
+      expect(screen.getByText(/5 of 20/i)).toBeInTheDocument();
+    });
+
+    it("shows elapsed time during the indeterminate discovery phase too", async () => {
+      vi.setSystemTime(new Date("2026-07-21T10:00:44.000Z")); // 43s after startedAt
+      mockGet.mockResolvedValue({
+        job: job({ status: "running", processed: 0, total: null }),
+      });
+
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      await waitFor(() => expect(screen.getByText(/discovering documents/i)).toBeInTheDocument());
+      expect(screen.getByText(/running 43 sec/i)).toBeInTheDocument();
+    });
+
+    it("omits the elapsed readout when the worker has not started the job yet", async () => {
+      vi.setSystemTime(new Date("2026-07-21T10:12:01.000Z"));
+      mockGet.mockResolvedValue({
+        job: job({ status: "running", processed: 0, total: null, startedAt: null }),
+      });
+
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      await waitFor(() => expect(screen.getByText(/discovering documents/i)).toBeInTheDocument());
+      expect(screen.queryByText(/running/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("formatElapsed", () => {
+    const base = Date.parse("2026-07-21T10:00:00.000Z");
+
+    it("shows whole seconds under a minute", () => {
+      expect(formatElapsed(base, base + 42_000)).toBe("42 sec");
+    });
+
+    it("shows whole minutes under an hour, flooring the seconds", () => {
+      expect(formatElapsed(base, base + 12 * 60_000 + 30_000)).toBe("12 min");
+    });
+
+    it("shows hours and minutes past an hour", () => {
+      expect(formatElapsed(base, base + (2 * 60 + 5) * 60_000)).toBe("2 h 5 min");
+    });
+
+    it("drops the minutes at an exact hour boundary", () => {
+      expect(formatElapsed(base, base + 3 * 3_600_000)).toBe("3 h");
+    });
+
+    it("clamps clock skew (now before start) to zero", () => {
+      expect(formatElapsed(base, base - 5_000)).toBe("0 sec");
+    });
   });
 });

--- a/packages/web/src/components/knowledge-reindex-section.tsx
+++ b/packages/web/src/components/knowledge-reindex-section.tsx
@@ -105,6 +105,21 @@ export function KnowledgeReindexSection({
     return () => clearInterval(id);
   }, [active, fetchStatus, pollIntervalMs]);
 
+  // A once-per-second clock, live ONLY while a run is active, so the elapsed
+  // readout ticks smoothly instead of jumping on each 3s poll. Reading the
+  // wall clock here (in an effect, not during render) keeps the component pure;
+  // `now` is null while idle so nothing renders an age for a finished/absent run.
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    if (!active) {
+      setNow(null);
+      return;
+    }
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+
   const handleReindex = useCallback(async () => {
     setSubmitting(true);
     try {
@@ -161,7 +176,7 @@ export function KnowledgeReindexSection({
           Grant at least one directory to enable indexing.
         </p>
       ) : active && job ? (
-        <RunningState job={job} />
+        <RunningState job={job} now={now} />
       ) : job?.status === "succeeded" ? (
         <SucceededState job={job} />
       ) : job?.status === "failed" ? (
@@ -173,14 +188,24 @@ export function KnowledgeReindexSection({
   );
 }
 
-function RunningState({ job }: { job: ReindexJob }) {
+function RunningState({ job, now }: { job: ReindexJob; now: number | null }) {
+  // How long the worker has been on this run. Deliberately an elapsed readout,
+  // NOT an ETA: per-document embedding cost varies too wildly on a real corpus
+  // (a single compilation PDF can be ~38% of all chunks) for a doc-count
+  // projection to be honest. A true ETA needs chunk-level progress (#907).
+  // Empty until the worker has started the job AND the clock ticked.
+  const elapsedSuffix =
+    job.startedAt && now !== null
+      ? ` · running ${formatElapsed(new Date(job.startedAt).getTime(), now)}`
+      : "";
+
   // `total` is null until discovery has walked every root — an indeterminate
   // phase we name rather than fake a percentage for.
   if (job.total === null) {
     return (
       <div className="space-y-2">
         <Progress value={0} />
-        <p className="text-sm text-muted-foreground">Discovering documents…</p>
+        <p className="text-sm text-muted-foreground">Discovering documents…{elapsedSuffix}</p>
       </div>
     );
   }
@@ -191,10 +216,26 @@ function RunningState({ job }: { job: ReindexJob }) {
     <div className="space-y-2">
       <Progress value={pct} />
       <p className="text-sm text-muted-foreground">
-        Indexing {job.processed} of {job.total} documents…
+        Indexing {job.processed} of {job.total} documents…{elapsedSuffix}
       </p>
     </div>
   );
+}
+
+/**
+ * Humanizes an elapsed duration (`nowMs − startedAtMs`) as a compact
+ * "42 sec" / "12 min" / "2 h 5 min" string. Clock skew (now before start)
+ * clamps to "0 sec" rather than showing a negative age. Seconds are floored
+ * once past a minute, and the minutes component is dropped on an exact hour.
+ */
+export function formatElapsed(startedAtMs: number, nowMs: number): string {
+  const totalSec = Math.max(0, Math.floor((nowMs - startedAtMs) / 1000));
+  if (totalSec < 60) return `${totalSec} sec`;
+  const totalMin = Math.floor(totalSec / 60);
+  if (totalMin < 60) return `${totalMin} min`;
+  const hours = Math.floor(totalMin / 60);
+  const minutes = totalMin % 60;
+  return minutes === 0 ? `${hours} h` : `${hours} h ${minutes} min`;
 }
 
 function SucceededState({ job }: { job: ReindexJob }) {

--- a/packages/web/src/components/knowledge-reindex-section.tsx
+++ b/packages/web/src/components/knowledge-reindex-section.tsx
@@ -225,11 +225,16 @@ function RunningState({ job, now }: { job: ReindexJob; now: number | null }) {
 /**
  * Humanizes an elapsed duration (`nowMs − startedAtMs`) as a compact
  * "42 sec" / "12 min" / "2 h 5 min" string. Clock skew (now before start)
- * clamps to "0 sec" rather than showing a negative age. Seconds are floored
- * once past a minute, and the minutes component is dropped on an exact hour.
+ * clamps to "0 sec" rather than showing a negative age, as does an
+ * unparseable timestamp — NaN survives Math.max/floor and would otherwise
+ * render as "NaN h NaN min" (same guard formatWhen applies to its own date).
+ * Seconds are floored once past a minute, and the minutes component is
+ * dropped on an exact hour.
  */
 export function formatElapsed(startedAtMs: number, nowMs: number): string {
-  const totalSec = Math.max(0, Math.floor((nowMs - startedAtMs) / 1000));
+  const elapsedMs = nowMs - startedAtMs;
+  if (Number.isNaN(elapsedMs)) return "0 sec";
+  const totalSec = Math.max(0, Math.floor(elapsedMs / 1000));
   if (totalSec < 60) return `${totalSec} sec`;
   const totalMin = Math.floor(totalSec / 60);
   if (totalMin < 60) return `${totalMin} min`;


### PR DESCRIPTION
## Summary

The reindex **Index** control (agent → Permissions → Knowledge Base, from #714) showed discovery, a live progress bar, and the last run's outcome — but gave no sense of **how long a run in flight had been going**. On a real corpus that's minutes to hours (the Noack dry-run: ~4h for 193 PDFs with native CPU embeddinggemma), so "is this stuck or just slow?" was unanswerable without reading logs.

This adds an elapsed-time readout next to both the discovery and indexing lines:

> Indexing 47 of 193 documents… · **running 12 min**
> Discovering documents… · **running 43 sec**

## Why elapsed, not an ETA

Deliberately an elapsed readout, **not** a time-to-completion estimate. A cheap doc-count ETA (`elapsed / processed × remaining`) would be actively misleading, because per-document embedding cost varies by orders of magnitude — the Noack dry-run had one compilation PDF at **38% of all chunks** and another at **16%**, while hundreds of product sheets are 1 chunk each. A projection would say "2 min left" and then spend an hour on a single document. An ETA that lies is worse than none.

A real ETA needs **chunk-level** progress (the actual unit of embedding work), which is worker + schema + projection work — filed as #907.

## Implementation notes

- `formatElapsed(startedAtMs, nowMs)` is a pure exported helper (`42 sec` / `12 min` / `2 h 5 min`), clamping clock skew to `0 sec`.
- A once-per-second `now` clock lives in a `useEffect` interval that runs **only while a run is active** and resets to `null` when idle — so a finished/absent run renders no age, and the readout ticks smoothly instead of jumping on each 3s poll.
- The wall clock is read inside the effect/interval, never during render, keeping the component pure (React rules-of-hooks lint — the naive `Date.now()`-in-render first draft failed exactly that gate).

## Test plan

- [x] `pnpm -C packages/web exec vitest run knowledge-reindex-section` — 21 pass (7 new: `formatElapsed` unit cases + rendered elapsed in indexing/discovery + omitted when `startedAt` is null)
- [x] `pnpm -C packages/web typecheck` (incl. test files)
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] `pnpm format:check` — whole tree clean
- [x] Docs updated (`create-knowledge-base-agent.mdx`) to describe the elapsed readout and why it isn't a countdown

## Follow-up

- #907 — chunk-level progress + a real ETA
