### PR TITLE
fix(ui): stop warning about an unsecured instance on a local install

### DIFF
--- a/packages/web/e2e/21-insecure-banner.spec.ts
+++ b/packages/web/e2e/21-insecure-banner.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin, seedProviderConfig } from "./helpers";
+
+/**
+ * The global "instance is not secured" banner must not appear on a local
+ * install. `baseURL` here is `http://localhost:7778`, which is exactly the
+ * situation: a browser already treats localhost as a secure context, and there
+ * is no domain to lock, so the advice cannot be acted on.
+ *
+ * This runs against a REAL Next.js server on purpose. The unit tests around
+ * `isLoopbackRequest` mock `next/headers`, and the first implementation of this
+ * feature passed all of them while doing nothing at all: it read any
+ * `x-forwarded-*` header as proof of a proxy, not knowing that Next.js
+ * back-fills those headers on every request that lacks them
+ * (`base-server.js`). Only a real server carries that back-fill, so only a
+ * real server can catch that class of mistake.
+ */
+test.describe("Insecure-mode banner", () => {
+  test("stays hidden on localhost while the instance really is unsecured", async ({ page }) => {
+    // Without a configured provider the first login lands on /setup/provider
+    // instead of the app shell, and `loginAsAdmin` waits for /chat/.
+    await seedProviderConfig();
+    await loginAsAdmin(page);
+
+    await page.goto("/settings?tab=security");
+
+    // Precondition, asserted rather than assumed: this instance has no domain
+    // locked, so `isInsecureMode()` is true and the banner is genuinely
+    // suppressed — not merely absent because there was nothing to warn about.
+    // Without this the test would still pass on a locked instance and prove
+    // nothing.
+    await expect(page.getByText(/your instance is not secured with https/i)).toBeVisible();
+
+    await expect(page.getByTestId("insecure-banner")).toHaveCount(0);
+  });
+});

--- a/packages/web/e2e/21-insecure-banner.spec.ts
+++ b/packages/web/e2e/21-insecure-banner.spec.ts
@@ -11,9 +11,17 @@ import { loginAsAdmin, seedProviderConfig } from "./helpers";
  * `isLoopbackRequest` mock `next/headers`, and the first implementation of this
  * feature passed all of them while doing nothing at all: it read any
  * `x-forwarded-*` header as proof of a proxy, not knowing that Next.js
- * back-fills those headers on every request that lacks them
- * (`base-server.js`). Only a real server carries that back-fill, so only a
- * real server can catch that class of mistake.
+ * back-fills those headers on every request that lacks them (`base-server.js`).
+ * That version fails here, which is the point of the file.
+ *
+ * Be precise about what it does and does not prove, though. The unit fixtures
+ * now carry the back-filled header themselves, so they cover the two paths
+ * (synthesized vs. real `X-Forwarded-Host`) far more sharply than this test can
+ * — from here both spell `localhost:7778` and reach the same verdict. What only
+ * a real server gives us is that the fixtures' PREMISE stays true: if a Next
+ * upgrade ever changes what a request carries by the time a Server Component
+ * sees it, the unit suite would keep describing a request that no longer
+ * exists, and this test is what notices.
  */
 test.describe("Insecure-mode banner", () => {
   test("stays hidden on localhost while the instance really is unsecured", async ({ page }) => {

--- a/packages/web/src/__tests__/components/insecure-banner.test.tsx
+++ b/packages/web/src/__tests__/components/insecure-banner.test.tsx
@@ -5,12 +5,30 @@ vi.mock("@/lib/domain", () => ({
   isInsecureMode: vi.fn(),
 }));
 
+const mockHeaders = vi.fn();
+vi.mock("next/headers", () => ({ headers: () => mockHeaders() }));
+
 import { InsecureBanner } from "@/components/insecure-banner";
 import { isInsecureMode } from "@/lib/domain";
+
+/**
+ * Requests arrive at a real domain unless a test says otherwise.
+ *
+ * `x-forwarded-host` is back-filled from `host` because that is what Next.js
+ * itself does to every request that lacks one (`base-server.js`) — a fixture
+ * without it describes a request that never reaches a Server Component, and an
+ * earlier version of this suite passed against exactly that fiction while the
+ * feature did nothing. `extra` overrides it to model a real proxy.
+ */
+function requestFrom(host: string, extra: Record<string, string> = {}) {
+  mockHeaders.mockResolvedValue(new Headers({ host, "x-forwarded-host": host, ...extra }));
+}
 
 describe("InsecureBanner", () => {
   beforeEach(() => {
     vi.mocked(isInsecureMode).mockReset();
+    mockHeaders.mockReset();
+    requestFrom("pinchy.example.com");
   });
 
   it("should render nothing when not in insecure mode", async () => {
@@ -53,6 +71,28 @@ describe("InsecureBanner", () => {
     const Component = await InsecureBanner({ isAdmin: true });
     render(Component);
     expect(screen.getByRole("alert").getAttribute("data-testid")).toBe("insecure-banner");
+  });
+
+  it("stays silent on a local install, where the advice cannot be acted on", async () => {
+    // A browser already treats http://localhost as a secure context, and there
+    // is no domain to lock. The warning would be wrong, not merely noisy.
+    vi.mocked(isInsecureMode).mockResolvedValue(true);
+    requestFrom("localhost:7777");
+    const Component = await InsecureBanner({ isAdmin: true });
+    const { container } = render(Component);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("still warns a proxied instance that merely looks local from inside", async () => {
+    // The case worth protecting: behind a proxy the `Host` header describes the
+    // hop into the container, so a PUBLIC instance can report `localhost`.
+    // Suppressing the banner there would hide it from precisely the operator
+    // who needs it, so the forwarded client-facing host decides instead.
+    vi.mocked(isInsecureMode).mockResolvedValue(true);
+    requestFrom("localhost:7777", { "x-forwarded-host": "pinchy.example.com" });
+    const Component = await InsecureBanner({ isAdmin: true });
+    render(Component);
+    expect(screen.getByRole("alert")).toBeDefined();
   });
 
   it("should show 'contact administrator' for non-admins", async () => {

--- a/packages/web/src/__tests__/components/insecure-banner.test.tsx
+++ b/packages/web/src/__tests__/components/insecure-banner.test.tsx
@@ -21,7 +21,9 @@ import { isInsecureMode } from "@/lib/domain";
  * feature did nothing. `extra` overrides it to model a real proxy.
  */
 function requestFrom(host: string, extra: Record<string, string> = {}) {
-  mockHeaders.mockResolvedValue(new Headers({ host, "x-forwarded-host": host, ...extra }));
+  mockHeaders.mockResolvedValue(
+    new Headers({ host, "x-forwarded-host": host, "x-forwarded-proto": "http", ...extra })
+  );
 }
 
 describe("InsecureBanner", () => {
@@ -90,6 +92,26 @@ describe("InsecureBanner", () => {
     // who needs it, so the forwarded client-facing host decides instead.
     vi.mocked(isInsecureMode).mockResolvedValue(true);
     requestFrom("localhost:7777", { "x-forwarded-host": "pinchy.example.com" });
+    const Component = await InsecureBanner({ isAdmin: true });
+    render(Component);
+    expect(screen.getByRole("alert")).toBeDefined();
+  });
+
+  it("keeps warning a loopback host reached over HTTPS, where locking IS possible", async () => {
+    // The gap the host comparison alone cannot close: nginx `proxy_pass
+    // http://localhost:7777` without `proxy_set_header Host` rewrites `Host` to
+    // `localhost` and sets no `X-Forwarded-Host`, so a PUBLIC instance looks
+    // local by every host-shaped measure.
+    //
+    // The scheme still gives it away. Next derives its back-fill from
+    // `socket.encrypted`, so a plain-HTTP container cannot manufacture `https`
+    // — whoever set it terminated TLS. And over HTTPS the banner's advice is
+    // actionable rather than empty: `POST /api/settings/domain` gates the lock
+    // on this very header, and settings then offers "Lock <host> & restart",
+    // localhost included. Suppressing here would hide an action the operator
+    // can actually take.
+    vi.mocked(isInsecureMode).mockResolvedValue(true);
+    requestFrom("localhost:7777", { "x-forwarded-proto": "https" });
     const Component = await InsecureBanner({ isAdmin: true });
     render(Component);
     expect(screen.getByRole("alert")).toBeDefined();

--- a/packages/web/src/__tests__/lib/loopback-request.test.ts
+++ b/packages/web/src/__tests__/lib/loopback-request.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Whether the address the operator's browser is actually pointed at is a
+ * loopback address.
+ *
+ * This exists so the "instance is not secured" banner stops firing on a local
+ * install, where it is not merely noisy but wrong: browsers treat
+ * `http://localhost` as a SECURE CONTEXT — crypto APIs and service workers all
+ * work there — precisely because the traffic never leaves the machine. Telling
+ * an operator to lock a domain they do not have is advice they cannot act on.
+ *
+ * THE THING THAT MAKES THESE CASES NON-OBVIOUS: Next.js manufactures the
+ * `x-forwarded-*` headers when they are absent, so their presence proves
+ * nothing about a proxy. From `next/dist/server/base-server.js`:
+ *
+ *     req.headers['x-forwarded-host']  ??= req.headers['host'] ?? this.hostname;
+ *     req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http';
+ *     req.headers['x-forwarded-for']   ??= originalRequest?.socket?.remoteAddress;
+ *
+ * A first version of this module read any `x-forwarded-*` header as evidence of
+ * a proxy and refused to suppress the banner. Under that synthesis the branch
+ * was taken on EVERY request, so the feature never once did anything — and the
+ * tests were green, because they hand-built a `Headers` object that omitted
+ * what Next.js always adds. So every case below carries the synthesized header,
+ * exactly as a real request does, and `e2e/21-insecure-banner.spec.ts` proves
+ * the same thing against a real Next.js server rather than a fixture.
+ *
+ * `x-forwarded-for` and `x-forwarded-proto` are consequently not read at all:
+ * they are present either way and can discriminate nothing. A check on them
+ * would look like a safeguard while deciding nothing, which is worse than no
+ * check.
+ */
+import { describe, it, expect } from "vitest";
+
+import { isLoopbackRequest } from "@/lib/loopback-request";
+
+/**
+ * A request as it really arrives with no proxy involved: Next.js has already
+ * back-filled `x-forwarded-host` from `Host`.
+ */
+const direct = (host: string) => isLoopbackRequest({ host, forwardedHost: host });
+
+/** A proxy that passed the client-facing host along in `X-Forwarded-Host`. */
+const proxied = (host: string, forwardedHost: string) => isLoopbackRequest({ host, forwardedHost });
+
+describe("isLoopbackRequest", () => {
+  it.each([
+    "localhost",
+    "localhost:7777",
+    "127.0.0.1",
+    "127.0.0.1:3000",
+    // Any 127/8 address is loopback, not just .0.1.
+    "127.1.2.3:8080",
+    "[::1]",
+    "[::1]:7777",
+    // RFC 6761 reserves the whole .localhost TLD for loopback.
+    "app.localhost",
+    "app.localhost:7777",
+  ])("recognises a direct request to %s as loopback", (host) => {
+    expect(direct(host)).toBe(true);
+  });
+
+  it.each([
+    "pinchy.example.com",
+    "192.168.1.10:7777",
+    // Deliberately adjacent to a loopback name without being one.
+    "notlocalhost",
+    "localhost.evil.com",
+    "127.0.0.1.evil.com",
+    // A private range is still a network the traffic travels over.
+    "10.0.0.5",
+  ])("does not treat a direct request to %s as loopback", (host) => {
+    expect(direct(host)).toBe(false);
+  });
+
+  it("does not treat a missing host as loopback", () => {
+    // Absent information is not evidence of safety.
+    expect(isLoopbackRequest({ host: null, forwardedHost: null })).toBe(false);
+  });
+
+  it("judges the client-facing host when a proxy forwarded a different one", () => {
+    // The case worth protecting. Behind a proxy, `Host` describes the hop into
+    // the container and says nothing about how the world reaches this instance.
+    // `X-Forwarded-Host` does — and differing from `Host` is exactly what marks
+    // it as a real value rather than Next.js's back-fill. A public instance
+    // must keep its banner.
+    expect(proxied("localhost:7777", "pinchy.example.com")).toBe(false);
+    expect(proxied("pinchy-web:7777", "pinchy.example.com")).toBe(false);
+  });
+
+  it("reads the first entry of a chained X-Forwarded-Host", () => {
+    // The chain is oldest-first, so the original client-facing host leads. A
+    // second proxy appending its own hop must not flip the verdict.
+    expect(
+      isLoopbackRequest({ host: "localhost:7777", forwardedHost: "pinchy.example.com, inner:7777" })
+    ).toBe(false);
+  });
+
+  it("still suppresses when a proxy forwarded a loopback host", () => {
+    // Someone put a proxy in front of a local install. Still local.
+    expect(proxied("pinchy-web:7777", "localhost:8443")).toBe(true);
+  });
+
+  it("falls back to Host when X-Forwarded-Host is absent entirely", () => {
+    // Not a shape Next.js produces, but the helper must not depend on Next
+    // having run — it is plain input/output and readable from anywhere.
+    expect(isLoopbackRequest({ host: "localhost:7777", forwardedHost: null })).toBe(true);
+    expect(isLoopbackRequest({ host: "pinchy.example.com", forwardedHost: null })).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/loopback-request.test.ts
+++ b/packages/web/src/__tests__/lib/loopback-request.test.ts
@@ -24,10 +24,17 @@
  * exactly as a real request does, and `e2e/21-insecure-banner.spec.ts` proves
  * the same thing against a real Next.js server rather than a fixture.
  *
- * `x-forwarded-for` and `x-forwarded-proto` are consequently not read at all:
- * they are present either way and can discriminate nothing. A check on them
- * would look like a safeguard while deciding nothing, which is worse than no
- * check.
+ * `x-forwarded-for` is consequently not read at all: it is present either way
+ * and can discriminate nothing. A check on it would look like a safeguard while
+ * deciding nothing, which is worse than no check.
+ *
+ * `x-forwarded-proto` is the one exception, and it is NOT read here — it is a
+ * question about the scheme, not about the host, so the banner asks it (see
+ * `insecure-banner.test.tsx`). Its back-fill is one-directional: Next derives
+ * `isHttps` from the incoming header or from `socket.encrypted`, so a container
+ * serving plain HTTP can never manufacture the value `https`. Whoever set it
+ * terminated TLS. `POST /api/settings/domain` already gates the domain lock on
+ * exactly that header.
  */
 import { describe, it, expect } from "vitest";
 
@@ -52,6 +59,16 @@ describe("isLoopbackRequest", () => {
     "127.1.2.3:8080",
     "[::1]",
     "[::1]:7777",
+    // RFC 7230 wants IPv6 literals bracketed in `Host`, but `X-Forwarded-Host`
+    // is written by proxies, and plenty of them emit the bare address. Stripping
+    // a `:port` off THAT naively turns `::1` into `:`, which is how the two
+    // equality checks below used to be unreachable for anything unbracketed.
+    "::1",
+    "0:0:0:0:0:0:0:1",
+    // A trailing dot is the fully-qualified form of the same name, and browsers
+    // put it in `Host` verbatim when the user types it.
+    "localhost.",
+    "127.0.0.1.",
     // RFC 6761 reserves the whole .localhost TLD for loopback.
     "app.localhost",
     "app.localhost:7777",
@@ -66,6 +83,9 @@ describe("isLoopbackRequest", () => {
     "notlocalhost",
     "localhost.evil.com",
     "127.0.0.1.evil.com",
+    // Fully-qualified spelling of the same trap: the trailing dot must not turn
+    // a registrable name into a loopback one.
+    "localhost.evil.com.",
     // A private range is still a network the traffic travels over.
     "10.0.0.5",
   ])("does not treat a direct request to %s as loopback", (host) => {

--- a/packages/web/src/components/insecure-banner.tsx
+++ b/packages/web/src/components/insecure-banner.tsx
@@ -8,17 +8,33 @@ export async function InsecureBanner({ isAdmin }: { isAdmin: boolean }) {
   const insecure = await isInsecureMode();
   if (!insecure) return null;
 
-  // On a local install the warning is not just noise, it is wrong: a browser
-  // already treats `http://localhost` as a secure context because the traffic
-  // never leaves the machine, and "lock your domain" is advice for a domain the
-  // operator does not have. A proxied instance keeps its banner — see
-  // `isLoopbackRequest` for how the two are told apart, and for the one
-  // proxy misconfiguration that defeats the distinction.
+  // On a local install over plain HTTP the warning is not just noise, it is
+  // wrong: a browser already treats `http://localhost` as a secure context
+  // because the traffic never leaves the machine, and "lock your domain" is
+  // advice for a domain the operator does not have. A proxied instance keeps
+  // its banner — see `isLoopbackRequest` for how the two are told apart.
+  //
+  // Both conditions matter. Over HTTPS the advice stops being empty: the lock
+  // route (`POST /api/settings/domain`) gates on this exact header, and
+  // settings then offers "Lock <host> & restart" for whatever host it sees,
+  // localhost included. So a request that reached us over TLS keeps its banner
+  // even from a loopback host — which is also what closes the nginx
+  // `proxy_pass`-without-`proxy_set_header` gap, where a public instance
+  // reports `localhost` and no forwarded host contradicts it.
+  //
+  // Reading the scheme is sound in a way that reading the other `x-forwarded-*`
+  // headers is not: Next back-fills them all, but it derives `isHttps` from
+  // `socket.encrypted`, so a plain-HTTP container can only ever synthesize
+  // `http`. The value `https` had to come from something that terminated TLS.
   //
   // Display only. Whether auth cookies are issued `Secure` is decided in
   // `secure-cookies.ts` from the persisted domain-lock flag, untouched by this.
   const h = await headers();
-  if (isLoopbackRequest({ host: h.get("host"), forwardedHost: h.get("x-forwarded-host") })) {
+  const overHttps = h.get("x-forwarded-proto")?.split(",")[0]?.trim() === "https";
+  if (
+    !overHttps &&
+    isLoopbackRequest({ host: h.get("host"), forwardedHost: h.get("x-forwarded-host") })
+  ) {
     return null;
   }
 

--- a/packages/web/src/components/insecure-banner.tsx
+++ b/packages/web/src/components/insecure-banner.tsx
@@ -1,10 +1,26 @@
 import Link from "next/link";
+import { headers } from "next/headers";
 import { ShieldAlert } from "lucide-react";
 import { isInsecureMode } from "@/lib/domain";
+import { isLoopbackRequest } from "@/lib/loopback-request";
 
 export async function InsecureBanner({ isAdmin }: { isAdmin: boolean }) {
   const insecure = await isInsecureMode();
   if (!insecure) return null;
+
+  // On a local install the warning is not just noise, it is wrong: a browser
+  // already treats `http://localhost` as a secure context because the traffic
+  // never leaves the machine, and "lock your domain" is advice for a domain the
+  // operator does not have. A proxied instance keeps its banner — see
+  // `isLoopbackRequest` for how the two are told apart, and for the one
+  // proxy misconfiguration that defeats the distinction.
+  //
+  // Display only. Whether auth cookies are issued `Secure` is decided in
+  // `secure-cookies.ts` from the persisted domain-lock flag, untouched by this.
+  const h = await headers();
+  if (isLoopbackRequest({ host: h.get("host"), forwardedHost: h.get("x-forwarded-host") })) {
+    return null;
+  }
 
   return (
     <div

--- a/packages/web/src/lib/loopback-request.ts
+++ b/packages/web/src/lib/loopback-request.ts
@@ -29,10 +29,23 @@ export interface RequestOrigin {
  * prefix match.
  */
 function isLoopbackHost(host: string): boolean {
-  // Strip the port. IPv6 literals arrive bracketed (`[::1]:7777`), so take the
-  // bracketed part first and only then look for a trailing `:port`.
+  // Strip the port. IPv6 literals belong in brackets (`[::1]:7777`), so take
+  // the bracketed part first and only then look for a trailing `:port`.
+  //
+  // Unbracketed IPv6 has to survive too: `Host` is bracketed per RFC 7230, but
+  // `X-Forwarded-Host` is written by proxies and plenty of them emit the bare
+  // address. A naive `:port` strip turns `::1` into `:` and
+  // `0:0:0:0:0:0:0:1` into `0:0:0:0:0:0:0`, which silently made both loopback
+  // checks below unreachable for exactly those inputs. So only strip when what
+  // is left cannot be an IPv6 address — a single colon. An unbracketed IPv6
+  // address WITH a port (`::1:7777`) stays ambiguous by construction and is not
+  // handled; nothing legitimate produces it.
   const bracketed = /^\[([^\]]+)\](?::\d+)?$/.exec(host);
-  const hostname = (bracketed ? bracketed[1] : host.replace(/:\d+$/, "")).toLowerCase();
+  const unbracketed = (host.match(/:/g)?.length ?? 0) > 1 ? host : host.replace(/:\d+$/, "");
+  // A trailing dot is the fully-qualified spelling of the same name — browsers
+  // pass it through to `Host` verbatim — and it must not be able to dodge the
+  // label-boundary anchoring below.
+  const hostname = (bracketed ? bracketed[1] : unbracketed).toLowerCase().replace(/\.$/, "");
 
   if (hostname === "localhost" || hostname.endsWith(".localhost")) return true;
   if (hostname === "::1" || hostname === "0:0:0:0:0:0:0:1") return true;
@@ -54,14 +67,25 @@ function isLoopbackHost(host: string): boolean {
  * only have come from a real proxy, and then it — not `Host`, which describes
  * the internal hop — is the client-facing name.
  *
- * Known limitation, deliberately accepted: a proxy that rewrites `Host` to
+ * The hard case for the comparison alone: a proxy that rewrites `Host` to
  * `localhost` and sets no `X-Forwarded-Host` (nginx `proxy_pass` without
- * `proxy_set_header`) is indistinguishable from a genuinely local request, and
- * a public instance configured that way loses the banner. No header can tell
- * those apart, because that configuration destroys the only evidence. It is
- * also not a silent state: such a proxy breaks Better Auth's trusted origins
- * and every absolute redirect, so the install announces itself in louder ways
- * than a missing banner.
+ * `proxy_set_header`) leaves a public instance indistinguishable from a local
+ * one by every host-shaped measure. No HOST header can tell those apart — that
+ * configuration destroys the evidence. The scheme still can, which is why the
+ * caller in `insecure-banner.tsx` also consults `x-forwarded-proto`; see the
+ * note there. What remains uncovered is such a proxy that terminates plain HTTP
+ * as well, i.e. an instance that is unencrypted end to end AND lies about its
+ * host — and that one is not a silent state either: it breaks Better Auth's
+ * trusted origins (`auth.ts` derives them from these same headers) and every
+ * absolute redirect, so it announces itself far louder than by a missing
+ * banner.
+ *
+ * Note also that `X-Forwarded-Host` is only as trustworthy as whatever sits in
+ * front: with no proxy stripping it, a client can send it and thereby move this
+ * verdict. That is tolerable here and nowhere else — the header steers a banner
+ * the sender sees themselves, so the only thing anyone can do with it is hide
+ * their own warning. Do NOT reuse this helper for a decision with a blast
+ * radius beyond the requester.
  */
 function externalHost({ host, forwardedHost }: RequestOrigin): string | null {
   if (forwardedHost && forwardedHost !== host) {

--- a/packages/web/src/lib/loopback-request.ts
+++ b/packages/web/src/lib/loopback-request.ts
@@ -1,0 +1,78 @@
+/**
+ * Is the address the operator's browser is actually pointed at a loopback
+ * address? Used to decide whether the "instance is not secured" banner has
+ * anything useful to say.
+ *
+ * On a local install it does not: browsers already treat `http://localhost` as
+ * a secure context — the traffic never leaves the machine — so telling an
+ * operator to lock a domain they do not have is advice they cannot act on.
+ *
+ * This is a DISPLAY decision only. The security behaviour that matters, whether
+ * auth cookies are issued `Secure`/`__Secure-`, is decided separately in
+ * `secure-cookies.ts` from the persisted domain-lock flag, and nothing here
+ * touches it.
+ */
+
+export interface RequestOrigin {
+  /** The `Host` header: which hop the request arrived on. */
+  host: string | null;
+  /** `X-Forwarded-Host`, if a proxy set one. See `externalHost` for the catch. */
+  forwardedHost: string | null;
+}
+
+/**
+ * A host that resolves to this machine and nowhere else: `localhost`, the whole
+ * 127/8 range, IPv6 `::1`, and the RFC 6761-reserved `.localhost` TLD.
+ *
+ * Anchored on a full label boundary so `localhost.evil.com` and
+ * `127.0.0.1.evil.com` — both perfectly registrable — do not slip through on a
+ * prefix match.
+ */
+function isLoopbackHost(host: string): boolean {
+  // Strip the port. IPv6 literals arrive bracketed (`[::1]:7777`), so take the
+  // bracketed part first and only then look for a trailing `:port`.
+  const bracketed = /^\[([^\]]+)\](?::\d+)?$/.exec(host);
+  const hostname = (bracketed ? bracketed[1] : host.replace(/:\d+$/, "")).toLowerCase();
+
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) return true;
+  if (hostname === "::1" || hostname === "0:0:0:0:0:0:0:1") return true;
+  // 127.0.0.0/8 — every address in it is loopback, not just 127.0.0.1.
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname);
+}
+
+/**
+ * The host the world uses to reach this instance, as best we can know it.
+ *
+ * The catch that shapes this whole function: **Next.js manufactures the
+ * `x-forwarded-*` headers when they are missing**, so their presence is not
+ * evidence of a proxy (`next/dist/server/base-server.js`):
+ *
+ *     req.headers['x-forwarded-host'] ??= req.headers['host'] ?? this.hostname;
+ *
+ * What that back-fill leaves usable is the COMPARISON. A synthesized
+ * `X-Forwarded-Host` equals `Host` by construction; a value that differs can
+ * only have come from a real proxy, and then it — not `Host`, which describes
+ * the internal hop — is the client-facing name.
+ *
+ * Known limitation, deliberately accepted: a proxy that rewrites `Host` to
+ * `localhost` and sets no `X-Forwarded-Host` (nginx `proxy_pass` without
+ * `proxy_set_header`) is indistinguishable from a genuinely local request, and
+ * a public instance configured that way loses the banner. No header can tell
+ * those apart, because that configuration destroys the only evidence. It is
+ * also not a silent state: such a proxy breaks Better Auth's trusted origins
+ * and every absolute redirect, so the install announces itself in louder ways
+ * than a missing banner.
+ */
+function externalHost({ host, forwardedHost }: RequestOrigin): string | null {
+  if (forwardedHost && forwardedHost !== host) {
+    // Oldest-first by convention, so the original client-facing host leads.
+    const first = forwardedHost.split(",")[0]!.trim();
+    if (first) return first;
+  }
+  return host;
+}
+
+export function isLoopbackRequest(origin: RequestOrigin): boolean {
+  const external = externalHost(origin);
+  return external !== null && isLoopbackHost(external);
+}


### PR DESCRIPTION
## The defect

`http://localhost:7777` greets every local operator with:

> Your Pinchy instance is not secured. Lock your domain to enable HTTPS hardening.

There is no domain to lock, and the browser already treats `http://localhost` as a **secure context** — crypto APIs, service workers, all of it — precisely because the traffic never leaves the machine. The advice cannot be acted on, so the banner is not merely noisy there, it is wrong.

## Why not `NODE_ENV`

`NODE_ENV` describes how the build was compiled, not how the instance is reachable. A production deployment accidentally started in development mode would lose the warning exactly when it needs it. The signal has to come from the request.

## The part that made this a redesign

The first implementation read *any* `x-forwarded-*` header as evidence of a proxy and refused to suppress the banner. It never suppressed anything, because Next.js manufactures those headers itself (`next/dist/server/base-server.js`):

```js
req.headers['x-forwarded-host']  ??= req.headers['host'] ?? this.hostname;
req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http';
req.headers['x-forwarded-for']   ??= originalRequest?.socket?.remoteAddress;
```

**Its unit tests were green the whole time**, because they hand-built a `Headers` fixture that omitted what Next.js always adds — the tests described a request that never reaches a Server Component. `x-forwarded-for` is consequently not read at all; a check on it would look like a safeguard while deciding nothing, which is worse than no check.

What the back-fill *does* leave usable is the **comparison**. A synthesized `X-Forwarded-Host` equals `Host` by construction, so a value that differs came from a real proxy — and then it, not `Host` (which describes the hop into the container), is the client-facing name. A public instance behind a proxy keeps its banner because its forwarded host is a real domain.

## The scheme is the second signal

`x-forwarded-proto` is the one `x-forwarded-*` header whose back-fill is **one-directional**, and an earlier revision of this PR wrongly lumped it in with the others. Next derives `isHttps` from the incoming header or from `socket.encrypted` (`base-server.js:573`), so a container serving plain HTTP can only ever synthesize `http`. The value `https` had to come from something that terminated TLS. The neighbouring code already relies on exactly this: `POST /api/settings/domain` refuses to lock a domain unless that header reads `https`.

It also changes what the banner *means*. Over HTTPS the advice is no longer empty — settings shows "Lock `<host>` & restart" for whatever host it sees, `localhost` included — so a request that reached us over TLS keeps its banner even from a loopback host.

That is what closes the gap this PR previously documented as accepted: nginx `proxy_pass http://localhost:7777` without `proxy_set_header Host` makes a public instance report `localhost` with no forwarded host to contradict it, but such a deployment sets `X-Forwarded-Proto: $scheme`, and the banner survives.

## Knowingly not covered

An instance that is unencrypted end to end **and** lies about its host — a plain-HTTP proxy rewriting `Host` to `localhost` while setting neither `X-Forwarded-Host` nor `X-Forwarded-Proto` — is still indistinguishable from a genuinely local request. That configuration destroys the evidence, and it is not a silent state either: it breaks Better Auth's trusted origins (`auth.ts` derives them from these same headers) and every absolute redirect. Documented at the call site rather than papered over.

Also documented: `X-Forwarded-Host` is only as trustworthy as whatever sits in front. With nothing stripping it, a client can send it and move the verdict — tolerable for a banner the sender sees themselves, and flagged so the helper is not reused for a decision with a wider blast radius.

## Tests

- `e2e/21-insecure-banner.spec.ts` — the test that would have caught the first version. Runs against a **real** Next.js server on `http://localhost:7778`, where the back-fill actually happens, and asserts the precondition as well (the settings page still reports the instance unsecured) so it cannot pass by warning about nothing. Verified load-bearing by mutation: stubbing `isLoopbackRequest` to `false` turns it red.
- `loopback-request.test.ts` — every case carries the synthesized header, exactly as a real request does. Label-boundary anchoring covers `localhost.evil.com` / `127.0.0.1.evil.com` (both registrable, neither loopback) and their trailing-dot spellings, the whole 127/8 range, IPv6 `::1` **bracketed and bare**, and the RFC 6761 `.localhost` TLD.
- `insecure-banner.test.tsx` — the scheme decision, including the case that matters: a loopback host reached over HTTPS keeps its banner.

Two host-parsing bugs the review surfaced, both now covered:

- Unbracketed IPv6 never matched. `Host` is bracketed per RFC 7230, but `X-Forwarded-Host` is written by proxies and plenty emit the bare address; the `:port` strip turned `::1` into `:` and `0:0:0:0:0:0:0:1` into `0:0:0:0:0:0:0`, leaving both equality checks unreachable for exactly the shape that needs them.
- A trailing-dot FQDN (`localhost.`) is the same host and now reads as one.

## Scope

Display only. Whether auth cookies are issued `Secure`/`__Secure-` is still decided in `secure-cookies.ts` from the persisted domain-lock flag; `isInsecureMode` has no reader other than this banner.

## Verification

`format:check`, `typecheck`, `lint` and the `21-insecure-banner` E2E (with `01-setup`, which seeds the admin every spec here relies on) — green locally.

`pnpm test`: 9856 passed, with one pre-existing load-dependent flake per run — `knowledge-reindex-section.test.tsx > shows elapsed time during the indeterminate discovery phase too` in one run, a `secure-cookies` case in another. Both pass in isolation, neither file imports anything this branch touches, and the failure moves between runs.

`pnpm test:db` could not be run: `pnpm db:migrate` fails against a freshly created local test DB. Reproduced on the base commit at the identical point without this branch's changes, and nothing here touches schema or DB code.
