### PR TITLE
fix(files): unblock the embedded PDF viewer for every serving route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,19 @@ Two things a shard must get right:
 
 Related: the images are built by a `build-images` **matrix** (two runners, ~2× faster than the old serial job) and fanned back in through `build-image`, whose only job is to preserve the `result` + `outputs` contract the 11 downstream jobs already encode. Its `if:` mirrors the matrix's verbatim, and `!cancelled()` plus its guard step is what keeps a _failed_ build from reading as `skipped` — which downstream would take as "fork PR, build locally" and cheerfully rebuild a Dockerfile CI just proved broken. Because a matrix cannot export per-entry outputs, the fan-in recomputes the tags; `scripts/lib/ci-image-tags.test.mjs` pins the two expressions together.
 
+## Embeddable Serving Routes Need A next.config Entry
+
+A header set by a route handler **loses** to `next.config.ts`'s `headers()`. The global `/(.*)` rule sets `X-Frame-Options: DENY`, so a file-serving route that sets `x-frame-options: SAMEORIGIN` in its own response still gets DENY on the wire: a valid `200 application/pdf` that the browser refuses to render, `net::ERR_BLOCKED_BY_RESPONSE`, blank viewer pane. It shipped twice this way — the KB citation viewer and agent-delivered artifacts (#703 / #788) — and every test was green both times, because route tests assert the header the **handler** declares.
+
+So a route that serves embeddable content needs **two** things, and `packages/web/src/__tests__/security/frame-options-route-coverage.test.ts` fails CI when they drift apart:
+
+- the handler's own `x-frame-options: SAMEORIGIN` (directly, or via `streamWorkspaceFile`), and
+- a `{ source, headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }] }` entry in `next.config.ts`, written **after** the catch-all — later rules win.
+
+The guard derives the expected `source` from the route's file path and prints the exact line to add. It checks both directions: a serving route without an entry, and an entry without a serving route (a relaxation must not outlive its route, nor be widened to one that renders HTML). `resolveHeader`/`matchesSource` in `packages/web/src/test-helpers/next-headers.ts` model Next.js's resolution for a concrete path; they throw on `has`/`missing` rather than guess.
+
+**The general lesson: assert the value a concrete URL resolves to, not the value a handler asked for.** The two are different questions, and only one of them is what the user's browser gets.
+
 ## Web Test Files Are Type-Checked
 
 `packages/web` test files (`*.test.ts(x)`, `*.integration.test.ts`, `*.test-d.ts`) are type-checked in CI by the `quality` job's "Typecheck web (incl. tests)" step: `pnpm -C packages/web typecheck` → `tsc --noEmit -p packages/web/tsconfig.typecheck.json`.

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -680,6 +680,11 @@ test.describe.serial("Plugin behavior — pinchy-files generate_file", () => {
         // (net::ERR_BLOCKED_BY_RESPONSE → blank PDF viewer). Asserting it here,
         // against the production image, is the only layer that sees the value
         // a user's browser actually gets.
+        //
+        // Limit worth knowing: this artifact is a CSV, so a pass proves the
+        // header, not that an <embed> renders. Nothing in CI drives the PDF
+        // lightbox end to end — that was verified by hand when the defect was
+        // reproduced.
         expect(res.headers()["x-frame-options"]).toBe("SAMEORIGIN");
         downloadOk = true;
         break;

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -672,6 +672,15 @@ test.describe.serial("Plugin behavior — pinchy-files generate_file", () => {
       const res = await page.request.get(`/api/agents/${agentId}/artifacts/e2e-export.csv`);
       if (res.status() === 200) {
         expect(res.headers()["content-type"]).toContain("text/csv");
+        // The RESOLVED header off a real Next.js server, not the one the route
+        // handler asked for. next.config.ts's `/(.*)` rule sets
+        // X-Frame-Options: DENY and OVERRIDES the handler's SAMEORIGIN, so
+        // without a per-route relaxation in next.config.ts this route serves
+        // perfect bytes that the browser then refuses to embed
+        // (net::ERR_BLOCKED_BY_RESPONSE → blank PDF viewer). Asserting it here,
+        // against the production image, is the only layer that sees the value
+        // a user's browser actually gets.
+        expect(res.headers()["x-frame-options"]).toBe("SAMEORIGIN");
         downloadOk = true;
         break;
       }

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -51,6 +51,16 @@ const nextConfig: NextConfig = {
         headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
       },
       {
+        // An agent-delivered file (#703 / #788) opens in the SAME
+        // AttachmentPreview <embed> as an upload — only the source zone differs
+        // — so it needs the same relaxation. The route handler sets SAMEORIGIN
+        // itself, but that header LOSES to the catch-all above, which is how
+        // this shipped broken: a valid 200 application/pdf and a blank viewer
+        // pane with net::ERR_BLOCKED_BY_RESPONSE. Same-origin only.
+        source: "/api/agents/:agentId/artifacts/:filename",
+        headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
+      },
+      {
         // Service worker must not be long-cached, otherwise future SW updates
         // never reach users. Same pattern as other PWAs (Slack, Mattermost).
         source: "/sw.js",

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -61,6 +61,16 @@ const nextConfig: NextConfig = {
         headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
       },
       {
+        // A cited knowledge-base source opens in the same PDF viewer, embedded
+        // over the chat. The route handler sets SAMEORIGIN itself, but that
+        // header LOSES to the catch-all above — which is how this shipped
+        // broken: perfect bytes, and a blank pane with
+        // ERR_BLOCKED_BY_RESPONSE. The relaxation has to be declared here, and
+        // stays same-origin only.
+        source: "/api/agents/:agentId/workspace-file",
+        headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
+      },
+      {
         // Service worker must not be long-cached, otherwise future SW updates
         // never reach users. Same pattern as other PWAs (Slack, Mattermost).
         source: "/sw.js",

--- a/packages/web/src/__tests__/security/frame-options-route-coverage.test.ts
+++ b/packages/web/src/__tests__/security/frame-options-route-coverage.test.ts
@@ -1,0 +1,102 @@
+// packages/web/src/__tests__/security/frame-options-route-coverage.test.ts
+//
+// Enforcement guard for a pair of lists that must move together:
+//
+//   1. API routes that serve content meant to be EMBEDDED same-origin
+//      (the AttachmentPreview <embed>, the PDF lightbox), which declare that
+//      posture with `x-frame-options: SAMEORIGIN` in their own response.
+//   2. The per-route SAMEORIGIN relaxations in next.config.ts.
+//
+// A route in (1) without an entry in (2) serves perfect bytes that the browser
+// refuses to render — the config's global `X-Frame-Options: DENY` wins over the
+// handler's header, so the user gets a blank viewer pane and
+// net::ERR_BLOCKED_BY_RESPONSE. It has shipped twice: the KB citation viewer
+// and agent-delivered artifacts (#703 / #788). Both times every test was green,
+// because route tests assert the header the HANDLER sets.
+//
+// This guard closes the class rather than the instance: add a serving route,
+// forget the config entry, and CI fails here with the exact line to add.
+//
+// See AGENTS.md § "Embeddable Serving Routes Need A next.config Entry".
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { resolveHeader, routeFileToSource } from "@/test-helpers/next-headers";
+
+const APP_DIR = resolve(__dirname, "../../app");
+const API_DIR = join(APP_DIR, "api");
+
+/**
+ * Helpers that set the SAMEORIGIN posture on a caller's behalf. A route calling
+ * one of these serves embeddable content without naming the header itself, so a
+ * plain grep for the header string would miss it — which is precisely the
+ * artifacts route that shipped broken.
+ *
+ * Matched on the SYMBOL, not the module: `serve-workspace-file` also exports
+ * `SERVABLE_DELIVERED_MIMES`, and a route importing only that does not serve
+ * anything.
+ */
+const SAMEORIGIN_HELPERS = ["streamWorkspaceFile"];
+
+function walkRouteFiles(dir: string): string[] {
+  const result: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      result.push(...walkRouteFiles(fullPath));
+    } else if (entry === "route.ts" || entry === "route.tsx") {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+/** Routes whose responses are meant to be embedded same-origin. */
+function findEmbeddableServingRoutes(): { file: string; source: string; samplePath: string }[] {
+  const found: { file: string; source: string; samplePath: string }[] = [];
+  for (const file of walkRouteFiles(API_DIR)) {
+    const content = readFileSync(file, "utf8");
+    const setsHeaderDirectly = /["']x-frame-options["']\s*:\s*["']SAMEORIGIN["']/i.test(content);
+    const usesHelper = SAMEORIGIN_HELPERS.some((helper) => content.includes(`${helper}(`));
+    if (!setsHeaderDirectly && !usesHelper) continue;
+    found.push({
+      file: relative(APP_DIR, file),
+      ...routeFileToSource(relative(APP_DIR, file)),
+    });
+  }
+  return found;
+}
+
+describe("embeddable serving routes are relaxed in next.config.ts", () => {
+  it("finds the serving routes at all (guard against a scanner that silently matches nothing)", () => {
+    // A scanner that finds zero routes would pass every assertion below while
+    // enforcing nothing — the failure mode of every grep-based guard.
+    const routes = findEmbeddableServingRoutes();
+    expect(routes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(findEmbeddableServingRoutes())(
+    "$file resolves to SAMEORIGIN, not the global DENY",
+    async ({ file, source, samplePath }) => {
+      const resolved = await resolveHeader(samplePath, "X-Frame-Options");
+      expect(
+        resolved,
+        `${file} serves embeddable content but ${samplePath} resolves to ${resolved}.\n` +
+          `Add this to next.config.ts headers(), AFTER the /(.*) catch-all:\n` +
+          `  { source: "${source}", headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }] }`
+      ).toBe("SAMEORIGIN");
+    }
+  );
+
+  it("relaxes no route that does not serve embeddable content", async () => {
+    // The other drift direction: a relaxation must not outlive the route that
+    // justified it, and must never be broadened to a route that renders HTML.
+    const entries = await (await import("../../../next.config")).default.headers!();
+    const relaxed = entries
+      .filter((e) => e.headers.some((h) => h.key === "X-Frame-Options" && h.value === "SAMEORIGIN"))
+      .map((e) => e.source);
+    const serving = findEmbeddableServingRoutes().map((r) => r.source);
+
+    expect([...relaxed].sort()).toEqual([...serving].sort());
+  });
+});

--- a/packages/web/src/__tests__/security/security-headers.test.ts
+++ b/packages/web/src/__tests__/security/security-headers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import nextConfig from "../../../next.config";
+import { matchesSource, resolveHeader } from "@/test-helpers/next-headers";
 
 /**
  * Security test: ensures all required security headers are configured.
@@ -65,34 +66,32 @@ describe("Security headers", () => {
  * own header stayed green while every delivered PDF rendered as a blank pane
  * with net::ERR_BLOCKED_BY_RESPONSE.
  *
- * So these tests resolve a concrete path the way Next.js does and assert the
- * value that path ends up with.
+ * So these tests resolve a concrete path the way Next.js does (see
+ * `@/test-helpers/next-headers`) and assert the value that path ends up with.
+ * The companion guard `frame-options-route-coverage.test.ts` enforces the same
+ * property for EVERY serving route, so a new one cannot ship without an entry.
  */
 
-/** Converts a next.config `source` pattern to a matcher: `:param` is one segment, `(.*)` is anything. */
-function matchesSource(source: string, path: string): boolean {
-  const pattern = source
-    .replace(/\(\.\*\)/g, " ANY ")
-    .replace(/:[A-Za-z0-9_]+/g, "[^/]+")
-    .replace(/ ANY /g, ".*");
-  return new RegExp(`^${pattern}$`).test(path);
-}
+describe("matchesSource", () => {
+  it("treats a `:param` as exactly one segment", () => {
+    const source = "/api/agents/:agentId/uploads/:filename";
+    expect(matchesSource(source, "/api/agents/a1/uploads/report.pdf")).toBe(true);
+    // Two segments where the pattern allows one.
+    expect(matchesSource(source, "/api/agents/a1/uploads/nested/report.pdf")).toBe(false);
+  });
 
-/**
- * Later entries override earlier ones for the same key — which is exactly why
- * the relaxing rules are written after the catch-all in next.config.ts.
- */
-async function resolveHeader(path: string, key: string): Promise<string | undefined> {
-  const entries = await nextConfig.headers!();
-  let value: string | undefined;
-  for (const entry of entries) {
-    if (!matchesSource(entry.source, path)) continue;
-    for (const header of entry.headers) {
-      if (header.key.toLowerCase() === key.toLowerCase()) value = header.value;
-    }
-  }
-  return value;
-}
+  it("treats a literal dot as a dot, not a wildcard", () => {
+    // Without escaping, `^/sw.js$` matches `/swXjs` — a rule silently applying
+    // to a path it was never meant to cover.
+    expect(matchesSource("/sw.js", "/sw.js")).toBe(true);
+    expect(matchesSource("/sw.js", "/swXjs")).toBe(false);
+  });
+
+  it("expands the `(.*)` catch-all across segments", () => {
+    expect(matchesSource("/(.*)", "/chat/agent-1")).toBe(true);
+    expect(matchesSource("/(.*)", "/")).toBe(true);
+  });
+});
 
 describe("X-Frame-Options as a given URL actually receives it", () => {
   it("keeps DENY for ordinary pages", () => {
@@ -116,7 +115,19 @@ describe("X-Frame-Options as a given URL actually receives it", () => {
     ).resolves.toBe("SAMEORIGIN");
   });
 
-  it("does not relax any route beyond those two", async () => {
+  it("relaxes to SAMEORIGIN for the workspace-file route a cited source opens from", () => {
+    // Without this the browser blocks the <embed> outright and the viewer shows
+    // a blank pane — the route can serve perfect bytes and the user sees nothing.
+    return expect(
+      resolveHeader("/api/agents/agent-1/workspace-file", "X-Frame-Options")
+    ).resolves.toBe("SAMEORIGIN");
+  });
+
+  it("relaxes no route beyond the file-serving ones", async () => {
+    // The list is the spec — deliberately exhaustive, so widening the
+    // relaxation to a route that renders HTML is a failing test, not a review
+    // catch. `frame-options-route-coverage.test.ts` keeps it tied to the
+    // routes that actually exist.
     const entries = await nextConfig.headers!();
     const relaxed = entries
       .filter((e) => e.headers.some((h) => h.key === "X-Frame-Options" && h.value === "SAMEORIGIN"))
@@ -125,6 +136,7 @@ describe("X-Frame-Options as a given URL actually receives it", () => {
     expect(relaxed.sort()).toEqual([
       "/api/agents/:agentId/artifacts/:filename",
       "/api/agents/:agentId/uploads/:filename",
+      "/api/agents/:agentId/workspace-file",
     ]);
   });
 });

--- a/packages/web/src/__tests__/security/security-headers.test.ts
+++ b/packages/web/src/__tests__/security/security-headers.test.ts
@@ -54,3 +54,77 @@ describe("Security headers", () => {
     expect(allHeaders).not.toContain("Strict-Transport-Security");
   });
 });
+
+/**
+ * The tests above ask whether a header value appears ANYWHERE in the config.
+ * That is not the same question as "what does this URL actually get", and the
+ * gap between them is not theoretical: agent-delivered artifacts (#703 / #788)
+ * shipped unviewable because the `artifacts` route inherited the global
+ * `X-Frame-Options: DENY` while its own handler set SAMEORIGIN. The route's
+ * header LOSES — next.config wins — so a route-level test asserting the route's
+ * own header stayed green while every delivered PDF rendered as a blank pane
+ * with net::ERR_BLOCKED_BY_RESPONSE.
+ *
+ * So these tests resolve a concrete path the way Next.js does and assert the
+ * value that path ends up with.
+ */
+
+/** Converts a next.config `source` pattern to a matcher: `:param` is one segment, `(.*)` is anything. */
+function matchesSource(source: string, path: string): boolean {
+  const pattern = source
+    .replace(/\(\.\*\)/g, " ANY ")
+    .replace(/:[A-Za-z0-9_]+/g, "[^/]+")
+    .replace(/ ANY /g, ".*");
+  return new RegExp(`^${pattern}$`).test(path);
+}
+
+/**
+ * Later entries override earlier ones for the same key — which is exactly why
+ * the relaxing rules are written after the catch-all in next.config.ts.
+ */
+async function resolveHeader(path: string, key: string): Promise<string | undefined> {
+  const entries = await nextConfig.headers!();
+  let value: string | undefined;
+  for (const entry of entries) {
+    if (!matchesSource(entry.source, path)) continue;
+    for (const header of entry.headers) {
+      if (header.key.toLowerCase() === key.toLowerCase()) value = header.value;
+    }
+  }
+  return value;
+}
+
+describe("X-Frame-Options as a given URL actually receives it", () => {
+  it("keeps DENY for ordinary pages", () => {
+    // The whole point of the relaxations below is that they stay narrow.
+    return expect(resolveHeader("/chat/agent-1", "X-Frame-Options")).resolves.toBe("DENY");
+  });
+
+  it("relaxes to SAMEORIGIN for the uploaded-file route the attachment preview embeds", () => {
+    return expect(
+      resolveHeader("/api/agents/agent-1/uploads/report.pdf", "X-Frame-Options")
+    ).resolves.toBe("SAMEORIGIN");
+  });
+
+  it("relaxes to SAMEORIGIN for the artifacts route an agent-delivered file opens from", () => {
+    // Same AttachmentPreview component, same <embed>, only the source zone
+    // differs (FileSourceContext = "artifacts"). Without this the browser
+    // blocks the embed outright and the user sees a blank viewer pane, even
+    // though the route serves a valid 200 application/pdf.
+    return expect(
+      resolveHeader("/api/agents/agent-1/artifacts/delivered-report.pdf", "X-Frame-Options")
+    ).resolves.toBe("SAMEORIGIN");
+  });
+
+  it("does not relax any route beyond those two", async () => {
+    const entries = await nextConfig.headers!();
+    const relaxed = entries
+      .filter((e) => e.headers.some((h) => h.key === "X-Frame-Options" && h.value === "SAMEORIGIN"))
+      .map((e) => e.source);
+
+    expect(relaxed.sort()).toEqual([
+      "/api/agents/:agentId/artifacts/:filename",
+      "/api/agents/:agentId/uploads/:filename",
+    ]);
+  });
+});

--- a/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
@@ -141,7 +141,12 @@ describe("GET /api/agents/[agentId]/artifacts/[filename]", () => {
     expect(res.status).toBe(415);
   });
 
-  it("sets X-Frame-Options: SAMEORIGIN so the browser can <embed> the file inline", async () => {
+  it("declares X-Frame-Options: SAMEORIGIN so the browser can <embed> the file inline", async () => {
+    // Handler-level declaration only — next.config.ts decides what the URL
+    // really receives and can override this to DENY. That is exactly how
+    // agent-delivered PDFs shipped unviewable with this test green. The
+    // resolved value is asserted in security-headers.test.ts, and enforced for
+    // every serving route by frame-options-route-coverage.test.ts.
     writeArtifact("agent-1", "workbench", "report.pdf", PDF_BYTES);
     const res = await callGET("agent-1", "report.pdf");
     expect(res.status).toBe(200);

--- a/packages/web/src/__tests__/server/agent-uploads-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-uploads-route.test.ts
@@ -150,12 +150,14 @@ describe("GET /api/agents/[agentId]/uploads/[filename]", () => {
     expect(res.status).toBe(415);
   });
 
-  it("sets X-Frame-Options: SAMEORIGIN so the browser can <embed> the file inline (PDF viewer)", async () => {
-    // Pinchy's global Next.js header rule emits X-Frame-Options: DENY for every
-    // path — which blocks AttachmentPreview's <embed> from loading the PDF.
-    // The uploads route MUST override this with SAMEORIGIN. Without this
-    // header the PDF preview silently fails: the user sees an empty modal
-    // and no console error.
+  it("declares X-Frame-Options: SAMEORIGIN so the browser can <embed> the file inline (PDF viewer)", async () => {
+    // This asserts what the HANDLER declares, which is NOT what the URL
+    // receives: next.config.ts's global `/(.*)` rule sets DENY and overrides
+    // anything set here, so this test stays green even when every PDF renders
+    // as a blank pane. The value a browser actually gets is asserted in
+    // src/__tests__/security/security-headers.test.ts (resolved per path) and
+    // enforced for every serving route by frame-options-route-coverage.test.ts.
+    // Keep this one anyway — the declaration is what those two resolve against.
     writeUpload("agent-1", "invoice.pdf", PDF_BYTES);
     const res = await callGET("agent-1", "invoice.pdf");
     expect(res.status).toBe(200);

--- a/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
@@ -187,10 +187,17 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
       // makes the inline/attachment split above meaningful.
       "x-content-type-options": "nosniff",
       "content-disposition": `${disposition}; filename="${documentName.replace(/[^\x20-\x7e]|["\\]/g, "_")}"; filename*=UTF-8''${encodeURIComponent(documentName)}`,
-      // Only relevant for the inline (PDF) case: without this override
-      // Next.js emits X-Frame-Options: DENY by default, which blocks a
-      // same-origin <embed>/<iframe> PDF viewer (see uploads/[filename]/route.ts
-      // for the same gotcha with the same fix).
+      // Declares the posture the inline (PDF) case wants: a same-origin
+      // <embed>/<iframe> viewer may frame this, nothing else may.
+      //
+      // It is NOT what makes the viewer work. next.config.ts's `headers()`
+      // applies `X-Frame-Options: DENY` to `/(.*)`, and that value OVERRIDES
+      // whatever is set here — the URL's real value is decided there, by the
+      // per-route SAMEORIGIN relaxation. Both this route and the artifacts
+      // route shipped without one: a valid 200 the browser refuses to render
+      // (net::ERR_BLOCKED_BY_RESPONSE, blank pane), while a line like this one
+      // sat here looking sufficient. `frame-options-route-coverage.test.ts`
+      // now fails CI if a serving route lacks its entry.
       ...(disposition === "inline" ? { "x-frame-options": "SAMEORIGIN" } : {}),
     },
   });

--- a/packages/web/src/lib/serve-workspace-file.ts
+++ b/packages/web/src/lib/serve-workspace-file.ts
@@ -47,8 +47,9 @@ export const SERVABLE_DELIVERED_MIMES: ReadonlySet<string> = new Set<string>([
  * (`uploads/[filename]`) and agent-delivered artifacts (`artifacts/[filename]`) —
  * which differ only in how they AUTHORIZE the request; once a caller is
  * authorized and a concrete on-disk path resolved, the serving posture is
- * identical (magic-byte MIME allowlist, inline disposition, SAMEORIGIN so the
- * PDF/image preview can embed).
+ * identical (magic-byte MIME allowlist, inline disposition, a SAMEORIGIN
+ * frame posture — see the header comment below for why that posture only
+ * takes effect together with a next.config.ts entry for the route).
  *
  * The caller MUST have already sanitized the filename and verified `fullPath`
  * is contained within the intended workspace zone — this helper does not
@@ -116,9 +117,20 @@ export async function streamWorkspaceFile(
       // Inline so the browser renders PDFs/images directly instead of forcing a
       // download. The filename is advisory.
       "content-disposition": `inline; filename="${safeName.replace(/[^\x20-\x7e]/g, "_")}"; filename*=UTF-8''${encodeURIComponent(safeName)}`,
-      // Allow same-origin embeds (<embed> thumbnail in AttachmentPreview).
-      // Without this override Next.js emits X-Frame-Options: DENY by default,
-      // which blocks the <embed> from loading the file.
+      // Declares the posture this response wants: same-origin embedding is
+      // fine (the <embed> thumbnail + lightbox in AttachmentPreview),
+      // cross-origin is not.
+      //
+      // It is NOT what makes the embed work. next.config.ts's `headers()`
+      // applies `X-Frame-Options: DENY` to `/(.*)`, and that value OVERRIDES
+      // whatever a route handler sets here — so what a URL actually receives is
+      // decided in next.config.ts, which carries an explicit SAMEORIGIN
+      // relaxation for each serving route. Adding a new serving route without
+      // that entry yields a valid 200 the browser refuses to render
+      // (net::ERR_BLOCKED_BY_RESPONSE) — which is exactly how the artifacts
+      // route shipped, while this line sat here looking sufficient. See
+      // `describe("X-Frame-Options as a given URL actually receives it")` in
+      // src/__tests__/security/security-headers.test.ts.
       "x-frame-options": "SAMEORIGIN",
     },
   });

--- a/packages/web/src/test-helpers/next-headers.ts
+++ b/packages/web/src/test-helpers/next-headers.ts
@@ -1,0 +1,119 @@
+/**
+ * Resolve what a CONCRETE URL actually receives from `next.config.ts`'s
+ * `headers()` — as opposed to what a route handler asks for, or what appears
+ * somewhere in the config.
+ *
+ * That distinction is the whole reason this module exists. A config-level
+ * header OVERRIDES whatever a route handler sets in its own response, so a
+ * route test asserting the handler's header can be green while every real
+ * response carries the opposite value. Two file-serving routes shipped broken
+ * exactly that way (#703 / #788 artifacts, and the KB citation viewer): a valid
+ * `200 application/pdf` that the browser refused to embed with
+ * `net::ERR_BLOCKED_BY_RESPONSE`, i.e. a blank viewer pane.
+ *
+ * Test-only. This models the subset of Next.js source syntax the config
+ * actually uses; `resolveHeader` throws rather than guessing when it meets
+ * anything outside that subset.
+ */
+import nextConfig from "../../next.config";
+
+/**
+ * Escapes EVERY regex metacharacter, backslash included. Completeness is the
+ * point: a partial escape is both a correctness bug and a CodeQL
+ * `js/incomplete-sanitization` finding.
+ */
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Converts a next.config `source` pattern to a matcher.
+ *
+ * Supported syntax: `:param` (exactly one path segment) and the `(.*)`
+ * catch-all. Everything else is a LITERAL — which is why the escape runs
+ * first: without it the dot in `/sw.js` would act as a wildcard and match
+ * `/swXjs`, silently applying a rule to a path it never covered.
+ */
+export function matchesSource(source: string, path: string): boolean {
+  const pattern = escapeRegex(source)
+    // `(.*)` survives the escape as `\(\.\*\)` — restore it as a wildcard.
+    .replace(/\\\(\\\.\\\*\\\)/g, ".*")
+    // `:param` has no metacharacters, so it reaches here untouched.
+    .replace(/:[A-Za-z0-9_]+/g, "[^/]+");
+  // eslint-disable-next-line security/detect-non-literal-regexp -- pattern is built from a fully-escaped literal plus two fixed expansions
+  return new RegExp(`^${pattern}$`).test(path);
+}
+
+/**
+ * The value `path` ends up with for `key`.
+ *
+ * Later entries override earlier ones for the same key — which is exactly why
+ * the relaxing rules are written AFTER the catch-all in next.config.ts. Get
+ * that order wrong and the catch-all wins silently.
+ */
+export async function resolveHeader(path: string, key: string): Promise<string | undefined> {
+  const entries = await nextConfig.headers!();
+  let value: string | undefined;
+  for (const entry of entries) {
+    if (!matchesSource(entry.source, path)) continue;
+    // `has`/`missing` make a rule conditional on the request (cookies, headers,
+    // query). Nothing here uses them, and silently ignoring them would make
+    // this resolver claim a value the request may not actually get — the exact
+    // class of false-green this module exists to prevent.
+    if ("has" in entry || "missing" in entry) {
+      throw new Error(
+        `next.config source ${entry.source} uses has/missing, which resolveHeader does not model. ` +
+          `Teach it the conditional, or assert against a real server instead.`
+      );
+    }
+    for (const header of entry.headers) {
+      if (header.key.toLowerCase() === key.toLowerCase()) value = header.value;
+    }
+  }
+  return value;
+}
+
+/**
+ * Maps an App Router `route.ts` file path to the `source` pattern that
+ * next.config must use to target it, and to a concrete URL for `resolveHeader`.
+ *
+ * `src/app/api/agents/[agentId]/artifacts/[filename]/route.ts`
+ *   → source `/api/agents/:agentId/artifacts/:filename`
+ *   → path   `/api/agents/sample/artifacts/sample`
+ */
+export function routeFileToSource(routeFileRelativeToApp: string): {
+  source: string;
+  samplePath: string;
+} {
+  const segments = routeFileRelativeToApp
+    .replace(/\\/g, "/")
+    .replace(/\/route\.tsx?$/, "")
+    .split("/")
+    .filter(Boolean);
+
+  const sourceSegments: string[] = [];
+  const pathSegments: string[] = [];
+  for (const segment of segments) {
+    const dynamic = /^\[(.+)]$/.exec(segment);
+    if (!dynamic) {
+      sourceSegments.push(segment);
+      pathSegments.push(segment);
+      continue;
+    }
+    const name = dynamic[1];
+    if (name.startsWith("...")) {
+      // A catch-all spans an unknown number of segments, so a single sample
+      // path cannot stand in for it. No serving route uses one today.
+      throw new Error(
+        `Catch-all segment [${name}] in ${routeFileRelativeToApp} is not modelled by routeFileToSource.`
+      );
+    }
+    sourceSegments.push(`:${name}`);
+    pathSegments.push("sample");
+  }
+
+  return {
+    source: `/${sourceSegments.join("/")}`,
+    samplePath: `/${pathSegments.join("/")}`,
+  };
+}


### PR DESCRIPTION
## The defect

An agent-delivered file (#703 / #788) renders through the **same** `AttachmentPreview` `<embed>` as a user upload — only `FileSourceContext` differs. But `next.config.ts` carried a SAMEORIGIN relaxation for the uploads route only. The global `/(.*)` rule set `X-Frame-Options: DENY` on the artifacts route, and that value **overrides** the SAMEORIGIN the route handler sets itself — so every delivered PDF served a valid `200 application/pdf` that the browser then refused to render: blank viewer pane, `net::ERR_BLOCKED_BY_RESPONSE`.

## Reproduced before fixing

Dev stack, real session, a real delivered-artifact state (grant row in `agent_delivered_files` + the file under `<workspace>/workbench`), then the exact `<embed src=… type="application/pdf">` the lightbox renders:

```
GET /api/agents/<id>/artifacts/delivered-report.pdf
    status         : 200
    content-type   : application/pdf
    X-Frame-Options: DENY            <-- artifacts route
    (sibling uploads route: X-Frame-Options: SAMEORIGIN)

<embed …> -> net::ERR_BLOCKED_BY_RESPONSE
console:  Refused to display '…' in a frame because it set 'X-Frame-Options' to 'deny'.
```

After the fix, same script against the same stack: `X-Frame-Options: SAMEORIGIN`, no network failures, the viewer renders.

## Review pass: this is a class, not an instance

The first version of this PR fixed the artifacts route. Review found the repo has now shipped this defect **twice**, and that `workspace-file` — a third serving route, on `main`, setting SAMEORIGIN itself — still had no entry. Worse, the exact-list test added here asserted that two relaxations were the complete correct set, i.e. it encoded the remaining gap as intended.

So the scope grew to close the class:

**`frame-options-route-coverage.test.ts`** — a drift guard over the two lists that must move together:

1. routes serving content meant to be embedded same-origin (the header directly, or via `streamWorkspaceFile`), and
2. the per-route relaxations in `next.config.ts`.

It derives the expected `source` from the route's file path and fails with the exact line to add. It checks both directions, so a relaxation cannot outlive the route that justified it, and includes a probe that the scanner matches something at all — the standard failure mode of a grep-based guard is silently enforcing nothing.

Written first, and it failed on `workspace-file` before the entry existed:

```
api/agents/[agentId]/workspace-file/route.ts serves embeddable content
but /api/agents/sample/workspace-file resolves to DENY.
Add this to next.config.ts headers(), AFTER the /(.*) catch-all:
  { source: "/api/agents/:agentId/workspace-file", headers: [...] }
```

**`test-helpers/next-headers.ts`** — `resolveHeader`/`matchesSource` extracted so the guard and `security-headers.test.ts` share one model of Next.js resolution. Two fixes to that model while extracting: escaping is now complete (a literal `.` in `/sw.js` was acting as a wildcard, matching `/swXjs`), and it throws on `has`/`missing` instead of guessing. A resolver that quietly answers the wrong question is precisely the bug it exists to prevent.

**Comments.** The route-level tests assert what a *handler* declares — green while every real response carries DENY. They keep that job and now say so, pointing at the tests that assert the resolved value. `workspace-file/route.ts` carried the same misleading comment this PR fixed one file over. `AGENTS.md` gets the convention and the general lesson: *assert the value a concrete URL resolves to, not the value a handler asked for.*

## Note on overlap

`feat/kb-sources-and-index-ui` fixes `workspace-file` independently. The `next.config.ts` entry here is **byte-identical** to that branch's, so that hunk merges clean. `security-headers.test.ts` will still conflict (that branch has the helpers inline; here they are imported) — resolution is to keep the import and the union of cases.

## Testing

- `pnpm test` — 9842 passed, 711 files
- `pnpm test:scripts` — 390 passed
- `pnpm -C packages/web test:db` — 366 passed
- `pnpm -C packages/web typecheck`, `lint` (0 errors), `pnpm build`, `pnpm format:check` — green
- Guard verified by mutation: red in both directions before the fix
- Manual: before/after repro above against a dev stack

One unrelated flake: `enterprise-banner.test.tsx` failed once in three full runs, isolated runs and two further full runs green. That is the region documented as not-reproducible on 2026-07-16. The obvious hypothesis (`toLocaleDateString` without `timeZone` against fixed UTC instants) was tested under `TZ=America/New_York` and is **not** the cause. Untouched by this PR, reported rather than papered over.
