### PR TITLE
feat(pinchy-odoo): read-back verification for account.move writes (#720)

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -1665,14 +1665,23 @@ const controlServer = http.createServer(async (req, res) => {
 
   // Configure a record-action method to return a wizard action (instead of
   // the default `true`), to exercise the Variant A handoff path.
-  // Body: { model, method, response }
+  // Body: { model, method, response } — or { model, method, clear: true } to
+  // remove a previously-set override WITHOUT wiping the store (pinchy#720: the
+  // read-after-write E2E injects a silent-no-op create, then clears just that
+  // override so the surrounding seeded probe records survive).
   if (req.method === "POST" && path === "/control/method-response") {
     const body = await readBody(req);
     if (!body || !body.model || !body.method) {
       sendJson(res, 400, { error: "Need { model, method, response }" });
       return;
     }
-    methodResponses[`${body.model}.${body.method}`] = body.response;
+    const key = `${body.model}.${body.method}`;
+    if (body.clear) {
+      delete methodResponses[key];
+      sendJson(res, 200, { status: "cleared" });
+      return;
+    }
+    methodResponses[key] = body.response;
     sendJson(res, 200, { status: "configured" });
     return;
   }

--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -162,6 +162,35 @@ This mirrors how Odoo itself keys duplicate detection for vendor documents — o
 
 **Deliberate re-filings have an escape hatch.** If a second entry really is intended, the agent can repeat the create with `allow_duplicate: true`. The bill is then created and the audit entry records the override alongside the bill it duplicated, so the decision stays traceable.
 
+## Verified writes
+
+When an agent books an invoice or bill, it should not have to _hope_ the write
+landed — and neither should you. Left to themselves, language models trust
+whatever a tool hands back: if the ERP returns a plausible record id, the agent
+reports success, even when nothing was actually saved. Our reliability
+benchmark found this failure in every model we tested, strong and weak alike, so
+we moved the check out of the model's hands and into the tool.
+
+For the highest-stakes writes — journal entries and invoices (`account.move`
+and its line items) — the `pinchy-odoo` plugin reads the record back before it
+reports success. It reads from the same authenticated session, so there is no
+lag to race, and compares the fields it just wrote:
+
+- **On a match**, the agent gets its normal success result, now enriched with
+  the verified values, and the audit entry records `verified: true`.
+- **On a missing record or a value that did not persist**, the agent gets a hard
+  error instead of a success it can narrate away — "Odoo returned an id but the
+  record could not be read back" — and the audit entry records the call as a
+  `failure` with `verified: false`.
+
+The result is a platform guarantee rather than a model behavior: a silent no-op
+in the ERP becomes a visible, audited failure your team can act on, whichever
+model an agent runs. This complements the existing read-back guarantee on
+`odoo_reconcile`, which already confirms a payment truly matched before reporting
+it done. Verification only runs where it is deterministic; writes that cannot be
+confirmed this way are covered instead by the confirmation-before-write habit the
+read-write finance templates carry.
+
 ## Re-syncing when Odoo permissions change
 
 If the Odoo admin changes the API user's permissions after you've set up the connection, agents may lose access to certain models. When this happens, the agent gets a clear error message explaining that access was denied.

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -2670,7 +2670,16 @@ describe("odoo_create vendor-bill duplicate guard (#721)", () => {
   });
 
   it("lets a first-time vendor bill through when no duplicate is on file", async () => {
-    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 1, offset: 0 });
+    // dup-guard read → no existing bill; then #720 verification read-back → the
+    // created bill (account.move is a verified-write model).
+    mockSearchRead
+      .mockResolvedValueOnce({ records: [], total: 0, limit: 1, offset: 0 })
+      .mockResolvedValue({
+        records: [{ id: 1002, move_type: "in_invoice", ref: "NEW-0001" }],
+        total: 1,
+        limit: 1,
+        offset: 0,
+      });
     mockCreate.mockResolvedValue(1002);
 
     const tools = createApi({ [agentId]: dupConfig });
@@ -2693,8 +2702,10 @@ describe("odoo_create vendor-bill duplicate guard (#721)", () => {
     // A same-ref customer invoice is a legitimate second entry: out-document refs
     // are not vendor document numbers. The guard must not run its search, so the
     // create proceeds even though a record with this ref exists.
+    // out_invoice is not dup-guarded, so no ref-keyed dup search runs; the only
+    // read is the #720 verification read-back of the created invoice.
     mockSearchRead.mockResolvedValue({
-      records: [EXISTING_BILL],
+      records: [{ id: 2002, move_type: "out_invoice", ref: "083000981540" }],
       total: 1,
       limit: 1,
       offset: 0,
@@ -2711,10 +2722,23 @@ describe("odoo_create vendor-bill duplicate guard (#721)", () => {
 
     expect(result.isError).toBeFalsy();
     expect(mockCreate).toHaveBeenCalled();
-    expect(mockSearchRead).not.toHaveBeenCalled();
+    // The duplicate guard (a `ref`-keyed search) never ran — the create proceeded
+    // despite a same-ref record. The only search performed was the #720
+    // verification read-back, which keys on `id`, not `ref`.
+    const dupSearched = mockSearchRead.mock.calls.some((c) =>
+      JSON.stringify(c[1] ?? "").includes('"ref"')
+    );
+    expect(dupSearched).toBe(false);
   });
 
   it("does NOT guard a plain journal entry (no move_type) — Odoo never dedups those", async () => {
+    // no move_type → not dup-guarded; only the #720 verification read-back runs.
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 3003, ref: "JE-0001" }],
+      total: 1,
+      limit: 1,
+      offset: 0,
+    });
     mockCreate.mockResolvedValue(3003);
 
     const tools = createApi({ [agentId]: dupConfig });
@@ -2727,16 +2751,25 @@ describe("odoo_create vendor-bill duplicate guard (#721)", () => {
 
     expect(result.isError).toBeFalsy();
     expect(mockCreate).toHaveBeenCalled();
-    expect(mockSearchRead).not.toHaveBeenCalled();
+    // No ref-keyed dup search ran; the only search was the id-keyed #720
+    // verification read-back.
+    const dupSearched = mockSearchRead.mock.calls.some((c) =>
+      JSON.stringify(c[1] ?? "").includes('"ref"')
+    );
+    expect(dupSearched).toBe(false);
   });
 
   it("proceeds and records a traceable override when allow_duplicate is true", async () => {
-    mockSearchRead.mockResolvedValue({
-      records: [EXISTING_BILL],
-      total: 1,
-      limit: 1,
-      offset: 0,
-    });
+    // dup-guard read → finds the on-file bill (override authorized); then the
+    // #720 verification read-back → the newly created bill.
+    mockSearchRead
+      .mockResolvedValueOnce({ records: [EXISTING_BILL], total: 1, limit: 1, offset: 0 })
+      .mockResolvedValue({
+        records: [{ id: 1003, move_type: "in_invoice", ref: "083000981540" }],
+        total: 1,
+        limit: 1,
+        offset: 0,
+      });
     mockCreate.mockResolvedValue(1003);
 
     const tools = createApi({ [agentId]: dupConfig });
@@ -2770,7 +2803,16 @@ describe("odoo_create vendor-bill duplicate guard (#721)", () => {
   });
 
   it("allow_duplicate on a bill with NO on-file duplicate is a normal create (no override detail)", async () => {
-    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 1, offset: 0 });
+    // dup-guard read → no existing bill; then #720 verification read-back → the
+    // created bill.
+    mockSearchRead
+      .mockResolvedValueOnce({ records: [], total: 0, limit: 1, offset: 0 })
+      .mockResolvedValue({
+        records: [{ id: 1004, move_type: "in_invoice", ref: "NEW-0002" }],
+        total: 1,
+        limit: 1,
+        offset: 0,
+      });
     mockCreate.mockResolvedValue(1004);
 
     const tools = createApi({ [agentId]: dupConfig });
@@ -2784,8 +2826,11 @@ describe("odoo_create vendor-bill duplicate guard (#721)", () => {
 
     expect(result.isError).toBeFalsy();
     expect(mockCreate).toHaveBeenCalled();
-    // No duplicate existed, so nothing was overridden — no override audit detail.
-    expect(result.details).toBeUndefined();
+    // No duplicate existed, so nothing was overridden — the detail carries only
+    // the #720 verification outcome, never an override record.
+    expect(
+      (result.details as Record<string, unknown> | undefined)?.duplicateOverride
+    ).toBeUndefined();
   });
 
   it("skips the guard when the agent lacks read on account.move (cannot verify, so cannot block)", async () => {
@@ -3821,6 +3866,15 @@ describe("odoo_attach_file", () => {
       mockCreate
         .mockResolvedValueOnce(123) // odoo_create returns id 123 for account.move
         .mockResolvedValueOnce(456); // odoo_attach_file create for ir.attachment
+      // #720: account.move is a verified-write model — odoo_create reads the
+      // record back before reporting success. Echo the submitted verbatim
+      // scalars so verification passes.
+      mockSearchRead.mockResolvedValueOnce({
+        records: [{ id: 123, move_type: "in_invoice", invoice_date: "2026-01-15" }],
+        total: 1,
+        limit: 1,
+        offset: 0,
+      });
 
       const tools = createApi({ [attachAgentId]: attachAgentConfig });
       const createTool = findTool(tools, "odoo_create", attachAgentId)!;

--- a/packages/plugins/pinchy-odoo/__tests__/write-verification.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/write-verification.test.ts
@@ -1,0 +1,380 @@
+// @vitest-environment node
+//
+// #720: plugin-side write verification (read-after-write). The plugin reads the
+// record back before reporting success, turning a silent no-op backend (Eval-v1
+// silent-failure scenario: id returned, nothing persisted) into a hard, visible
+// error instead of a false success.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentOdooConfig, OdooField } from "../index";
+
+const mockSearchRead = vi.fn();
+const mockSearchCount = vi.fn();
+const mockReadGroup = vi.fn();
+const mockCreate = vi.fn();
+const mockWrite = vi.fn();
+const mockUnlink = vi.fn();
+const mockFields = vi.fn();
+const mockCallMethod = vi.fn();
+
+vi.mock("odoo-node", () => {
+  const MockOdooClient = vi.fn(function (this: Record<string, unknown>) {
+    this.searchRead = mockSearchRead;
+    this.searchCount = mockSearchCount;
+    this.readGroup = mockReadGroup;
+    this.create = mockCreate;
+    this.write = mockWrite;
+    this.unlink = mockUnlink;
+    this.fields = mockFields;
+    this.callMethod = mockCallMethod;
+  });
+  return { OdooClient: MockOdooClient };
+});
+
+vi.mock("../io", () => ({ readFile: vi.fn(), stat: vi.fn() }));
+
+import plugin, {
+  isVerifiedModel,
+  isVerbatimScalarField,
+  verbatimFieldsToVerify,
+  findVerbatimMismatches,
+} from "../index";
+
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => ({
+    type: "odoo",
+    credentials: { url: "http://odoo-test:8069", db: "testdb", uid: 2, apiKey: "k" },
+  }),
+}));
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+interface AgentTool {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+    details?: { error?: string; verified?: boolean };
+  }>;
+}
+
+function createApi(agentConfigs: Record<string, AgentOdooConfig> = {}) {
+  const tools: Array<{ factory: (ctx: { agentId?: string }) => AgentTool | null; name: string }> =
+    [];
+  const api = {
+    pluginConfig: {
+      apiBaseUrl: "http://pinchy-test:7777",
+      gatewayToken: "test-gateway-token",
+      agents: agentConfigs,
+    },
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+      opts?: { name?: string }
+    ) => {
+      tools.push({ factory, name: opts?.name ?? "" });
+    },
+  };
+  plugin.register(api as never);
+  return tools;
+}
+
+function findTool(tools: ReturnType<typeof createApi>, name: string, agentId?: string): AgentTool {
+  const entry = tools.find((t) => t.name === name)!;
+  return entry.factory({ agentId })!;
+}
+
+const agentId = "agent-1";
+const CONN = "conn-test-1";
+
+// account.move schema the mock returns during m2o normalization. Covers a
+// verbatim char (ref), a selection (move_type), a many2one (partner_id, must be
+// EXCLUDED from comparison), and a monetary/float (amount_total, EXCLUDED).
+const MOVE_FIELDS = [
+  { name: "ref", string: "Reference", type: "char" },
+  {
+    name: "move_type",
+    string: "Type",
+    type: "selection",
+    selection: [
+      ["entry", "Journal Entry"],
+      ["out_invoice", "Customer Invoice"],
+      ["in_invoice", "Vendor Bill"],
+    ],
+  },
+  { name: "partner_id", string: "Partner", type: "many2one", relation: "res.partner" },
+  { name: "amount_total", string: "Total", type: "monetary" },
+];
+
+function moveConfig(
+  permissions: Record<string, string[]> = { "account.move": ["read", "create", "write"] }
+): AgentOdooConfig {
+  return { connectionId: CONN, permissions } as AgentOdooConfig;
+}
+
+function empty() {
+  return { records: [], total: 0, limit: 1000, offset: 0 };
+}
+function records(recs: Array<Record<string, unknown>>) {
+  return { records: recs, total: recs.length, limit: 1000, offset: 0 };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  mockFields.mockResolvedValue(MOVE_FIELDS);
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+describe("isVerifiedModel", () => {
+  it("covers account.move and its line model", () => {
+    expect(isVerifiedModel("account.move")).toBe(true);
+    expect(isVerifiedModel("account.move.line")).toBe(true);
+  });
+  it("does not cover other models (scoped start)", () => {
+    expect(isVerifiedModel("res.partner")).toBe(false);
+    expect(isVerifiedModel("sale.order")).toBe(false);
+  });
+});
+
+describe("isVerbatimScalarField", () => {
+  it("accepts verbatim scalar types Odoo stores unchanged", () => {
+    for (const type of ["char", "text", "boolean", "date", "selection", "integer"]) {
+      expect(isVerbatimScalarField({ name: "f", type })).toBe(true);
+    }
+  });
+  it("rejects types Odoo may legitimately transform (avoids false-failures)", () => {
+    for (const type of ["float", "monetary", "datetime", "many2one", "one2many", "many2many"]) {
+      expect(isVerbatimScalarField({ name: "f", type, relation: "x" })).toBe(false);
+    }
+  });
+  it("rejects readonly/computed fields (the server owns them)", () => {
+    expect(isVerbatimScalarField({ name: "name", type: "char", readonly: true })).toBe(false);
+  });
+});
+
+describe("verbatimFieldsToVerify", () => {
+  const fields: OdooField[] = MOVE_FIELDS as OdooField[];
+  it("returns only submitted fields that map to a verbatim scalar", () => {
+    const out = verbatimFieldsToVerify(fields, {
+      ref: "INV-1",
+      move_type: "in_invoice",
+      partner_id: 5, // many2one -> excluded
+      amount_total: 100, // monetary -> excluded
+      unknown_field: "x", // not in schema -> excluded
+    });
+    expect(out.map((f) => f.name).sort()).toEqual(["move_type", "ref"]);
+  });
+  it("returns nothing when no submitted field is a verbatim scalar", () => {
+    expect(verbatimFieldsToVerify(fields, { partner_id: 5, amount_total: 9 })).toEqual([]);
+  });
+});
+
+describe("findVerbatimMismatches", () => {
+  const fields: OdooField[] = MOVE_FIELDS as OdooField[];
+  it("flags a submitted verbatim scalar that read back different", () => {
+    const out = findVerbatimMismatches(fields, { ref: "INV-1" }, { ref: "SOMETHING-ELSE" });
+    expect(out).toEqual([{ field: "ref", expected: "INV-1", actual: "SOMETHING-ELSE" }]);
+  });
+  it("passes when the read-back value matches", () => {
+    expect(findVerbatimMismatches(fields, { ref: "INV-1" }, { ref: "INV-1" })).toEqual([]);
+  });
+  it("flags a missing value (Odoo returned false / dropped the field)", () => {
+    const out = findVerbatimMismatches(fields, { ref: "INV-1" }, { ref: false });
+    expect(out).toEqual([{ field: "ref", expected: "INV-1", actual: false }]);
+  });
+  it("ignores relational and monetary fields even when they differ", () => {
+    expect(
+      findVerbatimMismatches(
+        fields,
+        { partner_id: 5, amount_total: 100 },
+        { partner_id: [7, "Other"], amount_total: 99.5 }
+      )
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// odoo_create verification
+// ---------------------------------------------------------------------------
+describe("odoo_create verification", () => {
+  it("reads the record back and reports verified:true on a matching create", async () => {
+    mockCreate.mockResolvedValue(42);
+    // dup-guard read (ref set) → no dup; then verification read → the record.
+    mockSearchRead
+      .mockResolvedValueOnce(empty())
+      .mockResolvedValueOnce(records([{ id: 42, ref: "INV-1", move_type: "in_invoice" }]));
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_create", agentId);
+    const res = await tool.execute("c1", {
+      model: "account.move",
+      values: { ref: "INV-1", move_type: "in_invoice" },
+    });
+
+    expect(res.isError).toBeFalsy();
+    const data = JSON.parse(res.content[0].text);
+    expect(data.id).toBe(42);
+    expect(data.verified).toBe(true);
+    expect(res.details?.verified).toBe(true);
+    // The verification read really happened.
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "account.move",
+      [["id", "=", 42]],
+      expect.objectContaining({ fields: expect.arrayContaining(["id", "ref", "move_type"]) })
+    );
+  });
+
+  it("turns a silent no-op (id returned, record not persisted) into a hard error", async () => {
+    mockCreate.mockResolvedValue(42);
+    mockSearchRead
+      .mockResolvedValueOnce(empty()) // dup-guard
+      .mockResolvedValueOnce(empty()); // verification read: record MISSING
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_create", agentId);
+    const res = await tool.execute("c1", {
+      model: "account.move",
+      values: { ref: "INV-1", move_type: "in_invoice" },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.details?.verified).toBe(false);
+    // Audit failure signal is present.
+    expect(res.details?.error).toBeTruthy();
+    expect(res.content[0].text.toLowerCase()).toContain("could not be read back");
+  });
+
+  it("fails when a written verbatim scalar reads back different", async () => {
+    mockCreate.mockResolvedValue(42);
+    mockSearchRead
+      .mockResolvedValueOnce(empty()) // dup-guard
+      .mockResolvedValueOnce(records([{ id: 42, ref: "WRONG", move_type: "in_invoice" }]));
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_create", agentId);
+    const res = await tool.execute("c1", {
+      model: "account.move",
+      values: { ref: "INV-1", move_type: "in_invoice" },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.details?.verified).toBe(false);
+    expect(res.content[0].text).toContain("ref");
+  });
+
+  it("does not verify non-covered models (no read-back, no verified flag)", async () => {
+    mockCreate.mockResolvedValue(7);
+    const cfg = { connectionId: CONN, permissions: { "res.partner": ["create", "read"] } };
+    const tool = findTool(createApi({ [agentId]: cfg as AgentOdooConfig }), "odoo_create", agentId);
+    const res = await tool.execute("c1", {
+      model: "res.partner",
+      values: { name: "Acme" },
+    });
+
+    expect(res.isError).toBeFalsy();
+    const data = JSON.parse(res.content[0].text);
+    expect(data.id).toBe(7);
+    expect(data.verified).toBeUndefined();
+    expect(res.details?.verified).toBeUndefined();
+    // No verification read against res.partner by id.
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("skips verification (no false claim) when the agent lacks read permission", async () => {
+    mockCreate.mockResolvedValue(42);
+    const tool = findTool(
+      createApi({ [agentId]: moveConfig({ "account.move": ["create"] }) }),
+      "odoo_create",
+      agentId
+    );
+    const res = await tool.execute("c1", {
+      model: "account.move",
+      values: { ref: "INV-1", move_type: "in_invoice" },
+    });
+
+    expect(res.isError).toBeFalsy();
+    const data = JSON.parse(res.content[0].text);
+    expect(data.id).toBe(42);
+    expect(data.verified).toBeUndefined();
+    // Without read permission there is no verification read at all.
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("degrades to unverified success (no false-fail) when the verification read throws", async () => {
+    mockCreate.mockResolvedValue(42);
+    mockSearchRead
+      .mockResolvedValueOnce(empty()) // dup-guard
+      .mockRejectedValueOnce(new Error("network blip")); // verification read fails
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_create", agentId);
+    const res = await tool.execute("c1", {
+      model: "account.move",
+      values: { ref: "INV-1", move_type: "in_invoice" },
+    });
+
+    // The create DID happen — do not report failure and risk a duplicate retry.
+    expect(res.isError).toBeFalsy();
+    const data = JSON.parse(res.content[0].text);
+    expect(data.id).toBe(42);
+    expect(data.verified).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// odoo_write verification
+// ---------------------------------------------------------------------------
+describe("odoo_write verification", () => {
+  it("reads back and reports verified:true when the written scalar matches", async () => {
+    mockWrite.mockResolvedValue(true);
+    mockSearchRead.mockResolvedValueOnce(records([{ id: 42, ref: "INV-2" }]));
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_write", agentId);
+    const res = await tool.execute("w1", {
+      model: "account.move",
+      ids: [42],
+      values: { ref: "INV-2" },
+    });
+
+    expect(res.isError).toBeFalsy();
+    const data = JSON.parse(res.content[0].text);
+    expect(data.success).toBe(true);
+    expect(data.verified).toBe(true);
+    expect(res.details?.verified).toBe(true);
+  });
+
+  it("fails when Odoo reports success but the value did not persist", async () => {
+    mockWrite.mockResolvedValue(true);
+    mockSearchRead.mockResolvedValueOnce(records([{ id: 42, ref: "OLD-VALUE" }]));
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_write", agentId);
+    const res = await tool.execute("w1", {
+      model: "account.move",
+      ids: [42],
+      values: { ref: "INV-2" },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.details?.verified).toBe(false);
+    expect(res.content[0].text).toContain("ref");
+  });
+
+  it("does not verify non-covered models", async () => {
+    mockWrite.mockResolvedValue(true);
+    const cfg = { connectionId: CONN, permissions: { "res.partner": ["write", "read"] } };
+    const tool = findTool(createApi({ [agentId]: cfg as AgentOdooConfig }), "odoo_write", agentId);
+    const res = await tool.execute("w1", {
+      model: "res.partner",
+      ids: [7],
+      values: { name: "New Name" },
+    });
+
+    expect(res.isError).toBeFalsy();
+    const data = JSON.parse(res.content[0].text);
+    expect(data.success).toBe(true);
+    expect(data.verified).toBeUndefined();
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2166,6 +2166,115 @@ function toolError(text: string): {
   };
 }
 
+/**
+ * #720: error result for a failed read-after-write verification. Same
+ * `isError` + `details.error` contract as {@link toolError} (so the audit
+ * route records `outcome: failure`), plus `verified: false` so the audit row
+ * carries the verification outcome. The record was NOT persisted as reported;
+ * the model must surface the failure instead of narrating success.
+ */
+function verificationError(text: string): {
+  content: ContentBlock[];
+  isError: true;
+  details: { error: string; verified: false };
+} {
+  return {
+    isError: true,
+    content: [{ type: "text", text }],
+    details: { error: text, verified: false },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// #720: plugin-side write verification (read-after-write).
+//
+// Eval-v1's silent-failure scenario — the ERP returns a plausible id but
+// persists nothing — showed 0 of 162 graded runs across all 14 models
+// performing a verifying read after the write. Every model trusted the bare
+// return value and reported success while the ERP stayed empty. This is a
+// behavioural failure shared by the strongest and weakest models alike, so we
+// move verification into the deterministic tool layer: after a create/write on
+// a covered model the plugin reads the record back — from the SAME
+// authenticated session, so there is no replica lag — and only reports success
+// once the authoritative post-state confirms it (the "persist-before-
+// acknowledge" pattern, mirroring `odoo_reconcile`'s `didReconcile` check).
+// ---------------------------------------------------------------------------
+
+// Models whose writes we verify. Start with account.move + its line model (the
+// highest-stakes writes, per #720); widen only if the eval supports it.
+const VERIFIED_WRITE_MODELS = new Set(["account.move", "account.move.line"]);
+
+export function isVerifiedModel(model: string): boolean {
+  return VERIFIED_WRITE_MODELS.has(model);
+}
+
+// Field types Odoo stores VERBATIM — a read-back value equals what we wrote,
+// with no legitimate backend transformation, so comparing them cannot
+// false-fail. Deliberately EXCLUDED (each can differ from the submitted value
+// through legitimate Odoo behaviour, which a naive comparison would misread as
+// a failed write):
+//   - relational (many2one/one2many/many2many): normalization, command-tuple
+//     expansion, and the `[id, label]` read shape;
+//   - float / monetary: currency & decimal-precision rounding, net↔gross;
+//   - datetime: a submitted date is normalized to `... 00:00:00`;
+//   - readonly / computed: the server owns the value.
+const VERBATIM_SCALAR_TYPES = new Set(["char", "text", "boolean", "date", "selection", "integer"]);
+
+export function isVerbatimScalarField(field: OdooField): boolean {
+  return !field.readonly && !!field.type && VERBATIM_SCALAR_TYPES.has(field.type);
+}
+
+/**
+ * The submitted fields we can safely compare on read-back: those the caller
+ * explicitly set that map to a verbatim-scalar field in the model schema.
+ */
+export function verbatimFieldsToVerify(
+  fields: OdooField[],
+  submitted: Record<string, unknown>
+): OdooField[] {
+  const byName = new Map(fields.map((f) => [f.name, f]));
+  const out: OdooField[] = [];
+  for (const key of Object.keys(submitted)) {
+    const field = byName.get(key);
+    if (field && isVerbatimScalarField(field)) out.push(field);
+  }
+  return out;
+}
+
+function scalarEquals(field: OdooField, expected: unknown, actual: unknown): boolean {
+  // Odoo returns integers as numbers; tolerate a numeric-string submitted value
+  // (e.g. sequence). Everything else in the verbatim set round-trips exactly.
+  if (field.type === "integer") return Number(expected) === Number(actual);
+  return expected === actual;
+}
+
+export function findVerbatimMismatches(
+  fields: OdooField[],
+  submitted: Record<string, unknown>,
+  readBack: Record<string, unknown> | undefined
+): Array<{ field: string; expected: unknown; actual: unknown }> {
+  const out: Array<{ field: string; expected: unknown; actual: unknown }> = [];
+  for (const field of verbatimFieldsToVerify(fields, submitted)) {
+    const expected = submitted[field.name];
+    const actual = readBack?.[field.name];
+    if (!scalarEquals(field, expected, actual)) {
+      out.push({ field: field.name, expected, actual });
+    }
+  }
+  return out;
+}
+
+function formatMismatches(
+  mismatches: Array<{ field: string; expected: unknown; actual: unknown }>
+): string {
+  return mismatches
+    .map(
+      (m) =>
+        `${m.field}: wrote ${JSON.stringify(m.expected)}, read back ${JSON.stringify(m.actual)}`
+    )
+    .join("; ");
+}
+
 function permissionDenied(
   operation: string,
   model: string
@@ -2347,6 +2456,136 @@ const plugin = {
           throw retryErr;
         }
       }
+    }
+
+    /**
+     * #720: read the record back after `odoo_create` and confirm it persisted.
+     *
+     * Two gates, strongest first:
+     *   1. Existence — if the id cannot be read back, the write did not persist
+     *      (the Eval-v1 silent-failure scenario). This is deterministic and
+     *      cannot false-fail: a persisted record is always readable by its own
+     *      id in the same session.
+     *   2. Verbatim-scalar match — every submitted field Odoo stores verbatim
+     *      must read back unchanged (see `verbatimFieldsToVerify`).
+     *
+     * Only runs for covered models when the agent can read; otherwise it makes
+     * no verification claim (returns `verified: false`, and the caller omits the
+     * flag) rather than reporting an unverified success as verified.
+     */
+    async function verifyCreate(
+      agentId: string,
+      config: AgentOdooConfig,
+      model: string,
+      id: number,
+      sentValues: Record<string, unknown>,
+      modelFields: OdooField[] | null
+    ): Promise<
+      | { ok: true; verified: boolean; verifiedValues?: Record<string, unknown> }
+      | { ok: false; error: string }
+    > {
+      if (!isVerifiedModel(model)) return { ok: true, verified: false };
+      if (!checkPermission(config.permissions, model, "read")) return { ok: true, verified: false };
+
+      const compareFields = modelFields ? verbatimFieldsToVerify(modelFields, sentValues) : [];
+      const readFields = ["id", ...compareFields.map((f) => f.name)];
+
+      let record: Record<string, unknown> | undefined;
+      try {
+        const res = await withAuthRetry(agentId, config, (client) =>
+          client.searchRead(model, [["id", "=", id]], { fields: readFields, limit: 1 })
+        );
+        record = getSearchReadRecords(res)[0] as Record<string, unknown> | undefined;
+      } catch {
+        // The verification read failed (transport). The create may well have
+        // persisted, so reporting failure would risk a duplicate on retry —
+        // degrade to an unverified success rather than false-fail.
+        return { ok: true, verified: false };
+      }
+
+      if (!record) {
+        return {
+          ok: false,
+          error:
+            `Odoo returned id ${id} for ${model} but the record could not be read back — ` +
+            `the write did not persist. Odoo reports no error in this case, so this is not a ` +
+            `transient failure: nothing was saved. Do not report success — retry the create or ` +
+            `check the Odoo connection.`,
+        };
+      }
+
+      const mismatches = findVerbatimMismatches(compareFields, sentValues, record);
+      if (mismatches.length > 0) {
+        return {
+          ok: false,
+          error:
+            `Odoo created ${model} id ${id} but the saved values do not match what was written ` +
+            `(${formatMismatches(mismatches)}). The record was not persisted as intended — do ` +
+            `not report success.`,
+        };
+      }
+
+      const verifiedValues: Record<string, unknown> = {};
+      for (const f of compareFields) verifiedValues[f.name] = record[f.name];
+      return { ok: true, verified: true, verifiedValues };
+    }
+
+    /**
+     * #720: read the written records back after `odoo_write` and confirm the
+     * submitted verbatim scalars now match. `write` returns only a boolean and
+     * the record pre-exists, so existence is a weak signal — the authoritative
+     * check is that the fields we changed read back as written (mirrors
+     * `odoo_reconcile`). If we have nothing verbatim to compare (all submitted
+     * fields are relational/float), we make no verification claim.
+     */
+    async function verifyWrite(
+      agentId: string,
+      config: AgentOdooConfig,
+      model: string,
+      ids: number[],
+      sentValues: Record<string, unknown>,
+      modelFields: OdooField[] | null
+    ): Promise<{ ok: true; verified: boolean } | { ok: false; error: string }> {
+      if (!isVerifiedModel(model)) return { ok: true, verified: false };
+      if (!checkPermission(config.permissions, model, "read")) return { ok: true, verified: false };
+
+      const compareFields = modelFields ? verbatimFieldsToVerify(modelFields, sentValues) : [];
+      if (compareFields.length === 0) return { ok: true, verified: false };
+      const readFields = ["id", ...compareFields.map((f) => f.name)];
+
+      let recordsById: Map<unknown, Record<string, unknown>>;
+      try {
+        const res = await withAuthRetry(agentId, config, (client) =>
+          client.searchRead(model, [["id", "in", ids]], { fields: readFields })
+        );
+        recordsById = new Map(
+          getSearchReadRecords(res).map((r) => [(r as Record<string, unknown>).id, r])
+        );
+      } catch {
+        return { ok: true, verified: false };
+      }
+
+      for (const id of ids) {
+        const record = recordsById.get(id) as Record<string, unknown> | undefined;
+        if (!record) {
+          return {
+            ok: false,
+            error:
+              `Odoo reported the write to ${model} id ${id} succeeded but the record could not ` +
+              `be read back — the change did not persist. Do not report success.`,
+          };
+        }
+        const mismatches = findVerbatimMismatches(compareFields, sentValues, record);
+        if (mismatches.length > 0) {
+          return {
+            ok: false,
+            error:
+              `Odoo reported the write to ${model} id ${id} succeeded but the saved values do ` +
+              `not match what was written (${formatMismatches(mismatches)}). Do not report success.`,
+          };
+        }
+      }
+      return { ok: true, verified: true };
     }
 
     // Shared implementation of the list-models tool body. Reused by the
@@ -2835,6 +3074,10 @@ const plugin = {
                       override: ExistingBillSnapshot | null;
                       ref: string | null;
                       moveType: string;
+                      // #720: carried out so the post-create read-back can
+                      // compare the submitted verbatim scalars.
+                      sentValues: Record<string, unknown>;
+                      modelFields: OdooField[] | null;
                     }
                   | {
                       kind: "blocked";
@@ -2936,6 +3179,8 @@ const plugin = {
                     override,
                     ref: typeof values.ref === "string" ? values.ref : null,
                     moveType,
+                    sentValues: values,
+                    modelFields,
                   };
                 }
               );
@@ -2952,6 +3197,20 @@ const plugin = {
               }
 
               const id = outcome.id;
+
+              // #720: read the record back and confirm it persisted before
+              // reporting success. On a silent no-op (id returned, nothing
+              // saved) or a verbatim-scalar mismatch this returns a hard error
+              // so the model surfaces the failure instead of narrating success.
+              const verify = await verifyCreate(
+                agentId,
+                config,
+                model,
+                id,
+                outcome.sentValues,
+                outcome.modelFields
+              );
+              if (!verify.ok) return verificationError(verify.error);
 
               // Emit a self-ref so the LLM can chain into tools that consume
               // opaque references (most importantly odoo_attach_file). Without
@@ -2973,9 +3232,16 @@ const plugin = {
                 label,
               });
 
-              const body: Record<string, unknown> = { id, _pinchy_ref: selfRef };
+              // Deliberate duplicate override (pinchy#721): a distinct curated
+              // payload naming what was booked and the bill it duplicated. The
+              // create was already read back and verified above (#720).
               if (outcome.override) {
-                body.duplicate_override = { existing_bill: outcome.override };
+                const body: Record<string, unknown> = {
+                  id,
+                  _pinchy_ref: selfRef,
+                  duplicate_override: { existing_bill: outcome.override },
+                };
+                if (verify.verified) body.verified = true;
                 return {
                   content: [{ type: "text", text: JSON.stringify(body) }],
                   // Curated audit detail (the tool-use route lifts result.details
@@ -2992,17 +3258,29 @@ const plugin = {
                     bookedMoveType: outcome.moveType,
                     createdId: id,
                     existingBill: outcome.override,
+                    ...(verify.verified ? { verified: true } : {}),
                   },
                 };
               }
 
+              // Enrich the success payload with the verification outcome (#720).
+              // Only claim `verified: true` when we actually read the record back
+              // (covered model + read permission); otherwise omit the flag rather
+              // than assert a verification we did not perform.
+              const payload: Record<string, unknown> = { id, _pinchy_ref: selfRef };
+              if (verify.verified) {
+                payload.verified = true;
+                if (verify.verifiedValues && Object.keys(verify.verifiedValues).length > 0) {
+                  payload.verifiedValues = verify.verifiedValues;
+                }
+              }
+
               return {
-                content: [
-                  {
-                    type: "text",
-                    text: JSON.stringify(body),
-                  },
-                ],
+                content: [{ type: "text", text: JSON.stringify(payload) }],
+                // `details.verified` flows into the audit row (#720). Only set
+                // it when we verified — an unverified create must not audit a
+                // verification claim.
+                ...(verify.verified ? { details: { verified: true } } : {}),
               };
             } catch (error) {
               return errorResult(error, {
@@ -4114,29 +4392,55 @@ const plugin = {
                 throw itemWrappedError("values");
               }
 
-              const success = await withAuthRetry(agentId, config, async (client) => {
+              const written = await withAuthRetry(agentId, config, async (client) => {
                 let values: Record<string, unknown>;
+                let modelFields: OdooField[] | null = null;
                 if (isRecord(params.values)) {
                   const cleaned = unquoteFieldKeys(params.values);
                   assertNoCrossCompanyRefs(cleaned);
-                  values = (
-                    await normalizeMany2OneValues(
-                      client,
-                      config.connectionId,
-                      model,
-                      cleaned,
-                      config.permissions
-                    )
-                  ).values;
+                  const normalized = await normalizeMany2OneValues(
+                    client,
+                    config.connectionId,
+                    model,
+                    cleaned,
+                    config.permissions
+                  );
+                  values = normalized.values;
+                  modelFields = normalized.fields;
                   values = await ensureActivityResModelId(client, model, values);
                 } else {
                   values = params.values as Record<string, unknown>;
                 }
-                return client.write(model, params.ids as number[], values);
+                const ok = await client.write(model, params.ids as number[], values);
+                return { success: ok, sentValues: values, modelFields };
               });
 
+              const success = written.success;
+
+              // #720: read the written records back and confirm the change
+              // persisted. A backend that returns `true` but saved nothing (or
+              // saved a different value) becomes a hard, visible error instead
+              // of a false success.
+              const verify = await verifyWrite(
+                agentId,
+                config,
+                model,
+                params.ids as number[],
+                written.sentValues,
+                written.modelFields
+              );
+              if (!verify.ok) return verificationError(verify.error);
+
               return {
-                content: [{ type: "text", text: JSON.stringify({ success }) }],
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(
+                      verify.verified ? { success, verified: true } : { success }
+                    ),
+                  },
+                ],
+                ...(verify.verified ? { details: { verified: true } } : {}),
               };
             } catch (error) {
               return errorResult(error, {

--- a/packages/web/e2e/odoo/helpers.ts
+++ b/packages/web/e2e/odoo/helpers.ts
@@ -90,6 +90,35 @@ export async function setOdooAuthMode(mode: "ok" | "fail"): Promise<void> {
   if (!res.ok) throw new Error(`Failed to set Odoo auth mode: ${res.status}`);
 }
 
+/**
+ * Override the Odoo mock's response for `<model>.<method>` (pinchy#720). Used
+ * to inject a silent no-op create: the mock returns `response` (a plausible id)
+ * without persisting anything, so the plugin's read-after-write verification
+ * turns it into a hard failure instead of a false success.
+ */
+export async function setOdooMethodResponse(
+  model: string,
+  method: string,
+  response: unknown
+): Promise<void> {
+  const res = await fetch(`${MOCK_ODOO_URL}/control/method-response`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, method, response }),
+  });
+  if (!res.ok) throw new Error(`Failed to set Odoo method response: ${res.status}`);
+}
+
+/** Remove a `<model>.<method>` override without wiping the mock's store. */
+export async function clearOdooMethodResponse(model: string, method: string): Promise<void> {
+  const res = await fetch(`${MOCK_ODOO_URL}/control/method-response`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, method, clear: true }),
+  });
+  if (!res.ok) throw new Error(`Failed to clear Odoo method response: ${res.status}`);
+}
+
 export async function seedOdooRecords(
   model: string,
   records: Record<string, unknown>[]

--- a/packages/web/e2e/odoo/odoo-nested-lines.spec.ts
+++ b/packages/web/e2e/odoo/odoo-nested-lines.spec.ts
@@ -14,6 +14,8 @@ import {
   pinchyPost,
   pinchyDelete,
   getOdooRecords,
+  setOdooMethodResponse,
+  clearOdooMethodResponse,
 } from "./helpers";
 import {
   FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_TRIGGER,
@@ -23,7 +25,7 @@ import {
 } from "../shared/fake-ollama/fake-ollama-server";
 import {
   loginViaUI,
-  pollAuditForTool,
+  pollAuditForEvent,
   seedDefaultProviderToOllama,
   waitForOpenClawStable,
   waitForAgentDispatchable,
@@ -160,6 +162,8 @@ test.describe("Odoo nested one2many many2one resolution (#615)", () => {
 
     const input = page.getByPlaceholder(/send a message/i);
     await expect(input).toBeVisible({ timeout: 10_000 });
+    // Capture the cutoff BEFORE dispatch so the poll cannot match a stale row.
+    const since = new Date().toISOString();
     await input.fill(`${FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_TRIGGER}: book the opening entry`);
     await input.press("Enter");
 
@@ -167,12 +171,20 @@ test.describe("Odoo nested one2many many2one resolution (#615)", () => {
     // poll is still running when a late dispatch finally writes its audit. No
     // chat re-send — see odoo-agent-chat.spec.ts for why re-sending worsens
     // this flake.
-    const found = await pollAuditForTool(page, {
-      toolName: "odoo_create",
-      agentId,
+    //
+    // #720: assert not just that odoo_create dispatched, but that the plugin's
+    // read-after-write verification RAN and PASSED — outcome=success AND
+    // detail.verified=true. account.move is a verified-write model, so a green
+    // row here proves the record was read back and confirmed, not merely that
+    // the create call returned.
+    const entry = await pollAuditForEvent(page, {
+      eventType: "tool.odoo_create",
+      predicate: (e) => e.resource === `agent:${agentId}` && e.outcome === "success",
+      since,
       deadlineMs: 160_000,
     });
-    expect(found).toBe(true);
+    expect(entry.outcome).toBe("success");
+    expect(entry.detail?.verified).toBe(true);
 
     // Proof beyond the audit row: assert directly against the mock that the
     // move was created with two lines, and each line's account_id resolved
@@ -194,6 +206,51 @@ test.describe("Odoo nested one2many many2one resolution (#615)", () => {
     expect(createdLines).toHaveLength(2);
     for (const line of createdLines) {
       expect(line.account_id).toBe(40);
+    }
+  });
+
+  test("a silent no-op create (id returned, nothing persisted) is audited as failure, not false-success (#720)", async ({
+    page,
+  }, testInfo) => {
+    // The Eval-v1 flagship finding: the ERP returns a plausible id but persists
+    // nothing, and every model reported success. Here we inject exactly that —
+    // the mock's account.move `create` returns id 999999 without storing a
+    // record — and prove the plugin's read-after-write verification turns it
+    // into a hard, visible failure (outcome=failure, detail.verified=false)
+    // instead of a green checkmark.
+    testInfo.setTimeout(180_000);
+
+    // Make account.move.create a silent no-op: return an id, store nothing.
+    await setOdooMethodResponse("account.move", "create", 999999);
+    try {
+      await loginViaUI(page, getAdminEmail(), getAdminPassword());
+      await page.goto(`/chat/${agentId}`);
+      await expect(page).toHaveURL(`/chat/${agentId}`, { timeout: 10_000 });
+
+      const input = page.getByPlaceholder(/send a message/i);
+      await expect(input).toBeVisible({ timeout: 10_000 });
+      // Capture the cutoff BEFORE dispatch so the poll cannot match a stale row.
+      const since = new Date().toISOString();
+      await input.fill(`${FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_TRIGGER}: book the opening entry`);
+      await input.press("Enter");
+
+      const entry = await pollAuditForEvent(page, {
+        eventType: "tool.odoo_create",
+        predicate: (e) => e.resource === `agent:${agentId}` && e.outcome === "failure",
+        since,
+        deadlineMs: 160_000,
+      });
+      expect(entry.outcome).toBe("failure");
+      expect(entry.detail?.verified).toBe(false);
+
+      // The injected id was never persisted — verification proves the ERP is
+      // still empty of that record.
+      const stored = await getOdooRecords("account.move");
+      expect(stored.some((m) => m.id === 999999)).toBe(false);
+    } finally {
+      // Clear ONLY this override so the surrounding suite's seeded records and
+      // the other test's stored move are untouched.
+      await clearOdooMethodResponse("account.move", "create");
     }
   });
 });

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -806,6 +806,67 @@ describe("POST /api/internal/audit/tool-use", () => {
       expect((detail.params as Record<string, unknown>).model).toBe("account.move");
     });
 
+    it("records verified:true and keeps params for a verified success (#720)", async () => {
+      // #720: pinchy-odoo returns `details: { verified: true }` after reading a
+      // create/write back. `verified` is a verification-outcome flag, NOT a
+      // curated PII field, so it must land in the audit detail AND must not
+      // trigger param-suppression — the params still belong in the audit row.
+      await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "odoo_create",
+          agentId: "agent-1",
+          params: { model: "account.move", values: { move_type: "in_invoice" } },
+          result: {
+            content: [{ type: "text", text: JSON.stringify({ id: 5, verified: true }) }],
+            details: { verified: true },
+          },
+        })
+      );
+
+      const call = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+      expect(call?.outcome).toBe("success");
+      const detail = call?.detail as Record<string, unknown>;
+      expect(detail.verified).toBe(true);
+      // params retained (verified is not a curated PII field)
+      expect(detail).toHaveProperty("params");
+      expect((detail.params as Record<string, unknown>).model).toBe("account.move");
+    });
+
+    it("records verified:false and keeps params on a verification failure (#720)", async () => {
+      // The failure path returns `details: { error, verified: false }`. The
+      // extra `verified: false` must NOT suppress params — forensics still need
+      // to know what the failed create attempted (same contract as the
+      // error-only case above).
+      await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "odoo_create",
+          agentId: "agent-1",
+          params: { model: "account.move", values: { ref: "INV-1" } },
+          result: {
+            content: [
+              { type: "text", text: "Odoo returned id 5 but the record could not be read back" },
+            ],
+            details: {
+              error: "Odoo returned id 5 but the record could not be read back",
+              verified: false,
+            },
+          },
+        })
+      );
+
+      const call = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+      expect(call?.outcome).toBe("failure");
+      const detail = call?.detail as Record<string, unknown>;
+      expect(detail.verified).toBe(false);
+      expect(detail.success).toBe(false);
+      // params retained for forensics
+      expect(detail).toHaveProperty("params");
+      const params = (detail.params as Record<string, unknown>).values as Record<string, unknown>;
+      expect(params.ref).toBe("INV-1");
+    });
+
     it("keeps params when result.details is not a plain object", async () => {
       await POST(
         makeRequest({

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -219,8 +219,12 @@ export async function POST(request: NextRequest) {
     // failed tool now emits so OpenClaw's isError-stripping (#404) can't mask
     // the failure, must NOT suppress params: forensics need to know what the
     // failed call attempted (the 2026-06-25 false-success incident hinged on
-    // those params being lost).
-    const curatesNonErrorFields = Object.keys(resultDetails).some((k) => k !== "error");
+    // those params being lost). `verified` (#720: pinchy-odoo's read-after-write
+    // outcome) is likewise a verification flag, not curated PII — it records
+    // into the audit detail but must not suppress params on either path.
+    const curatesNonErrorFields = Object.keys(resultDetails).some(
+      (k) => k !== "error" && k !== "verified"
+    );
     if (curatesNonErrorFields) delete detail.params;
     Object.assign(detail, resultDetails);
     // Plugins must not override these system fields. Re-apply after merge.


### PR DESCRIPTION
## What does this PR do?

Moves write verification into the deterministic `pinchy-odoo` tool layer, so a
silent no-op backend can no longer be reported as success.

Closes #720

Eval-v1's silent-failure scenario (the ERP returns a plausible id but persists
nothing) showed **0 of 162 graded runs across all 14 models** performing a
verifying read after the write — every model trusted the bare return value and
reported success while the ERP stayed empty. This is a behavioural failure the
strongest and weakest open-weight models share, so neither "wait for better
models" nor a skippable prompt mandate fixes it. We make it a platform guarantee
instead.

After `odoo_create` and value-bearing `odoo_write` on `account.move` (+ its line
model), the plugin now reads the record back **from the same authenticated
session** before reporting success — the canonical *persist-before-acknowledge*
pattern, mirroring the existing `odoo_reconcile` read-back (`didReconcile`):

- **Existence gate** (deterministic, zero false-positives): a missing record →
  hard error. This turns the silent no-op into a visible, audited failure.
- **Verbatim-scalar gate**: every submitted `char`/`text`/`boolean`/`date`/
  `selection`/`integer` field must read back unchanged. Relational, `float`/
  `monetary`, `datetime`, and readonly/computed fields are **excluded** so
  legitimate Odoo transformation (m2o normalization, rounding, net↔gross,
  date→datetime) cannot false-fail a correct write.

On success the result is enriched with `verified: true`; on mismatch/missing it
returns a hard error with `verified: false`. The web audit route records the
`verified` flag on both paths and no longer suppresses the forensic `params`
because of it (so a failed create's attempted values are still logged).

Scope is intentionally `account.move` (+ `account.move.line`) — the
highest-stakes writes — behind a single `isVerifiedModel()` predicate we can
widen later. Nothing else changes behaviour.

## Type of change

- [x] ✨ New feature

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated the documentation
- [x] All existing tests pass

## Testing

- **Plugin unit tests** (`write-verification.test.ts`, 20 new): read-back on
  create, mismatch, missing-record (silent no-op → hard error), write
  verification, non-covered-model passthrough, no-read-permission skip,
  transport-error degrade-to-unverified. Full pinchy-odoo suite green (426).
- **Audit route** (`internal-audit-tool-use.test.ts`): `verified` recorded on
  success and failure; `params` retained on both (forensics).
- **Odoo E2E** (`odoo-nested-lines.spec.ts`): verified-create round trip
  (asserts `outcome=success` + `detail.verified=true`) and a new probe that
  injects a silent no-op create (mock returns an id, stores nothing) and asserts
  the row is audited as `failure`. New `setOdooMethodResponse` /
  `clearOdooMethodResponse` mock-control helpers.
- **Typecheck**: `pnpm typecheck:plugins` + web tsc (incl. tests) clean.

## Eval validation (keep-or-revert)

Probe (N=3, #720 build) through the governed layer confirms **KEEP**:

| model | silent-failure false-success: baseline → #720 |
| --- | --- |
| qwen3.5:397b | 12/12 → 1/3 |
| gemma4:31b | 12/12 → 0/3 |
| gpt-oss:120b | 6/12 → 0/2 valid |

End-to-end audit (eval DB): 26× `failure`/`verified=false` (silent no-op caught),
10× `success`/`verified=true`. Happy-path shows **no** verification false-fail
(failures are pre-existing model extraction incapacity).

Honest nuance: the hard error does not drop false-success to zero "by
construction" — it converts it into an honest failure report *or* a retry-loop
in weak models (visible/audited either way, not a silent lie). The full
publish-grade sweep (11 runnable models × silent-failure/happy/line-items × N=12;
`minimax-m3` is blocklisted #766 and `glm-4.7`/`deepseek-v3.2` are retired, so
those keep their baseline numbers) is running separately; the published
`eval/data` scorecards will be refreshed in a follow-up `data(eval):` commit.
