### PR TITLE
test(web): make the reindex elapsed-readout test load-independent

### DIFF
--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
+import { flushPendingRenders } from "@/test-helpers/react";
 import { KnowledgeReindexSection, formatElapsed } from "@/components/knowledge-reindex-section";
 import { apiGet, apiPost, ApiError } from "@/lib/api-client";
 import { toast } from "sonner";
@@ -239,10 +240,10 @@ describe("KnowledgeReindexSection", () => {
     // The optimistic pending job is a React commit queued by the POST's
     // continuation. `waitFor` would poll for it against a 1000ms WALL-CLOCK
     // budget, which one blocked event-loop turn under a full parallel run
-    // consumes entirely. act() forces the pending work to settle first, so the
-    // assertion is both deterministic and stricter: the run must be live the
-    // moment the click settles.
-    await act(async () => {});
+    // consumes entirely. Draining forces the pending work to settle first, so
+    // the assertion is both deterministic and stricter: the run must be live
+    // the moment the click settles.
+    await flushPendingRenders();
     expect(screen.getByRole("button", { name: /reindexing/i })).toBeDisabled();
 
     // The pre-click read finally answers "no job ever ran". It is stale — it
@@ -301,13 +302,11 @@ describe("KnowledgeReindexSection", () => {
       // The two halves of this assertion land in DIFFERENT commits: the status
       // read renders "Discovering documents…" while `now` is still null, and
       // only the effect that starts the elapsed clock appends the " · running
-      // 43 sec" suffix. A waitFor gated on the phase text passes on the FIRST
-      // commit and races the second — an ordering that holds in a warm run and
-      // opens under preemption, which is how the elapsed line failed in a full
-      // parallel run while an isolated rerun stayed green. act() drains both
-      // commits, so the readout is asserted on settled output rather than on
-      // whichever commit the poll happened to catch.
-      await act(async () => {});
+      // 43 sec" suffix. Gating on the phase text is therefore the flake shape
+      // flushPendingRenders documents — and it did flake exactly so, failing on
+      // the elapsed line in a full parallel run while an isolated rerun stayed
+      // green. Draining both commits asserts the readout on settled output.
+      await flushPendingRenders();
       expect(screen.getByText(/discovering documents/i)).toBeInTheDocument();
       expect(screen.getByText(/running 43 sec/i)).toBeInTheDocument();
     });

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -298,7 +298,17 @@ describe("KnowledgeReindexSection", () => {
 
       render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
 
-      await waitFor(() => expect(screen.getByText(/discovering documents/i)).toBeInTheDocument());
+      // The two halves of this assertion land in DIFFERENT commits: the status
+      // read renders "Discovering documents…" while `now` is still null, and
+      // only the effect that starts the elapsed clock appends the " · running
+      // 43 sec" suffix. A waitFor gated on the phase text passes on the FIRST
+      // commit and races the second — an ordering that holds in a warm run and
+      // opens under preemption, which is how the elapsed line failed in a full
+      // parallel run while an isolated rerun stayed green. act() drains both
+      // commits, so the readout is asserted on settled output rather than on
+      // whichever commit the poll happened to catch.
+      await act(async () => {});
+      expect(screen.getByText(/discovering documents/i)).toBeInTheDocument();
       expect(screen.getByText(/running 43 sec/i)).toBeInTheDocument();
     });
 

--- a/packages/web/src/__tests__/components/new-agent-form.test.tsx
+++ b/packages/web/src/__tests__/components/new-agent-form.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Mock } from "vitest";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import { flushPendingRenders } from "@/test-helpers/react";
 import { NewAgentForm } from "@/components/new-agent-form";
 import { toast } from "sonner";
 
@@ -269,7 +270,7 @@ describe("NewAgentForm — tagline field", () => {
 
     // Flush remaining async effects (name prefill + fetchDirectories) so they
     // complete before the mock is torn down in afterEach.
-    await act(async () => {});
+    await flushPendingRenders();
   });
 
   it("shows empty tagline field when template has null defaultTagline", async () => {

--- a/packages/web/src/hooks/__tests__/use-odoo-permissions.test.ts
+++ b/packages/web/src/hooks/__tests__/use-odoo-permissions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { flushPendingRenders } from "@/test-helpers/react";
 import { useOdooPermissions, type Connection } from "../use-odoo-permissions";
 
 // Mock fetch — only used for /api/agents/:id/integrations (per-agent permissions)
@@ -72,7 +73,7 @@ describe("useOdooPermissions", () => {
 
     expect(result.current.loading).toBe(true);
 
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.loading).toBe(false);
     expect(result.current.connections).toHaveLength(2);
@@ -94,7 +95,7 @@ describe("useOdooPermissions", () => {
     ]);
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.connectionId).toBe("conn-1");
     expect(result.current.addedModels.size).toBe(2);
@@ -117,7 +118,7 @@ describe("useOdooPermissions", () => {
     ]);
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", []));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.connectionId).toBe("");
     expect(result.current.addedModels.size).toBe(0);
@@ -141,7 +142,7 @@ describe("useOdooPermissions", () => {
     ]);
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.connectionId).toBe("conn-1");
     expect(result.current.addedModels.size).toBe(1);
@@ -159,7 +160,7 @@ describe("useOdooPermissions", () => {
     ]);
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.addedModels.size).toBe(1);
 
@@ -177,7 +178,7 @@ describe("useOdooPermissions", () => {
   it("setAccessLevel('read-only') sets all added models to read only", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -205,7 +206,7 @@ describe("useOdooPermissions", () => {
   it("setAccessLevel('read-write') sets all added models to read, create, write", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -227,7 +228,7 @@ describe("useOdooPermissions", () => {
   it("setAccessLevel('full') sets all added models to all operations", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -264,7 +265,7 @@ describe("useOdooPermissions", () => {
     ]);
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.accessLevel).toBe("read-write");
   });
@@ -284,7 +285,7 @@ describe("useOdooPermissions", () => {
     ]);
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.accessLevel).toBe("custom");
   });
@@ -294,7 +295,7 @@ describe("useOdooPermissions", () => {
   it("addModel adds a model with operations based on current access level", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -330,7 +331,7 @@ describe("useOdooPermissions", () => {
   it("addAllModels adds all available models", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -353,7 +354,7 @@ describe("useOdooPermissions", () => {
   it("removeModel removes a model", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -376,7 +377,7 @@ describe("useOdooPermissions", () => {
   it("availableModels excludes already-added models", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -397,7 +398,7 @@ describe("useOdooPermissions", () => {
   it("toggleOperation toggles a single operation", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -425,7 +426,7 @@ describe("useOdooPermissions", () => {
   it("toggleOperation switches access level to custom when it diverges from preset", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -452,7 +453,7 @@ describe("useOdooPermissions", () => {
   it("toggleOperation detects when operations match a preset again", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -478,7 +479,7 @@ describe("useOdooPermissions", () => {
   it("getPermissions returns flat array of {model, operation} tuples", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -506,7 +507,7 @@ describe("useOdooPermissions", () => {
   it("isDirty is false when connection selected but no models added", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.isDirty).toBe(false);
 
@@ -520,7 +521,7 @@ describe("useOdooPermissions", () => {
   it("isDirty is true when connection selected AND models added", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -536,7 +537,7 @@ describe("useOdooPermissions", () => {
   it("getPermissions returns empty array when no models added", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -556,7 +557,7 @@ describe("useOdooPermissions", () => {
     ]);
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.isDirty).toBe(false);
   });
@@ -567,7 +568,7 @@ describe("useOdooPermissions", () => {
     mockAgentPerms();
 
     const { result } = renderHook(() => useOdooPermissions("agent-1", []));
-    await act(async () => {});
+    await flushPendingRenders();
 
     expect(result.current.connections).toHaveLength(0);
     expect(result.current.availableModels).toHaveLength(0);
@@ -579,7 +580,7 @@ describe("useOdooPermissions", () => {
     const { result } = renderHook(() =>
       useOdooPermissions("agent-1", [makeConnection("conn-no-models", "No Models", undefined)])
     );
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-no-models");
@@ -593,7 +594,7 @@ describe("useOdooPermissions", () => {
   it("addModel respects access restrictions", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -614,7 +615,7 @@ describe("useOdooPermissions", () => {
   it("setAccessLevel respects access restrictions", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -639,7 +640,7 @@ describe("useOdooPermissions", () => {
   it("toggleOperation is no-op for restricted operations", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -659,7 +660,7 @@ describe("useOdooPermissions", () => {
   it("addAllModels respects per-model access restrictions", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -702,7 +703,7 @@ describe("useOdooPermissions", () => {
     const { result } = renderHook(() =>
       useOdooPermissions("agent-1", [makeConnection("conn-legacy", "Legacy", modelsWithoutAccess)])
     );
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-legacy");
@@ -715,7 +716,7 @@ describe("useOdooPermissions", () => {
   it("addAllModels does not re-add already existing models", async () => {
     mockAgentPerms();
     const { result } = renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     act(() => {
       result.current.setConnectionId("conn-1");
@@ -750,7 +751,7 @@ describe("useOdooPermissions", () => {
     mockAgentPerms();
 
     renderHook(() => useOdooPermissions("agent-1", CONNECTIONS));
-    await act(async () => {});
+    await flushPendingRenders();
 
     const calls = mockFetch.mock.calls.map((c) => c[0] as string);
     expect(calls).not.toContain("/api/integrations");

--- a/packages/web/src/test-helpers/react.ts
+++ b/packages/web/src/test-helpers/react.ts
@@ -1,0 +1,33 @@
+import { act } from "@testing-library/react";
+
+/**
+ * Drain every React update that is already queued — renders, effects, and the
+ * state updates those effects schedule — and return once the tree has settled.
+ *
+ * This is the counterpart to `waitFor`, not a synonym for it, and the choice
+ * between them is a correctness decision rather than a style one:
+ *
+ * - `waitFor` POLLS for something that has yet to happen. It is right for work
+ *   whose arrival the test cannot force (a timer firing, a debounce elapsing).
+ * - `flushPendingRenders` DRAINS work that is already pending. It is right when
+ *   the test knows the update is queued and only needs it applied.
+ *
+ * Reaching for `waitFor` where a drain belongs is how load-dependent flakes are
+ * born. A `waitFor` gated on one piece of state is satisfied by the FIRST
+ * commit that shows it, so a second value arriving one commit later — the
+ * classic "effect reads the clock and re-renders" shape — is left to macrotask
+ * ordering: green in a warm run, red under preemption. Draining first makes the
+ * assertion both deterministic and stricter, because it fails immediately with
+ * the rendered DOM instead of after a timeout.
+ *
+ * ASSUMPTION worth knowing: this settles work that resolves through
+ * MICROTASKS — an already-resolved promise, a `mockResolvedValue`, a state
+ * update cascading out of an effect. Work gated on a real timer is NOT drained;
+ * advance the clock (`vi.advanceTimersByTimeAsync`) or poll with `waitFor`
+ * instead. A mock rewritten to resolve on a macrotask therefore turns such a
+ * test red deterministically rather than flaky, which is the failure mode to
+ * prefer.
+ */
+export async function flushPendingRenders(): Promise<void> {
+  await act(async () => {});
+}


### PR DESCRIPTION
## What does this PR do?

De-flakes `shows elapsed time during the indeterminate discovery phase too` in `packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx`. Third and last of the load-dependent waits in this file, after 55e20c5c1 / 2e7316326.

**Root cause — the gate and the assertion are two different React commits.**

`KnowledgeReindexSection` starts the elapsed clock in an effect: `now` is `null` on the commit that renders the status read, so that commit paints `"Discovering documents…"` *without* the readout, and only the follow-up commit (`setNow(Date.now())`) appends `" · running 43 sec"`. The test gated on the phase text and then asserted the suffix:

```tsx
await waitFor(() => expect(screen.getByText(/discovering documents/i)).toBeInTheDocument());
expect(screen.getByText(/running 43 sec/i)).toBeInTheDocument();
```

`waitFor` is satisfied by the **first** commit, so whether the second has landed is macrotask ordering. It holds in a warm, unloaded run and opens under preemption — which is exactly how the line hit a `getElementError` in a full parallel run (715 files, ~300s) and then passed 23/23 on an isolated rerun.

**The fake clock is *not* the mechanism** (the plausible alternative, `43 sec` drifting to `44 sec`, is ruled out). `shouldAdvanceTime` is driven by a *real* 20 ms `setInterval` calling `clock.tick(20)`; a blocked event loop coalesces those callbacks, so the mocked clock lags real time rather than running ahead of it. Measured `now` stayed at `10:00:44.020` under every injected stall, and the reproduced failure DOM shows `"Discovering documents…"` with **no suffix at all**, not a drifted value.

**Fix:** drain both commits with `act()` and assert on settled output — the same treatment 55e20c5c1 applied to the stale-read test.

### Measurements

Reproduction: a 1.2 s event-loop block injected after `render()` (real-clock spin — `process.hrtime` is faked by the fake timers and hangs the runner).

| variant | isolated (`-t`, cold React) | whole file, stall 0 | whole file, stall 1200 ms | isolated, stalls 0/400/1200/2500 |
|---|---|---|---|---|
| `waitFor` (before) | fails 3/3 | passes | **fails** | fails every time |
| `act()` (after) | passes 3/3 | passes | passes | passes, 0 failures |

### Coverage is unchanged

Mutation-tested: removing `{elapsedSuffix}` from the discovery branch of `RunningState` still turns the assertion red. The component is untouched by this PR.

No skip, no widened timeout, no test removed — net test count is unchanged.

Gates run locally: `pnpm format:check` ✅, `pnpm -C packages/web typecheck` (incl. tests) ✅, `pnpm test` → **9842 passed | 16 skipped (715 files)** ✅.

---

## Second commit: name the idiom (`0d185c660`)

Review turned up that `await act(async () => {})` appears **34 times verbatim** across three test files (`use-odoo-permissions` 31×, this file 2×, `new-agent-form` 1×) with nothing anywhere saying what it is for — so the distinction that this PR's flake turned on is folklore rather than written down.

Extracted as `flushPendingRenders()` in `packages/web/src/test-helpers/react.ts`, where the doc comment carries the part that matters:

- `waitFor` **polls** for work that has yet to happen (a timer, a debounce) — right when the test cannot force it.
- `flushPendingRenders` **drains** work already queued — right when the test knows the update is pending and only needs it applied.
- Reaching for the first where the second belongs is precisely how the flake above was written.

It also writes down the assumption the bare idiom makes silently: it settles **microtask**-resolved work only (`mockResolvedValue`, effect cascades). Work gated on a real timer needs `vi.advanceTimersByTimeAsync` or a `waitFor`. A mock rewritten to resolve on a macrotask therefore fails such a test *deterministically*, not flakily.

The helper's body **is** the idiom it replaces, so this is a rename, not a behavior change. Full suite after: **9842 passed | 16 skipped (715 files)** — byte-identical to before. `pnpm -C packages/web lint` 0 errors, `typecheck` ✅, `format:check` ✅.

## Type of change

- [x] 🧪 Tests

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated the documentation (if applicable) — no product behavior change
- [x] All existing tests pass
