### PR TITLE
fix(chat): remove the redundant /help slash command

### DIFF
--- a/docs/src/content/docs/guides/slash-commands.mdx
+++ b/docs/src/content/docs/guides/slash-commands.mdx
@@ -1,6 +1,6 @@
 ---
 title: Slash Commands in Chat
-description: Type /compact, /new, /reset, or /help in the composer to act on the conversation without leaving the chat.
+description: Type /compact, /new, or /reset in the composer to act on the conversation without leaving the chat.
 ---
 
 The chat composer recognizes a few slash commands. Type one as the first thing in your message and press Send — Pinchy runs the action instead of sending the text to the model. The command is consumed; it does not appear as a message in the thread.
@@ -9,6 +9,8 @@ The chat composer recognizes a few slash commands. Type one as the first thing i
 
 Start a message with `/` and a menu opens above the composer listing the available commands with a short description of each. Keep typing to filter (`/c` narrows to `/compact`), use the **up/down arrows** to move, **Enter** to run the highlighted command, **Tab** to complete it into the input, and **Escape** to dismiss the menu. You can also click a command to run it. The composer placeholder hints at this: _"Send a message, or type / for commands."_
 
+This menu is the full list — there is no `/help` command. Typing `/help` sends it to the agent as a normal message.
+
 ## Available commands
 
 | Command    | What it does                                                                                                                                                      |
@@ -16,7 +18,6 @@ Start a message with `/` and a menu opens above the composer listing the availab
 | `/compact` | Compact the conversation: free up context by summarizing the in-context transcript. The full history stays on disk; compaction takes effect on your next message. |
 | `/new`     | Start a new conversation with this agent. The current chat stays in your chat list.                                                                               |
 | `/reset`   | Reset **this** conversation: clear its context so the agent starts fresh, in the same chat. The thread is cleared to a clean slate.                               |
-| `/help`    | Show the available slash commands.                                                                                                                                |
 
 ### `/reset` vs `/new`
 
@@ -29,7 +30,7 @@ Use `/new` when you want to keep a copy of the conversation; use `/reset` when y
 
 ## How commands are matched
 
-The composer looks at the **first whitespace-delimited token** of your message. If it is `/compact`, `/new`, `/reset`, or `/help` (case-insensitive), the command runs and the rest of the line is ignored. Anything else is sent to the model as a normal message — so text that merely _starts_ with a slash (like `/path/to/file`) is delivered unchanged, and unknown commands like `/foo` are sent through.
+The composer looks at the **first whitespace-delimited token** of your message. If it is `/compact`, `/new`, or `/reset` (case-insensitive), the command runs and the rest of the line is ignored. Anything else is sent to the model as a normal message — so text that merely _starts_ with a slash (like `/path/to/file`) is delivered unchanged, and unknown commands like `/foo` or `/help` are sent through.
 
 Commands only run when there are **no attachments**. If you attach a file, the message (even if it starts with a command) is sent as a captioned message to the agent.
 
@@ -38,7 +39,6 @@ Commands only run when there are **no attachments**. If you attach a file, the m
 - `/compact` shows a toast confirming the conversation was compacted (or an error if it couldn't be). Compaction is throttled — if you just compacted, wait a moment before trying again.
 - `/reset` clears the thread in place and shows a toast; the empty chat is your confirmation.
 - `/new` navigates you to a fresh chat immediately.
-- `/help` lists the commands in a toast.
 
 :::note
 Slash commands work in the web chat composer. Messages sent through Telegram or other channels are not affected — those go to the agent as normal text.

--- a/packages/web/src/__tests__/components/chat-session-mounts.test.tsx
+++ b/packages/web/src/__tests__/components/chat-session-mounts.test.tsx
@@ -135,7 +135,12 @@ describe("ChatSessionMounts", () => {
     expect(useWsRuntimeSpy).toHaveBeenCalledWith("agent-A", "chat-x", expect.any(Function));
   });
 
-  it("wires a slash-command handler that surfaces /help via toast (#611)", () => {
+  it("runs /compact against the compact route and toasts success (#611)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify({ ok: true }) });
+    vi.stubGlobal("fetch", fetchMock);
+
     function Visitor() {
       const session = useChatSession("agent-A", "chat-x");
       if (!session.bundle) {
@@ -152,7 +157,6 @@ describe("ChatSessionMounts", () => {
           isDelayed: false,
           reconnectExhausted: false,
           payloadRejected: false,
-          isOrphaned: false,
           onRetryContinue: vi.fn(),
           onRetryResend: vi.fn(),
           lastError: null,
@@ -177,11 +181,20 @@ describe("ChatSessionMounts", () => {
     const onSlashCommand = lastCall![2] as (c: { name: string }) => void;
     expect(typeof onSlashCommand).toBe("function");
 
-    act(() => onSlashCommand({ name: "help" }));
-    expect(toastSuccessSpy).toHaveBeenCalledWith(
-      "Slash commands",
-      expect.objectContaining({ description: expect.stringContaining("/compact") })
+    await act(async () => {
+      onSlashCommand({ name: "compact" });
+      // Flush the apiPost microtasks behind the success toast.
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Hit the compact route (not /new navigation) for THIS chat's session.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/agents/agent-A/sessions/compact",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ chatId: "chat-x" }) })
     );
+    expect(toastSuccessSpy).toHaveBeenCalledWith(expect.stringContaining("compacted"));
+
+    vi.unstubAllGlobals();
   });
 
   it("runs /reset against the reset route and remounts the thread (#611)", async () => {

--- a/packages/web/src/__tests__/components/chat-session-mounts.test.tsx
+++ b/packages/web/src/__tests__/components/chat-session-mounts.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import { useState } from "react";
 import { ChatSessionProvider, useChatSession } from "@/components/chat-session-provider";
@@ -10,9 +10,15 @@ let mockReconnectExhausted = false;
 let mockPayloadRejected = false;
 let mockPathname = "/agents";
 
+// Hoisted so tests can assert on navigation — the `/compact` and `/reset`
+// commands must act on THIS session in place and never route away like `/new`.
+const routerPushSpy = vi.fn();
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({
+    push: (...args: unknown[]) => routerPushSpy(...args),
+    replace: vi.fn(),
+  }),
 }));
 
 const toastSuccessSpy = vi.fn();
@@ -71,6 +77,13 @@ describe("ChatSessionMounts", () => {
     mockReconnectExhausted = false;
     mockPayloadRejected = false;
     mockPathname = "/agents";
+    routerPushSpy.mockClear();
+  });
+
+  // Restore stubbed globals (`fetch`) here rather than at the end of each test,
+  // so a failing assertion can't leak the stub into the next one.
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("calls useWsRuntime once per visited agentId", () => {
@@ -114,7 +127,6 @@ describe("ChatSessionMounts", () => {
           isDelayed: false,
           reconnectExhausted: false,
           payloadRejected: false,
-          isOrphaned: false,
           onRetryContinue: vi.fn(),
           onRetryResend: vi.fn(),
           lastError: null,
@@ -187,14 +199,14 @@ describe("ChatSessionMounts", () => {
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    // Hit the compact route (not /new navigation) for THIS chat's session.
+    // Hit the compact route for THIS chat's session...
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/agents/agent-A/sessions/compact",
       expect.objectContaining({ method: "POST", body: JSON.stringify({ chatId: "chat-x" }) })
     );
+    // ...and stay put: compaction acts in place, unlike /new.
+    expect(routerPushSpy).not.toHaveBeenCalled();
     expect(toastSuccessSpy).toHaveBeenCalledWith(expect.stringContaining("compacted"));
-
-    vi.unstubAllGlobals();
   });
 
   it("runs /reset against the reset route and remounts the thread (#611)", async () => {
@@ -248,11 +260,13 @@ describe("ChatSessionMounts", () => {
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    // Hit the reset route (not /new navigation) for THIS chat's session.
+    // Hit the reset route for THIS chat's session...
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/agents/agent-A/sessions/reset",
       expect.objectContaining({ method: "POST", body: JSON.stringify({ chatId: "chat-x" }) })
     );
+    // ...and stay put: reset clears in place, unlike /new.
+    expect(routerPushSpy).not.toHaveBeenCalled();
     // The bumped nonce changes the instance's React key → remount → a fresh
     // useWsRuntime call, cold-starting the (now-empty) session.
     const mountsAfter = useWsRuntimeSpy.mock.calls.filter(
@@ -260,8 +274,6 @@ describe("ChatSessionMounts", () => {
     ).length;
     expect(mountsAfter).toBeGreaterThan(mountsBefore);
     expect(toastSuccessSpy).toHaveBeenCalledWith(expect.stringContaining("reset"));
-
-    vi.unstubAllGlobals();
   });
 
   it("keeps a mount alive when an unrelated child remounts", () => {
@@ -339,8 +351,6 @@ describe("ChatSessionMounts", () => {
         "/api/internal/audit/background-run",
         expect.objectContaining({ method: "POST" })
       );
-
-      vi.unstubAllGlobals();
     });
 
     it("does NOT call fetch when isRunning flips true → false and user IS on the agent chat page", async () => {
@@ -368,8 +378,6 @@ describe("ChatSessionMounts", () => {
       });
 
       expect(fetchMock).not.toHaveBeenCalled();
-
-      vi.unstubAllGlobals();
     });
 
     it("does NOT call fetch on initial render when isRunning is already false", async () => {
@@ -389,8 +397,6 @@ describe("ChatSessionMounts", () => {
       });
 
       expect(fetchMock).not.toHaveBeenCalled();
-
-      vi.unstubAllGlobals();
     });
   });
 

--- a/packages/web/src/__tests__/lib/slash-commands.test.ts
+++ b/packages/web/src/__tests__/lib/slash-commands.test.ts
@@ -6,20 +6,19 @@ describe("parseSlashCommand", () => {
     expect(parseSlashCommand("/compact")).toEqual({ name: "compact" });
     expect(parseSlashCommand("/new")).toEqual({ name: "new" });
     expect(parseSlashCommand("/reset")).toEqual({ name: "reset" });
-    expect(parseSlashCommand("/help")).toEqual({ name: "help" });
   });
 
   it("parses a command with an argument", () => {
     expect(parseSlashCommand("/compact now")).toEqual({ name: "compact", arg: "now" });
-    expect(parseSlashCommand("/help me please")).toEqual({
-      name: "help",
+    expect(parseSlashCommand("/reset me please")).toEqual({
+      name: "reset",
       arg: "me please",
     });
   });
 
   it("is case-insensitive on the command token", () => {
     expect(parseSlashCommand("/COMPACT")).toEqual({ name: "compact" });
-    expect(parseSlashCommand("/Help")).toEqual({ name: "help" });
+    expect(parseSlashCommand("/Reset")).toEqual({ name: "reset" });
   });
 
   it("trims surrounding whitespace before parsing", () => {
@@ -41,6 +40,10 @@ describe("parseSlashCommand", () => {
     expect(parseSlashCommand("/comp")).toBeNull();
     expect(parseSlashCommand("/path/to/file")).toBeNull();
     expect(parseSlashCommand("/unknown thing")).toBeNull();
+    // /help was removed — the "/" autocomplete menu is the discovery surface,
+    // so a typed "/help" is now just normal text, not a command.
+    expect(parseSlashCommand("/help")).toBeNull();
+    expect(parseSlashCommand("/help me please")).toBeNull();
   });
 
   it("returns an empty-arg-less command when the arg is only whitespace", () => {
@@ -48,7 +51,7 @@ describe("parseSlashCommand", () => {
   });
 
   it("covers every command advertised in SLASH_COMMANDS", () => {
-    // Guards drift between the parser's known set and the help listing.
+    // Guards drift between the parser's known set and the autocomplete listing.
     for (const cmd of SLASH_COMMANDS) {
       expect(parseSlashCommand(`/${cmd.name}`)).toEqual({ name: cmd.name });
     }
@@ -58,7 +61,7 @@ describe("parseSlashCommand", () => {
 describe("SLASH_COMMANDS", () => {
   it("lists exactly the supported commands", () => {
     const names = SLASH_COMMANDS.map((c) => c.name).sort();
-    expect(names).toEqual<SlashCommandName[]>(["compact", "help", "new", "reset"]);
+    expect(names).toEqual<SlashCommandName[]>(["compact", "new", "reset"]);
   });
 
   it("every entry has a non-empty description", () => {

--- a/packages/web/src/components/assistant-ui/__tests__/slash-command-menu.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/slash-command-menu.test.tsx
@@ -71,7 +71,6 @@ describe("SlashCommandMenu (#611)", () => {
       expect.stringContaining("/compact"),
       expect.stringContaining("/new"),
       expect.stringContaining("/reset"),
-      expect.stringContaining("/help"),
     ]);
   });
 
@@ -128,7 +127,7 @@ describe("SlashCommandMenu (#611)", () => {
     fireEvent.keyDown(getByTestId("input"), { key: "Escape" });
     expect(queryByRole("listbox")).toBeNull();
     // Typing more changes the query and reopens the menu.
-    type("/h");
+    type("/r");
     expect(getByRole("listbox")).toBeTruthy();
   });
 

--- a/packages/web/src/components/chat-session-mounts.tsx
+++ b/packages/web/src/components/chat-session-mounts.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/chat-session-provider";
 import { apiPost, ApiError } from "@/lib/api-client";
 import { generateChatId } from "@/lib/chats/generate-chat-id";
-import { SLASH_COMMANDS, type SlashCommand } from "@/lib/slash-commands";
+import { type SlashCommand } from "@/lib/slash-commands";
 import type { CompactSessionRequest, ResetSessionRequest } from "@/lib/schemas/sessions";
 
 export function ChatSessionMounts() {
@@ -58,7 +58,8 @@ function ChatSessionInstance({
   //  - /reset   → existing reset route (clears THIS session's context in place),
   //               then remounts the thread so the user sees the clean slate.
   //  - /new     → navigate to a fresh chat (new chatId); the old one is kept.
-  //  - /help    → toast listing the commands.
+  // (There is no /help command — the composer's "/" autocomplete menu already
+  // lists every command with its description, so a help output is redundant.)
   // Confirmations are toasts per the error/notification policy (success →
   // toast; the toast survives the reset remount because sonner renders it
   // outside this subtree). The handler is stable across renders so
@@ -108,11 +109,6 @@ function ChatSessionInstance({
         }
         case "new": {
           router.push(`/chat/${agentId}/${generateChatId()}`);
-          break;
-        }
-        case "help": {
-          const lines = SLASH_COMMANDS.map((c) => `/${c.name} — ${c.description}`);
-          toast.success("Slash commands", { description: lines.join("\n") });
           break;
         }
       }

--- a/packages/web/src/lib/slash-commands.ts
+++ b/packages/web/src/lib/slash-commands.ts
@@ -12,7 +12,7 @@
  * handlers.
  */
 
-export type SlashCommandName = "compact" | "new" | "reset" | "help";
+export type SlashCommandName = "compact" | "new" | "reset";
 
 export interface SlashCommand {
   name: SlashCommandName;
@@ -21,8 +21,11 @@ export interface SlashCommand {
 }
 
 /**
- * Metadata for the `/help` listing and any future autocomplete UI. Keep the
- * descriptions short — they are shown verbatim in the help toast.
+ * Metadata driving the composer's slash-command autocomplete menu (the "/"
+ * listing). Keep the descriptions short — they are shown verbatim there.
+ * (There is deliberately no `/help` command: the autocomplete menu already
+ * lists every command with its description, so a separate help output would be
+ * redundant.)
  */
 export const SLASH_COMMANDS: ReadonlyArray<{
   name: SlashCommandName;
@@ -31,7 +34,6 @@ export const SLASH_COMMANDS: ReadonlyArray<{
   { name: "compact", description: "Compact the conversation (free up context, keep history)." },
   { name: "new", description: "Start a new conversation with this agent." },
   { name: "reset", description: "Reset this conversation — clear its context and start fresh." },
-  { name: "help", description: "Show the available slash commands." },
 ];
 
 const KNOWN_COMMANDS: ReadonlySet<string> = new Set(SLASH_COMMANDS.map((c) => c.name));


### PR DESCRIPTION
## What

Removes the `/help` slash command. The composer's `/` **autocomplete menu already lists every command with its description**, so `/help` just re-printed that same list as a toast — redundant and (per the screenshot below) visually noisy. Flagged during 0.9.0 Flow-3 (chat UX) release testing.

## Changes

- `lib/slash-commands.ts` — drop `"help"` from `SlashCommandName` and `SLASH_COMMANDS` (so it also leaves the `/` autocomplete menu), and `parseSlashCommand("/help")` now returns `null` → a typed `/help` falls through as normal text.
- `components/chat-session-mounts.tsx` — remove the `case "help"` handler (the toast) and its now-unused `SLASH_COMMANDS` import.
- Tests: **net-neutral** (no test-case count change — 10/10, 10/10, 9/9):
  - repurposed the orphaned "/help via toast" test into a **"/compact against the compact route"** test (command had no dedicated dispatch test before),
  - `slash-commands.test.ts` gains an explicit regression guard that `/help` is no longer a command,
  - `slash-command-menu.test.tsx` now expects the 3 remaining commands.

## Verification

- 3 affected test files green (29 tests). Changed files typecheck clean and pass `prettier --check`.
- No production `/help` slash references remain.

Small UX polish for the slash-commands feature (#611) shipping in 0.9.0. Will backport to `release/0.9` once merged.