### PR TITLE
fix(db): make a failed migration say what failed

### DIFF
--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -10,7 +10,7 @@
 #   4. runtime  — a clean node:22-slim that copies in ONLY what the server
 #      needs at boot: pruned node_modules, the built `.next` (minus the
 #      build-only `.next/cache`), the TypeScript source `tsx` executes
-#      directly, the drizzle migrations `drizzle-kit migrate` applies, the
+#      directly, the drizzle migrations `pnpm db:migrate` applies, the
 #      `scripts/` the entrypoint runs, and the 8 Pinchy plugins.
 #
 # Why this is correct for THIS app (no Next.js standalone, no compiled
@@ -18,10 +18,12 @@
 #   NODE_ENV=production node -r ./server-preload.cjs --import tsx server.ts
 # run from /app/packages/web. The server runs the TypeScript source directly
 # via `tsx` — so `tsx`, the TS source, and the `.next` build all have to be
-# present at runtime. `tsx` and `drizzle-kit` are therefore genuine RUNTIME
-# dependencies (the entrypoint runs `drizzle-kit migrate` at boot) and live
-# in `dependencies`, not `devDependencies`, so `pnpm install --prod` keeps
-# them.
+# present at runtime. `tsx` is therefore a genuine RUNTIME dependency and
+# lives in `dependencies`, not `devDependencies`, so `pnpm install --prod`
+# keeps it. `drizzle-kit` sits there too, but no longer needs to: the boot
+# migration is `node scripts/db-migrate.mjs` (drizzle-orm's migrator, which
+# reports failures — drizzle-kit's CLI swallowed them), and drizzle-kit is
+# now only a `db:generate` / `db:studio` tool. Prunable, separately.
 
 # ---------------------------------------------------------------------------
 # Stage: base — shared layout + corepack-enabled pnpm.
@@ -159,9 +161,11 @@ COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=prod-deps /app/packages/web/node_modules ./packages/web/node_modules
 
 # The runtime TypeScript source that `tsx` executes directly, plus the config
-# the server + drizzle-kit read at boot (next.config.ts, drizzle.config.ts,
-# tsconfig.json), the scripts/ the entrypoint calls (resolve-db-password.mjs),
-# the drizzle migrations drizzle-kit applies, server.ts and server-preload.cjs,
+# the server reads at boot (next.config.ts, tsconfig.json; drizzle.config.ts
+# rides along for `db:generate`/`db:studio` — the boot migration resolves its
+# folder from its own path, not from the config), the scripts/ the entrypoint
+# calls (resolve-db-password.mjs, db-migrate.mjs), the drizzle migrations
+# db-migrate.mjs applies, server.ts and server-preload.cjs,
 # and the public/ assets. The source tree is small; node_modules and
 # .next/cache (the bloat) are handled separately above. Build-only configs
 # (postcss.config.mjs, components.json) are intentionally NOT copied — PostCSS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ echo "[entrypoint] all Pinchy plugins present in /openclaw-extensions/"
 # Issue #156: migrate the database off the public default password before
 # anything connects. The resolver prints the effective DATABASE_URL on stdout
 # (empty when unchanged, diagnostics on stderr) and never fails the boot —
-# drizzle-kit and the server below both consume the exported value.
+# the migrate runner and the server below both consume the exported value.
 echo '[pinchy] Resolving database credentials...'
 RESOLVED_DATABASE_URL=$(su -s /bin/sh pinchy -c 'cd /app/packages/web && node scripts/resolve-db-password.mjs' || true)
 if [ -n "$RESOLVED_DATABASE_URL" ]; then

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
     "kb-eval:selftest": "playwright test --config playwright.integration.config.ts e2e/integration/kb-attribution.spec.ts",
     "kb-eval:models": "CI=true ENCRYPTION_KEY=00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff EVAL_MODE=kb-models PINCHY_URL=http://localhost:7781 MOCK_ODOO_URL=http://localhost:9502 GRAPH_MOCK_URL=http://localhost:9505 DATABASE_URL=postgresql://pinchy:${DB_PASSWORD:-eval_dev_pw}@localhost:5437/pinchy playwright test --config eval/playwright.eval.config.ts",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate",
+    "db:migrate": "node scripts/db-migrate.mjs",
     "db:studio": "drizzle-kit studio",
     "reset-admin": "node --import tsx scripts/reset-admin.ts",
     "domain:reset": "node --import tsx scripts/domain-reset.ts",

--- a/packages/web/scripts/db-migrate.mjs
+++ b/packages/web/scripts/db-migrate.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// `pnpm db:migrate` — apply pending Drizzle migrations, and say what happened.
+//
+// This replaces `drizzle-kit migrate`, which was silent on failure: its bundled
+// `hanji.renderWithTask` does `catch (err) { terminal.reject(err); process.exit(1) }`,
+// where `reject` only re-renders the spinner and the `exit` fires before
+// drizzle-kit's own `console.error`. A failed migration therefore printed a
+// spinner line and exit code 1 — no statement, no PostgresError, not even the
+// migration's name. entrypoint.sh runs this command on every production
+// upgrade under `set -e`, so that blank wall was an operator's view of an
+// aborted upgrade, not just a local annoyance.
+//
+// The migrator itself is unchanged: drizzle-orm's `migrate()` is what
+// drizzle-kit called too, with the same defaults (drizzle.__drizzle_migrations,
+// every pending migration in one transaction). Only the reporting is ours.
+// `db:generate` and `db:studio` stay on drizzle-kit.
+//
+// Plain .mjs on plain node, like scripts/resolve-db-password.mjs: entrypoint.sh
+// runs it in the production image, where there is no tsx and no path aliases.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { formatMigrationFailure } from "./lib/migration-failure.mjs";
+
+// Resolved from this file, not from cwd, so `pnpm -C`, the entrypoint's
+// `cd /app/packages/web` and a test harness all read the same folder. Pinned
+// to drizzle.config.ts's `out` by migration-failure-report.test.ts.
+const MIGRATIONS_DIR = fileURLToPath(new URL("../drizzle/", import.meta.url));
+
+const out = (msg) => process.stdout.write(`${msg}\n`);
+const err = (msg) => process.stderr.write(`${msg}\n`);
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  err("[db:migrate] DATABASE_URL is not set");
+  process.exit(1);
+}
+
+/**
+ * Read the migration files in journal order so a failing statement can be
+ * attributed to the migration it came from. Only called on the failure path.
+ */
+async function readMigrationFiles() {
+  const journalPath = join(MIGRATIONS_DIR, "meta", "_journal.json");
+  const journal = JSON.parse(await readFile(journalPath, "utf-8"));
+  return Promise.all(
+    journal.entries.map(async (entry) => ({
+      tag: entry.tag,
+      sql: await readFile(join(MIGRATIONS_DIR, `${entry.tag}.sql`), "utf-8"),
+    }))
+  );
+}
+
+const client = postgres(databaseUrl, {
+  max: 1,
+  // The default handler console.logs the whole notice object. These are
+  // routine during a migration ("identifier will be truncated", "already
+  // exists, skipping") and used to bury the run in JSON blobs.
+  onnotice: (notice) => err(`[db:migrate] ${notice.severity}: ${notice.message}`),
+});
+
+try {
+  out(`[db:migrate] applying migrations from ${MIGRATIONS_DIR}`);
+  await migrate(drizzle(client), { migrationsFolder: MIGRATIONS_DIR });
+  const [row] = await client`
+    select count(*)::text as n, max(created_at)::text as watermark
+    from drizzle.__drizzle_migrations
+  `;
+  out(`[db:migrate] up to date — ${row.n} migrations recorded, watermark ${row.watermark}`);
+} catch (error) {
+  const migrationFiles = await readMigrationFiles().catch(() => []);
+  err(formatMigrationFailure({ error, migrationFiles }));
+  process.exitCode = 1;
+} finally {
+  await client.end({ timeout: 5 });
+}

--- a/packages/web/scripts/db-migrate.mjs
+++ b/packages/web/scripts/db-migrate.mjs
@@ -24,7 +24,11 @@ import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
-import { formatMigrationFailure } from "./lib/migration-failure.mjs";
+import {
+  formatMigrationFailure,
+  describeTarget,
+  pendingMigrations,
+} from "./lib/migration-failure.mjs";
 
 // Resolved from this file, not from cwd, so `pnpm -C`, the entrypoint's
 // `cd /app/packages/web` and a test harness all read the same folder. Pinned
@@ -40,19 +44,46 @@ if (!databaseUrl) {
   process.exit(1);
 }
 
+// host:port/database, never the password — see describeTarget. Printed on both
+// paths: which Postgres this actually reached is half the diagnosis when the
+// URL comes from a compose file or a test config rather than from the reader.
+const target = describeTarget(databaseUrl);
+
 /**
- * Read the migration files in journal order so a failing statement can be
- * attributed to the migration it came from. Only called on the failure path.
+ * The migrations that were still pending when this run started, in journal
+ * order, so a failing statement can be attributed to the migration it came
+ * from. Only called on the failure path.
+ *
+ * Narrowed by the watermark because migrations repeat statements verbatim
+ * (`DROP VIEW "public"."active_agents";` lives in 0016, 0042 and 0045); the
+ * already-applied ones cannot be the culprit and only add false candidates.
  */
-async function readMigrationFiles() {
+async function readPendingMigrationFiles(watermark) {
   const journalPath = join(MIGRATIONS_DIR, "meta", "_journal.json");
   const journal = JSON.parse(await readFile(journalPath, "utf-8"));
   return Promise.all(
-    journal.entries.map(async (entry) => ({
+    pendingMigrations(journal.entries, watermark).map(async (entry) => ({
       tag: entry.tag,
       sql: await readFile(join(MIGRATIONS_DIR, `${entry.tag}.sql`), "utf-8"),
     }))
   );
+}
+
+/**
+ * The watermark as it stands AFTER the failure. Drizzle rolls the whole run
+ * back, so this is the pre-run state: exactly the boundary that says which
+ * migrations this run was trying to apply. Null when the table isn't there
+ * yet (a fresh database) or the connection is gone — then nothing is narrowed.
+ */
+async function readWatermark(client) {
+  try {
+    const [row] = await client`
+      select max(created_at)::text as watermark from drizzle.__drizzle_migrations
+    `;
+    return row?.watermark ?? null;
+  } catch {
+    return null;
+  }
 }
 
 const client = postgres(databaseUrl, {
@@ -63,18 +94,42 @@ const client = postgres(databaseUrl, {
   onnotice: (notice) => err(`[db:migrate] ${notice.severity}: ${notice.message}`),
 });
 
+let migrated = false;
 try {
-  out(`[db:migrate] applying migrations from ${MIGRATIONS_DIR}`);
-  await migrate(drizzle(client), { migrationsFolder: MIGRATIONS_DIR });
-  const [row] = await client`
-    select count(*)::text as n, max(created_at)::text as watermark
-    from drizzle.__drizzle_migrations
-  `;
-  out(`[db:migrate] up to date — ${row.n} migrations recorded, watermark ${row.watermark}`);
-} catch (error) {
-  const migrationFiles = await readMigrationFiles().catch(() => []);
-  err(formatMigrationFailure({ error, migrationFiles }));
-  process.exitCode = 1;
+  out(`[db:migrate] applying migrations from ${MIGRATIONS_DIR}${target ? ` to ${target}` : ""}`);
+  try {
+    await migrate(drizzle(client), { migrationsFolder: MIGRATIONS_DIR });
+    migrated = true;
+  } catch (error) {
+    const migrationFiles = await readPendingMigrationFiles(await readWatermark(client)).catch(
+      () => []
+    );
+    err(formatMigrationFailure({ error, migrationFiles, target }));
+    process.exitCode = 1;
+  }
+
+  // Deliberately NOT inside the catch above. This query is decoration; if it
+  // fails after every migration landed, reporting "migration failed — nothing
+  // was applied" would be the exact opposite of the truth, in the one script
+  // whose entire purpose is to tell it. Say what happened and still exit 0.
+  if (migrated) {
+    try {
+      const [row] = await client`
+        select
+          count(*)::text as n,
+          to_char(
+            to_timestamp(max(created_at) / 1000.0) at time zone 'UTC',
+            'YYYY-MM-DD HH24:MI:SS'
+          ) as watermark
+        from drizzle.__drizzle_migrations
+      `;
+      out(
+        `[db:migrate] up to date — ${row.n} migrations recorded, watermark ${row.watermark ?? "none"} UTC`
+      );
+    } catch (error) {
+      err(`[db:migrate] migrations applied; the summary query failed: ${error.message}`);
+    }
+  }
 } finally {
   await client.end({ timeout: 5 });
 }

--- a/packages/web/scripts/lib/migration-failure.mjs
+++ b/packages/web/scripts/lib/migration-failure.mjs
@@ -73,20 +73,84 @@ function indent(text, pad = "    ") {
 }
 
 /**
- * Find the migration a statement came from.
+ * Find the migrations a statement could have come from.
  *
  * Substring match against the file, not an equality check against a re-split
  * statement list: drizzle splits on `--> statement-breakpoint` and trims, and
  * replicating that split here would be a second implementation to keep in sync
- * for no gain. A DDL statement is distinctive enough that the first file
- * containing it verbatim is the right one.
+ * for no gain.
  *
- * @returns {string | null} the migration tag, or null when nothing matches.
+ * ALL matches are returned, not the first. Migrations do repeat a statement
+ * verbatim (`DROP VIEW "public"."active_agents";` is byte-identical in 0016,
+ * 0042 and 0045), and naming one of them reads as a fact. The runner narrows
+ * the candidate list to the pending migrations first, which usually leaves
+ * exactly one; when it does not, saying so beats guessing.
+ *
+ * @returns {string[]} matching migration tags, in journal order.
  */
 function attributeStatement(statement, migrationFiles) {
   const needle = statement.trim();
-  const hit = migrationFiles.find((file) => file.sql.includes(needle));
-  return hit ? hit.tag : null;
+  return migrationFiles.filter((file) => file.sql.includes(needle)).map((file) => file.tag);
+}
+
+/**
+ * The database a connection string points at, as `host:port/database`.
+ *
+ * The failing target is often the whole answer — the bug that prompted this
+ * runner was a migration hitting a stale Postgres container on the port the
+ * test suite defaults to. But a connection string carries a password, so the
+ * URL is never echoed: only `host` (which by definition excludes credentials)
+ * and the database name. An unparseable string yields null rather than a
+ * best-effort print, because we cannot know which part of it is the secret.
+ *
+ * @returns {string | null}
+ */
+export function describeTarget(databaseUrl) {
+  if (typeof databaseUrl !== "string") return null;
+  try {
+    const url = new URL(databaseUrl);
+    if (!url.host) return null;
+    const database = url.pathname.replace(/^\//, "");
+    return database ? `${url.host}/${database}` : url.host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The journal entries drizzle would still have to apply, given the watermark
+ * currently in `drizzle.__drizzle_migrations`.
+ *
+ * Mirrors drizzle's own boundary (`entry.when > lastRow.created_at`, strictly
+ * greater) so statement attribution cannot blame a migration that was applied
+ * releases ago. A null watermark means the table does not exist yet: a fresh
+ * database, where everything is pending.
+ *
+ * @template {{when: number|string}} T
+ * @param {T[]} entries
+ * @param {number|string|null|undefined} watermark
+ * @returns {T[]}
+ */
+export function pendingMigrations(entries, watermark) {
+  if (watermark === null || watermark === undefined) return entries;
+  return entries.filter((entry) => Number(entry.when) > Number(watermark));
+}
+
+/** Render the attribution honestly: none, one, or "these three all contain it". */
+function describeAttribution(tags) {
+  if (tags.length === 0) return "unknown (statement matched no migration)";
+  if (tags.length === 1) return `${tags[0]}.sql`;
+  return `${tags[0]}.sql (identical statement also in ${tags.slice(1).join(", ")})`;
+}
+
+/** The error's stack with its leading "Name: message" headline removed. */
+function stripStackHeadline(error) {
+  if (typeof error.stack !== "string") return null;
+  const headline = `${error.name}: ${error.message}`;
+  const frames = error.stack.startsWith(headline)
+    ? error.stack.slice(headline.length)
+    : error.stack;
+  return frames.trim() ? frames.replace(/^\n/, "") : null;
 }
 
 /**
@@ -95,17 +159,22 @@ function attributeStatement(statement, migrationFiles) {
  * @param {object} args
  * @param {unknown} args.error  what the migrator threw
  * @param {{tag: string, sql: string}[]} args.migrationFiles  journal order
+ * @param {string | null} [args.target]  from describeTarget(), never a raw URL
  * @returns {string}
  */
-export function formatMigrationFailure({ error, migrationFiles = [] }) {
+export function formatMigrationFailure({ error, migrationFiles = [], target = null }) {
   const lines = ["[db:migrate] migration failed", ""];
+
+  if (target) lines.push(`  target: ${target}`);
 
   const statement = findStatement(error);
   if (statement) {
-    const tag = attributeStatement(statement, migrationFiles);
-    lines.push(`  migration: ${tag ? `${tag}.sql` : "unknown (statement matched no migration)"}`);
+    const tags = attributeStatement(statement, migrationFiles);
+    lines.push(`  migration: ${describeAttribution(tags)}`);
     lines.push("  statement:");
     lines.push(indent(statement.trim()));
+    lines.push("");
+  } else if (target) {
     lines.push("");
   }
 
@@ -120,7 +189,12 @@ export function formatMigrationFailure({ error, migrationFiles = [] }) {
     }
   } else if (error instanceof Error) {
     lines.push(`  ${error.name}: ${error.message}`);
-    if (error.stack) lines.push(indent(error.stack));
+    // A stack opens by repeating "Name: message" verbatim; strip that prefix so
+    // the headline is stated once and the frames still get printed. Matching
+    // the prefix rather than slicing the first line keeps multi-line messages
+    // intact instead of leaking their tail into the frame list.
+    const frames = stripStackHeadline(error);
+    if (frames) lines.push(indent(frames));
   } else {
     lines.push(`  ${String(error)}`);
   }

--- a/packages/web/scripts/lib/migration-failure.mjs
+++ b/packages/web/scripts/lib/migration-failure.mjs
@@ -1,0 +1,135 @@
+// Diagnostic report for a failed database migration.
+//
+// Pure formatting, no I/O, so the shape is pinned by a Docker-free unit test
+// (src/__tests__/db/migration-failure-report.test.ts) while the runner that
+// feeds it is proved against a real Postgres by db-migrate-runner.integration.
+//
+// Postgres tells us everything we need — which statement, which relation, why —
+// and drizzle-kit's bundled `hanji` threw all of it away (see the unit test's
+// header for the exact three lines). This turns it back into text.
+
+// postgres.js PostgresError fields worth printing, in the order a reader wants
+// them. `message` is rendered in the headline instead. Anything the server did
+// not send is skipped rather than printed empty — an empty `hint:` reads like
+// "Postgres had no hint", which is a different claim from "we never asked".
+const PG_FIELDS = [
+  "severity",
+  "code",
+  "detail",
+  "hint",
+  "position",
+  "where",
+  "schema_name",
+  "table_name",
+  "column_name",
+  "constraint_name",
+];
+
+// A migrator failure arrives double-wrapped: drizzle throws DrizzleQueryError
+// (which carries `.query`, the exact SQL it sent) with the driver's
+// PostgresError (which carries the diagnostics) as `.cause`. Both halves are
+// needed and neither is on the outer object, so every lookup walks the chain.
+function* causeChain(error) {
+  const seen = new Set();
+  let current = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    yield current;
+    current = current.cause;
+  }
+}
+
+/**
+ * A postgres.js PostgresError carries `severity`; a connection failure or a
+ * plain programmer error does not. Node's fs/net errors have `code` too, so
+ * `severity` is the discriminator, not `code`.
+ */
+function findPostgresError(error) {
+  for (const link of causeChain(error)) {
+    if ("severity" in link && "code" in link) return link;
+  }
+  return null;
+}
+
+/**
+ * The statement drizzle was executing, straight off DrizzleQueryError.
+ *
+ * Deliberately NOT "the last statement postgres.js sent": the driver issues a
+ * `rollback` immediately after the failure, so last-statement tracking reports
+ * `rollback` and attributes it to no migration at all.
+ */
+function findStatement(error) {
+  for (const link of causeChain(error)) {
+    if (typeof link.query === "string" && link.query.trim()) return link.query;
+  }
+  return null;
+}
+
+function indent(text, pad = "    ") {
+  return String(text)
+    .split("\n")
+    .map((line) => pad + line)
+    .join("\n");
+}
+
+/**
+ * Find the migration a statement came from.
+ *
+ * Substring match against the file, not an equality check against a re-split
+ * statement list: drizzle splits on `--> statement-breakpoint` and trims, and
+ * replicating that split here would be a second implementation to keep in sync
+ * for no gain. A DDL statement is distinctive enough that the first file
+ * containing it verbatim is the right one.
+ *
+ * @returns {string | null} the migration tag, or null when nothing matches.
+ */
+function attributeStatement(statement, migrationFiles) {
+  const needle = statement.trim();
+  const hit = migrationFiles.find((file) => file.sql.includes(needle));
+  return hit ? hit.tag : null;
+}
+
+/**
+ * Render a migration failure as something a human can act on.
+ *
+ * @param {object} args
+ * @param {unknown} args.error  what the migrator threw
+ * @param {{tag: string, sql: string}[]} args.migrationFiles  journal order
+ * @returns {string}
+ */
+export function formatMigrationFailure({ error, migrationFiles = [] }) {
+  const lines = ["[db:migrate] migration failed", ""];
+
+  const statement = findStatement(error);
+  if (statement) {
+    const tag = attributeStatement(statement, migrationFiles);
+    lines.push(`  migration: ${tag ? `${tag}.sql` : "unknown (statement matched no migration)"}`);
+    lines.push("  statement:");
+    lines.push(indent(statement.trim()));
+    lines.push("");
+  }
+
+  const pgError = findPostgresError(error);
+  if (pgError) {
+    lines.push(`  PostgresError: ${pgError.message}`);
+    for (const field of PG_FIELDS) {
+      const value = pgError[field];
+      if (value !== undefined && value !== null && value !== "") {
+        lines.push(`    ${field}: ${value}`);
+      }
+    }
+  } else if (error instanceof Error) {
+    lines.push(`  ${error.name}: ${error.message}`);
+    if (error.stack) lines.push(indent(error.stack));
+  } else {
+    lines.push(`  ${String(error)}`);
+  }
+
+  lines.push("");
+  lines.push(
+    "  Nothing was applied. Drizzle runs every pending migration inside a",
+    "  single transaction, so the database is exactly as it was."
+  );
+
+  return lines.join("\n");
+}

--- a/packages/web/scripts/resolve-db-password.mjs
+++ b/packages/web/scripts/resolve-db-password.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Entrypoint runner for the DB password auto-migration (#156).
 //
-// Called by entrypoint.sh BEFORE drizzle-kit migrate and the server start,
+// Called by entrypoint.sh BEFORE the migrate runner and the server start,
 // because both consume DATABASE_URL. Prints the resolved URL to stdout
 // (nothing when the URL is unchanged); all diagnostics go to stderr so the
 // captured stdout never mixes with logs. Always exits 0 — a failed migration

--- a/packages/web/src/__tests__/db/db-migrate-runner.integration.test.ts
+++ b/packages/web/src/__tests__/db/db-migrate-runner.integration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Behavioural guard for `pnpm db:migrate` against a real Postgres.
+ *
+ * Two things must hold, and the second is the one that was missing for as long
+ * as `db:migrate` was `drizzle-kit migrate`:
+ *
+ *   1. A fresh database ends up fully migrated — the runner must keep drizzle's
+ *      exact watermark semantics (one row per journal entry), because
+ *      migration-090-upgrade-path and friends rest on them.
+ *   2. A failing migration says WHAT failed and WHERE. drizzle-kit printed a
+ *      spinner and exit code 1, nothing else: no statement, no PostgresError,
+ *      not even the migration's name. entrypoint.sh runs the same command on
+ *      every production upgrade, so that blank wall was also what an operator
+ *      got when an upgrade aborted.
+ *
+ * The failure is provoked the way a real botched upgrade does it: the table
+ * 0058 creates already exists. That also pins the ATTRIBUTION — the report has
+ * to name 0058, not the first pending migration.
+ *
+ * Runs under `pnpm -C packages/web test:db` against the dev-stack Postgres on
+ * :5434 (or VITEST_INTEGRATION_DB_URL). Uses its own throwaway database.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import postgres from "postgres";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// vitest runs with cwd = packages/web.
+const WEB_ROOT = process.cwd();
+const RUNNER = join(WEB_ROOT, "scripts", "db-migrate.mjs");
+const MIGRATIONS_DIR = join(WEB_ROOT, "drizzle");
+
+// Per-process DB names so concurrent runs can't collide on the throwaways.
+const OK_DB = `pinchy_db_migrate_ok_${process.pid}`;
+const FAIL_DB = `pinchy_db_migrate_fail_${process.pid}`;
+
+function withDbName(url: string, name: string): string {
+  const u = new URL(url);
+  u.pathname = `/${name}`;
+  return u.toString();
+}
+
+function runMigrate(databaseUrl: string) {
+  const result = spawnSync(process.execPath, [RUNNER], {
+    // Deliberately not packages/web: the runner must resolve its migrations
+    // folder from its own location, not from whoever's cwd invoked it.
+    cwd: WEB_ROOT === "/" ? WEB_ROOT : join(WEB_ROOT, ".."),
+    env: { ...process.env, DATABASE_URL: databaseUrl },
+    encoding: "utf-8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+async function appliedCount(url: string): Promise<number> {
+  const client = postgres(url, { max: 1 });
+  try {
+    const [row] = await client<{ n: string }[]>`
+      select count(*)::text as n from drizzle.__drizzle_migrations
+    `;
+    return Number(row.n);
+  } finally {
+    await client.end();
+  }
+}
+
+describe("db:migrate runner", () => {
+  const baseUrl =
+    process.env.DATABASE_URL ??
+    process.env.VITEST_INTEGRATION_DB_URL ??
+    "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy_test_vitest";
+  const adminUrl = withDbName(baseUrl, "postgres");
+  let journalEntries = 0;
+
+  beforeAll(async () => {
+    const journal = JSON.parse(
+      await readFile(join(MIGRATIONS_DIR, "meta", "_journal.json"), "utf-8")
+    ) as { entries: unknown[] };
+    journalEntries = journal.entries.length;
+
+    const admin = postgres(adminUrl, { max: 1 });
+    try {
+      for (const name of [OK_DB, FAIL_DB]) {
+        await admin.unsafe(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+        await admin.unsafe(`CREATE DATABASE ${name}`);
+      }
+    } finally {
+      await admin.end();
+    }
+  });
+
+  afterAll(async () => {
+    const admin = postgres(adminUrl, { max: 1 });
+    try {
+      for (const name of [OK_DB, FAIL_DB]) {
+        await admin.unsafe(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+      }
+    } finally {
+      await admin.end();
+    }
+  });
+
+  it("migrates a fresh database and records one row per journal entry", async () => {
+    const url = withDbName(baseUrl, OK_DB);
+    const run = runMigrate(url);
+
+    expect(run.status, run.output).toBe(0);
+    expect(await appliedCount(url)).toBe(journalEntries);
+  });
+
+  it("reports the migration, the statement and the PostgresError when one fails", async () => {
+    const url = withDbName(baseUrl, FAIL_DB);
+
+    // Squat on the table 0058_sudden_jubilee creates. Migrations 0000-0057
+    // then apply and 0058 aborts — the shape of a real half-upgraded database.
+    const client = postgres(url, { max: 1 });
+    try {
+      await client.unsafe(`CREATE TABLE "agent_delivered_files" ("id" text PRIMARY KEY)`);
+    } finally {
+      await client.end();
+    }
+
+    const run = runMigrate(url);
+
+    expect(run.status, run.output).toBe(1);
+    // The migration that actually threw, not the first pending one.
+    expect(run.output).toContain("0058_sudden_jubilee");
+    expect(run.output).not.toContain("0000_cold_young_avengers");
+    // The statement.
+    expect(run.output).toContain('CREATE TABLE "agent_delivered_files"');
+    // The PostgresError, with the server's own code.
+    expect(run.output).toContain('relation "agent_delivered_files" already exists');
+    expect(run.output).toContain("42P07");
+
+    // The report claims nothing was applied. Prove that claim is true rather
+    // than merely reassuring: drizzle wraps all pending migrations in one
+    // transaction, so the abort must have rolled every one of them back.
+    expect(await appliedCount(url)).toBe(0);
+  });
+});

--- a/packages/web/src/__tests__/db/db-migrate-runner.integration.test.ts
+++ b/packages/web/src/__tests__/db/db-migrate-runner.integration.test.ts
@@ -45,7 +45,7 @@ function runMigrate(databaseUrl: string) {
   const result = spawnSync(process.execPath, [RUNNER], {
     // Deliberately not packages/web: the runner must resolve its migrations
     // folder from its own location, not from whoever's cwd invoked it.
-    cwd: WEB_ROOT === "/" ? WEB_ROOT : join(WEB_ROOT, ".."),
+    cwd: join(WEB_ROOT, ".."),
     env: { ...process.env, DATABASE_URL: databaseUrl },
     encoding: "utf-8",
   });
@@ -136,6 +136,14 @@ describe("db:migrate runner", () => {
     // The PostgresError, with the server's own code.
     expect(run.output).toContain('relation "agent_delivered_files" already exists');
     expect(run.output).toContain("42P07");
+
+    // WHICH database it reached — the clue that would have ended this bug's
+    // investigation in a minute — but never the password that gets it there.
+    // stderr from this runner lands in CI logs and container logs verbatim.
+    expect(run.output).toContain(FAIL_DB);
+    const password = new URL(url).password;
+    expect(password.length).toBeGreaterThan(0);
+    expect(run.output).not.toContain(password);
 
     // The report claims nothing was applied. Prove that claim is true rather
     // than merely reassuring: drizzle wraps all pending migrations in one

--- a/packages/web/src/__tests__/db/migration-failure-report.test.ts
+++ b/packages/web/src/__tests__/db/migration-failure-report.test.ts
@@ -20,7 +20,11 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { formatMigrationFailure } from "../../../scripts/lib/migration-failure.mjs";
+import {
+  formatMigrationFailure,
+  describeTarget,
+  pendingMigrations,
+} from "../../../scripts/lib/migration-failure.mjs";
 
 const MIGRATION_FILES = [
   { tag: "0057_kb_archive_status_backfill", sql: 'UPDATE "kb_documents" SET "status" = 0;' },
@@ -148,6 +152,90 @@ describe("formatMigrationFailure", () => {
     expect(report).toContain("connect ECONNREFUSED 127.0.0.1:5434");
     expect(report).not.toMatch(/^\s*severity:/m);
     expect(report).not.toContain("0058_sudden_jubilee");
+  });
+
+  it("prints the failure message once, not again inside the stack", () => {
+    // `error.stack` already opens with "Name: message". Printing the headline
+    // and then the whole stack said the same sentence twice — noise on exactly
+    // the path (unreachable DB) a reader is most likely to hit.
+    const report = formatMigrationFailure({
+      error: new Error("connect ECONNREFUSED 127.0.0.1:5434"),
+      migrationFiles: [],
+    });
+
+    const occurrences = report.split("connect ECONNREFUSED 127.0.0.1:5434").length - 1;
+    expect(occurrences).toBe(1);
+    // The trace itself is still there — it is the only clue for a non-Postgres
+    // failure.
+    expect(report).toMatch(/\bat\b/);
+  });
+
+  it("names every candidate when the same statement appears in several migrations", () => {
+    // Real case: `DROP VIEW "public"."active_agents";` is byte-identical in
+    // 0016, 0042 and 0045. Naming the first one reads as a fact and sends the
+    // reader to the wrong file — the confidently-wrong failure this whole
+    // change exists to remove. List them instead.
+    const dropView = 'DROP VIEW "public"."active_agents";';
+    const report = formatMigrationFailure({
+      error: drizzleError(dropView, pgError({ message: 'view "active_agents" does not exist' })),
+      migrationFiles: [
+        { tag: "0016_abnormal_wasp", sql: dropView },
+        { tag: "0042_silly_revanche", sql: dropView },
+        { tag: "0045_black_orphan", sql: dropView },
+      ],
+    });
+
+    expect(report).toContain("0016_abnormal_wasp");
+    expect(report).toContain("0042_silly_revanche");
+    expect(report).toContain("0045_black_orphan");
+  });
+
+  it("names the database it was talking to, without the password", () => {
+    // The bug that started this: the migration failed against the wrong
+    // Postgres (a stale dev-stack container on :5434). host/port/database is
+    // the decisive clue, and it must never drag the password along with it.
+    const report = formatMigrationFailure({
+      error: drizzleError("CREATE EXTENSION IF NOT EXISTS vector", pgError()),
+      migrationFiles: MIGRATION_FILES,
+      target: describeTarget("postgresql://pinchy:sup3r-s3cret@db.internal:5434/pinchy"),
+    });
+
+    expect(report).toContain("db.internal:5434/pinchy");
+    expect(report).not.toContain("sup3r-s3cret");
+  });
+});
+
+describe("describeTarget", () => {
+  it("keeps host, port and database and drops the credentials", () => {
+    expect(describeTarget("postgresql://pinchy:pinchy_dev@localhost:5434/pinchy_test")).toBe(
+      "localhost:5434/pinchy_test"
+    );
+  });
+
+  it("returns null for something that is not a URL rather than echoing it", () => {
+    // Never risk printing an unparseable connection string verbatim: if it is
+    // not a URL we cannot know which part of it is the password.
+    expect(describeTarget("host=localhost password=hunter2")).toBeNull();
+    expect(describeTarget(undefined)).toBeNull();
+  });
+});
+
+describe("pendingMigrations", () => {
+  const entries = [
+    { tag: "0016_abnormal_wasp", when: 1000 },
+    { tag: "0042_silly_revanche", when: 2000 },
+    { tag: "0045_black_orphan", when: 3000 },
+  ];
+
+  it("keeps only entries newer than the watermark, like drizzle's own check", () => {
+    // drizzle applies `entry.when > lastRow.created_at`; attribution has to use
+    // the same boundary or it can blame an already-applied migration.
+    expect(pendingMigrations(entries, 2000).map((e) => e.tag)).toEqual(["0045_black_orphan"]);
+  });
+
+  it("treats a missing watermark as 'everything is pending'", () => {
+    // Fresh database: no drizzle schema yet, so there is nothing to narrow by.
+    expect(pendingMigrations(entries, null)).toHaveLength(3);
   });
 });
 

--- a/packages/web/src/__tests__/db/migration-failure-report.test.ts
+++ b/packages/web/src/__tests__/db/migration-failure-report.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Static guards for the migration failure report.
+ *
+ * `db:migrate` used to be `drizzle-kit migrate`, whose bundled `hanji`
+ * swallows the error outright:
+ *
+ *     catch (err) { terminal.reject(err); process.exit(1); }
+ *
+ * `terminal.reject` only re-renders the spinner view (whose "rejected" state
+ * prints the same `applying migrations...` line), and `process.exit(1)` fires
+ * before drizzle-kit's own `catch { console.error(e) }` can run. The result is
+ * a boot that ends on a spinner and exit code 1 with nothing to diagnose — in
+ * `pnpm test:db` locally AND in `entrypoint.sh`, which runs the same command
+ * under `set -e` on every production upgrade.
+ *
+ * The behavioural proof (a real Postgres, a real aborted upgrade) lives in
+ * db-migrate-runner.integration.test.ts. These are the Docker-free halves:
+ * the report's shape, and the folder the runner reads.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { formatMigrationFailure } from "../../../scripts/lib/migration-failure.mjs";
+
+const MIGRATION_FILES = [
+  { tag: "0057_kb_archive_status_backfill", sql: 'UPDATE "kb_documents" SET "status" = 0;' },
+  {
+    tag: "0058_sudden_jubilee",
+    sql: 'CREATE TABLE "agent_delivered_files" (\n\t"id" text PRIMARY KEY NOT NULL\n);',
+  },
+];
+
+/** Shaped like a postgres.js PostgresError: `severity` is what discriminates it. */
+const pgError = (over: Record<string, unknown> = {}) =>
+  Object.assign(new Error('relation "agent_delivered_files" already exists'), {
+    name: "PostgresError",
+    severity: "ERROR",
+    code: "42P07",
+    ...over,
+  });
+
+/**
+ * Shaped like drizzle-orm's DrizzleQueryError — the object the migrator
+ * actually throws. It carries `.query` (the SQL it sent) and wraps the driver's
+ * PostgresError as `.cause`; neither half is on the outer error.
+ */
+const drizzleError = (query: string, cause: Error) =>
+  Object.assign(new Error(`Failed query: ${query}\nparams: `), { query, cause });
+
+describe("formatMigrationFailure", () => {
+  it("names the migration the failing statement came from", () => {
+    const report = formatMigrationFailure({
+      error: drizzleError(
+        'CREATE TABLE "agent_delivered_files" (\n\t"id" text PRIMARY KEY NOT NULL\n);',
+        pgError()
+      ),
+      migrationFiles: MIGRATION_FILES,
+    });
+
+    expect(report).toContain("0058_sudden_jubilee");
+    // Not the first pending migration, the one that actually threw.
+    expect(report).not.toContain("0057_kb_archive_status_backfill");
+  });
+
+  it("digs the statement and the PostgresError out of the drizzle wrapper", () => {
+    // Regression: the first cut read "the last statement postgres.js sent" via
+    // the driver's debug hook and matched `severity` on the outer error. Both
+    // miss — the driver issues a `rollback` right after the failure (so the
+    // report blamed `rollback`, attributed to no migration), and the
+    // PostgresError sits one `.cause` deeper (so no Postgres field printed at
+    // all). Only the wrapper's own `.query` and `.cause` are authoritative.
+    const report = formatMigrationFailure({
+      error: drizzleError(
+        'CREATE TABLE "agent_delivered_files" (\n\t"id" text PRIMARY KEY NOT NULL\n);',
+        pgError()
+      ),
+      migrationFiles: MIGRATION_FILES,
+    });
+
+    expect(report).not.toMatch(/\brollback\b/i);
+    expect(report).toContain("PostgresError");
+    expect(report).toContain("42P07");
+    expect(report).toContain("0058_sudden_jubilee");
+  });
+
+  it("surfaces the statement and every PostgresError field the server sent", () => {
+    const report = formatMigrationFailure({
+      error: drizzleError(
+        "CREATE EXTENSION IF NOT EXISTS vector",
+        pgError({
+          message: 'extension "vector" is not available',
+          code: "0A000",
+          detail: 'Could not open extension control file ".../vector.control": No such file.',
+          hint: "The extension must first be installed on the system.",
+          position: "1",
+        })
+      ),
+      migrationFiles: [{ tag: "0054_safe_vision", sql: "CREATE EXTENSION IF NOT EXISTS vector;" }],
+    });
+
+    expect(report).toContain("CREATE EXTENSION IF NOT EXISTS vector");
+    expect(report).toContain('extension "vector" is not available');
+    expect(report).toContain("0A000");
+    expect(report).toContain("Could not open extension control file");
+    expect(report).toContain("The extension must first be installed");
+    expect(report).toContain("0054_safe_vision");
+  });
+
+  it("omits fields the server did not send rather than printing empty ones", () => {
+    const report = formatMigrationFailure({
+      error: drizzleError('CREATE TABLE "agent_delivered_files" ();', pgError()),
+      migrationFiles: MIGRATION_FILES,
+    });
+
+    expect(report).not.toMatch(/^\s*(detail|hint|position):/m);
+  });
+
+  it("states that nothing was applied, because the migrator uses one transaction", () => {
+    const report = formatMigrationFailure({
+      error: drizzleError("SELECT 1", pgError()),
+      migrationFiles: MIGRATION_FILES,
+    });
+
+    expect(report).toMatch(/single transaction/i);
+  });
+
+  it("says the migration is unknown instead of guessing when nothing matches", () => {
+    const report = formatMigrationFailure({
+      error: drizzleError("CREATE TABLE something_not_in_any_migration ()", pgError()),
+      migrationFiles: MIGRATION_FILES,
+    });
+
+    expect(report).toContain("CREATE TABLE something_not_in_any_migration ()");
+    expect(report).toMatch(/unknown/i);
+    expect(report).not.toContain("0058_sudden_jubilee");
+  });
+
+  it("reports a non-Postgres failure verbatim without inventing Postgres fields", () => {
+    // The other way `db:migrate` fails: the DB is not reachable at all. There
+    // is no statement and no severity, so the report must not pretend either.
+    const report = formatMigrationFailure({
+      error: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:5434"), {
+        code: "ECONNREFUSED",
+      }),
+      migrationFiles: MIGRATION_FILES,
+    });
+
+    expect(report).toContain("connect ECONNREFUSED 127.0.0.1:5434");
+    expect(report).not.toMatch(/^\s*severity:/m);
+    expect(report).not.toContain("0058_sudden_jubilee");
+  });
+});
+
+describe("db-migrate runner wiring", () => {
+  const webRoot = join(__dirname, "..", "..", "..");
+
+  it("reads the same migrations folder drizzle-kit generates into", () => {
+    // `db:generate` is still drizzle-kit and writes to drizzle.config.ts's
+    // `out`; `db:migrate` is our runner and resolves the folder relative to
+    // its own file. If the two drift, the runner silently applies nothing —
+    // the exact class of quiet failure this whole change exists to remove.
+    const config = readFileSync(join(webRoot, "drizzle.config.ts"), "utf-8");
+    const runner = readFileSync(join(webRoot, "scripts", "db-migrate.mjs"), "utf-8");
+
+    expect(config).toMatch(/out:\s*"\.\/drizzle"/);
+    expect(runner).toMatch(/new URL\("\.\.\/drizzle\/", import\.meta\.url\)/);
+  });
+
+  it("is what `pnpm db:migrate` runs, so entrypoint.sh gets the report too", () => {
+    const pkg = JSON.parse(readFileSync(join(webRoot, "package.json"), "utf-8"));
+    expect(pkg.scripts["db:migrate"]).toBe("node scripts/db-migrate.mjs");
+  });
+});

--- a/packages/web/src/test-helpers/integration/global-setup.ts
+++ b/packages/web/src/test-helpers/integration/global-setup.ts
@@ -37,7 +37,13 @@ export default async function globalSetup() {
   const dbName = dbNameFromUrl(testDbUrl);
 
   const postgres = (await import("postgres")).default;
-  const sql = postgres(adminUrl);
+  // `database "…" does not exist, skipping` is the expected first-run NOTICE;
+  // postgres.js's default handler console.logs the whole notice object, which
+  // opens every `pnpm test:db` with a JSON blob that reads like a failure.
+  const onnotice = (notice: Record<string, string>) => {
+    process.stderr.write(`[test:db] ${notice.severity}: ${notice.message}\n`);
+  };
+  const sql = postgres(adminUrl, { onnotice });
   try {
     await sql.unsafe(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE)`);
     await sql.unsafe(`CREATE DATABASE ${dbName}`);
@@ -57,7 +63,7 @@ export default async function globalSetup() {
 
   // Teardown
   return async () => {
-    const sql2 = postgres(adminUrl);
+    const sql2 = postgres(adminUrl, { onnotice });
     try {
       await sql2.unsafe(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE)`);
     } finally {


### PR DESCRIPTION
## What does this PR do?

`pnpm db:migrate` was `drizzle-kit migrate`, and drizzle-kit's bundled `hanji` ends `renderWithTask` with:

```js
catch (err) { terminal.reject(err); process.exit(1) }
```

`reject` only re-renders the spinner view — whose `"rejected"` state prints the same `applying migrations...` line — and the `exit` fires before drizzle-kit's own `catch { console.error(e) }` can run. A failed migration therefore produced a spinner, exit code 1, and **nothing else**: no statement, no PostgresError, not even the migration's name.

That is not just a local annoyance. `entrypoint.sh:72` runs the same command on every production upgrade under `set -e`, so an operator whose upgrade aborted saw `[pinchy] Running database migrations...` and a dead container. The 0.9.0 → 0.10 work (73a6382, 801e184) was about *surviving* such an abort; this is about being able to *read* one.

### What changed

`db:migrate` is now `node scripts/db-migrate.mjs`. **The migrator is unchanged** — drizzle-orm's `migrate()` is what drizzle-kit called too, with the same defaults (`drizzle.__drizzle_migrations`, every pending migration in one transaction), and it is already the migrator the 0.9.0 upgrade tests treat as canonical. Only the reporting is new.

Before: a spinner. After:

```
[db:migrate] migration failed

  target: localhost:5434/pinchy_test_vitest
  migration: 0054_safe_vision.sql
  statement:
    CREATE EXTENSION IF NOT EXISTS vector;

  PostgresError: extension "vector" is not available
    severity: ERROR
    code: 0A000
    detail: Could not open extension control file ".../vector.control": No such file or directory.
    hint: The extension must first be installed on the system where PostgreSQL is running.

  Nothing was applied. Drizzle runs every pending migration inside a
  single transaction, so the database is exactly as it was.
```

Routine NOTICEs (`identifier will be truncated`, `already exists, skipping`) are now one line each on stderr instead of `console.log`'d notice objects.

### Two details the implementation had to get right

Both are pinned by tests, because the first cut got both wrong:

- **The statement comes from `DrizzleQueryError.query`, not from tracking the last statement postgres.js sent.** The driver issues a `rollback` immediately after the failure, so last-statement tracking blames `rollback` and attributes it to no migration at all.
- **The PostgresError sits one `.cause` deeper than the error thrown**, so the lookup walks the chain. Matching `severity` on the outer object printed no Postgres field whatsoever.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [x] 🔧 Tooling / CI

## Notes for the reviewer

**How this surfaced.** `pnpm test:db` failed locally against a freshly created database with no error output at all. The actual cause was environmental — the Postgres on `:5434` was another worktree's dev-stack container still running the `postgres:17` image rather than the pinned `pgvector/pgvector:pg17-trixie`, so `0054_safe_vision.sql`'s `CREATE EXTENSION IF NOT EXISTS vector` failed. No migration bug, and CI was right to be green: all 60 migrations apply cleanly against a pgvector image. But finding that took reading drizzle-kit's bundled sources, which is the actual defect this PR fixes.

**Guards added**

- `migration-failure-report.test.ts` (Docker-free, runs in `pnpm test`) pins the report's shape, including that omitted server fields are not printed empty, and that a non-Postgres failure (unreachable DB) is reported verbatim without inventing Postgres fields. It also pins the runner's migrations folder against `drizzle.config.ts`'s `out` — a drift there would apply *nothing, quietly*, which is the very failure class this PR removes — and pins the package script itself.
- `db-migrate-runner.integration.test.ts` (`pnpm test:db`) provokes a real abort the way a botched upgrade does: the table `0058` creates already exists. It asserts the report names **0058** rather than the first pending migration, carries the statement and code `42P07`, and that the "nothing was applied" claim is *true* (0 rows — the transaction rolled back) rather than merely reassuring. A fresh database still records one row per journal entry, which is the drizzle-semantics equivalence check.
- Teeth verified: the 0058 attribution assertion was red for exactly as long as the `.cause` unwrap was missing.

**Scope deliberately left out.** `drizzle-kit` is no longer a genuine runtime dependency — it is now only a `db:generate` / `db:studio` tool. Pruning it from the production image is a separate, independently verifiable change; the `Dockerfile.pinchy` and `entrypoint.sh` comments have been corrected to say so rather than continuing to describe a `drizzle-kit migrate` boot.

## Review follow-ups (second commit)

Four things the first commit got wrong in the same way it accuses drizzle-kit of being wrong — output that reads as fact but is not:

- **The report never said WHICH database it reached.** That is the clue that would have ended this investigation in a minute, and it was the one thing missing. Now printed as `host:port/database` on both the start line and the report — never the password, and `describeTarget` returns null rather than best-effort-printing a connection string it cannot parse.
- **Attribution named the first matching migration as if it were a fact.** Statements do repeat verbatim: `DROP VIEW "public"."active_agents";` is byte-identical in 0016, 0042 and 0045. Candidates are now narrowed to the migrations that were actually pending (drizzle's own `when > watermark` boundary, re-derived after the rollback), and if more than one still matches, all of them are named.
- **A failing summary query was reported as a failed migration.** The post-success `count(*)` sat inside the failure catch, so if it threw, the runner printed "migration failed — nothing was applied" *after* every migration had landed. It is decoration; it now warns and exits 0.
- Cosmetics: the message was printed twice on the non-Postgres path (headline plus the stack that repeats it), and the watermark was raw epoch milliseconds.

Also swept up: `resolve-db-password.mjs` still described a `drizzle-kit migrate` boot, and `test:db`'s global-setup opened every run with postgres.js's default notice handler dumping a JSON blob that reads like a failure — the same one-line fix already applied inside the runner.

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated the documentation (Dockerfile / entrypoint comments; no user-facing docs affected)
- [x] All existing tests pass

Gates run locally: `pnpm test` 9851 passed · `pnpm test:db` 368 passed (49 files) · `pnpm test:scripts` 390 passed · `pnpm -C packages/web typecheck` clean · `pnpm lint` 0 errors · `pnpm format:check` clean.
