### PR TITLE
feat(kb): open a cited source in the PDF viewer, at its page

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -128,6 +128,14 @@ That makes every claim in the answer traceable back to a specific document and p
 
 Sources are named by their full path, not just the filename. In a real document tree a bare filename is often impossible to act on — you can't tell which of several folders it lives in, and two folders may hold files with the same name. The path is what lets you open the document and check the claim for yourself.
 
+### Open a source and check it
+
+Each source path in an answer is a link. Click it and the PDF opens in a viewer over the chat, at the cited page, with the answer still visible behind it — the same viewer a PDF you attach to a message opens into. Checking a claim takes a click instead of a hunt through folders.
+
+Document size is not a limit. Knowledge bases routinely contain scanned compilation binders of several hundred megabytes, and because those contain the most, they tend to be cited the most. Pinchy streams the file and serves byte ranges, so the viewer fetches the pages it renders rather than the whole document — opening page 510 of a 268 MB binder transfers a fraction of it.
+
+Opening a source is governed like every other access. The link resolves against the same allowed directories that scope the agent's search, so a path outside them is refused even if an answer names one, and each view is written to the audit trail as `knowledge.source_viewed`.
+
 The list resolves exactly the numbers the answer cites — no more and no fewer. A number with no entry would be a dead end, and an entry the answer never cited would make a single source look like several.
 
 ### Regression-protected

--- a/packages/web/src/__tests__/api/agent-workspace-file.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file.test.ts
@@ -13,7 +13,17 @@
  * `api/knowledge-search.test.ts`).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  symlinkSync,
+  openSync,
+  writeSync,
+  ftruncateSync,
+  closeSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { NextRequest, NextResponse } from "next/server";
@@ -62,15 +72,43 @@ afterEach(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-async function callGET(agentId: string, requestedPath: string) {
+async function callGET(agentId: string, requestedPath: string, headers?: HeadersInit) {
   const { GET } = await import("@/app/api/agents/[agentId]/workspace-file/route");
   const url = new URL(`http://localhost/api/agents/${agentId}/workspace-file`);
   url.searchParams.set("path", requestedPath);
-  const req = new NextRequest(url);
+  const req = new NextRequest(url, headers ? { headers } : undefined);
   return GET(req, {
     params: Promise.resolve({ agentId }),
   } as unknown as Parameters<typeof GET>[1]);
 }
+
+/**
+ * Creates a file of `size` bytes that occupies almost no disk: the header is
+ * written, then the length is extended with `ftruncate`, which allocates no
+ * blocks on any filesystem this runs on (apfs, ext4, xfs, overlayfs, tmpfs).
+ * That is what makes it practical to assert behaviour on a file larger than
+ * memory in an ordinary unit test.
+ */
+function writeSparseFile(path: string, size: number, header: Buffer): void {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+  const fd = openSync(path, "w");
+  try {
+    writeSync(fd, header, 0, header.length, 0);
+    ftruncateSync(fd, size);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * One byte past the largest buffer `fs.readFile` will produce — it throws
+ * ERR_FS_FILE_TOO_LARGE above 2 GiB. A file this size therefore cannot be
+ * served by any implementation that materialises it first, which is what makes
+ * the two tests below a structural proof of streaming rather than a
+ * measurement of it. If Node ever raises that ceiling the tests stay valid;
+ * they assert the route's behaviour, not Node's limit.
+ */
+const OVER_BUFFER_LIMIT = 2 * 1024 * 1024 * 1024 + 1;
 
 describe("GET /api/agents/[agentId]/workspace-file", () => {
   it("serves a PDF under an allowed root inline with the right headers, bytes, and audit row", async () => {
@@ -229,5 +267,139 @@ describe("GET /api/agents/[agentId]/workspace-file", () => {
     } as unknown as Parameters<typeof GET>[1]);
 
     expect(res.status).toBe(400);
+  });
+});
+
+/**
+ * A knowledge-base corpus is not a folder of small handouts. The corpus this
+ * route was built against contains a 268 MB and a 174 MB scanned compilation
+ * binder, and because they contain the most, retrieval cites them the most —
+ * so the largest files in the corpus are exactly the ones a user is most
+ * likely to click. An earlier revision refused anything over 50 MB with 413 to
+ * avoid loading it into memory; the fix is to stop loading it into memory.
+ */
+describe("GET /api/agents/[agentId]/workspace-file — large files and byte ranges", () => {
+  it("serves a file too large to fit in a buffer at all", async () => {
+    // No implementation that reads the file into memory can pass this: at this
+    // size fs.readFile throws ERR_FS_FILE_TOO_LARGE before producing a byte.
+    const hugePath = join(allowedRoot, "compilation-binder.pdf");
+    writeSparseFile(hugePath, OVER_BUFFER_LIMIT, PDF_BYTES);
+
+    const res = await callGET("agent-1", hugePath);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-length")).toBe(String(OVER_BUFFER_LIMIT));
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("content-disposition")).toMatch(/^inline/);
+
+    // Read one chunk and walk away. A buffering implementation would have had
+    // to finish the whole file before the first byte ever arrived here.
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    await reader.cancel();
+    expect(Buffer.from(value!.subarray(0, PDF_BYTES.length)).equals(PDF_BYTES)).toBe(true);
+  });
+
+  it("advertises range support so a PDF viewer fetches pages instead of the whole file", async () => {
+    // Without this header a viewer has no way to know it may seek, and opening
+    // a citation at #page=510 downloads every byte before rendering anything.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callGET("agent-1", pdfPath);
+
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+  });
+
+  it("answers a byte range from a file too large to buffer, reading only that span", async () => {
+    const hugePath = join(allowedRoot, "compilation-binder.pdf");
+    writeSparseFile(hugePath, OVER_BUFFER_LIMIT, PDF_BYTES);
+
+    const res = await callGET("agent-1", hugePath, { Range: "bytes=0-7" });
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe(`bytes 0-7/${OVER_BUFFER_LIMIT}`);
+    expect(res.headers.get("content-length")).toBe("8");
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(PDF_BYTES.subarray(0, 8))).toBe(true);
+  });
+
+  it("answers a suffix range with the tail of the file", async () => {
+    // How a PDF viewer starts: it reads the trailer to find the cross-reference
+    // table before it knows where anything else lives.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callGET("agent-1", pdfPath, { Range: "bytes=-6" });
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe(
+      `bytes ${PDF_BYTES.length - 6}-${PDF_BYTES.length - 1}/${PDF_BYTES.length}`
+    );
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(PDF_BYTES.subarray(PDF_BYTES.length - 6))).toBe(true);
+  });
+
+  it("rejects a range past the end of the file with 416 rather than wrong bytes", async () => {
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callGET("agent-1", pdfPath, { Range: `bytes=${PDF_BYTES.length}-99999` });
+
+    expect(res.status).toBe(416);
+    // Tells the client the real length so it can retry correctly instead of guessing.
+    expect(res.headers.get("content-range")).toBe(`bytes */${PDF_BYTES.length}`);
+  });
+
+  it("serves the whole file when the range header is one it does not implement", async () => {
+    // Multi-range needs a multipart/byteranges body; answering with only the
+    // first span while claiming 206 would misplace every following byte.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callGET("agent-1", pdfPath, { Range: "bytes=0-3,8-11" });
+
+    expect(res.status).toBe(200);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(PDF_BYTES)).toBe(true);
+  });
+
+  it("still enforces access control on a range request", async () => {
+    // The range path must not become a second, unguarded way in.
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, SECRET_BYTES);
+
+    const res = await callGET("agent-1", secretPath, { Range: "bytes=0-10" });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain("top secret");
+  });
+
+  it("records a partial read as such in the audit trail", async () => {
+    // Governance still sees every access — a viewer fetching a document in
+    // twenty range requests must not be a way to read it unlogged. The flag is
+    // what lets an analyst count document views without counting chunks.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    await callGET("agent-1", pdfPath, { Range: "bytes=0-7" });
+
+    expect(mockDeferAuditLog).toHaveBeenCalledTimes(1);
+    const entry = mockDeferAuditLog.mock.calls[0][0];
+    expect(entry.eventType).toBe("knowledge.source_viewed");
+    expect(entry.outcome).toBe("success");
+    expect(entry.detail).toMatchObject({
+      document: { name: "handbook.pdf" },
+      partial: true,
+    });
+  });
+
+  it("marks a whole-file read as not partial, so views are countable", async () => {
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    await callGET("agent-1", pdfPath);
+
+    expect(mockDeferAuditLog.mock.calls[0][0].detail).toMatchObject({ partial: false });
   });
 });

--- a/packages/web/src/__tests__/api/agent-workspace-file.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file.test.ts
@@ -23,6 +23,7 @@ import {
   writeSync,
   ftruncateSync,
   closeSync,
+  readdirSync,
 } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -80,6 +81,34 @@ async function callGET(agentId: string, requestedPath: string, headers?: Headers
   return GET(req, {
     params: Promise.resolve({ agentId }),
   } as unknown as Parameters<typeof GET>[1]);
+}
+
+/**
+ * Next.js does not route HEAD separately: with no HEAD export it calls the GET
+ * handler and then discards the body without reading or cancelling it
+ * (`send-response.js`: `if (response.body && req.method !== 'HEAD')`). So the
+ * handler must see the real method — passing it here is not test scaffolding,
+ * it is the only shape in which the HEAD path exists.
+ */
+async function callHEAD(agentId: string, requestedPath: string) {
+  const { GET } = await import("@/app/api/agents/[agentId]/workspace-file/route");
+  const url = new URL(`http://localhost/api/agents/${agentId}/workspace-file`);
+  url.searchParams.set("path", requestedPath);
+  const req = new NextRequest(url, { method: "HEAD" });
+  return GET(req, {
+    params: Promise.resolve({ agentId }),
+  } as unknown as Parameters<typeof GET>[1]);
+}
+
+/**
+ * Open file descriptors of this process. `/dev/fd` is a directory on both
+ * macOS and Linux (where it is a symlink to /proc/self/fd), which is what makes
+ * a descriptor leak assertable in an ordinary unit test instead of only in
+ * production, where it surfaces as EMFILE under load.
+ */
+function countOpenDescriptors(): number {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- constant path
+  return readdirSync("/dev/fd").length;
 }
 
 /**
@@ -401,5 +430,81 @@ describe("GET /api/agents/[agentId]/workspace-file — large files and byte rang
     await callGET("agent-1", pdfPath);
 
     expect(mockDeferAuditLog.mock.calls[0][0].detail).toMatchObject({ partial: false });
+  });
+});
+
+/**
+ * Streaming replaced a buffered read, and it brought a failure mode buffering
+ * did not have: the descriptor now outlives the handler. `createReadStream` on
+ * an open handle closes it when the stream ENDS or is CANCELLED — but a body
+ * that is never touched at all does neither, and the handle stays open until a
+ * garbage collection that may not come ("Warning: Closing file descriptor N on
+ * garbage collection").
+ *
+ * That is not a hypothetical path. Next.js auto-implements HEAD by calling the
+ * GET handler (`auto-implement-methods.js`) and then throws the body away
+ * unread, so every HEAD request against this route parks a descriptor — and a
+ * file-serving route is exactly what proxies, monitors and PDF viewers probe
+ * with HEAD. Any authenticated user could then exhaust the process's descriptor
+ * limit with a loop.
+ */
+describe("GET /api/agents/[agentId]/workspace-file — HEAD does not leak descriptors", () => {
+  // Larger than the read stream's internal buffer. Below that the stream drains
+  // itself and closes the handle by accident, which would make this pass
+  // against a leaking implementation — and it is the LARGE knowledge-base
+  // binders this route exists for that never drain.
+  const BIGGER_THAN_ONE_READ = 8 * 1024 * 1024;
+
+  it("answers HEAD with the headers of a GET but no body", async () => {
+    const pdfPath = join(allowedRoot, "compilation-binder.pdf");
+    writeSparseFile(pdfPath, BIGGER_THAN_ONE_READ, PDF_BYTES);
+
+    const res = await callHEAD("agent-1", pdfPath);
+
+    expect(res.status).toBe(200);
+    // A HEAD must be usable for what clients ask it for: size and seekability.
+    expect(res.headers.get("content-length")).toBe(String(BIGGER_THAN_ONE_READ));
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.body).toBeNull();
+  });
+
+  it("holds no descriptor open after a burst of HEAD requests", async () => {
+    const pdfPath = join(allowedRoot, "compilation-binder.pdf");
+    writeSparseFile(pdfPath, BIGGER_THAN_ONE_READ, PDF_BYTES);
+
+    // Warm up first: the first call imports the route module and opens whatever
+    // it opens once, which would otherwise read as a leak.
+    await callHEAD("agent-1", pdfPath);
+    const before = countOpenDescriptors();
+
+    for (let i = 0; i < 40; i++) await callHEAD("agent-1", pdfPath);
+
+    // Slack for unrelated descriptors the runner may open concurrently; a leak
+    // is 40, not a handful.
+    expect(countOpenDescriptors() - before).toBeLessThan(10);
+  });
+
+  it("still audits the access, because a HEAD reveals the document exists", async () => {
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    await callHEAD("agent-1", pdfPath);
+
+    expect(mockDeferAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockDeferAuditLog.mock.calls[0][0]).toMatchObject({
+      eventType: "knowledge.source_viewed",
+      outcome: "success",
+    });
+  });
+
+  it("still refuses a path outside the allowed roots", async () => {
+    // The HEAD path must not become a way to probe for files by status code.
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, SECRET_BYTES);
+
+    const res = await callHEAD("agent-1", secretPath);
+
+    expect(res.status).toBe(403);
   });
 });

--- a/packages/web/src/__tests__/components/markdown-citation-render.test.tsx
+++ b/packages/web/src/__tests__/components/markdown-citation-render.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Renders a knowledge-base answer through the REAL markdown pipeline and
+ * checks that a cited source ends up clickable.
+ *
+ * The other two tests around this feature each stop one step short, on purpose,
+ * and the gap between them is exactly where this feature has failed before:
+ *
+ *   - `source-links.test.ts` hands the transformer an mdast tree built BY HAND
+ *     (`root > paragraph > text`). It proves the transform is right about a
+ *     tree — not that remark produces that tree. A real Sources list is a
+ *     markdown LIST, so the text arrives at `list > listItem > paragraph >
+ *     text`, and `[2]` is a shape markdown could have claimed for itself as a
+ *     link reference.
+ *   - `markdown-remark-plugins.test.ts` reimplements unified's attach step to
+ *     catch an attacher/transformer mixup. A reimplementation cannot be wrong
+ *     in the same way the real thing is.
+ *
+ * So this one uses `TextMessagePartProvider` to feed the real `MarkdownText`
+ * the way a streamed message does: real remark, real remark-gfm, real
+ * react-markdown, the real component overrides — including the `a` override
+ * that turns a citation into the lightbox trigger. If any link in that chain
+ * stops holding, no unit test above would notice, and the failure mode is a
+ * whole answer rendering as plain text.
+ *
+ * It deliberately stops at the trigger and does not click it. Opening the
+ * lightbox for real means driving a Radix dialog through a portal in jsdom,
+ * which does not settle reliably here — `pdf-dialog.test.tsx` covers what is
+ * behind the click by rendering the dialog open (which is what its
+ * `defaultOpen` escape hatch exists for). A test that is occasionally right is
+ * worse than a boundary drawn on purpose.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TextMessagePartProvider } from "@assistant-ui/react";
+
+import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { AgentIdContext } from "@/components/chat";
+
+/**
+ * The template's Sources shape, verbatim: a markdown list, a bracketed index,
+ * an em dash, a page. Every element here is one markdown could parse into
+ * something other than a plain text node.
+ */
+const ANSWER = [
+  "Die Nachweisgrenze liegt bei 0,05 mg/kg.",
+  "",
+  "**Quellen:**",
+  "",
+  "- [1] /data/noack/PPR/document.pdf — p. 510",
+  "- [2] /data/noack/PF LAB/afnor_update_&_support.pdf — p. 44",
+].join("\n");
+
+function renderAnswer(agentId: string | null, text = ANSWER) {
+  return render(
+    <AgentIdContext.Provider value={agentId}>
+      <TextMessagePartProvider text={text} isRunning={false}>
+        {/*
+          Smoothing off. It animates the text in over requestAnimationFrame, so
+          with it on these assertions wait on an animation clock rather than on
+          the pipeline they are about — which is a flake on a loaded runner, not
+          a signal. Off, the whole answer is present from the first render.
+         */}
+        <MarkdownText smooth={false} />
+      </TextMessagePartProvider>
+    </AgentIdContext.Provider>
+  );
+}
+
+describe("a cited source rendered through the real markdown pipeline", () => {
+  it("comes out clickable, once per source, with the page kept in the visible text", async () => {
+    renderAnswer("agent-1");
+
+    // Queried by text rather than by role+name: an accessible-name lookup
+    // rescans the whole tree on every retry, which is slow enough under load to
+    // exhaust the timeout before the assertion ever runs. The tag check below
+    // keeps the guarantee that matters.
+    const first = await screen.findByText("/data/noack/PPR/document.pdf");
+    const second = await screen.findByText("/data/noack/PF LAB/afnor_update_&_support.pdf");
+
+    // A citation opens the lightbox rather than navigating away from the answer
+    // it belongs to, so the trigger is a button and not an anchor.
+    expect(first.tagName).toBe("BUTTON");
+    expect(second.tagName).toBe("BUTTON");
+
+    // The page stays readable in the answer; only the link opens at it.
+    expect(screen.getByText(/p\. 510/)).toBeInTheDocument();
+  });
+
+  it("leaves the answer as plain text when there is no agent to scope a link to", async () => {
+    renderAnswer(null);
+
+    expect(await screen.findByText(/Nachweisgrenze/)).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("does not touch a path shown as code", async () => {
+    // Inside backticks a path is being displayed, not referenced. remark gives
+    // it its own node type, and the plugin has to respect that in the real tree
+    // and not only in a hand-built one.
+    renderAnswer("agent-1", "Der Pfad `/data/noack/PPR/document.pdf` liegt im Korpus.");
+
+    expect(await screen.findByText("/data/noack/PPR/document.pdf")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/__tests__/components/markdown-remark-plugins.test.ts
+++ b/packages/web/src/__tests__/components/markdown-remark-plugins.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Guards the WIRING of the source-link plugin, which its own unit tests
+ * structurally cannot.
+ *
+ * `source-links.test.ts` calls the transformer directly — `remarkSourceLinks({
+ * agentId })(tree)` — and passes whether or not the plugin is registered
+ * correctly. unified expects an ATTACHER: a function it calls with the options
+ * to obtain the transformer. Hand it the transformer instead and TypeScript is
+ * satisfied (both are functions), the unit tests stay green, and every chat
+ * message fails to render with "Cannot read properties of undefined (reading
+ * 'type')" — because unified called the transformer with the options as its
+ * tree, then walked `undefined`. That shipped once.
+ *
+ * So this test applies the plugin list the way unified does, and asserts the
+ * result is a transformer that actually transforms.
+ */
+import { describe, it, expect } from "vitest";
+
+import { buildRemarkPlugins } from "@/components/assistant-ui/markdown-text";
+
+type MdastNode = { type: string; value?: string; url?: string; children?: MdastNode[] };
+type Transformer = (tree: MdastNode) => void;
+
+/**
+ * The part of unified's plugin protocol this test depends on: an entry is
+ * either a bare attacher or an `[attacher, options]` pair; the attacher is
+ * CALLED, with the processor as `this`, and MAY return a transformer (remarkGfm
+ * returns none — it only registers micromark extensions through `this.data()`).
+ *
+ * Reimplemented here rather than mocked, so a wrongly-registered plugin fails
+ * the way it fails in the browser instead of the way a stand-in decides to.
+ */
+function applyPlugins(plugins: unknown): Transformer[] {
+  const data: Record<string, unknown> = {};
+  const processor = {
+    data(key?: string, value?: unknown) {
+      if (key === undefined) return data;
+      if (value === undefined) return data[key];
+      data[key] = value;
+      return this;
+    },
+  };
+
+  const entries = plugins as Array<unknown>;
+  return entries
+    .map((entry) => {
+      const [attacher, options] = Array.isArray(entry) ? entry : [entry, undefined];
+      return (attacher as (this: unknown, opts?: unknown) => Transformer | undefined).call(
+        processor,
+        options
+      );
+    })
+    .filter((transform): transform is Transformer => typeof transform === "function");
+}
+
+function paragraph(text: string): MdastNode {
+  return {
+    type: "root",
+    children: [{ type: "paragraph", children: [{ type: "text", value: text }] }],
+  };
+}
+
+function firstLink(tree: MdastNode): MdastNode | null {
+  if (tree.type === "link") return tree;
+  for (const child of tree.children ?? []) {
+    const found = firstLink(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+describe("buildRemarkPlugins", () => {
+  it("registers the source-link plugin so unified can attach it and it rewrites a citation", () => {
+    const transformers = applyPlugins(buildRemarkPlugins("agent-1"));
+    const tree = paragraph("- [1] /data/noack/PPR/document.pdf — p. 510");
+
+    // Every transformer runs, exactly as it would during a real render. If the
+    // list carried a transformer instead of an attacher, `applyPlugins` above
+    // would already have produced garbage and this call would throw.
+    for (const transform of transformers) transform(tree);
+
+    const link = firstLink(tree);
+    expect(link).not.toBeNull();
+    expect(link!.url).toBe(
+      "/api/agents/agent-1/workspace-file?path=%2Fdata%2Fnoack%2FPPR%2Fdocument.pdf#page=510"
+    );
+  });
+
+  it("leaves the citation as plain text when there is no agent to scope the link to", () => {
+    // An href without an agent id cannot resolve to anything the route would
+    // authorize, so no link is better than a broken one.
+    const transformers = applyPlugins(buildRemarkPlugins(null));
+    const tree = paragraph("- [1] /data/noack/PPR/document.pdf — p. 510");
+
+    for (const transform of transformers) transform(tree);
+
+    expect(firstLink(tree)).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/components/pdf-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/pdf-dialog.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The lightbox a PDF opens into — shared by a chat attachment and a cited
+ * knowledge-base source.
+ *
+ * Its layout is constrained by something we do not control: the PDF viewer
+ * inside it belongs to the browser. Chrome, Firefox and Safari each render a
+ * different toolbar, in different places, and none of them is ours to arrange.
+ * Floating our own controls on top of that surface is what produced the
+ * original defect — the close button landed on Chrome's overflow menu, and had
+ * to be tinted dark just to stay legible against a viewer whose colours we
+ * cannot predict.
+ *
+ * So our chrome sits in a row ABOVE the viewer instead of on top of it. These
+ * tests pin the consequences of that decision: the row identifies the document
+ * (the browser's own title bar shows the route name, "workspace-file", which
+ * tells a reader nothing), and it carries an escape hatch to a full tab —
+ * which is also the only thing that works on iOS Safari, where an embedded PDF
+ * renders blank no matter what we do.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { PdfDialog } from "@/components/assistant-ui/attachment-preview";
+
+function openDialog(url: string, title: string) {
+  return render(
+    <PdfDialog url={url} title={title} defaultOpen>
+      <button type="button">trigger</button>
+    </PdfDialog>
+  );
+}
+
+const SOURCE_URL =
+  "/api/agents/a1/workspace-file?path=%2Fdata%2Fnoack%2FPPR%2Fdocument.pdf#page=510";
+
+describe("PdfDialog", () => {
+  it("names the document by its filename, not the route or the full path", () => {
+    // Chrome's own title bar reads "workspace-file" here — the route segment.
+    // A reader checking a citation needs to know WHICH document opened.
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    expect(screen.getByText("document.pdf")).toBeInTheDocument();
+  });
+
+  it("keeps the full path reachable without spending width on it", () => {
+    // A corpus has same-named files in different folders, so the path has to
+    // survive somewhere — but it must not push the controls off a narrow screen.
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    expect(screen.getByTitle("/data/noack/PPR/document.pdf")).toBeInTheDocument();
+  });
+
+  it("shows which page the citation pointed at", () => {
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    expect(screen.getByText(/page 510/i)).toBeInTheDocument();
+  });
+
+  it("says nothing about a page when the file was not opened at one", () => {
+    // An attachment opens at the start; inventing "Page 1" would be noise.
+    openDialog("/api/agents/a1/uploads/report.pdf", "report.pdf");
+
+    expect(screen.queryByText(/page \d/i)).not.toBeInTheDocument();
+  });
+
+  it("offers a full tab, which is the only working path on iOS Safari", () => {
+    // iOS Safari renders an embedded PDF blank regardless of headers or markup.
+    // Without this link the dialog is a dead end on every iPhone.
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    const link = screen.getByRole("link", { name: /open in new tab/i });
+    expect(link).toHaveAttribute("href", SOURCE_URL);
+    expect(link).toHaveAttribute("target", "_blank");
+    // noreferrer keeps the opened tab from reaching back via window.opener.
+    expect(link.getAttribute("rel")).toContain("noreferrer");
+  });
+
+  it("still closes", () => {
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+  });
+
+  it("renders the viewer at the exact url it was given, fragment included", () => {
+    // The `#page=N` fragment is the whole reason a citation lands where it does.
+    const { container } = openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    const embed = container.ownerDocument.querySelector("embed");
+    expect(embed).toHaveAttribute("src", SOURCE_URL);
+    expect(embed).toHaveAttribute("type", "application/pdf");
+  });
+});

--- a/packages/web/src/__tests__/components/pdf-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/pdf-dialog.test.tsx
@@ -22,9 +22,9 @@ import { render, screen } from "@testing-library/react";
 
 import { PdfDialog } from "@/components/assistant-ui/attachment-preview";
 
-function openDialog(url: string, title: string) {
+function openDialog(url: string, title: string, page: number | null = null) {
   return render(
-    <PdfDialog url={url} title={title} defaultOpen>
+    <PdfDialog url={url} title={title} page={page} defaultOpen>
       <button type="button">trigger</button>
     </PdfDialog>
   );
@@ -51,7 +51,11 @@ describe("PdfDialog", () => {
   });
 
   it("shows which page the citation pointed at", () => {
-    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+    // The page is PASSED IN, not re-read from the url. `parseSourceHref` already
+    // decided what a citation's page is; a second regex here would be a second
+    // answer to the same question, and the two had already drifted (`\d{1,5}`
+    // against a whole fragment vs `\d+` anywhere in the string).
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf", 510);
 
     expect(screen.getByText(/page 510/i)).toBeInTheDocument();
   });

--- a/packages/web/src/__tests__/lib/http-range.test.ts
+++ b/packages/web/src/__tests__/lib/http-range.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Byte-range parsing for the workspace-file serving route.
+ *
+ * This exists because a knowledge-base corpus contains genuinely large PDFs —
+ * the Noack corpus has a 268 MB and a 174 MB scanned compilation binder, and
+ * those two are also the most-cited documents in it. Serving them means never
+ * materialising the file in memory, and it means answering range requests:
+ * a browser PDF viewer asked to open at `#page=510` fetches the trailer, then
+ * the pages it needs, and downloads a fraction of the file instead of all of it.
+ *
+ * The parse is deliberately conservative. Anything this module does not
+ * understand — a multi-range request, a non-`bytes` unit, a malformed value —
+ * resolves to `full`, which is an explicitly allowed server response (RFC 9110
+ * §14.2: "A server MAY ignore the Range header field"). Only a syntactically
+ * VALID range that cannot be satisfied against the real file length becomes
+ * `unsatisfiable`, because that one has to be a 416 to keep a viewer from
+ * silently rendering the wrong bytes.
+ */
+import { describe, it, expect } from "vitest";
+
+import { parseRangeHeader } from "@/lib/http-range";
+
+const SIZE = 1000;
+
+describe("parseRangeHeader", () => {
+  it("treats a missing header as a request for the whole file", () => {
+    expect(parseRangeHeader(null, SIZE)).toEqual({ kind: "full" });
+  });
+
+  it("reads a closed range as an inclusive byte span", () => {
+    // Inclusive on both ends per RFC 9110 — `bytes=0-99` is 100 bytes, not 99.
+    // Getting this wrong truncates every chunk a PDF viewer asks for.
+    expect(parseRangeHeader("bytes=0-99", SIZE)).toEqual({ kind: "partial", start: 0, end: 99 });
+  });
+
+  it("reads an open-ended range as running to the last byte", () => {
+    expect(parseRangeHeader("bytes=500-", SIZE)).toEqual({ kind: "partial", start: 500, end: 999 });
+  });
+
+  it("reads a suffix range as the last N bytes", () => {
+    // How a PDF viewer finds the cross-reference table: it asks for the tail
+    // first, without knowing where the file's structures begin.
+    expect(parseRangeHeader("bytes=-500", SIZE)).toEqual({ kind: "partial", start: 500, end: 999 });
+  });
+
+  it("clamps a suffix longer than the file to the whole file", () => {
+    expect(parseRangeHeader("bytes=-5000", SIZE)).toEqual({ kind: "partial", start: 0, end: 999 });
+  });
+
+  it("clamps an end past the last byte instead of over-reading", () => {
+    expect(parseRangeHeader("bytes=900-99999", SIZE)).toEqual({
+      kind: "partial",
+      start: 900,
+      end: 999,
+    });
+  });
+
+  it("reads a single-byte range as one byte, not as an empty span", () => {
+    // `bytes=0-0` is how some clients probe whether range support is real.
+    // Collapsing it to empty would make that probe conclude it is not.
+    expect(parseRangeHeader("bytes=0-0", SIZE)).toEqual({ kind: "partial", start: 0, end: 0 });
+  });
+
+  it("serves the final byte of the file as a valid range", () => {
+    expect(parseRangeHeader("bytes=999-999", SIZE)).toEqual({
+      kind: "partial",
+      start: 999,
+      end: 999,
+    });
+  });
+
+  it("rejects a start at or past the end of the file", () => {
+    // Must be 416, not a silent empty 206: a viewer that gets zero bytes where
+    // it expected content renders a corrupt document rather than an error.
+    expect(parseRangeHeader("bytes=1000-1099", SIZE)).toEqual({ kind: "unsatisfiable" });
+  });
+
+  it("rejects a range whose start is past its end", () => {
+    expect(parseRangeHeader("bytes=500-100", SIZE)).toEqual({ kind: "unsatisfiable" });
+  });
+
+  it("rejects any range against an empty file", () => {
+    expect(parseRangeHeader("bytes=0-0", 0)).toEqual({ kind: "unsatisfiable" });
+  });
+
+  it("ignores a zero-length suffix request", () => {
+    // `bytes=-0` asks for the last zero bytes. RFC 9110 calls it unsatisfiable;
+    // serving the whole file is the safe reading and matches what nginx does.
+    expect(parseRangeHeader("bytes=-0", SIZE)).toEqual({ kind: "full" });
+  });
+
+  it("ignores a multi-range request rather than answering only its first part", () => {
+    // Answering `bytes=0-99,200-299` with just 0-99 while claiming 206 would
+    // hand the client bytes it did not ask for at offsets it did not expect.
+    // A multipart/byteranges body is the only correct 206 here, so we decline
+    // the whole optimisation and send the complete file instead.
+    expect(parseRangeHeader("bytes=0-99,200-299", SIZE)).toEqual({ kind: "full" });
+  });
+
+  it("ignores a unit other than bytes", () => {
+    expect(parseRangeHeader("items=0-99", SIZE)).toEqual({ kind: "full" });
+  });
+
+  it.each(["bytes=", "bytes=-", "bytes=abc-def", "bytes=1.5-2", "0-99", ""])(
+    "ignores the malformed value %j",
+    (header) => {
+      expect(parseRangeHeader(header, SIZE)).toEqual({ kind: "full" });
+    }
+  );
+
+  it("ignores a range whose numbers exceed what a byte offset can be", () => {
+    // Beyond Number.MAX_SAFE_INTEGER the arithmetic stops being exact, and an
+    // inexact offset would be passed straight to a file read.
+    expect(parseRangeHeader("bytes=99999999999999999999-", SIZE)).toEqual({ kind: "full" });
+  });
+
+  it("tolerates the optional whitespace a client may send", () => {
+    expect(parseRangeHeader("bytes = 0-99", SIZE)).toEqual({ kind: "partial", start: 0, end: 99 });
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The knowledge-base answer names its sources as plain prose, because the
+ * Sources list is written by the model — nothing renders it. Three real shapes
+ * were observed against the same corpus within one day:
+ *
+ *   - kimi-k2.6, obeying the template:  `- [2] /data/x/doc.pdf — p. 44`
+ *   - kimi-k2.6, embellishing:          `[1] /data/x/doc.pdf – AOAC study, Tabelle 18 …`
+ *   - deepseek-v4-pro, its own idea:    `*Quelle: PPR document.pdf, S. 275*`
+ *
+ * So the transform keys off the ONE thing every shape carries — a path with a
+ * known document extension — and never off the surrounding format. Whatever it
+ * does not recognise it leaves untouched: the fallback is today's plain text,
+ * so a model inventing a fourth shape costs a link, never a broken answer.
+ */
+import { describe, it, expect } from "vitest";
+
+import { remarkSourceLinks, buildSourceHref, parseSourceHref } from "@/lib/knowledge/source-links";
+
+/** Minimal mdast subset — the plugin only ever walks children and rewrites text nodes. */
+type Node = { type: string; value?: string; url?: string; children?: Node[] };
+
+function paragraph(text: string): Node {
+  return {
+    type: "root",
+    children: [{ type: "paragraph", children: [{ type: "text", value: text }] }],
+  };
+}
+
+/** Collects every link node in tree order, so assertions read as "what became clickable". */
+function links(tree: Node): Array<{ url: string; text: string }> {
+  const found: Array<{ url: string; text: string }> = [];
+  const walk = (node: Node) => {
+    if (node.type === "link" && node.url) {
+      found.push({ url: node.url, text: (node.children ?? []).map((c) => c.value ?? "").join("") });
+    }
+    (node.children ?? []).forEach(walk);
+  };
+  walk(tree);
+  return found;
+}
+
+const AGENT = "agent-1";
+const run = (tree: Node) => {
+  remarkSourceLinks({ agentId: AGENT })(tree as never);
+  return tree;
+};
+
+describe("buildSourceHref", () => {
+  it("points at the agent's workspace-file route with the path encoded", () => {
+    // Spaces and & are both real in this corpus ("PF LAB/… afnor_update_&_support.pdf")
+    // and both break a bare query string, so encoding is not cosmetic.
+    const href = buildSourceHref(AGENT, "/data/noack/PF LAB/a & b.pdf", null);
+    expect(href).toBe(
+      "/api/agents/agent-1/workspace-file?path=%2Fdata%2Fnoack%2FPF%20LAB%2Fa%20%26%20b.pdf"
+    );
+  });
+
+  it("appends the PDF viewer's page fragment when a page is known", () => {
+    const href = buildSourceHref(AGENT, "/data/x/doc.pdf", 44);
+    expect(href.endsWith("#page=44")).toBe(true);
+  });
+});
+
+describe("parseSourceHref", () => {
+  it("round-trips a path built by buildSourceHref, so the viewer gets a real title", () => {
+    const path = "/data/noack/PF LAB/a & b.pdf";
+    expect(parseSourceHref(buildSourceHref(AGENT, path, 44))).toEqual({ path, page: 44 });
+  });
+
+  it("reports no page when the href carries none", () => {
+    expect(parseSourceHref(buildSourceHref(AGENT, "/data/x/doc.pdf", null))).toEqual({
+      path: "/data/x/doc.pdf",
+      page: null,
+    });
+  });
+
+  it("returns null for an ordinary link, which is how a citation is told apart", () => {
+    expect(parseSourceHref("https://example.com/doc.pdf")).toBeNull();
+  });
+
+  it("survives a malformed escape instead of throwing mid-render", () => {
+    expect(parseSourceHref("/api/agents/a/workspace-file?path=%E0%A4%A")).toBeNull();
+  });
+});
+
+describe("remarkSourceLinks", () => {
+  it("links a template-formatted source and keeps its page", () => {
+    const tree = run(paragraph("- [2] /data/noack/PPR/document.pdf — p. 44"));
+    expect(links(tree)).toEqual([
+      {
+        url: "/api/agents/agent-1/workspace-file?path=%2Fdata%2Fnoack%2FPPR%2Fdocument.pdf#page=44",
+        text: "/data/noack/PPR/document.pdf",
+      },
+    ]);
+  });
+
+  it("links a source buried in prose, where the format collapsed", () => {
+    const tree = run(
+      paragraph("Quellen: [1] /data/noack/PF RAC/study.pdf – AOAC Performance Tested Method Study")
+    );
+    const found = links(tree);
+    expect(found).toHaveLength(1);
+    expect(found[0].text).toBe("/data/noack/PF RAC/study.pdf");
+  });
+
+  it("reads a German page abbreviation", () => {
+    const tree = run(paragraph("Quelle: /data/noack/PPR/document.pdf, S. 275"));
+    expect(links(tree)[0].url.endsWith("#page=275")).toBe(true);
+  });
+
+  it("keeps the surrounding words as text around the link", () => {
+    const tree = run(paragraph("siehe /data/x/doc.pdf für Details"));
+    const para = tree.children![0];
+    expect(para.children!.map((c) => c.type)).toEqual(["text", "link", "text"]);
+    expect(para.children![0].value).toBe("siehe ");
+    expect(para.children![2].value).toBe(" für Details");
+  });
+
+  it("links every source when one line names several", () => {
+    const tree = run(paragraph("[1] /data/a/one.pdf — p. 1 [2] /data/b/two.pdf — p. 2"));
+    expect(links(tree).map((l) => l.text)).toEqual(["/data/a/one.pdf", "/data/b/two.pdf"]);
+  });
+
+  it("leaves text without a document path completely alone", () => {
+    // The fallback that makes this safe to ship: no match, no rewrite.
+    const tree = paragraph("Die Nachweisgrenze hängt vom Verdünnungsfaktor ab.");
+    const before = JSON.stringify(tree);
+    run(tree);
+    expect(JSON.stringify(tree)).toBe(before);
+  });
+
+  it("does not rewrite inside code or an existing link", () => {
+    // A path inside `code` is being shown, not referenced; a path already inside
+    // a link would nest an <a> in an <a>, which React drops on the floor.
+    const tree: Node = {
+      type: "root",
+      children: [
+        { type: "inlineCode", value: "/data/x/doc.pdf" },
+        { type: "link", url: "/elsewhere", children: [{ type: "text", value: "/data/x/doc.pdf" }] },
+      ],
+    };
+    run(tree);
+    expect(links(tree)).toEqual([{ url: "/elsewhere", text: "/data/x/doc.pdf" }]);
+  });
+
+  it("ignores a path whose extension we cannot serve", () => {
+    const tree = paragraph("/etc/passwd and /data/x/notes.exe");
+    const before = JSON.stringify(tree);
+    run(tree);
+    expect(JSON.stringify(tree)).toBe(before);
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
@@ -81,6 +81,22 @@ describe("parseSourceHref", () => {
   it("survives a malformed escape instead of throwing mid-render", () => {
     expect(parseSourceHref("/api/agents/a/workspace-file?path=%E0%A4%A")).toBeNull();
   });
+
+  it.each([
+    "https://evil.example/workspace-file?path=%2Fx.pdf",
+    "//evil.example/workspace-file?path=%2Fx.pdf",
+    "http://localhost:1234/workspace-file?path=%2Fx.pdf",
+    "https://evil.example/api/agents/a1/workspace-file?path=%2Fx.pdf",
+  ])("refuses the foreign origin %j instead of embedding it", (href) => {
+    // The answer this renders is MODEL output, and a knowledge base ingests
+    // documents an attacker may have authored — so "the model wrote it" is not
+    // a trust boundary. Recognising a citation by an unanchored substring let
+    // any absolute url carrying `/workspace-file?path=` through, and the
+    // renderer hands what it recognises to <embed src>. There is no CSP to
+    // catch that downstream, so the check has to be here: a citation is a
+    // same-origin path under /api/agents/, or it is not a citation.
+    expect(parseSourceHref(href)).toBeNull();
+  });
 });
 
 describe("remarkSourceLinks", () => {
@@ -148,5 +164,68 @@ describe("remarkSourceLinks", () => {
     const before = JSON.stringify(tree);
     run(tree);
     expect(JSON.stringify(tree)).toBe(before);
+  });
+
+  it("links a url-shaped path the same way, because the route decides access", () => {
+    // remark-gfm turns a real `https://…` url into a link node before this
+    // plugin runs, so it never sees one. What DOES reach here is a bare
+    // `example.com/docs/manual.pdf`, which gfm does not autolink. Linking its
+    // path part is harmless — the route resolves it against allowed_paths and
+    // 403s — but it should be a decision on record, not an accident.
+    const tree = run(paragraph("siehe example.com/docs/manual.pdf"));
+    expect(links(tree).map((l) => l.text)).toEqual(["/docs/manual.pdf"]);
+  });
+
+  it("keeps the path intact when earlier text case-folds to a different length", () => {
+    // Finding the extension case-insensitively must not be done by lowercasing
+    // the whole node and indexing into the original: "İ".toLowerCase() is TWO
+    // characters, so every offset after it shifts by one and the extracted path
+    // silently loses its first character. A German lab corpus with a Turkish
+    // name in a sentence is enough to hit it.
+    const tree = run(paragraph("İ siehe /data/x/doc.PDF hier"));
+    expect(links(tree).map((l) => l.text)).toEqual(["/data/x/doc.PDF"]);
+  });
+
+  it("reads a doubled extension as the shorter path", () => {
+    // `/x.pdf.pdf` is ambiguous and neither reading is more correct. It is
+    // pinned only so the windowed scan below cannot change it unnoticed: the
+    // scan stops at the FIRST `.pdf` that a path can legally end on, where the
+    // earlier unbounded regex kept expanding across it.
+    const tree = run(paragraph("/data/x/report.pdf.pdf"));
+    expect(links(tree).map((l) => l.text)).toEqual(["/data/x/report.pdf"]);
+  });
+
+  describe("pathological input", () => {
+    /**
+     * This transform runs SYNCHRONOUSLY IN THE BROWSER, on every streamed
+     * chunk of every message — so a slow parse is a frozen chat, not a slow
+     * request. The original pattern scanned the whole text node with nested
+     * lazy quantifiers, which backtracks catastrophically on path-shaped text
+     * that never completes a match: the three shapes below each took 6-7
+     * SECONDS at this size, and grow superlinearly from there.
+     *
+     * The budget is deliberately loose (a second, where the fixed
+     * implementation needs well under a millisecond) so this measures the
+     * difference between "linear" and "catastrophic" rather than the speed of
+     * the machine it runs on. It cannot flake into red on a loaded runner
+     * without the regression being real.
+     */
+    const BUDGET_MS = 1000;
+
+    it.each([
+      ["path-shaped text with no extension at all", "/" + "a/".repeat(6000) + "b".repeat(6000)],
+      ["an extension the lookahead rejects", "/" + "a/".repeat(6000) + "b".repeat(6000) + ".pdfX"],
+      ["many near-misses in one node", ("/" + "a/".repeat(20) + "b.pdfX ").repeat(300)],
+    ])("finishes %s in linear time", (_label, text) => {
+      const tree = paragraph(text);
+      const before = JSON.stringify(tree);
+
+      const started = performance.now();
+      run(tree);
+      const elapsed = performance.now() - started;
+
+      expect(JSON.stringify(tree)).toBe(before);
+      expect(elapsed).toBeLessThan(BUDGET_MS);
+    });
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
@@ -198,10 +198,18 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
   // corpus this was built against has a 268 MB scanned binder, and it is also
   // its most-cited document). `createReadStream` on the already-open handle
   // closes it when the stream ends OR when the client disconnects mid-download.
-  const body =
-    contentLength === 0
-      ? (await fh.close(), null)
-      : (Readable.toWeb(fh.createReadStream({ start, end })) as ReadableStream<Uint8Array>);
+  //
+  // A body nobody ever touches does NEITHER, and that is reachable: Next.js
+  // auto-implements HEAD by calling this handler and then discarding the body
+  // unread (`send-response.js` skips `pipeToNodeResponse` for HEAD), so a
+  // streamed HEAD parks the descriptor until a GC that may never come. On a
+  // route proxies and PDF viewers probe with HEAD, that is a descriptor leak
+  // per request. HEAD wants the headers anyway, so close the handle and answer
+  // without a body — which is also what the method is defined to return.
+  const wantsBody = req.method !== "HEAD" && contentLength > 0;
+  const body = wantsBody
+    ? (Readable.toWeb(fh.createReadStream({ start, end })) as ReadableStream<Uint8Array>)
+    : (await fh.close(), null);
 
   return new NextResponse(body, {
     status: isPartial ? 206 : 200,

--- a/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
@@ -3,7 +3,8 @@
 // the ESLint require-audit-log rule only gates POST/PUT/PATCH/DELETE, so this
 // comment documents intent for a human reader rather than satisfying the rule.
 import { NextResponse } from "next/server";
-import { stat, readFile } from "node:fs/promises";
+import { open } from "node:fs/promises";
+import { Readable } from "node:stream";
 import { basename } from "node:path";
 
 import { withAuth } from "@/lib/api-auth";
@@ -12,15 +13,10 @@ import { deferAuditLog } from "@/lib/audit-deferred";
 import type { AuditLogEntry } from "@/lib/audit";
 import { resolveAllowedFile } from "@/lib/agent-file-access";
 import { contentTypeForFile } from "@/lib/agent-file-content-type";
+import { parseRangeHeader } from "@/lib/http-range";
 import type { AgentPluginConfig } from "@/db/schema";
 
 type Params = { params: Promise<{ agentId: string }> };
-
-// Defense in depth against loading an oversized file fully into memory. Well
-// above any real KB source PDF; mirrors pinchy-files' MAX_PDF_FILE_SIZE (50MB)
-// in packages/plugins/pinchy-files/validate.ts (a separate package, so the
-// constant is duplicated rather than imported).
-const MAX_SERVE_FILE_SIZE = 50 * 1024 * 1024;
 
 function sourceViewedAuditEntry(args: {
   userId: string;
@@ -29,6 +25,7 @@ function sourceViewedAuditEntry(args: {
   documentName: string;
   outcome: "success" | "failure";
   reason?: string;
+  partial?: boolean;
 }): AuditLogEntry {
   return {
     actorType: "user",
@@ -41,6 +38,11 @@ function sourceViewedAuditEntry(args: {
       agent: { id: args.agentId, name: args.agentName ?? args.agentId },
       document: { name: args.documentName },
       ...(args.reason !== undefined ? { reason: args.reason } : {}),
+      // A PDF viewer fetches a large document as a series of ranges, so one
+      // opened document produces several rows. Every access stays logged —
+      // reading a file in chunks must not be a way to read it unobserved — and
+      // this flag is what lets an analyst count views rather than chunks.
+      ...(args.partial !== undefined ? { partial: args.partial } : {}),
     },
   };
 }
@@ -112,59 +114,72 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
   }
 
   const { realPath } = resolved;
+  const documentName = basename(realPath);
 
-  let info;
-  try {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- realPath is containment-checked by resolveAllowedFile above
-    info = await stat(realPath);
-  } catch {
+  const auditFailure = (reason: string) => {
     deferAuditLog(
       sourceViewedAuditEntry({
         userId: session.user.id!,
         agentId: agent.id,
         agentName: agent.name,
-        documentName: basename(realPath),
+        documentName,
         outcome: "failure",
-        reason: "not_found",
+        reason,
       })
     );
+  };
+
+  // Open FIRST, then stat the open handle rather than re-stat the path: a
+  // stat-then-open pair is a TOCTOU race (js/file-system-race), and the
+  // handle's own stat is authoritative for the bytes we are about to serve.
+  // Same posture as `serve-workspace-file.ts`.
+  let fh;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- realPath is containment-checked by resolveAllowedFile above
+    fh = await open(realPath, "r");
+  } catch {
+    auditFailure("not_found");
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  // From here every path that does NOT hand the handle to a stream must close
+  // it, or the process leaks a descriptor per request.
+  let info;
+  try {
+    info = await fh.stat();
+  } catch {
+    await fh.close();
+    auditFailure("not_found");
     return new NextResponse("Not found", { status: 404 });
   }
 
   // Only regular files. A directory (or anything else — socket, FIFO, ...)
   // is not servable content; treat it the same as "missing" rather than
-  // disclosing what it actually is.
+  // disclosing what it actually is. Note a directory opens successfully on
+  // Linux and macOS, so this check is what rejects it.
   if (!info.isFile()) {
-    deferAuditLog(
-      sourceViewedAuditEntry({
-        userId: session.user.id!,
-        agentId: agent.id,
-        agentName: agent.name,
-        documentName: basename(realPath),
-        outcome: "failure",
-        reason: "not_a_file",
-      })
-    );
+    await fh.close();
+    auditFailure("not_a_file");
     return new NextResponse("Not found", { status: 404 });
   }
 
-  if (info.size > MAX_SERVE_FILE_SIZE) {
-    deferAuditLog(
-      sourceViewedAuditEntry({
-        userId: session.user.id!,
-        agentId: agent.id,
-        agentName: agent.name,
-        documentName: basename(realPath),
-        outcome: "failure",
-        reason: "file_too_large",
-      })
-    );
-    return new NextResponse("File too large", { status: 413 });
+  const range = parseRangeHeader(req.headers.get("range"), info.size);
+  if (range.kind === "unsatisfiable") {
+    await fh.close();
+    auditFailure("range_not_satisfiable");
+    return new NextResponse("Range not satisfiable", {
+      status: 416,
+      // Tell the client the real length so it can retry correctly rather than
+      // probe for it.
+      headers: { "content-range": `bytes */${info.size}`, "accept-ranges": "bytes" },
+    });
   }
 
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- realPath is containment-checked by resolveAllowedFile above
-  const buffer = await readFile(realPath);
-  const documentName = basename(realPath);
+  const isPartial = range.kind === "partial";
+  const start = isPartial ? range.start : 0;
+  const end = isPartial ? range.end : Math.max(0, info.size - 1);
+  const contentLength = info.size === 0 ? 0 : end - start + 1;
+
   const { contentType, disposition } = contentTypeForFile(realPath);
 
   deferAuditLog(
@@ -174,13 +189,30 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
       agentName: agent.name,
       documentName,
       outcome: "success",
+      partial: isPartial,
     })
   );
 
-  return new NextResponse(Uint8Array.from(buffer), {
+  // The bytes are streamed off disk, never materialised: a knowledge base
+  // legitimately contains documents larger than this process's memory (the
+  // corpus this was built against has a 268 MB scanned binder, and it is also
+  // its most-cited document). `createReadStream` on the already-open handle
+  // closes it when the stream ends OR when the client disconnects mid-download.
+  const body =
+    contentLength === 0
+      ? (await fh.close(), null)
+      : (Readable.toWeb(fh.createReadStream({ start, end })) as ReadableStream<Uint8Array>);
+
+  return new NextResponse(body, {
+    status: isPartial ? 206 : 200,
     headers: {
       "content-type": contentType,
-      "content-length": String(buffer.byteLength),
+      "content-length": String(contentLength),
+      // Advertised on every response: without it a viewer has no way to know it
+      // may seek, so opening a citation at `#page=510` would pull the entire
+      // document before rendering anything.
+      "accept-ranges": "bytes",
+      ...(isPartial ? { "content-range": `bytes ${start}-${end}/${info.size}` } : {}),
       "cache-control": "private, max-age=3600",
       // nosniff so the browser can never override our extension-derived
       // Content-Type via its own MIME sniffing — the anti-XSS control that

--- a/packages/web/src/components/assistant-ui/attachment-preview.tsx
+++ b/packages/web/src/components/assistant-ui/attachment-preview.tsx
@@ -2,9 +2,16 @@
 
 import { useContext, useEffect, useRef, useState, type FC, type ReactNode } from "react";
 import { useMessagePartFile } from "@assistant-ui/react";
-import { FileText, Loader2 } from "lucide-react";
+import { ExternalLink, FileText, Loader2, X } from "lucide-react";
 import { AgentIdContext, AgentModelContext, FileSourceContext } from "@/components/chat";
-import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { imageInputNote } from "@/lib/attachment-capability";
 
 import { useModelCapabilities } from "@/hooks/use-model-capabilities";
@@ -125,33 +132,85 @@ const CapabilityWarning: FC<{ message: string }> = ({ message }) => (
  * The lightbox a PDF opens into, and the only place its presentation is
  * defined. Shared so a chat attachment and a cited knowledge-base source open
  * the exact same way — two viewers for "look at this PDF" would drift in
- * sizing, close-button treatment and keyboard behaviour, and the citation link
- * exists precisely so a reader can check a claim without leaving the answer.
+ * sizing, close treatment and keyboard behaviour, and the citation link exists
+ * precisely so a reader can check a claim without leaving the answer.
+ *
+ * The layout is dictated by one constraint: the viewer inside is the BROWSER's,
+ * not ours. Chrome, Firefox and Safari each draw a different toolbar in a
+ * different place, so there is no region we can reliably float a control over.
+ * An earlier version tried — the close button landed on Chrome's overflow menu
+ * and had to be tinted dark just to stay legible against a surface whose colour
+ * we cannot predict, while the dialog's own padding showed as a pale frame
+ * around a viewer that already draws its own.
+ *
+ * So our chrome occupies a row ABOVE the viewer and the viewer gets everything
+ * below it, edge to edge. Nothing overlaps, nothing needs tinting, and the row
+ * earns its height: it names the document (the browser's title bar shows the
+ * route segment, "workspace-file", which tells a reader nothing) and it offers
+ * a full tab — the only thing that works on iOS Safari, where an embedded PDF
+ * renders blank whatever we do.
  *
  * `children` is the trigger, so each caller keeps its own affordance: the
  * attachment renders an <embed> thumbnail, a citation renders its path as text.
  */
-export const PdfDialog: FC<{ url: string; title: string; children: ReactNode }> = ({
-  url,
-  title,
-  children,
-}) => (
-  <Dialog>
-    <DialogTrigger asChild>{children}</DialogTrigger>
-    <DialogContent
-      className="p-2 sm:max-w-4xl [&>button]:rounded-full [&>button]:bg-foreground/60 [&>button]:p-1 [&>button]:opacity-100 [&>button]:ring-0! [&_svg]:text-background [&>button]:hover:[&_svg]:text-destructive"
-      aria-describedby={undefined}
-    >
-      <DialogTitle className="sr-only">{title}</DialogTitle>
-      {/*
-        Remounted per open (the dialog unmounts its content when closed), which
-        is what makes `#page=N` in the url actually land: a PDF viewer honours
-        the fragment on load, not on a later fragment change.
-       */}
-      <embed src={url} type="application/pdf" className="block h-[80dvh] w-full" />
-    </DialogContent>
-  </Dialog>
-);
+export const PdfDialog: FC<{
+  url: string;
+  title: string;
+  children: ReactNode;
+  /** Test-only escape hatch; the dialog is trigger-driven in the app. */
+  defaultOpen?: boolean;
+}> = ({ url, title, children, defaultOpen }) => {
+  // `title` is a filename for an attachment and a full path for a citation.
+  // Show the leaf either way and keep the rest in the tooltip: a corpus has
+  // same-named files in different folders, so the path has to stay reachable,
+  // but spending header width on it would push the controls off a narrow screen.
+  const filename = title.split("/").filter(Boolean).pop() ?? title;
+  const page = /#page=(\d+)/.exec(url)?.[1];
+
+  return (
+    <Dialog defaultOpen={defaultOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent
+        // Taller and wider than a default dialog because a page of A4 at a
+        // readable zoom is simply large — but deliberately not full-screen: the
+        // answer staying visible behind it is the point of checking a citation
+        // here rather than in a new tab. `dvh` (not `vh`) so a mobile browser's
+        // collapsing toolbar cannot cut off the bottom of the viewer.
+        className="flex h-[92dvh] flex-col gap-0 overflow-hidden p-0 sm:max-w-6xl"
+        showCloseButton={false}
+        aria-describedby={undefined}
+      >
+        <div className="flex shrink-0 items-center gap-2 border-b bg-background px-3 py-2">
+          <FileText className="size-4 shrink-0 text-muted-foreground" />
+          <DialogTitle className="truncate font-medium text-sm" title={title}>
+            {filename}
+          </DialogTitle>
+          {page && <span className="shrink-0 text-muted-foreground text-xs">Page {page}</span>}
+          <div className="ml-auto flex shrink-0 items-center gap-0.5">
+            <Button variant="ghost" size="icon" className="size-8" asChild>
+              <a href={url} target="_blank" rel="noreferrer noopener" aria-label="Open in new tab">
+                <ExternalLink className="size-4" />
+              </a>
+            </Button>
+            <DialogClose asChild>
+              <Button variant="ghost" size="icon" className="size-8" aria-label="Close">
+                <X className="size-4" />
+              </Button>
+            </DialogClose>
+          </div>
+        </div>
+        {/*
+          Remounted per open (the dialog unmounts its content when closed), which
+          is what makes `#page=N` in the url actually land: a PDF viewer honours
+          the fragment on load, not on a later fragment change.
+          `min-h-0` lets this shrink inside the flex column — without it the
+          embed keeps its intrinsic height and pushes the header off-screen.
+         */}
+        <embed src={url} type="application/pdf" className="block min-h-0 w-full flex-1" />
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 const PdfPreview: FC<{ url: string; filename: string; warning: string | null }> = ({
   url,

--- a/packages/web/src/components/assistant-ui/attachment-preview.tsx
+++ b/packages/web/src/components/assistant-ui/attachment-preview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useEffect, useRef, useState, type FC } from "react";
+import { useContext, useEffect, useRef, useState, type FC, type ReactNode } from "react";
 import { useMessagePartFile } from "@assistant-ui/react";
 import { FileText, Loader2 } from "lucide-react";
 import { AgentIdContext, AgentModelContext, FileSourceContext } from "@/components/chat";
@@ -121,14 +121,47 @@ const CapabilityWarning: FC<{ message: string }> = ({ message }) => (
   <p className="mt-1 text-xs text-amber-600 dark:text-amber-500">{message}</p>
 );
 
+/**
+ * The lightbox a PDF opens into, and the only place its presentation is
+ * defined. Shared so a chat attachment and a cited knowledge-base source open
+ * the exact same way — two viewers for "look at this PDF" would drift in
+ * sizing, close-button treatment and keyboard behaviour, and the citation link
+ * exists precisely so a reader can check a claim without leaving the answer.
+ *
+ * `children` is the trigger, so each caller keeps its own affordance: the
+ * attachment renders an <embed> thumbnail, a citation renders its path as text.
+ */
+export const PdfDialog: FC<{ url: string; title: string; children: ReactNode }> = ({
+  url,
+  title,
+  children,
+}) => (
+  <Dialog>
+    <DialogTrigger asChild>{children}</DialogTrigger>
+    <DialogContent
+      className="p-2 sm:max-w-4xl [&>button]:rounded-full [&>button]:bg-foreground/60 [&>button]:p-1 [&>button]:opacity-100 [&>button]:ring-0! [&_svg]:text-background [&>button]:hover:[&_svg]:text-destructive"
+      aria-describedby={undefined}
+    >
+      <DialogTitle className="sr-only">{title}</DialogTitle>
+      {/*
+        Remounted per open (the dialog unmounts its content when closed), which
+        is what makes `#page=N` in the url actually land: a PDF viewer honours
+        the fragment on load, not on a later fragment change.
+       */}
+      <embed src={url} type="application/pdf" className="block h-[80dvh] w-full" />
+    </DialogContent>
+  </Dialog>
+);
+
 const PdfPreview: FC<{ url: string; filename: string; warning: string | null }> = ({
   url,
   filename,
   warning,
 }) => (
   <div>
-    <Dialog>
-      <DialogTrigger
+    <PdfDialog url={url} title={filename}>
+      <button
+        type="button"
         aria-label={`Preview ${filename}`}
         className={`my-2 block max-w-sm cursor-pointer overflow-hidden rounded-lg border bg-muted/40 transition-opacity hover:opacity-80${warning ? " border-amber-500/60" : ""}`}
       >
@@ -142,15 +175,8 @@ const PdfPreview: FC<{ url: string; filename: string; warning: string | null }> 
           <FileText className="size-4 shrink-0 text-muted-foreground" />
           <span className="truncate text-sm">{filename}</span>
         </div>
-      </DialogTrigger>
-      <DialogContent
-        className="p-2 sm:max-w-4xl [&>button]:rounded-full [&>button]:bg-foreground/60 [&>button]:p-1 [&>button]:opacity-100 [&>button]:ring-0! [&_svg]:text-background [&>button]:hover:[&_svg]:text-destructive"
-        aria-describedby={undefined}
-      >
-        <DialogTitle className="sr-only">{filename}</DialogTitle>
-        <embed src={url} type="application/pdf" className="block h-[80dvh] w-full" />
-      </DialogContent>
-    </Dialog>
+      </button>
+    </PdfDialog>
     {warning && <CapabilityWarning message={warning} />}
   </div>
 );

--- a/packages/web/src/components/assistant-ui/attachment-preview.tsx
+++ b/packages/web/src/components/assistant-ui/attachment-preview.tsx
@@ -156,16 +156,22 @@ const CapabilityWarning: FC<{ message: string }> = ({ message }) => (
 export const PdfDialog: FC<{
   url: string;
   title: string;
+  /**
+   * The page the url opens at, when it opens at one. Passed in rather than
+   * re-read from the url: `parseSourceHref` already answers that question for a
+   * citation, and a second reading here is a pair that drifts — the two had in
+   * fact already disagreed on what counts as a page fragment.
+   */
+  page?: number | null;
   children: ReactNode;
   /** Test-only escape hatch; the dialog is trigger-driven in the app. */
   defaultOpen?: boolean;
-}> = ({ url, title, children, defaultOpen }) => {
+}> = ({ url, title, page, children, defaultOpen }) => {
   // `title` is a filename for an attachment and a full path for a citation.
   // Show the leaf either way and keep the rest in the tooltip: a corpus has
   // same-named files in different folders, so the path has to stay reachable,
   // but spending header width on it would push the controls off a narrow screen.
   const filename = title.split("/").filter(Boolean).pop() ?? title;
-  const page = /#page=(\d+)/.exec(url)?.[1];
 
   return (
     <Dialog defaultOpen={defaultOpen}>
@@ -185,7 +191,9 @@ export const PdfDialog: FC<{
           <DialogTitle className="truncate font-medium text-sm" title={title}>
             {filename}
           </DialogTitle>
-          {page && <span className="shrink-0 text-muted-foreground text-xs">Page {page}</span>}
+          {page !== null && page !== undefined && (
+            <span className="shrink-0 text-muted-foreground text-xs">Page {page}</span>
+          )}
           <div className="ml-auto flex shrink-0 items-center gap-0.5">
             <Button variant="ghost" size="icon" className="size-8" asChild>
               <a href={url} target="_blank" rel="noreferrer noopener" aria-label="Open in new tab">

--- a/packages/web/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/web/src/components/assistant-ui/markdown-text.tsx
@@ -13,6 +13,8 @@ import { type ComponentProps, type FC, memo, useContext, useMemo } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
+import type { TextMessagePartProps } from "@assistant-ui/react";
+
 import { AgentIdContext } from "@/components/chat";
 import { PdfDialog } from "@/components/assistant-ui/attachment-preview";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
@@ -41,7 +43,16 @@ export function buildRemarkPlugins(agentId: string | null): RemarkPlugins {
   return agentId ? [remarkGfm, [remarkSourceLinks, { agentId }]] : [remarkGfm];
 }
 
-const MarkdownTextImpl = () => {
+/**
+ * This component is registered as assistant-ui's `Text` part renderer, so it
+ * must stay assignable to `TextMessagePartComponent` — it is handed the part's
+ * own props even though it reads none of them. Declaring only `smooth` would
+ * make the props type share no field with that signature, which TypeScript
+ * rejects outright (and the typecheck gate caught).
+ */
+type MarkdownTextProps = Partial<TextMessagePartProps> & { smooth?: boolean };
+
+const MarkdownTextImpl = ({ smooth = true }: MarkdownTextProps) => {
   const agentId = useContext(AgentIdContext);
 
   // Rebuilt only when the agent changes: remark re-parses the whole message on
@@ -51,6 +62,12 @@ const MarkdownTextImpl = () => {
   return (
     <MarkdownTextPrimitive
       remarkPlugins={remarkPlugins}
+      // On by default, which is the streaming look the chat wants. A test that
+      // renders a whole answer at once turns it OFF: the animation is driven by
+      // requestAnimationFrame, so with it on the assertion is really waiting on
+      // an animation clock, and that is a timing-dependent test rather than a
+      // test of the markdown pipeline it is actually about.
+      smooth={smooth}
       className="aui-md"
       components={defaultComponents}
     />

--- a/packages/web/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/web/src/components/assistant-ui/markdown-text.tsx
@@ -146,7 +146,7 @@ const defaultComponents = memoizeMarkdownComponents({
     const source = href ? parseSourceHref(href) : null;
     if (source && href) {
       return (
-        <PdfDialog url={href} title={source.path}>
+        <PdfDialog url={href} title={source.path} page={source.page}>
           <button type="button" className={cn(linkClasses, "cursor-pointer text-left")}>
             {children}
           </button>

--- a/packages/web/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/web/src/components/assistant-ui/markdown-text.tsx
@@ -9,17 +9,31 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
-import { type FC, memo } from "react";
+import { type FC, memo, useContext, useMemo } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
+import { AgentIdContext } from "@/components/chat";
+import { PdfDialog } from "@/components/assistant-ui/attachment-preview";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { remarkSourceLinks, parseSourceHref } from "@/lib/knowledge/source-links";
 import { cn } from "@/lib/utils";
 
 const MarkdownTextImpl = () => {
+  const agentId = useContext(AgentIdContext);
+
+  // Rebuilt only when the agent changes: remark re-parses the whole message on
+  // a new plugin array identity, and this renderer runs per streamed chunk.
+  // Without an agent id there is no route to link to, so the plugin is left out
+  // entirely rather than emitting hrefs that cannot resolve.
+  const remarkPlugins = useMemo(
+    () => (agentId ? [remarkGfm, remarkSourceLinks({ agentId })] : [remarkGfm]),
+    [agentId]
+  );
+
   return (
     <MarkdownTextPrimitive
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={remarkPlugins}
       className="aui-md"
       components={defaultComponents}
     />
@@ -103,15 +117,32 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary-accent underline underline-offset-2 hover:text-primary-accent/80",
-        className
-      )}
-      {...props}
-    />
-  ),
+  a: function Anchor({ className, href, children, ...props }) {
+    const linkClasses = cn(
+      "aui-md-a text-primary-accent underline underline-offset-2 hover:text-primary-accent/80",
+      className
+    );
+
+    // A cited source opens in the same lightbox as an uploaded PDF rather than
+    // navigating: the point of the citation is to check a claim against the
+    // answer still on screen. Every other link keeps normal anchor behaviour.
+    const source = href ? parseSourceHref(href) : null;
+    if (source && href) {
+      return (
+        <PdfDialog url={href} title={source.path}>
+          <button type="button" className={cn(linkClasses, "cursor-pointer text-left")}>
+            {children}
+          </button>
+        </PdfDialog>
+      );
+    }
+
+    return (
+      <a className={linkClasses} href={href} {...props}>
+        {children}
+      </a>
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(

--- a/packages/web/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/web/src/components/assistant-ui/markdown-text.tsx
@@ -9,7 +9,7 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
-import { type FC, memo, useContext, useMemo } from "react";
+import { type ComponentProps, type FC, memo, useContext, useMemo } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
@@ -19,17 +19,34 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { remarkSourceLinks, parseSourceHref } from "@/lib/knowledge/source-links";
 import { cn } from "@/lib/utils";
 
+/** Taken from the consuming component so the list below cannot drift from what it accepts. */
+type RemarkPlugins = ComponentProps<typeof MarkdownTextPrimitive>["remarkPlugins"];
+
+/**
+ * The remark plugins a chat message is rendered with.
+ *
+ * Exported ONLY so a test can apply this list the way unified does. The types
+ * do not protect the distinction that matters here: unified wants an ATTACHER
+ * (`(options) => transformer`), and an already-applied transformer is also just
+ * a function, so `remarkSourceLinks({ agentId })` type-checks perfectly and then
+ * crashes the render of every message. That is not hypothetical — it shipped
+ * once and took the chat down with "Cannot read properties of undefined". The
+ * unit tests could not see it because they invoke the transformer directly,
+ * which is precisely the step this list gets to skip.
+ *
+ * Without an agent id there is no route to link a citation to, so the plugin is
+ * left out entirely rather than emitting hrefs that cannot resolve.
+ */
+export function buildRemarkPlugins(agentId: string | null): RemarkPlugins {
+  return agentId ? [remarkGfm, [remarkSourceLinks, { agentId }]] : [remarkGfm];
+}
+
 const MarkdownTextImpl = () => {
   const agentId = useContext(AgentIdContext);
 
   // Rebuilt only when the agent changes: remark re-parses the whole message on
   // a new plugin array identity, and this renderer runs per streamed chunk.
-  // Without an agent id there is no route to link to, so the plugin is left out
-  // entirely rather than emitting hrefs that cannot resolve.
-  const remarkPlugins = useMemo(
-    () => (agentId ? [remarkGfm, remarkSourceLinks({ agentId })] : [remarkGfm]),
-    [agentId]
-  );
+  const remarkPlugins = useMemo(() => buildRemarkPlugins(agentId), [agentId]);
 
   return (
     <MarkdownTextPrimitive

--- a/packages/web/src/lib/http-range.ts
+++ b/packages/web/src/lib/http-range.ts
@@ -1,0 +1,88 @@
+/**
+ * Parses an HTTP `Range` request header into a concrete byte span.
+ *
+ * Why the workspace-file route needs this at all: a real knowledge-base corpus
+ * contains scanned compilation binders in the hundreds of megabytes, and those
+ * tend to be the MOST-cited documents in it (they contain the most). Opening a
+ * citation at `#page=510` should not mean transferring the whole file — a
+ * browser's PDF viewer fetches the trailer, reads the cross-reference table,
+ * then pulls only the pages it renders, but it only does that when the server
+ * advertises `Accept-Ranges: bytes` and honours the follow-up requests.
+ *
+ * The parse is deliberately conservative: anything not understood resolves to
+ * `full`, which RFC 9110 §14.2 explicitly permits ("A server MAY ignore the
+ * Range header field"). The one case that must NOT be silently downgraded is a
+ * well-formed range that the file cannot satisfy — answering that with 200, or
+ * with an empty 206, hands a viewer bytes at offsets it did not ask for, and it
+ * renders a corrupt document rather than reporting an error.
+ */
+
+export type RangeRequest =
+  /** Serve the entire file with 200. Also the answer for anything unparsed. */
+  | { kind: "full" }
+  /** Serve `[start, end]` INCLUSIVE with 206 — the same convention as HTTP and as `createReadStream`. */
+  | { kind: "partial"; start: number; end: number }
+  /** Syntactically valid, but outside the file. Must become 416. */
+  | { kind: "unsatisfiable" };
+
+const FULL: RangeRequest = { kind: "full" };
+
+/**
+ * A single `bytes=` range: `start-end`, `start-`, or `-suffix`. Digits only —
+ * no signs, no decimals — because the captured text is turned straight into a
+ * file offset. A comma anywhere makes this fail to match, which is how
+ * multi-range requests fall through to `full`: answering only the first part
+ * while claiming 206 would misplace every subsequent byte, and a correct answer
+ * would need a `multipart/byteranges` body that no caller here wants.
+ */
+const SINGLE_BYTE_RANGE = /^\s*bytes\s*=\s*(\d*)\s*-\s*(\d*)\s*$/i;
+
+export function parseRangeHeader(header: string | null, size: number): RangeRequest {
+  if (!header) return FULL;
+
+  const match = SINGLE_BYTE_RANGE.exec(header);
+  if (!match) return FULL;
+
+  const [, rawStart, rawEnd] = match;
+  // `bytes=-` carries neither bound and means nothing.
+  if (rawStart === "" && rawEnd === "") return FULL;
+
+  // An empty file can satisfy no range at all, and the clamping below would
+  // otherwise produce the nonsensical span [0, -1].
+  if (size <= 0) return { kind: "unsatisfiable" };
+
+  let start: number;
+  let end: number;
+
+  if (rawStart === "") {
+    // Suffix form: `bytes=-500` is the LAST 500 bytes, not "up to byte 500".
+    const suffixLength = Number(rawEnd);
+    if (!Number.isSafeInteger(suffixLength)) return FULL;
+    // `bytes=-0` requests the last zero bytes. Treated as unparseable rather
+    // than unsatisfiable: there is no sane partial answer, and a 416 for what
+    // is plainly a client bug would break an otherwise fine download.
+    if (suffixLength === 0) return FULL;
+    start = Math.max(0, size - suffixLength);
+    end = size - 1;
+  } else {
+    start = Number(rawStart);
+    if (!Number.isSafeInteger(start)) return FULL;
+    if (rawEnd === "") {
+      end = size - 1;
+    } else {
+      end = Number(rawEnd);
+      if (!Number.isSafeInteger(end)) return FULL;
+      // A client may ask past the end without knowing the length; serve what
+      // exists rather than refusing.
+      end = Math.min(end, size - 1);
+    }
+    // `end` is already clamped to the last byte, so this one comparison also
+    // covers a start at or past the end of the file. An explicit `start >= size`
+    // check next to it looks like belt and braces but is unreachable — a
+    // mutation test proved nothing depended on it — and a second place deciding
+    // the same thing is a pair that drifts.
+    if (start > end) return { kind: "unsatisfiable" };
+  }
+
+  return { kind: "partial", start, end };
+}

--- a/packages/web/src/lib/knowledge/source-links.ts
+++ b/packages/web/src/lib/knowledge/source-links.ts
@@ -22,19 +22,82 @@
  */
 
 /**
- * An absolute path ending in an extension we can serve. The extension is baked
- * into the pattern rather than checked separately: a second predicate deciding
- * the same thing is a pair that drifts, and a mutation test proved the separate
- * check was already unreachable. Widening what is linkable therefore means
- * editing this alternation — today only `.pdf`, which is also the only type the
- * ingest accepts and the only one the route renders inline.
+ * An absolute path ending in an extension we can serve, anchored at the END of
+ * the slice it is run against — see `findSourcePaths` for why it is never let
+ * loose on a whole text node. The extension is baked into the pattern rather
+ * than checked separately: a second predicate deciding the same thing is a pair
+ * that drifts, and a mutation test proved the separate check was already
+ * unreachable. Widening what is linkable therefore means editing this
+ * alternation — today only `.pdf`, which is also the only type the ingest
+ * accepts and the only one the route renders inline.
  *
  * Anchoring on the extension is what keeps arbitrary path-shaped strings
- * (`/etc/passwd`) out. The lookahead trims trailing sentence punctuation, so
- * "…/doc.pdf." links the file and not the full stop. Paths in a real corpus
- * routinely contain spaces ("PF LAB/…"), so segments allow them.
+ * (`/etc/passwd`) out. Paths in a real corpus routinely contain spaces
+ * ("PF LAB/…"), so segments allow them.
  */
-const SOURCE_PATH = /\/(?:[^\s/]|[^\s/][^/]*?[^\s/])?(?:\/[^/\n]+?)*?\.pdf(?=[\s,.;:)\]]|$)/gi;
+const SOURCE_PATH_ENDING_HERE = /\/(?:[^\s/]|[^\s/][^/]*?[^\s/])?(?:\/[^/\n]+?)*?\.pdf$/i;
+
+/** What may follow a path so that "…/doc.pdf." links the file and not the full stop. */
+const PATH_BOUNDARY = /[\s,.;:)\]]/;
+
+/**
+ * Locates the extension case-insensitively. A plain `indexOf` on a lowercased
+ * copy would be the obvious way and is wrong: case folding is not
+ * length-preserving ("İ".toLowerCase() is two characters), so every offset
+ * after such a character shifts and the path is extracted one character short.
+ * Matching on the ORIGINAL string keeps offsets meaning what they say.
+ */
+const EXTENSION = /\.pdf/gi;
+
+/**
+ * How far back from an extension a path may reasonably start. The longest path
+ * in the corpus this was built against is under 120 characters; 256 is slack,
+ * not a fit. A path longer than this is read from its last 256 characters, so
+ * the worst case is a link that opens a shorter path (and 403s) rather than a
+ * scan that grows with the message.
+ */
+const MAX_PATH_LENGTH = 256;
+
+/**
+ * Finds the cited paths in one text node, left to right, non-overlapping.
+ *
+ * The obvious implementation — one global regex over the whole string — is what
+ * this replaces, and the reason is not style. The pattern's nested lazy
+ * quantifiers backtrack catastrophically on text that is path-SHAPED but never
+ * completes a match (`/a/a/a/…/bbbb`, or an extension the boundary check
+ * rejects): 18 KB of it took nearly seven seconds. This transform runs
+ * synchronously in the browser on every streamed chunk of every message, so
+ * that is a frozen chat, and the text is model output about documents a
+ * knowledge base ingested — not something we get to assume is benign.
+ *
+ * So the scan is driven by the ONE landmark a citation must contain: the
+ * extension. Each occurrence is found with `indexOf` (linear, no backtracking),
+ * and only then is the regex run — anchored, over at most `MAX_PATH_LENGTH`
+ * characters ending exactly there. Total work is bounded by
+ * occurrences × constant instead of growing with the text.
+ */
+function findSourcePaths(value: string): Array<{ start: number; end: number }> {
+  const found: Array<{ start: number; end: number }> = [];
+  let cursor = 0;
+
+  EXTENSION.lastIndex = 0;
+  for (let hit = EXTENSION.exec(value); hit !== null; hit = EXTENSION.exec(value)) {
+    const end = hit.index + hit[0].length;
+
+    // The character AFTER the extension, read from the real text rather than
+    // the window below, so a path at the very end of the node is still a path.
+    if (end < value.length && !PATH_BOUNDARY.test(value[end])) continue;
+
+    const windowStart = Math.max(cursor, end - MAX_PATH_LENGTH);
+    const match = SOURCE_PATH_ENDING_HERE.exec(value.slice(windowStart, end));
+    if (!match) continue;
+
+    found.push({ start: windowStart + match.index, end });
+    cursor = end;
+  }
+
+  return found;
+}
 
 /** `p. 44`, `S. 275`, `page 12`, `Seite 3` — the page hint that may follow a path. */
 const TRAILING_PAGE = /^\s*[—–\-,]?\s*(?:p\.?|pp\.?|page|s\.|seite)\s*(\d{1,5})\b/i;
@@ -57,8 +120,21 @@ export function buildSourceHref(agentId: string, path: string, page: number | nu
   return page === null ? base : `${base}#page=${page}`;
 }
 
-/** The marker that identifies an href this module produced. Exported so the renderer recognises its own links without re-deriving the shape. */
-export const WORKSPACE_FILE_MARKER = "/workspace-file?path=";
+/**
+ * The shape of an href this module produced, anchored at the START of the
+ * string. The anchor is the security-relevant part.
+ *
+ * Recognising a citation by a substring search let ANY absolute url carrying
+ * `/workspace-file?path=` through — `https://evil.example/workspace-file?path=…`
+ * included. What the renderer recognises it hands to `<embed src>`, so that is
+ * an arbitrary cross-origin frame inside the chat, reachable from model output
+ * about documents the knowledge base ingested. There is no CSP to stop it
+ * downstream. A citation is a same-origin path under `/api/agents/`, and the
+ * only thing that can assert "same origin" is a leading `/` with no second one.
+ *
+ * Exported so the renderer recognises its own links without re-deriving the shape.
+ */
+export const WORKSPACE_FILE_HREF = /^\/api\/agents\/[^/]+\/workspace-file\?path=([^#]*)(?:#(.*))?$/;
 
 /**
  * Recovers the document path from an href built by `buildSourceHref`, for use
@@ -69,11 +145,10 @@ export const WORKSPACE_FILE_MARKER = "/workspace-file?path=";
  * a url is exactly the kind of code that decays quietly.
  */
 export function parseSourceHref(href: string): { path: string; page: number | null } | null {
-  const markerIndex = href.indexOf(WORKSPACE_FILE_MARKER);
-  if (markerIndex === -1) return null;
+  const match = WORKSPACE_FILE_HREF.exec(href);
+  if (!match) return null;
 
-  const afterMarker = href.slice(markerIndex + WORKSPACE_FILE_MARKER.length);
-  const [encodedPath, fragment] = afterMarker.split("#");
+  const [, encodedPath, fragment] = match;
   if (!encodedPath) return null;
 
   const pageMatch = /^page=(\d{1,5})$/.exec(fragment ?? "");
@@ -91,31 +166,30 @@ export function parseSourceHref(href: string): { path: string; page: number | nu
  * replace it with an equivalent copy.
  */
 function linkifyText(value: string, agentId: string): MdastNode[] | null {
+  const matches = findSourcePaths(value);
+  if (matches.length === 0) return null;
+
   const parts: MdastNode[] = [];
   let cursor = 0;
-  SOURCE_PATH.lastIndex = 0;
 
-  for (let match = SOURCE_PATH.exec(value); match !== null; match = SOURCE_PATH.exec(value)) {
-    const path = match[0];
+  for (const { start, end } of matches) {
+    const path = value.slice(start, end);
 
     // A page number may trail the path ("— p. 44"). It is consumed into the
     // href but left in the visible text: the reader still sees which page is
     // being cited, and the link merely opens there.
-    const pageMatch = TRAILING_PAGE.exec(value.slice(match.index + path.length));
+    const pageMatch = TRAILING_PAGE.exec(value.slice(end));
     const page = pageMatch ? Number(pageMatch[1]) : null;
 
-    if (match.index > cursor) {
-      parts.push({ type: "text", value: value.slice(cursor, match.index) });
-    }
+    if (start > cursor) parts.push({ type: "text", value: value.slice(cursor, start) });
     parts.push({
       type: "link",
       url: buildSourceHref(agentId, path, page),
       children: [{ type: "text", value: path }],
     });
-    cursor = match.index + path.length;
+    cursor = end;
   }
 
-  if (parts.length === 0) return null;
   if (cursor < value.length) parts.push({ type: "text", value: value.slice(cursor) });
   return parts;
 }

--- a/packages/web/src/lib/knowledge/source-links.ts
+++ b/packages/web/src/lib/knowledge/source-links.ts
@@ -1,0 +1,157 @@
+/**
+ * Turns the document paths a knowledge-base answer mentions into links to the
+ * agent's workspace-file route, so a citation can be opened and checked.
+ *
+ * Why a remark plugin and not a post-processing pass over the rendered DOM:
+ * the Sources list is written by the MODEL, and its shape is not stable. Within
+ * one day, against one corpus, three shapes appeared — the template's bullet
+ * list, the same model embellishing into a run-on paragraph, and another model
+ * inventing `*Quelle: …, S. 275*` under each section. Working on the mdast means
+ * one implementation covers bullets, paragraphs and table cells alike, because
+ * it keys off the path itself rather than the format around it.
+ *
+ * The transform is deliberately additive: text it does not recognise is left
+ * exactly as it was. The fallback is therefore today's behaviour (plain text),
+ * so a model that invents a fourth shape costs a link, never a broken answer.
+ *
+ * Authorization is unaffected. The href points at
+ * `/api/agents/[agentId]/workspace-file`, which resolves the request against the
+ * SAME `allowed_paths` that scope retrieval, re-checks the session, and audits
+ * the view. A fabricated path in an answer therefore yields a link that 403s —
+ * it cannot widen what the user may read.
+ */
+
+/**
+ * An absolute path ending in an extension we can serve. The extension is baked
+ * into the pattern rather than checked separately: a second predicate deciding
+ * the same thing is a pair that drifts, and a mutation test proved the separate
+ * check was already unreachable. Widening what is linkable therefore means
+ * editing this alternation — today only `.pdf`, which is also the only type the
+ * ingest accepts and the only one the route renders inline.
+ *
+ * Anchoring on the extension is what keeps arbitrary path-shaped strings
+ * (`/etc/passwd`) out. The lookahead trims trailing sentence punctuation, so
+ * "…/doc.pdf." links the file and not the full stop. Paths in a real corpus
+ * routinely contain spaces ("PF LAB/…"), so segments allow them.
+ */
+const SOURCE_PATH = /\/(?:[^\s/]|[^\s/][^/]*?[^\s/])?(?:\/[^/\n]+?)*?\.pdf(?=[\s,.;:)\]]|$)/gi;
+
+/** `p. 44`, `S. 275`, `page 12`, `Seite 3` — the page hint that may follow a path. */
+const TRAILING_PAGE = /^\s*[—–\-,]?\s*(?:p\.?|pp\.?|page|s\.|seite)\s*(\d{1,5})\b/i;
+
+interface MdastNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdastNode[];
+}
+
+/**
+ * Builds the href for one cited document. The path is carried as a query
+ * parameter (not a path segment) because it is absolute and may contain any
+ * character a filesystem allows; `#page=N` is the fragment Chrome's and
+ * Firefox's built-in PDF viewers both honour, and it is inert for anything else.
+ */
+export function buildSourceHref(agentId: string, path: string, page: number | null): string {
+  const base = `/api/agents/${encodeURIComponent(agentId)}/workspace-file?path=${encodeURIComponent(path)}`;
+  return page === null ? base : `${base}#page=${page}`;
+}
+
+/** The marker that identifies an href this module produced. Exported so the renderer recognises its own links without re-deriving the shape. */
+export const WORKSPACE_FILE_MARKER = "/workspace-file?path=";
+
+/**
+ * Recovers the document path from an href built by `buildSourceHref`, for use
+ * as the viewer's title. Returns null for anything else, which is how the
+ * renderer tells a citation from an ordinary link. Kept beside the builder so
+ * the two cannot drift — a dialog whose accessible name silently came back
+ * empty would be a real defect for a screen-reader user, and string surgery on
+ * a url is exactly the kind of code that decays quietly.
+ */
+export function parseSourceHref(href: string): { path: string; page: number | null } | null {
+  const markerIndex = href.indexOf(WORKSPACE_FILE_MARKER);
+  if (markerIndex === -1) return null;
+
+  const afterMarker = href.slice(markerIndex + WORKSPACE_FILE_MARKER.length);
+  const [encodedPath, fragment] = afterMarker.split("#");
+  if (!encodedPath) return null;
+
+  const pageMatch = /^page=(\d{1,5})$/.exec(fragment ?? "");
+  try {
+    return { path: decodeURIComponent(encodedPath), page: pageMatch ? Number(pageMatch[1]) : null };
+  } catch {
+    // A malformed percent-escape must not take down the render of a whole message.
+    return null;
+  }
+}
+
+/**
+ * Splits one text node into text/link/text… parts. Returns null when nothing
+ * matched, which lets the caller leave the original node untouched rather than
+ * replace it with an equivalent copy.
+ */
+function linkifyText(value: string, agentId: string): MdastNode[] | null {
+  const parts: MdastNode[] = [];
+  let cursor = 0;
+  SOURCE_PATH.lastIndex = 0;
+
+  for (let match = SOURCE_PATH.exec(value); match !== null; match = SOURCE_PATH.exec(value)) {
+    const path = match[0];
+
+    // A page number may trail the path ("— p. 44"). It is consumed into the
+    // href but left in the visible text: the reader still sees which page is
+    // being cited, and the link merely opens there.
+    const pageMatch = TRAILING_PAGE.exec(value.slice(match.index + path.length));
+    const page = pageMatch ? Number(pageMatch[1]) : null;
+
+    if (match.index > cursor) {
+      parts.push({ type: "text", value: value.slice(cursor, match.index) });
+    }
+    parts.push({
+      type: "link",
+      url: buildSourceHref(agentId, path, page),
+      children: [{ type: "text", value: path }],
+    });
+    cursor = match.index + path.length;
+  }
+
+  if (parts.length === 0) return null;
+  if (cursor < value.length) parts.push({ type: "text", value: value.slice(cursor) });
+  return parts;
+}
+
+/**
+ * remark plugin factory. `agentId` scopes every generated href to the agent
+ * whose answer this is — the route rejects anything outside that agent's
+ * granted folders, so the id must come from the rendering context and never
+ * from the answer text.
+ */
+export function remarkSourceLinks({ agentId }: { agentId: string }) {
+  return (tree: MdastNode) => {
+    const visit = (node: MdastNode) => {
+      // `link` is skipped so we never nest an anchor inside an anchor; `code`
+      // and `inlineCode` because a path shown as code is being displayed, not
+      // referenced. Neither carries text children we should rewrite.
+      if (node.type === "link" || node.type === "code" || node.type === "inlineCode") return;
+      if (!node.children) return;
+
+      const rewritten: MdastNode[] = [];
+      let changed = false;
+      for (const child of node.children) {
+        if (child.type === "text" && child.value) {
+          const parts = linkifyText(child.value, agentId);
+          if (parts) {
+            rewritten.push(...parts);
+            changed = true;
+            continue;
+          }
+        }
+        visit(child);
+        rewritten.push(child);
+      }
+      if (changed) node.children = rewritten;
+    };
+
+    visit(tree);
+  };
+}


### PR DESCRIPTION
Makes a knowledge-base citation checkable: the source path in an answer becomes a link that opens the document in a viewer over the chat, at the cited page, with the answer still visible behind it.

Motivated by demo feedback (2026-07-28): *"hätte aber trotzdem gern das Dokument"*. Downloading is the other half, tracked in #934.

## Four commits

1. **`feat(kb)`** — source paths in an answer become links (`lib/knowledge/source-links.ts`, a remark plugin) opening the shared lightbox at `#page=N`.
2. **`fix(kb)`** — serve by **streaming with byte ranges**. The route buffered via `readFile` behind a 50 MB ceiling whose comment claimed it sat *"above any real KB source PDF"*. The corpus's largest PDF is **268 MB**, the next 174 MB / 1159 pages, and six exceed 10 MB. The ceiling was removed, not raised.
3. **`test(kb)`** — pin how the remark plugin is *registered*, not only what it does.
4. **`fix(ui)`** — the lightbox gets its own header row instead of controls floating over the browser's viewer.

## Streaming is proven structurally, not by timing

Two tests serve a **2 GiB + 1** sparse file, which `fs.readFile` refuses outright (`ERR_FS_FILE_TOO_LARGE`). No buffering implementation can pass them, so the guarantee does not rest on measuring a duration. `ftruncate` keeps the fixture at 4096 bytes on disk.

`lib/http-range.ts` parses `Range` per RFC 9110 §14.2 into a discriminated union (`full` / `partial` / `unsatisfiable`), inclusive `[start, end]` matching `createReadStream`. Multi-range falls through to a full response rather than pretending to support it. Mutation testing removed a redundant `start >= size` check — `end` is already clamped, so one comparison covers both, and a second place deciding the same thing is a pair that drifts.

## The registration test, and why it exists

I first wrote a comment claiming a type alias made the attacher-vs-transformer mistake impossible. Mutation testing showed the mutation **survives typecheck** — `PluggableList` accepts any function, so the types cannot express that distinction. The comment was wrong and is corrected; `markdown-remark-plugins.test.ts` reimplements unified's attach step (processor as `this`, attachers returning no transformer) and catches the crash the types cannot.

## Lightbox

The viewer inside is the *browser's*, and Chrome, Firefox and Safari each draw their toolbar somewhere different — there is no region a control can safely float over. An earlier version tried: the close button landed on Chrome's overflow menu and needed tinting just to stay legible against a surface we cannot predict. Our chrome now sits in a row **above** the viewer, which also earns its height by naming the document (the tab title otherwise reads `workspace-file`) and offering a full tab — the only thing that works on iOS Safari, where an embedded PDF renders blank regardless.

## Governance unchanged

The link resolves against the **same allowed directories** that scope the agent's search, so a path outside them is refused even when an answer names one, and every view is audited as `knowledge.source_viewed`. Range requests carry a `partial` flag so they stay logged without inflating view counts.

## Rebase note

The `X-Frame-Options` half of this work was superseded by #928, which closed the whole class with a drift guard, so that commit was **dropped rather than duplicated**. The rebase left one comment conflict in `workspace-file/route.ts`; #928's wording was kept, since it references the guard that now exists.

## Verification

`typecheck` clean, `pnpm build` (pre-push) clean, **228 tests green** across the touched areas including #928's `frame-options-route-coverage` and `security-headers` suites.

Full-suite and E2E verification is deliberately left to CI: this machine is under sustained external load (load average ~40) and produced timeout-shaped failures in files this branch does not touch. A green local run under those conditions would not have meant anything.