### PR TITLE
test(web): make the reindex stale-read test load-independent

### DIFF
--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -237,13 +237,11 @@ describe("KnowledgeReindexSection", () => {
     );
     await user.click(screen.getByRole("button", { name: /reindex/i }));
     // The optimistic pending job is a React commit queued by the POST's
-    // continuation — pending work to flush, not a timed event to poll for.
-    // `waitFor` would spend a 1000ms WALL-CLOCK budget on it, and under a full
-    // parallel suite a single blocked event-loop turn in exactly this window
-    // eats all of it (measured: >6s for this same await), which is how the line
-    // timed out under load while an isolated rerun stayed green. act() drains
-    // the work in ~2ms independent of machine load, and the assertion gets
-    // stricter: the run must be live the moment the click settles.
+    // continuation. `waitFor` would poll for it against a 1000ms WALL-CLOCK
+    // budget, which one blocked event-loop turn under a full parallel run
+    // consumes entirely. act() forces the pending work to settle first, so the
+    // assertion is both deterministic and stricter: the run must be live the
+    // moment the click settles.
     await act(async () => {});
     expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled();
 

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -236,7 +236,16 @@ describe("KnowledgeReindexSection", () => {
       <KnowledgeReindexSection agentId="a1" allowedPathCount={2} pollIntervalMs={1_000_000} />
     );
     await user.click(screen.getByRole("button", { name: /reindex/i }));
-    await waitFor(() => expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled());
+    // The optimistic pending job is a React commit queued by the POST's
+    // continuation — pending work to flush, not a timed event to poll for.
+    // `waitFor` would spend a 1000ms WALL-CLOCK budget on it, and under a full
+    // parallel suite a single blocked event-loop turn in exactly this window
+    // eats all of it (measured: >6s for this same await), which is how the line
+    // timed out under load while an isolated rerun stayed green. act() drains
+    // the work in ~2ms independent of machine load, and the assertion gets
+    // stricter: the run must be live the moment the click settles.
+    await act(async () => {});
+    expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled();
 
     // The pre-click read finally answers "no job ever ran". It is stale — it
     // must not clear the run the admin just started and is watching. Flush its


### PR DESCRIPTION
## What does this PR do?

De-flakes `ignores a slow status read that resolves after a reindex was triggered` in `packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx`.

The test polled for the post-click `Reindexing…` state with `waitFor`'s default **1000 ms wall-clock** budget. That budget is not bounded by CPU time. Measured on the real test body with a deliberately blocked worker event loop:

| injected stall | `waitFor` (before) | `act()` flush (after) |
| --- | --- | --- |
| 0 ms | p50 3.5 ms / p99 105 ms | p50 2.4 ms |
| 300 ms | p50 303 ms | p50 2.5 ms |
| 600 ms | p50 603 ms | p50 2.1 ms |
| 1200 ms, landing in the click-continuation window | **p50 3201 ms, max 6004 ms** | p50 2.6 ms |

`waitFor` latency tracks the stall 1:1, so one blocked event-loop turn in that window consumes the whole budget — which is how the line timed out in a full 683-file parallel run while an isolated rerun of the same suite stayed green.

**No product defect.** The transition itself is correct: the optimistic pending job is a React commit queued by the POST's continuation, and it lands ~2 ms after the click regardless of machine load.

The fix stops polling for pending work and flushes it instead:

```ts
await user.click(screen.getByRole("button", { name: /reindex/i }));
await act(async () => {});
expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled();
```

This is **stricter** than before: the run must be live the moment the click settles, not merely within a second.


## Type of change

- [x] 🧪 Tests

## Notes for reviewers

- **The race the test exists for is untouched.** Mutation-tested: removing the fetch-sequence guard (`if (seq === fetchSeq.current)`) from `knowledge-reindex-section.tsx` still turns the test red — and it fails on the *final* assertion (the stale mount read must not clear the run), so the new intermediate assertion masks nothing.
- Determinism check: 0 failures over ~95 iterations of the reworked shape with injected stalls of 0/300/600/1200/2000 ms.
- Net-zero test cases; no skips added.
- Side note found while measuring: a uniform stall usually does *not* trip `waitFor`, because when the loop catches up the overdue 50 ms interval check fires before the overdue 1000 ms timeout. Tripping it needs fine-grained OS preemption — exactly what an oversubscribed 14-worker run produces, which is why this flake is rare and unreproducible in isolation.

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass
