### PR TITLE
fix: constrain DialogContent height so tall modals scroll on short viewports

### DIFF
--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

Closes #906

The shared `DialogContent` in `packages/web/src/components/ui/dialog.tsx` constrained **width** (`max-w-[calc(100%-2rem)]`) but not **height**, while being vertically centered via `translate-y-[-50%]`. Once a dialog's content grew taller than the viewport (e.g. the IMAP connect wizard with the SMTP port-block banner on a short window), it spilled off **both** the top and bottom edges with no way to scroll — title, fields, and footer actions became unreachable.

## Change

Added two classes to the base `DialogContent` class list, exactly as suggested in the issue:

- `max-h-[calc(100dvh-2rem)]` — caps the dialog height to the dynamic viewport (handles mobile browser chrome) with a small margin so it never touches the edges
- `overflow-y-auto` — lets the content scroll internally when it exceeds that cap

## Behavior

- **Tall dialogs**: scroll internally; the close (×) button and footer actions stay reachable
- **Short dialogs**: unchanged — still centered, no scrollbar appears
- Since this is the shared component, every dialog built on it (add-integration, agent create, confirm dialogs) inherits the fix

Chose the simple whole-content scroll from the issue over pinned header/footer to keep the change minimal; a sticky header/footer variant could be a follow-up if preferred.