### PR TITLE
fix(db): make 0059 idempotent so the 0.9.0 → 0.10 upgrade survives

### DIFF
--- a/packages/web/drizzle/0059_right_speedball.sql
+++ b/packages/web/drizzle/0059_right_speedball.sql
@@ -1,4 +1,16 @@
-CREATE TABLE "openai_compatible_providers" (
+-- IF NOT EXISTS is load-bearing, not defensive habit. The 0.9 release branch
+-- backported this table (#905/#894) as its own migration
+-- 0056_openai_compatible_providers, numbered and timestamped to sit BELOW
+-- 0056_serious_expediter so a 0.9.0 database's drizzle watermark stays under
+-- every 0.10 migration and the upgrade still applies 0056-0058 in order. The
+-- cost of that ordering is that a 0.9.0 database reaches this migration with
+-- the table already created, and a plain CREATE TABLE would abort the whole
+-- 0.9.0 -> 0.10 upgrade. The DDL below is byte-identical to what the release
+-- branch ran, so skipping it there is correct rather than merely tolerable.
+--
+-- Do not regenerate this file with `db:generate` without re-adding the guard.
+-- migration-090-upgrade-path.integration.test.ts fails if it goes missing.
+CREATE TABLE IF NOT EXISTS "openai_compatible_providers" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"slug" text NOT NULL,
 	"display_name" text NOT NULL,

--- a/packages/web/drizzle/0059_right_speedball.sql
+++ b/packages/web/drizzle/0059_right_speedball.sql
@@ -8,8 +8,10 @@
 -- 0.9.0 -> 0.10 upgrade. The DDL below is byte-identical to what the release
 -- branch ran, so skipping it there is correct rather than merely tolerable.
 --
--- Do not regenerate this file with `db:generate` without re-adding the guard.
--- migration-090-upgrade-path.integration.test.ts fails if it goes missing.
+-- Do not regenerate this file with `db:generate` without re-adding the guard,
+-- and do not edit the DDL below: migration-090-baseline.test.ts fails on either
+-- (statically, in `pnpm test`), and migration-090-upgrade-path.integration.test
+-- reproduces the aborted upgrade itself under `pnpm test:db`.
 CREATE TABLE IF NOT EXISTS "openai_compatible_providers" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"slug" text NOT NULL,

--- a/packages/web/src/__tests__/db/migration-090-baseline.test.ts
+++ b/packages/web/src/__tests__/db/migration-090-baseline.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Static guards for the v0.9.0 → v0.10 upgrade path.
+ *
+ * The behavioral proof lives in migration-090-upgrade-path.integration.test.ts:
+ * it rebuilds a released 0.9.0 database and upgrades it to HEAD. That test needs
+ * a real Postgres, so it only runs under `pnpm test:db` — and its own beforeAll
+ * creates a throwaway database, which means a DB-less run cannot even report on
+ * the premises.
+ *
+ * Those premises are pure facts about files in this repo, so they are checked
+ * here as well: in the Docker-free suite, where a regenerated 0059 or a
+ * backdated new migration is caught the moment it is written. Same split as
+ * migration-journal-order.test.ts (static) ↔ migration-upgrade-path (behavior).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  PROVIDER_MIGRATION_TAG,
+  PROVIDER_TABLE,
+  REL09_SQL,
+  REL09_WHEN,
+  V090_LAST_IDX,
+  V090_LAST_TAG,
+} from "@/test-helpers/release-090";
+
+// vitest runs with cwd = packages/web (pnpm -C packages/web test).
+const MIGRATIONS_DIR = join(process.cwd(), "drizzle");
+
+type JournalEntry = { idx: number; when: number; tag: string };
+const journal = JSON.parse(readFileSync(join(MIGRATIONS_DIR, "meta/_journal.json"), "utf-8")) as {
+  entries: JournalEntry[];
+};
+
+const providerMigration = readFileSync(
+  join(MIGRATIONS_DIR, `${PROVIDER_MIGRATION_TAG}.sql`),
+  "utf-8"
+);
+
+/** The migration's SQL with its comment header removed (`-->` breakpoints kept). */
+function stripComments(sql: string): string {
+  return sql
+    .split("\n")
+    .filter((line) => !/^--(?!>)/.test(line))
+    .join("\n")
+    .trimStart();
+}
+
+describe("v0.9.0 upgrade baseline", () => {
+  it("pins the v0.9.0 cut to the migration it actually shipped", () => {
+    // V090_LAST_IDX is a bare number everywhere else; this is what gives it a
+    // meaning that a reader (and a future renumbering) can check.
+    const last = journal.entries.find((e) => e.idx === V090_LAST_IDX);
+    expect(last?.tag).toBe(V090_LAST_TAG);
+  });
+
+  it("keeps every post-0.9.0 migration above the 0.9.0 watermark", () => {
+    // The premise the whole upgrade rests on: a 0.9.0 database's drizzle
+    // watermark sits at REL09_WHEN, and drizzle applies a migration only when
+    // its `when` exceeds the watermark. A new migration backdated below
+    // REL09_WHEN would be skipped forever on exactly this upgrade path — the
+    // 0035_smart_misty_knight failure, one release later.
+    const later = journal.entries.filter((e) => e.idx > V090_LAST_IDX);
+    expect(later.length).toBeGreaterThan(0);
+    const violations = later
+      .filter((e) => e.when <= REL09_WHEN)
+      .map(
+        (e) =>
+          `${e.tag} (when=${e.when}) is not after the v0.9.0 watermark ${REL09_WHEN} — it would be skipped on every v0.9.0 → v0.10 upgrade`
+      );
+    expect(violations).toEqual([]);
+  });
+
+  it(`creates ${PROVIDER_TABLE} idempotently in ${PROVIDER_MIGRATION_TAG}`, () => {
+    // A 0.9.0 database reaches this migration with the table already present.
+    // `db:generate` emits a plain CREATE TABLE, so a regeneration silently
+    // re-arms the upgrade abort; the integration test catches it too, but only
+    // where a Postgres is running.
+    expect(providerMigration).toContain(`CREATE TABLE IF NOT EXISTS "${PROVIDER_TABLE}"`);
+  });
+
+  it("keeps the released 0.9.0 DDL identical to the migration under test", () => {
+    // REL09_SQL is what release/0.9 ran and what the integration test replays.
+    // If 0059 is ever edited, that reproduction stops describing reality — so
+    // report the edit here rather than letting the replay follow it silently.
+    expect(
+      stripComments(providerMigration).replace(
+        `CREATE TABLE IF NOT EXISTS "${PROVIDER_TABLE}"`,
+        `CREATE TABLE "${PROVIDER_TABLE}"`
+      )
+    ).toBe(REL09_SQL);
+  });
+});

--- a/packages/web/src/__tests__/db/migration-090-upgrade-path.integration.test.ts
+++ b/packages/web/src/__tests__/db/migration-090-upgrade-path.integration.test.ts
@@ -25,8 +25,12 @@
  * CREATE TABLE IF NOT EXISTS or the whole upgrade aborts on first boot.
  *
  * This test reproduces a released 0.9.0 database with the REAL migrator — never
- * hand-written DDL — and proves the upgrade to HEAD both succeeds and delivers
- * 0056-0058. It fails if someone regenerates 0059 without the guard.
+ * hand-written DDL — and proves the upgrade to HEAD both succeeds and applies
+ * every 0.10 migration. It fails if someone regenerates 0059 without the guard.
+ *
+ * The static premises it rests on (the watermark ordering, the guard's presence,
+ * the released DDL) are pinned in migration-090-baseline.test.ts as well, so
+ * they are also checked in the Docker-free suite.
  *
  * Runs under `pnpm -C packages/web test:db` against the dev-stack Postgres on
  * :5434 (or VITEST_INTEGRATION_DB_URL). Uses its own throwaway database.
@@ -38,32 +42,16 @@ import { migrate } from "drizzle-orm/postgres-js/migrator";
 import { cp, mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  PROVIDER_TABLE,
+  REL09_SQL,
+  REL09_TAG,
+  REL09_WHEN,
+  V090_LAST_IDX,
+} from "@/test-helpers/release-090";
 
 // vitest runs with cwd = packages/web; the real migrations live in ./drizzle.
 const REAL_MIGRATIONS = join(process.cwd(), "drizzle");
-
-// v0.9.0 branched after idx 55; 0056-0059 are the 0.10 additions.
-const V090_LAST_IDX = 55;
-
-// The release branch's own migration, mirrored here so this test reproduces a
-// real 0.9.0 database instead of approximating one. The SQL is byte-identical
-// to 0059_right_speedball's table definition (WITHOUT the IF NOT EXISTS guard —
-// on a 0.9.0 database the table cannot pre-exist), and the timestamp is the one
-// release/0.9 pins so its watermark stays below main's 0056.
-const REL09_TAG = "0056_openai_compatible_providers";
-const REL09_WHEN = 1784300000000;
-const REL09_SQL = `CREATE TABLE "openai_compatible_providers" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"slug" text NOT NULL,
-	"display_name" text NOT NULL,
-	"base_url" text NOT NULL,
-	"api_key" text NOT NULL,
-	"models" jsonb DEFAULT '[]'::jsonb NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "openai_compatible_providers_slug_unique" UNIQUE("slug")
-);
-`;
 
 // Per-process DB name so concurrent runs can't collide on the throwaway DB.
 const DB_NAME = `pinchy_090_upgrade_test_${process.pid}`;
@@ -107,8 +95,8 @@ describe("migration upgrade path (v0.9.0 → HEAD)", () => {
     }
 
     // Build a "v0.9.0" migrations folder: every .sql file, the journal truncated
-    // to idx <= 55, plus the release branch's own 0056 appended exactly as
-    // release/0.9 ships it.
+    // to idx <= V090_LAST_IDX, plus the release branch's own 0056 appended
+    // exactly as release/0.9 ships it.
     v090MigrationsDir = await mkdtemp(join(tmpdir(), "pinchy-v090-"));
     await cp(REAL_MIGRATIONS, v090MigrationsDir, { recursive: true });
     const journal = await readJournal(v090MigrationsDir);
@@ -127,7 +115,7 @@ describe("migration upgrade path (v0.9.0 → HEAD)", () => {
     // main's 0056_serious_expediter.sql was copied along; the truncated journal
     // never references it, and the release tag gets its own file.
     await writeFile(join(v090MigrationsDir, `${REL09_TAG}.sql`), REL09_SQL);
-  }, 120_000);
+  });
 
   afterAll(async () => {
     if (v090MigrationsDir) await rm(v090MigrationsDir, { recursive: true, force: true });
@@ -139,23 +127,7 @@ describe("migration upgrade path (v0.9.0 → HEAD)", () => {
     }
   });
 
-  it("keeps the 0.9.0 watermark below every 0.10 migration", async () => {
-    // The premise the whole upgrade rests on. If a future 0.10 migration were
-    // ever backdated below REL09_WHEN it would be skipped on exactly this path,
-    // and the behavioral assertions below would not necessarily catch it (they
-    // only witness 0056 and 0058).
-    const journal = await readJournal(REAL_MIGRATIONS);
-    const laterThan090 = journal.entries.filter((e) => e.idx > V090_LAST_IDX);
-    expect(laterThan090.length).toBeGreaterThan(0);
-    for (const entry of laterThan090) {
-      expect({ tag: entry.tag, above: entry.when > REL09_WHEN }).toEqual({
-        tag: entry.tag,
-        above: true,
-      });
-    }
-  });
-
-  it("upgrades a released 0.9.0 database to HEAD without losing 0056-0058", async () => {
+  it("upgrades a released 0.9.0 database to HEAD without skipping 0056-0058", async () => {
     const relExists = async (client: postgres.Sql, rel: string): Promise<boolean> => {
       const [{ ok }] = await client`select to_regclass(${rel}) is not null as ok`;
       return ok as boolean;
@@ -168,7 +140,7 @@ describe("migration upgrade path (v0.9.0 → HEAD)", () => {
         await migrate(drizzle(client), { migrationsFolder: v090MigrationsDir });
 
         // It really is a 0.9.0 database: it HAS the backported provider table…
-        expect(await relExists(client, "public.openai_compatible_providers")).toBe(true);
+        expect(await relExists(client, `public.${PROVIDER_TABLE}`)).toBe(true);
         // …and none of the 0.10 migrations, or the upgrade below proves nothing.
         expect(await relExists(client, "public.agent_delivered_files")).toBe(false);
 
@@ -192,22 +164,35 @@ describe("migration upgrade path (v0.9.0 → HEAD)", () => {
       }
     }
 
-    // Phase 3 — the three migrations the naive backport would have skipped.
+    // Phase 3 — the migrations the naive backport would have skipped.
     {
       const client = postgres(testUrl, { max: 1 });
       try {
+        // Completeness first, and generically: one applied row per HEAD journal
+        // entry plus the release branch's own 0056, watermark parked at HEAD's
+        // last migration. This is what covers 0057 — a data backfill on a table
+        // 0056 truncates, so it can leave no witness of its own here; its
+        // behavior is pinned by migration-kb-archive-backfill — and every 0.10
+        // migration added after this test was written.
+        const journal = await readJournal(REAL_MIGRATIONS);
+        const applied = await client<{ created_at: string }[]>`
+          select created_at from drizzle.__drizzle_migrations order by created_at desc`;
+        expect(applied.length).toBe(journal.entries.length + 1);
+        expect(Number(applied[0].created_at)).toBe(journal.entries.at(-1)!.when);
+
         // 0058 — the clean binary signal.
         expect(await relExists(client, "public.agent_delivered_files")).toBe(true);
-        // 0056 — the KB embedding column really was re-widened to 768 dims.
+        // 0056 — the KB embedding column really was re-created at 768 dims.
+        // pgvector stores the declared dimension verbatim in atttypmod.
         const [{ dims }] = await client<{ dims: number | null }[]>`
           select atttypmod as dims from pg_attribute
           where attrelid = 'public.kb_chunks'::regclass and attname = 'embedding'`;
         expect(dims).toBe(768);
         // And the 0.9.0 table survived 0059 re-running as a no-op.
-        expect(await relExists(client, "public.openai_compatible_providers")).toBe(true);
+        expect(await relExists(client, `public.${PROVIDER_TABLE}`)).toBe(true);
       } finally {
         await client.end();
       }
     }
-  }, 180_000);
+  });
 });

--- a/packages/web/src/__tests__/db/migration-090-upgrade-path.integration.test.ts
+++ b/packages/web/src/__tests__/db/migration-090-upgrade-path.integration.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Behavior-layer guard for the v0.9.0 → v0.10 upgrade path.
+ *
+ * v0.9.0 was cut from the `release/0.9` branch, which carries a backport of
+ * #905/#894 (the generic OpenAI-compatible provider). That feature needs the
+ * `openai_compatible_providers` table, which on main is migration
+ * 0059_right_speedball — sitting BEHIND three migrations that are not part of
+ * 0.9.0: 0056 (KB embedder switch to 768-dim embeddinggemma), 0057 (KB archive
+ * status backfill) and 0058 (agent_delivered_files).
+ *
+ * Drizzle's migrator is gated on a single high-water mark: pg-core's dialect
+ * reads `select id, hash, created_at ... order by created_at desc limit 1` and
+ * applies a migration only when its journal `when` exceeds that value. Shipping
+ * the table as 0059 on the release branch would therefore park every 0.9.0
+ * database's watermark at 0059's timestamp and skip 0056-0058 FOREVER — the KB
+ * left on the old 1024-dim column that 0.10 expects to be 768-dim,
+ * agent_delivered_files never created. That is the failure mode
+ * 0035_smart_misty_knight shipped in v0.5.7 (see migration-upgrade-path and
+ * migration-gap-repair) and migration-journal-order now prevents statically.
+ *
+ * The release branch avoids it by numbering its copy 0056_openai_compatible_
+ * providers with a `when` BELOW main's 0056, keeping a 0.9.0 watermark under
+ * every 0.10 migration. The cost lands here: such a database reaches
+ * 0059_right_speedball with the table already present, so 0059 must be a
+ * CREATE TABLE IF NOT EXISTS or the whole upgrade aborts on first boot.
+ *
+ * This test reproduces a released 0.9.0 database with the REAL migrator — never
+ * hand-written DDL — and proves the upgrade to HEAD both succeeds and delivers
+ * 0056-0058. It fails if someone regenerates 0059 without the guard.
+ *
+ * Runs under `pnpm -C packages/web test:db` against the dev-stack Postgres on
+ * :5434 (or VITEST_INTEGRATION_DB_URL). Uses its own throwaway database.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { cp, mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// vitest runs with cwd = packages/web; the real migrations live in ./drizzle.
+const REAL_MIGRATIONS = join(process.cwd(), "drizzle");
+
+// v0.9.0 branched after idx 55; 0056-0059 are the 0.10 additions.
+const V090_LAST_IDX = 55;
+
+// The release branch's own migration, mirrored here so this test reproduces a
+// real 0.9.0 database instead of approximating one. The SQL is byte-identical
+// to 0059_right_speedball's table definition (WITHOUT the IF NOT EXISTS guard —
+// on a 0.9.0 database the table cannot pre-exist), and the timestamp is the one
+// release/0.9 pins so its watermark stays below main's 0056.
+const REL09_TAG = "0056_openai_compatible_providers";
+const REL09_WHEN = 1784300000000;
+const REL09_SQL = `CREATE TABLE "openai_compatible_providers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"display_name" text NOT NULL,
+	"base_url" text NOT NULL,
+	"api_key" text NOT NULL,
+	"models" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "openai_compatible_providers_slug_unique" UNIQUE("slug")
+);
+`;
+
+// Per-process DB name so concurrent runs can't collide on the throwaway DB.
+const DB_NAME = `pinchy_090_upgrade_test_${process.pid}`;
+
+type JournalEntry = {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+};
+
+function withDbName(url: string, name: string): string {
+  const u = new URL(url);
+  u.pathname = `/${name}`;
+  return u.toString();
+}
+
+async function readJournal(dir: string): Promise<{ entries: JournalEntry[] }> {
+  return JSON.parse(await readFile(join(dir, "meta", "_journal.json"), "utf-8")) as {
+    entries: JournalEntry[];
+  };
+}
+
+describe("migration upgrade path (v0.9.0 → HEAD)", () => {
+  const baseUrl =
+    process.env.DATABASE_URL ??
+    process.env.VITEST_INTEGRATION_DB_URL ??
+    "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy_test_vitest";
+  const adminUrl = withDbName(baseUrl, "postgres");
+  const testUrl = withDbName(baseUrl, DB_NAME);
+  let v090MigrationsDir: string;
+
+  beforeAll(async () => {
+    const admin = postgres(adminUrl, { max: 1 });
+    try {
+      await admin.unsafe(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`);
+      await admin.unsafe(`CREATE DATABASE ${DB_NAME}`);
+    } finally {
+      await admin.end();
+    }
+
+    // Build a "v0.9.0" migrations folder: every .sql file, the journal truncated
+    // to idx <= 55, plus the release branch's own 0056 appended exactly as
+    // release/0.9 ships it.
+    v090MigrationsDir = await mkdtemp(join(tmpdir(), "pinchy-v090-"));
+    await cp(REAL_MIGRATIONS, v090MigrationsDir, { recursive: true });
+    const journal = await readJournal(v090MigrationsDir);
+    journal.entries = journal.entries.filter((e) => e.idx <= V090_LAST_IDX);
+    journal.entries.push({
+      idx: V090_LAST_IDX + 1,
+      version: "7",
+      when: REL09_WHEN,
+      tag: REL09_TAG,
+      breakpoints: true,
+    });
+    await writeFile(
+      join(v090MigrationsDir, "meta", "_journal.json"),
+      JSON.stringify(journal, null, 2)
+    );
+    // main's 0056_serious_expediter.sql was copied along; the truncated journal
+    // never references it, and the release tag gets its own file.
+    await writeFile(join(v090MigrationsDir, `${REL09_TAG}.sql`), REL09_SQL);
+  }, 120_000);
+
+  afterAll(async () => {
+    if (v090MigrationsDir) await rm(v090MigrationsDir, { recursive: true, force: true });
+    const admin = postgres(adminUrl, { max: 1 });
+    try {
+      await admin.unsafe(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`);
+    } finally {
+      await admin.end();
+    }
+  });
+
+  it("keeps the 0.9.0 watermark below every 0.10 migration", async () => {
+    // The premise the whole upgrade rests on. If a future 0.10 migration were
+    // ever backdated below REL09_WHEN it would be skipped on exactly this path,
+    // and the behavioral assertions below would not necessarily catch it (they
+    // only witness 0056 and 0058).
+    const journal = await readJournal(REAL_MIGRATIONS);
+    const laterThan090 = journal.entries.filter((e) => e.idx > V090_LAST_IDX);
+    expect(laterThan090.length).toBeGreaterThan(0);
+    for (const entry of laterThan090) {
+      expect({ tag: entry.tag, above: entry.when > REL09_WHEN }).toEqual({
+        tag: entry.tag,
+        above: true,
+      });
+    }
+  });
+
+  it("upgrades a released 0.9.0 database to HEAD without losing 0056-0058", async () => {
+    const relExists = async (client: postgres.Sql, rel: string): Promise<boolean> => {
+      const [{ ok }] = await client`select to_regclass(${rel}) is not null as ok`;
+      return ok as boolean;
+    };
+
+    // Phase 1 — reproduce a released 0.9.0 database with the real migrator.
+    {
+      const client = postgres(testUrl, { max: 1 });
+      try {
+        await migrate(drizzle(client), { migrationsFolder: v090MigrationsDir });
+
+        // It really is a 0.9.0 database: it HAS the backported provider table…
+        expect(await relExists(client, "public.openai_compatible_providers")).toBe(true);
+        // …and none of the 0.10 migrations, or the upgrade below proves nothing.
+        expect(await relExists(client, "public.agent_delivered_files")).toBe(false);
+
+        const [{ created_at: watermark }] = await client<{ created_at: string }[]>`
+          select created_at from drizzle.__drizzle_migrations order by created_at desc limit 1`;
+        expect(Number(watermark)).toBe(REL09_WHEN);
+      } finally {
+        await client.end();
+      }
+    }
+
+    // Phase 2 — upgrade to HEAD. Without IF NOT EXISTS on 0059 this throws
+    // 'relation "openai_compatible_providers" already exists' and a real
+    // customer's container never finishes booting.
+    {
+      const client = postgres(testUrl, { max: 1 });
+      try {
+        await migrate(drizzle(client), { migrationsFolder: REAL_MIGRATIONS });
+      } finally {
+        await client.end();
+      }
+    }
+
+    // Phase 3 — the three migrations the naive backport would have skipped.
+    {
+      const client = postgres(testUrl, { max: 1 });
+      try {
+        // 0058 — the clean binary signal.
+        expect(await relExists(client, "public.agent_delivered_files")).toBe(true);
+        // 0056 — the KB embedding column really was re-widened to 768 dims.
+        const [{ dims }] = await client<{ dims: number | null }[]>`
+          select atttypmod as dims from pg_attribute
+          where attrelid = 'public.kb_chunks'::regclass and attname = 'embedding'`;
+        expect(dims).toBe(768);
+        // And the 0.9.0 table survived 0059 re-running as a no-op.
+        expect(await relExists(client, "public.openai_compatible_providers")).toBe(true);
+      } finally {
+        await client.end();
+      }
+    }
+  }, 180_000);
+});

--- a/packages/web/src/test-helpers/release-090.ts
+++ b/packages/web/src/test-helpers/release-090.ts
@@ -1,0 +1,49 @@
+/**
+ * Facts about the released v0.9.0 database, shared by the static guard
+ * (src/__tests__/db/migration-090-baseline.test.ts) and the behavioral one
+ * (src/__tests__/db/migration-090-upgrade-path.integration.test.ts).
+ *
+ * These are historical constants, not configuration. They describe a branch
+ * that has already shipped (`release/0.9`); editing them here changes nothing
+ * about what customers run, it only makes both guards describe a database that
+ * does not exist. They live in one module so the two guards cannot drift apart.
+ */
+
+/** Last migration idx that shipped in v0.9.0. 0056-0059 are the 0.10 additions. */
+export const V090_LAST_IDX = 55;
+export const V090_LAST_TAG = "0055_odd_microbe";
+
+/**
+ * release/0.9 backported #905/#894 as its own migration, numbered and
+ * timestamped to sit BETWEEN 0055 (1784286855381) and main's
+ * 0056_serious_expediter (1784536753112), so a 0.9.0 database's drizzle
+ * watermark stays below every 0.10 migration. See the header of
+ * drizzle/0059_right_speedball.sql for why that ordering is load-bearing.
+ */
+export const REL09_TAG = "0056_openai_compatible_providers";
+export const REL09_WHEN = 1784300000000;
+
+/** The table the backport creates, and that 0059 must re-create idempotently. */
+export const PROVIDER_TABLE = "openai_compatible_providers";
+
+/** main's migration for the same table. */
+export const PROVIDER_MIGRATION_TAG = "0059_right_speedball";
+
+/**
+ * The DDL release/0.9 actually ran — main's 0059 without the IF NOT EXISTS
+ * guard, which on a 0.9.0 database has nothing to guard against. Mirrored
+ * rather than derived from 0059 so that an edit to 0059 is reported instead of
+ * silently followed; migration-090-baseline.test.ts pins the two together.
+ */
+export const REL09_SQL = `CREATE TABLE "openai_compatible_providers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"display_name" text NOT NULL,
+	"base_url" text NOT NULL,
+	"api_key" text NOT NULL,
+	"models" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "openai_compatible_providers_slug_unique" UNIQUE("slug")
+);
+`;


### PR DESCRIPTION
## What

`0059_right_speedball.sql` now creates `openai_compatible_providers` with `CREATE TABLE IF NOT EXISTS`, plus a new integration test that proves the v0.9.0 → v0.10 upgrade path.

## Why

v0.9.0 backports #905/#894, so `release/0.9` needs that table. On main it is migration **0059**, sitting behind three migrations that are *not* part of 0.9.0: 0056 (KB embedder switch), 0057 (KB archive backfill), 0058 (`agent_delivered_files`).

Drizzle's migrator is gated on a single high-water mark — `pg-core/dialect`: `select id, hash, created_at … order by created_at desc limit 1`, then apply only where the journal `when` exceeds it. Backporting 0059 as-is would park every 0.9.0 database's watermark at `1784794312121` and **skip 0056–0058 forever**: the KB left on the old 1024-dim `bge-m3` column that 0.10 reads as 768-dim embeddinggemma, `kb_documents.status` unbackfilled, `agent_delivered_files` absent. Same failure as `0035_smart_misty_knight` in v0.5.7.

`release/0.9` therefore ships the table as its own `0056_openai_compatible_providers` with `when = 1784300000000` (between 0055 and this branch's 0056), keeping a 0.9.0 watermark below every 0.10 migration. The cost lands here: such a database reaches 0059 with the table already present, and a plain `CREATE TABLE` aborts the whole upgrade on first boot.

## Verification

`migration-090-upgrade-path.integration.test.ts` rebuilds a released 0.9.0 database with the **real migrator** (truncated journal + the release branch's own migration file — no hand-written DDL), then upgrades it to HEAD:

- 0.9.0 preconditions asserted (provider table present, `agent_delivered_files` absent, watermark `== 1784300000000`) so the upgrade assertion can't false-pass
- upgrade completes
- 0056 and 0058 really landed: `kb_chunks.embedding` is `vector(768)`, `agent_delivered_files` exists
- a second case pins the premise: every journal entry above idx 55 must post-date `REL09_WHEN`

**Has teeth:** reverting `IF NOT EXISTS` fails it with `relation "openai_compatible_providers" already exists`. Verified locally against `pgvector/pgvector:pg17-trixie`; `migration-upgrade-path` and `migration-gap-repair` stay green. `pnpm format:check` ✅ · `pnpm -C packages/web typecheck` ✅