### PR TITLE
fix(e2e): recover KB dispatch setup from OpenClaw's config.apply rate limit

### DIFF
--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -15,6 +15,7 @@ import {
   pollAuditForTool,
   waitForOpenClawStable,
   waitForAgentDispatchable,
+  ensureAgentDispatchable,
 } from "../shared/dispatch-probe";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 
@@ -465,9 +466,11 @@ test.describe.serial("Plugin behavior — pinchy-knowledge", () => {
   let agentId: string;
 
   test.beforeAll(async ({ browser }) => {
-    // The config-regen wait can exceed the 120 s per-test default; give the
-    // setup hook its own generous budget so the dispatch test stays focused.
-    test.setTimeout(300_000);
+    // The config-regen wait — plus recovery from OC's hardcoded config.apply
+    // rate limit (a toggle + extra stability waits) — can far exceed the 120 s
+    // per-test default; give the setup hook its own generous budget so the
+    // dispatch test stays focused.
+    test.setTimeout(420_000);
     const context = await browser.newContext();
     const page = await context.newPage();
     try {
@@ -491,19 +494,27 @@ test.describe.serial("Plugin behavior — pinchy-knowledge", () => {
       expect(patchRes.status(), await patchRes.text()).toBe(200);
 
       // Wait for OC to settle after the create+PATCH regens, then confirm the
-      // new agent is actually in OC's runtime agents.list before dispatching.
-      await waitForOpenClawStable(async () => {
-        const r = await page.request.get("/api/health/openclaw");
-        return { ok: r.ok(), json: () => r.json() };
-      });
-      await waitForAgentDispatchable(
-        async (id) => {
+      // new agent is actually in OC's runtime agents.list before dispatching —
+      // with recovery from OC's hardcoded config.apply rate limit
+      // (heypinchy/pinchy#881).
+      await ensureAgentDispatchable({
+        agentId,
+        allowedTools: ["knowledge_search"],
+        fetchHealth: async () => {
+          const r = await page.request.get("/api/health/openclaw");
+          return { ok: r.ok(), json: () => r.json() };
+        },
+        fetchDispatch: async (id) => {
           const r = await page.request.get(`/api/health/openclaw?agentId=${id}`);
           return { ok: r.ok(), json: () => r.json() };
         },
-        agentId,
-        { deadlineMs: 120_000 }
-      );
+        setAllowedTools: async (tools) => {
+          const r = await page.request.patch(`/api/agents/${agentId}`, {
+            data: { allowedTools: tools },
+          });
+          expect(r.status(), await r.text()).toBe(200);
+        },
+      });
     } finally {
       await context.close();
     }

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -469,7 +469,9 @@ test.describe.serial("Plugin behavior — pinchy-knowledge", () => {
     // The config-regen wait — plus recovery from OC's hardcoded config.apply
     // rate limit (a toggle + extra stability waits) — can far exceed the 120 s
     // per-test default; give the setup hook its own generous budget so the
-    // dispatch test stays focused.
+    // dispatch test stays focused. `ensureAgentDispatchable` self-bounds to
+    // ~360 s, so this 420 s budget leaves margin for its own informative
+    // give-up error to surface instead of a bare Playwright timeout.
     test.setTimeout(420_000);
     const context = await browser.newContext();
     const page = await context.newPage();

--- a/packages/web/e2e/integration/kb-attribution.spec.ts
+++ b/packages/web/e2e/integration/kb-attribution.spec.ts
@@ -153,7 +153,9 @@ test.describe.serial("KB Eval Harness — Layer-2 attribution self-test", () => 
     // WITH recovery from OC's hardcoded config.apply rate limit (which can add a
     // toggle + extra stability waits) — give it its own generous budget so the
     // five dispatch tests below stay focused, mirroring the pinchy-knowledge
-    // probe's beforeAll in agent-chat.spec.ts.
+    // probe's beforeAll in agent-chat.spec.ts. `ensureAgentDispatchable`
+    // self-bounds to ~360 s, so this 420 s budget leaves margin for its own
+    // informative give-up error to surface instead of a bare Playwright timeout.
     test.setTimeout(420_000);
     const context = await browser.newContext();
     const page = await context.newPage();

--- a/packages/web/e2e/integration/kb-attribution.spec.ts
+++ b/packages/web/e2e/integration/kb-attribution.spec.ts
@@ -149,11 +149,12 @@ test.describe.serial("KB Eval Harness — Layer-2 attribution self-test", () => 
   let agentId: string;
 
   test.beforeAll(async ({ browser }) => {
-    // Setup grants a tool, waits for OC stability (up to 150s) and
-    // dispatchability (up to 120s) — give it its own generous budget so the
+    // Setup grants a tool, waits for OC stability, and confirms dispatchability
+    // WITH recovery from OC's hardcoded config.apply rate limit (which can add a
+    // toggle + extra stability waits) — give it its own generous budget so the
     // five dispatch tests below stay focused, mirroring the pinchy-knowledge
     // probe's beforeAll in agent-chat.spec.ts.
-    test.setTimeout(300_000);
+    test.setTimeout(420_000);
     const context = await browser.newContext();
     const page = await context.newPage();
     try {

--- a/packages/web/e2e/shared/dispatch-probe.ts
+++ b/packages/web/e2e/shared/dispatch-probe.ts
@@ -193,6 +193,14 @@ export interface EnsureAgentDispatchableParams {
     dispatchIntervalMs?: number;
     /** Recovery toggles before giving up (default 2). */
     maxRecoveryAttempts?: number;
+    /**
+     * Overall wall-clock budget for the whole ensure (default 360 s). Every
+     * internal wait is clamped to the REMAINING budget, so once it expires the
+     * helper throws its own attempt-counted error almost immediately — before a
+     * surrounding `beforeAll` Playwright timeout (e.g. 420 s) can preempt it and
+     * mask the diagnostic. Must stay comfortably below that `beforeAll` budget.
+     */
+    overallDeadlineMs?: number;
   };
 }
 
@@ -217,8 +225,14 @@ export interface EnsureAgentDispatchableParams {
  * is a genuine on-disk diff rather than a superseded no-op) forces a clean WS
  * `config.apply`, and that path refreshes OC's runtime IN-PROCESS — it does not
  * depend on the lagging file-watcher, so the agent reliably re-materialises
- * regardless of whether the earlier file-write reload ever landed. Bounded by
- * `maxRecoveryAttempts` so a genuinely-broken stack still fails loudly.
+ * regardless of whether the earlier file-write reload ever landed.
+ *
+ * Bounded two ways so a genuinely-broken stack still fails loudly WITH this
+ * diagnostic: `maxRecoveryAttempts` caps the number of toggles, and
+ * `overallDeadlineMs` (default 360 s) caps total wall-clock. Every internal
+ * wait is clamped to the remaining overall budget, so the helper self-throws an
+ * attempt-counted error before a surrounding `beforeAll` Playwright timeout can
+ * preempt it and swap this message for an opaque one.
  */
 export async function ensureAgentDispatchable(
   params: EnsureAgentDispatchableParams
@@ -228,26 +242,54 @@ export async function ensureAgentDispatchable(
   const dispatchDeadlineMs = params.opts?.dispatchDeadlineMs ?? 120_000;
   const dispatchIntervalMs = params.opts?.dispatchIntervalMs;
   const maxRecoveryAttempts = params.opts?.maxRecoveryAttempts ?? 2;
+  const overallDeadline = Date.now() + (params.opts?.overallDeadlineMs ?? 360_000);
+  const remainingMs = () => Math.max(overallDeadline - Date.now(), 0);
 
-  await waitForOpenClawStable(fetchHealth, stableOpts);
+  // A stability wait clamped to the overall budget. When the budget is spent it
+  // returns immediately (rather than throwing "did not stabilise") so the loop's
+  // next dispatch check produces the informative, attempt-counted error instead.
+  const stableWithinBudget = async () => {
+    const budget = remainingMs();
+    if (budget === 0) return;
+    try {
+      await waitForOpenClawStable(fetchHealth, {
+        ...stableOpts,
+        deadlineMs: Math.min(stableOpts?.deadlineMs ?? 150_000, budget),
+      });
+    } catch (err) {
+      // Only swallow a stabilise timeout that coincides with budget exhaustion;
+      // a genuine early stabilise failure (budget left) is still surfaced.
+      if (remainingMs() > 0) throw err;
+    }
+  };
+
+  await stableWithinBudget();
 
   for (let attempt = 0; ; attempt++) {
     try {
       await waitForAgentDispatchable(fetchDispatch, agentId, {
-        deadlineMs: dispatchDeadlineMs,
+        deadlineMs: Math.min(dispatchDeadlineMs, remainingMs()),
         intervalMs: dispatchIntervalMs,
       });
       return;
-    } catch (err) {
-      if (attempt >= maxRecoveryAttempts) throw err;
+    } catch {
+      // Give up loudly — with our OWN attempt-counted message — the moment
+      // either bound trips, so the surrounding beforeAll timeout never masks it.
+      if (attempt >= maxRecoveryAttempts || remainingMs() === 0) {
+        throw new Error(
+          `OpenClaw runtime did not see agent ${agentId} as dispatchable after ${String(
+            attempt
+          )} recovery attempt(s) — config.apply likely stuck in file-watcher debounce`
+        );
+      }
       // Force a genuine config diff so a clean WS config.apply re-materialises
       // the agent in OC's runtime. Clear the grant, let it settle to disk, then
       // restore it — the stability wait between the halves is what makes each a
       // real diff instead of a self-superseding no-op.
       await setAllowedTools([]);
-      await waitForOpenClawStable(fetchHealth, stableOpts);
+      await stableWithinBudget();
       await setAllowedTools(allowedTools);
-      await waitForOpenClawStable(fetchHealth, stableOpts);
+      await stableWithinBudget();
     }
   }
 }

--- a/packages/web/e2e/shared/dispatch-probe.ts
+++ b/packages/web/e2e/shared/dispatch-probe.ts
@@ -173,6 +173,85 @@ export async function waitForAgentDispatchable(
   );
 }
 
+export interface EnsureAgentDispatchableParams {
+  agentId: string;
+  /** The tool grant the agent must end up with (also the toggle's restore value). */
+  allowedTools: string[];
+  fetchHealth: () => Promise<{
+    ok: boolean;
+    json: () => Promise<{ connected?: boolean; configPushesPending?: number }>;
+  }>;
+  fetchDispatch: (
+    agentId: string
+  ) => Promise<{ ok: boolean; json: () => Promise<{ agentDispatchable?: boolean }> }>;
+  /** Sets the agent's `allowedTools` (a `PATCH /api/agents/:id`). */
+  setAllowedTools: (tools: string[]) => Promise<void>;
+  opts?: {
+    stableOpts?: { deadlineMs?: number; stableForMs?: number; intervalMs?: number };
+    /** Per-attempt dispatchability deadline (default 120 s). */
+    dispatchDeadlineMs?: number;
+    dispatchIntervalMs?: number;
+    /** Recovery toggles before giving up (default 2). */
+    maxRecoveryAttempts?: number;
+  };
+}
+
+/**
+ * Wait until a freshly-created agent is dispatchable, RECOVERING from OpenClaw's
+ * `config.apply` rate limit instead of flaking on it.
+ *
+ * OpenClaw hard-caps control-plane writes at 3 per 60 s per connection — a
+ * compiled-in constant (`CONTROL_PLANE_RATE_LIMIT_*`) with no env/config knob,
+ * shared across every `config.apply` Pinchy makes. Under the integration
+ * suite's cumulative config-mutation rate, `pushConfigInBackground` parks a
+ * rejected apply for ~2×50 s and then falls back to a file write whose inotify
+ * reload can lag past a fixed dispatchability deadline. When that happens
+ * `waitForOpenClawStable` reports settled (the fallback drained
+ * `configPushesPending`) while the agent is NOT yet in OC's runtime, and a
+ * plain `waitForAgentDispatchable` times out — the kb-attribution /
+ * pinchy-knowledge `beforeAll` flake (heypinchy/pinchy#881).
+ *
+ * The recovery works because this runs inside a BLOCKING `beforeAll`: no other
+ * `config.apply` competes, so the rate-limit window drains within ~60 s.
+ * Toggling the tool grant off→on (with a stability wait between, so each half
+ * is a genuine on-disk diff rather than a superseded no-op) forces a clean WS
+ * `config.apply`, and that path refreshes OC's runtime IN-PROCESS — it does not
+ * depend on the lagging file-watcher, so the agent reliably re-materialises
+ * regardless of whether the earlier file-write reload ever landed. Bounded by
+ * `maxRecoveryAttempts` so a genuinely-broken stack still fails loudly.
+ */
+export async function ensureAgentDispatchable(
+  params: EnsureAgentDispatchableParams
+): Promise<void> {
+  const { agentId, allowedTools, fetchHealth, fetchDispatch, setAllowedTools } = params;
+  const stableOpts = params.opts?.stableOpts;
+  const dispatchDeadlineMs = params.opts?.dispatchDeadlineMs ?? 120_000;
+  const dispatchIntervalMs = params.opts?.dispatchIntervalMs;
+  const maxRecoveryAttempts = params.opts?.maxRecoveryAttempts ?? 2;
+
+  await waitForOpenClawStable(fetchHealth, stableOpts);
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await waitForAgentDispatchable(fetchDispatch, agentId, {
+        deadlineMs: dispatchDeadlineMs,
+        intervalMs: dispatchIntervalMs,
+      });
+      return;
+    } catch (err) {
+      if (attempt >= maxRecoveryAttempts) throw err;
+      // Force a genuine config diff so a clean WS config.apply re-materialises
+      // the agent in OC's runtime. Clear the grant, let it settle to disk, then
+      // restore it — the stability wait between the halves is what makes each a
+      // real diff instead of a self-superseding no-op.
+      await setAllowedTools([]);
+      await waitForOpenClawStable(fetchHealth, stableOpts);
+      await setAllowedTools(allowedTools);
+      await waitForOpenClawStable(fetchHealth, stableOpts);
+    }
+  }
+}
+
 /**
  * Drive the UI login form so the Playwright `page` has a session cookie.
  * Asserts the post-login redirect to `/chat/...` so the next navigation does

--- a/packages/web/eval/kb/kb-eval-shared.ts
+++ b/packages/web/eval/kb/kb-eval-shared.ts
@@ -18,7 +18,7 @@
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import { login } from "../../e2e/integration/helpers";
-import { waitForOpenClawStable, waitForAgentDispatchable } from "../../e2e/shared/dispatch-probe";
+import { ensureAgentDispatchable } from "../../e2e/shared/dispatch-probe";
 
 export const KB_EVAL_ALLOWED_TOOLS = ["knowledge_search"];
 
@@ -48,18 +48,26 @@ export async function setupKbAgent(page: Page): Promise<{ agentId: string }> {
   });
   expect(patchRes.status(), await patchRes.text()).toBe(200);
 
-  await waitForOpenClawStable(async () => {
-    const r = await page.request.get("/api/health/openclaw");
-    return { ok: r.ok(), json: () => r.json() };
-  });
-  await waitForAgentDispatchable(
-    async (id) => {
+  // Wait for OC to settle, then confirm the agent is in OC's runtime — with
+  // recovery from OC's hardcoded config.apply rate limit (heypinchy/pinchy#881).
+  await ensureAgentDispatchable({
+    agentId,
+    allowedTools: KB_EVAL_ALLOWED_TOOLS,
+    fetchHealth: async () => {
+      const r = await page.request.get("/api/health/openclaw");
+      return { ok: r.ok(), json: () => r.json() };
+    },
+    fetchDispatch: async (id) => {
       const r = await page.request.get(`/api/health/openclaw?agentId=${id}`);
       return { ok: r.ok(), json: () => r.json() };
     },
-    agentId,
-    { deadlineMs: 120_000 }
-  );
+    setAllowedTools: async (tools) => {
+      const r = await page.request.patch(`/api/agents/${agentId}`, {
+        data: { allowedTools: tools },
+      });
+      expect(r.status(), await r.text()).toBe(200);
+    },
+  });
 
   return { agentId };
 }

--- a/packages/web/src/__tests__/lib/dispatch-probe-recovery.test.ts
+++ b/packages/web/src/__tests__/lib/dispatch-probe-recovery.test.ts
@@ -1,0 +1,102 @@
+// Unit tests for the E2E dispatch-probe recovery orchestrator
+// `ensureAgentDispatchable` (e2e/shared/dispatch-probe.ts).
+//
+// OpenClaw hard-caps control-plane writes (`config.apply`) at 3 per 60s per
+// connection — a compiled-in constant with NO env/config override. Under the
+// integration suite's cumulative config-mutation rate, `pushConfigInBackground`
+// parks a rejected apply for ~2×50s and then falls back to a file write whose
+// inotify reload can lag past a fixed dispatchability deadline. That is the
+// kb-attribution / pinchy-knowledge `beforeAll` flake: `waitForOpenClawStable`
+// reports settled (the file-write fallback drained `configPushesPending`) while
+// the agent is not yet in OC's runtime, and `waitForAgentDispatchable` then
+// times out.
+//
+// `ensureAgentDispatchable` recovers because it runs inside a BLOCKING
+// `beforeAll` — no other `config.apply` competes, so the rate-limit window
+// drains within ~60s. Toggling the tool grant off→on forces a genuine config
+// diff, and the resulting clean WS `config.apply` refreshes OC's runtime
+// in-process, bypassing the lagging file-watcher entirely.
+//
+// These tests are wall-clock/interaction based, not poll-count based, mirroring
+// dispatch-probe-stability.test.ts (under CI load `setTimeout` stretches).
+
+import { describe, it, expect, vi } from "vitest";
+import { ensureAgentDispatchable } from "../../../e2e/shared/dispatch-probe";
+
+const TOOLS = ["knowledge_search"];
+
+/** Always-settled health so the stability gate never gates these tests. */
+const settledHealth = async () => ({
+  ok: true,
+  json: async () => ({ connected: true, configPushesPending: 0 }),
+});
+
+const fastOpts = {
+  stableOpts: { deadlineMs: 1_000, stableForMs: 10, intervalMs: 5 },
+  dispatchDeadlineMs: 40,
+  dispatchIntervalMs: 5,
+  maxRecoveryAttempts: 2,
+} as const;
+
+describe("ensureAgentDispatchable", () => {
+  it("returns without recovery when the agent is already dispatchable", async () => {
+    const setAllowedTools = vi.fn(async () => {});
+
+    await ensureAgentDispatchable({
+      agentId: "a1",
+      allowedTools: TOOLS,
+      fetchHealth: settledHealth,
+      fetchDispatch: async () => ({ ok: true, json: async () => ({ agentDispatchable: true }) }),
+      setAllowedTools,
+      opts: fastOpts,
+    });
+
+    // The happy path never touches the tool grant.
+    expect(setAllowedTools).not.toHaveBeenCalled();
+  });
+
+  it("recovers by toggling the tool grant off→on when the first dispatch wait times out", async () => {
+    // Model the real system: the agent only enters OC's runtime once the grant
+    // is RESTORED (the clean WS config.apply). Until then dispatch stays false.
+    let restored = false;
+    const setAllowedTools = vi.fn(async (tools: string[]) => {
+      if (tools.length > 0) restored = true;
+    });
+
+    await ensureAgentDispatchable({
+      agentId: "a1",
+      allowedTools: TOOLS,
+      fetchHealth: settledHealth,
+      fetchDispatch: async () => ({
+        ok: true,
+        json: async () => ({ agentDispatchable: restored }),
+      }),
+      setAllowedTools,
+      opts: fastOpts,
+    });
+
+    // Exactly one toggle: clear the grant, then restore it.
+    expect(setAllowedTools.mock.calls.map((c) => c[0])).toEqual([[], TOOLS]);
+  });
+
+  it("throws after exhausting recovery attempts when the agent never becomes dispatchable", async () => {
+    const setAllowedTools = vi.fn(async () => {});
+
+    await expect(
+      ensureAgentDispatchable({
+        agentId: "a1",
+        allowedTools: TOOLS,
+        fetchHealth: settledHealth,
+        fetchDispatch: async () => ({
+          ok: true,
+          json: async () => ({ agentDispatchable: false }),
+        }),
+        setAllowedTools,
+        opts: fastOpts,
+      })
+    ).rejects.toThrow(/dispatchable/i);
+
+    // maxRecoveryAttempts (2) toggles, each = clear + restore = 2 calls.
+    expect(setAllowedTools).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/web/src/__tests__/lib/dispatch-probe-recovery.test.ts
+++ b/packages/web/src/__tests__/lib/dispatch-probe-recovery.test.ts
@@ -36,6 +36,15 @@ const fastOpts = {
   dispatchDeadlineMs: 40,
   dispatchIntervalMs: 5,
   maxRecoveryAttempts: 2,
+  overallDeadlineMs: 10_000,
+} as const;
+
+/** `fastOpts` without `maxRecoveryAttempts`, to exercise its `?? 2` default. */
+const fastOptsDefaultAttempts = {
+  stableOpts: fastOpts.stableOpts,
+  dispatchDeadlineMs: fastOpts.dispatchDeadlineMs,
+  dispatchIntervalMs: fastOpts.dispatchIntervalMs,
+  overallDeadlineMs: fastOpts.overallDeadlineMs,
 } as const;
 
 describe("ensureAgentDispatchable", () => {
@@ -94,9 +103,63 @@ describe("ensureAgentDispatchable", () => {
         setAllowedTools,
         opts: fastOpts,
       })
-    ).rejects.toThrow(/dispatchable/i);
+      // The helper's OWN attempt-counted message, not a bare relay of the inner
+      // wait's error — this is what a beforeAll timeout must not be allowed to
+      // mask (Fix: informative give-up).
+    ).rejects.toThrow(/dispatchable after 2 recovery attempt/i);
 
     // maxRecoveryAttempts (2) toggles, each = clear + restore = 2 calls.
     expect(setAllowedTools).toHaveBeenCalledTimes(4);
+  });
+
+  it("defaults to 2 recovery attempts when maxRecoveryAttempts is omitted", async () => {
+    const setAllowedTools = vi.fn(async () => {});
+
+    await expect(
+      ensureAgentDispatchable({
+        agentId: "a1",
+        allowedTools: TOOLS,
+        fetchHealth: settledHealth,
+        fetchDispatch: async () => ({
+          ok: true,
+          json: async () => ({ agentDispatchable: false }),
+        }),
+        setAllowedTools,
+        opts: fastOptsDefaultAttempts,
+      })
+    ).rejects.toThrow(/dispatchable after 2 recovery attempt/i);
+
+    // The `?? 2` default still yields exactly two toggles (4 calls).
+    expect(setAllowedTools).toHaveBeenCalledTimes(4);
+  });
+
+  it("honours the overall wall-clock budget even when maxRecoveryAttempts is high", async () => {
+    // With a huge attempt cap, only the overall budget can stop the loop — this
+    // pins the bound that keeps the helper self-throwing before a beforeAll
+    // Playwright timeout (Fix: overall budget clamps every internal wait).
+    const setAllowedTools = vi.fn(async () => {});
+
+    await expect(
+      ensureAgentDispatchable({
+        agentId: "a1",
+        allowedTools: TOOLS,
+        fetchHealth: settledHealth,
+        fetchDispatch: async () => ({
+          ok: true,
+          json: async () => ({ agentDispatchable: false }),
+        }),
+        setAllowedTools,
+        opts: {
+          stableOpts: { deadlineMs: 200, stableForMs: 10, intervalMs: 5 },
+          dispatchDeadlineMs: 20,
+          dispatchIntervalMs: 5,
+          maxRecoveryAttempts: 1_000,
+          overallDeadlineMs: 60,
+        },
+      })
+    ).rejects.toThrow(/dispatchable/i);
+
+    // It gave up on the budget, not the (never-reached) 1000-attempt cap.
+    expect(setAllowedTools.mock.calls.length).toBeLessThan(2_000);
   });
 });


### PR DESCRIPTION
## Problem

The `kb-attribution` and `pinchy-knowledge` integration `beforeAll`s flake in the sharded `integration` job (shard 2/2). Root cause: OpenClaw hard-caps control-plane writes (`config.apply`) at **3 per 60s per connection** — a compiled-in constant (`CONTROL_PLANE_RATE_LIMIT_*`) with **no env/config knob**, shared across every `config.apply` Pinchy makes.

Under the suite's cumulative config-mutation rate, `pushConfigInBackground` parks a rejected apply for ~2×50s then falls back to a file write whose inotify reload lags past the fixed **120s** dispatchability deadline. `waitForOpenClawStable` then reports settled (the fallback drained `configPushesPending`) while the agent is **not yet in OC's runtime**, and `waitForAgentDispatchable` times out:

```
Error: OpenClaw runtime did not see agent <id> as dispatchable within deadline
  at kb-attribution.spec.ts:160 (inside setupKbAgent's beforeAll wait loop)
```

## Why not options 1 / 3

- **Option 1 (raise the OC limit for the test stack):** impossible. `CONTROL_PLANE_RATE_LIMIT_MAX_REQUESTS = 3` / `WINDOW_MS = 60000` are compiled-in constants in the vendored OpenClaw dist, with no config/env binding and no existing pnpm patch to build on. A patch would also weaken production's DoS protection and need re-applying on every OC bump.
- **Option 3 (serialize setup):** moot. `playwright.integration.config.ts` is already `workers: 1` / `fullyParallel: false` — the pressure is *temporal* (cumulative rate across sequential tests), not concurrent, so there's no concurrency to remove.

## Fix (option 2)

A shared `ensureAgentDispatchable` orchestrator that **recovers** instead of flaking. Because setup runs in a **blocking** `beforeAll`, no other `config.apply` competes, so the rate-limit window drains within ~60s. Toggling the tool grant off→on (with a stability wait between, so each half is a genuine on-disk diff rather than a superseded no-op) forces a clean WS `config.apply` — which refreshes OC's runtime **in-process**, bypassing the lagging file-watcher. Bounded by `maxRecoveryAttempts` so a genuinely-broken stack still fails loudly.

Both setup call sites (`setupKbAgent` + the sibling `pinchy-knowledge` probe) delegate to the helper; `beforeAll` budgets bumped 300s→420s for the extra toggle.

## Tests

- New `dispatch-probe-recovery.test.ts` unit-tests the orchestrator (happy path / recovery-toggle / bounded-failure), DI-style like the sibling `dispatch-probe-stability.test.ts`.
- Real recovery is exercised by the existing integration specs; verifying via repeated `integration` job runs.

Gates run locally: `typecheck` (incl. eval), `format:check`, `test:scripts` (379✓), dispatch-probe unit tests (15✓).

Note: KB is dormant/out-of-scope in the 0.9.0 release — this is CI-hygiene, not a release blocker. Will cherry-pick to `release/0.9` after merge.

Refs #881