### PR TITLE
fix(kb): make a knowledge-base agent search and cite regardless of its template

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -32,6 +32,8 @@ Give your agent a descriptive name, for example "HR Policy Assistant" or "Engine
 
 The agent is created with an auto-generated avatar and you are taken to its chat page. The Knowledge Base template pre-fills operating instructions (AGENTS.md) with cite-then-answer guidelines, but the agent doesn't know which documents to search yet — you scope that in the Permissions tab, then index those documents.
 
+Citing isn't left to those instructions alone. `knowledge_search` states the contract in its own results — cite the passages you used, and say so when they don't answer the question — so an agent cites its sources even if you rewrite the instructions or build an agent without this template.
+
 ## 5. Configure directory access
 
 Open the agent's settings by clicking the gear icon, then select the **Permissions** tab.

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -32,7 +32,13 @@ Give your agent a descriptive name, for example "HR Policy Assistant" or "Engine
 
 The agent is created with an auto-generated avatar and you are taken to its chat page. The Knowledge Base template pre-fills operating instructions (AGENTS.md) with cite-then-answer guidelines, but the agent doesn't know which documents to search yet — you scope that in the Permissions tab, then index those documents.
 
-Citing isn't left to those instructions alone. `knowledge_search` states the contract in its own results — cite the passages you used, and say so when they don't answer the question — so an agent cites its sources even if you rewrite the instructions or build an agent without this template.
+Citing isn't left to those instructions alone. `knowledge_search` states the contract in its own results — cite the passages you used, list them with path and page so a reader can check them, and say so when they don't answer the question — so an agent cites its sources even if you rewrite the instructions or build an agent without this template.
+
+:::caution[Agents you created earlier]
+Operating instructions are written once, when the agent is created, and are yours to edit from then on — Pinchy never rewrites them behind your back, which also means an upgrade cannot fix them for you. Open an existing agent's settings and check the **Instructions** tab: if they end in a `## File Access` block with a numbered **"Tool use workflow"** list, that agent still carries older guidance telling it to walk the folder tree instead of searching.
+
+Delete that list and keep the paths above it, or create the agent fresh. Tool descriptions and search results steer the agent the right way regardless, so this is not a broken agent — but the two instructions pull against each other, and on a large corpus the older one has won.
+:::
 
 ## 5. Configure directory access
 

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -231,6 +231,11 @@ describe("pinchy-files plugin", () => {
     )?.[0];
     const tool = lsFactory({ agentId: "agent-1" });
 
+    // Paired with a positive assertion on purpose: two `not.toMatch`es alone
+    // pass loudest against an empty description, which would delete the tool's
+    // guidance rather than correct it. The granted paths still have to reach
+    // the model — the description is where it learns which tree it may list.
+    expect(tool.description).toContain("/data/docs/");
     expect(tool.description).not.toMatch(/knowledge base/i);
     expect(tool.description).not.toMatch(/start here first/i);
   });
@@ -245,6 +250,13 @@ describe("pinchy-files plugin", () => {
     )?.[0];
     const tool = readFactory({ agentId: "agent-1" });
 
+    // Positive anchor first, same reason as the pinchy_ls test above. The
+    // "cannot be cited" half is asserted too: it is the reason a KB agent
+    // reaches for knowledge_search instead, and it is a claim about this
+    // tool's OWN output — formatPdfResult emits <pages>N</pages> for the
+    // document and no per-page marker, so a passage read here has no anchor.
+    expect(tool.description).toContain("/data/docs/");
+    expect(tool.description).toMatch(/cannot be cited/i);
     expect(tool.description).not.toMatch(/knowledge base/i);
   });
 

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -208,7 +208,20 @@ describe("pinchy-files plugin", () => {
     expect(pathParamDescription).toContain("/data/docs/");
   });
 
-  it("pinchy_ls description instructs model to use it first", async () => {
+  // pinchy-files predates real retrieval, back when it WAS the knowledge base.
+  // That wording now competes with knowledge_search for the same job: an agent
+  // told "your knowledge base is at /data/x — start here first" walks the folder
+  // tree instead of searching. Reading files returns no page numbers, so nothing
+  // it finds can be cited, and the answer's Sources list comes out broken.
+  // Measured on the Noack corpus: 4x ls + 5x read + 8x search over ~5 minutes
+  // with a malformed citation list, against 3 searches in ~30s once the agent
+  // stopped being pointed at the file tools.
+  //
+  // So these tools state what they DO; knowledge_search claims the priority
+  // (see its own description test). That split also keeps the document agents
+  // — Contract Analyzer and friends, which have no knowledge_search at all —
+  // working: with no alternative tool there is no priority to declare.
+  it("pinchy_ls description does not present itself as the knowledge base", async () => {
     const api = createMockApi({ "agent-1": { allowed_paths: ["/data/docs/"] } });
     const { default: plugin } = await import("./index");
     plugin.register!(api as any);
@@ -218,7 +231,21 @@ describe("pinchy-files plugin", () => {
     )?.[0];
     const tool = lsFactory({ agentId: "agent-1" });
 
-    expect(tool.description.toLowerCase()).toMatch(/first|start/);
+    expect(tool.description).not.toMatch(/knowledge base/i);
+    expect(tool.description).not.toMatch(/start here first/i);
+  });
+
+  it("pinchy_read description does not present itself as the knowledge base", async () => {
+    const api = createMockApi({ "agent-1": { allowed_paths: ["/data/docs/"] } });
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const readFactory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_read"
+    )?.[0];
+    const tool = readFactory({ agentId: "agent-1" });
+
+    expect(tool.description).not.toMatch(/knowledge base/i);
   });
 
   it("pinchy_read path parameter description includes the allowed paths", async () => {

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -266,7 +266,7 @@ async function readPdf(
 const plugin = {
   id: "pinchy-files",
   name: "Pinchy Files",
-  description: "Scoped read-only file access for Pinchy Knowledge Base agents.",
+  description: "Scoped file access to the directories an agent has been granted.",
   configSchema: {
     validate: (value: unknown) => {
       if (value && typeof value === "object" && "agents" in value) {
@@ -313,7 +313,7 @@ const plugin = {
         return {
           name: "pinchy_ls",
           label: "List Files",
-          description: `List files and directories. Start here first to discover available files. Your knowledge base is at: ${pathList}`,
+          description: `List files and directories in the paths this agent may access: ${pathList}`,
           parameters: {
             type: "object",
             properties: {
@@ -378,7 +378,7 @@ const plugin = {
         return {
           name: "pinchy_read",
           label: "Read File",
-          description: `Read a file's content. Use pinchy_ls first to discover the exact file path. Your knowledge base is at: ${pathList}`,
+          description: `Read one file in full. Needs an exact path — use pinchy_ls to discover it. Best when you already know which document you need; it returns no page numbers, so what you read here cannot be cited. Accessible paths: ${pathList}`,
           parameters: {
             type: "object",
             properties: {

--- a/packages/plugins/pinchy-knowledge/index.test.ts
+++ b/packages/plugins/pinchy-knowledge/index.test.ts
@@ -168,6 +168,9 @@ describe("pinchy-knowledge plugin", () => {
         type: "text",
         text:
           "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
+          "The reader sees only your answer, never these passages, so end it with a Sources list " +
+          "giving each number you cited the document path and page exactly as written above — " +
+          "every number you cite, and no number you did not. " +
           "If they do not answer the question, say so instead of answering from memory.\n\n" +
           '[1] /data/kb/a.pdf (p. 3): "Snippet one."',
       },
@@ -329,6 +332,9 @@ describe("formatWithCitations", () => {
   it("formats results as numbered, citable sources with sourcePath and page", () => {
     expect(formatWithCitations(results)).toBe(
       "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
+        "The reader sees only your answer, never these passages, so end it with a Sources list " +
+        "giving each number you cited the document path and page exactly as written above — " +
+        "every number you cite, and no number you did not. " +
         "If they do not answer the question, say so instead of answering from memory.\n\n" +
         '[1] /data/kb/a.pdf (p. 3): "Snippet one."\n\n[2] /data/kb/b.pdf: "Snippet two."'
     );
@@ -361,6 +367,23 @@ describe("formatWithCitations", () => {
     expect(instruction).toBeGreaterThanOrEqual(0);
     expect(firstSource).toBeGreaterThanOrEqual(0);
     expect(instruction).toBeLessThan(firstSource);
+  });
+
+  it("demands a Sources list, so an inline number resolves to something", () => {
+    // Without this the contract turns "no citation" into "unresolvable
+    // citation", which is not an improvement: the reader never sees this tool
+    // result, so a bare inline [1] in the answer points at nothing. Pinchy's
+    // own KB grader calls that out by name — `gradeCitationResolution` fails
+    // an answer whose inline [N] has no matching Sources entry ("the reader
+    // hits a dead end and cannot verify the claim"), and `gradePathCitation`
+    // fails a Sources entry that shortens the path to a bare filename.
+    //
+    // The knowledge-base template spells all of this out. An agent built
+    // without a template does not have it — which is the exact gap this whole
+    // change exists to close, so the contract has to close it here too.
+    const out = formatWithCitations(results);
+    expect(out).toMatch(/sources list/i);
+    expect(out).toMatch(/path and page/i);
   });
 
   it("tells the model to admit a miss rather than answer from memory", () => {

--- a/packages/plugins/pinchy-knowledge/index.test.ts
+++ b/packages/plugins/pinchy-knowledge/index.test.ts
@@ -158,8 +158,19 @@ describe("pinchy-knowledge plugin", () => {
       })
     );
 
+    // Whole text asserted, not a substring: what the model receives is the
+    // citation contract AND the sources, and this is the only test that sees
+    // them as one dispatched payload rather than as a formatter's return
+    // value. Matching loosely here would let the contract silently fall out of
+    // the wiring while `formatWithCitations`'s own tests stayed green.
     expect(result.content).toEqual([
-      { type: "text", text: '[1] /data/kb/a.pdf (p. 3): "Snippet one."' },
+      {
+        type: "text",
+        text:
+          "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
+          "If they do not answer the question, say so instead of answering from memory.\n\n" +
+          '[1] /data/kb/a.pdf (p. 3): "Snippet one."',
+      },
     ]);
     // details keeps the human-readable docName: an audit reviewer wants to
     // read WHICH document was returned, while the model needs a locator it
@@ -317,8 +328,46 @@ describe("formatWithCitations", () => {
 
   it("formats results as numbered, citable sources with sourcePath and page", () => {
     expect(formatWithCitations(results)).toBe(
-      '[1] /data/kb/a.pdf (p. 3): "Snippet one."\n\n[2] /data/kb/b.pdf: "Snippet two."'
+      "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
+        "If they do not answer the question, say so instead of answering from memory.\n\n" +
+        '[1] /data/kb/a.pdf (p. 3): "Snippet one."\n\n[2] /data/kb/b.pdf: "Snippet two."'
     );
+  });
+
+  it("states the citation contract in the result, not only in a template", () => {
+    // The behaviour this pins: an agent cites its sources because the TOOL
+    // asked it to, not because someone pasted the instruction into its
+    // AGENTS.md. Observed on the Noack corpus 2026-07-27: the same question,
+    // the same 5 successful knowledge_search calls with 8 hits each, produced
+    // a fully-cited answer for an agent carrying the knowledge-base template
+    // and an uncited one for an agent whose template slot was empty. The
+    // retrieval was identical; only the prose differed. Anything that depends
+    // on a template is missing for every agent created without one — including
+    // every agent an admin builds from scratch.
+    const out = formatWithCitations(results);
+    expect(out).toMatch(/cite the passages you use inline as \[1\], \[2\]/i);
+  });
+
+  it("puts the instruction ahead of the passages so it cannot read as content", () => {
+    // Trailing it would sit flush against the last snippet, where it is one
+    // more block of text after a quoted passage rather than a directive about
+    // all of them.
+    const out = formatWithCitations(results);
+    const instruction = out.indexOf("Cite the passages");
+    const firstSource = out.indexOf("[1]");
+    // Both anchors asserted present first: `indexOf` returns -1 for a missing
+    // needle, and -1 is less than any real index, so a bare ordering
+    // comparison passes loudest when the instruction is absent entirely.
+    expect(instruction).toBeGreaterThanOrEqual(0);
+    expect(firstSource).toBeGreaterThanOrEqual(0);
+    expect(instruction).toBeLessThan(firstSource);
+  });
+
+  it("tells the model to admit a miss rather than answer from memory", () => {
+    // The other half of grounding, and the one a template is least likely to
+    // spell out: a retrieval tool that returns nothing is a fact about the
+    // corpus, not an invitation to fall back on training data.
+    expect(formatWithCitations(results)).toMatch(/say so instead of answering from memory/i);
   });
 
   it("identifies a source by its full path, not its bare filename", () => {
@@ -368,7 +417,10 @@ describe("formatWithCitations", () => {
   });
 
   it("returns a deterministic empty-state message for no results", () => {
-    expect(formatWithCitations([])).toBe("No matching passages found in the knowledge base.");
+    expect(formatWithCitations([])).toBe(
+      "No matching passages found in the knowledge base. Tell the user the knowledge base " +
+        "does not cover this instead of answering from memory."
+    );
   });
 });
 

--- a/packages/plugins/pinchy-knowledge/index.test.ts
+++ b/packages/plugins/pinchy-knowledge/index.test.ts
@@ -78,6 +78,29 @@ describe("pinchy-knowledge plugin", () => {
     });
   });
 
+  // The counterpart to the pinchy-files description tests: this tool carries the
+  // priority claim, because it only exists for agents that actually have it.
+  // Putting the claim here rather than into a template-specific prompt means a
+  // custom agent (no template at all) gets the same guidance, and a new template
+  // inherits it without a conditional anywhere.
+  //
+  // "Citable" is the load-bearing word: retrieval returns numbered passages WITH
+  // page numbers, which is what the cite-then-answer contract needs. Reading a
+  // file yields text with no such anchor, which is how a source ends up in the
+  // Sources list with no number in front of it.
+  it("knowledge_search description claims priority for content questions and names its citation advantage", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls[0][0];
+    const tool = factory({ agentId: "agent-1" });
+
+    expect(tool.description.toLowerCase()).toMatch(/\bfirst\b|\bbefore\b/);
+    expect(tool.description.toLowerCase()).toMatch(/cite|citable/);
+    expect(tool.description.toLowerCase()).toMatch(/page/);
+  });
+
   it("factory returns null for an agent not granted the tool", async () => {
     const api = createMockApi(defaultConfig);
     const { default: plugin } = await import("./index");

--- a/packages/plugins/pinchy-knowledge/index.ts
+++ b/packages/plugins/pinchy-knowledge/index.ts
@@ -106,16 +106,46 @@ export function returnedDocumentIds(results: KnowledgeSearchResult[]): DocumentR
  * for `returnedDocumentIds`, which wants a human-readable name for the audit
  * row, not a locator.
  */
+/**
+ * What the caller is expected to do with these passages, carried by the result
+ * itself rather than by the agent's instructions.
+ *
+ * The distinction is not cosmetic. On the Noack corpus (2026-07-27) the same
+ * question produced a fully-cited answer from an agent carrying the
+ * knowledge-base template and an uncited one from an agent whose template slot
+ * was empty — identical retrieval, five successful searches with eight hits
+ * each, only the prose differed. Anything stated only in a template is absent
+ * for every agent created without one, which includes every agent an admin
+ * builds from scratch. A tool result reaches the model on every call, for
+ * every agent, whatever it was configured from.
+ *
+ * It leads rather than trails so it reads as a directive about the passages
+ * instead of one more block of text after the last quoted one.
+ */
+const CITATION_CONTRACT =
+  "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
+  "If they do not answer the question, say so instead of answering from memory.";
+
+/**
+ * The other half of grounding, and the half a template is least likely to
+ * spell out: an empty retrieval is a fact about the corpus, not an invitation
+ * to fall back on training data.
+ */
+const NO_RESULTS =
+  "No matching passages found in the knowledge base. Tell the user the knowledge base " +
+  "does not cover this instead of answering from memory.";
+
 export function formatWithCitations(results: KnowledgeSearchResult[]): string {
   if (results.length === 0) {
-    return "No matching passages found in the knowledge base.";
+    return NO_RESULTS;
   }
-  return results
+  const sources = results
     .map((result, index) => {
       const pageSuffix = result.page != null ? ` (p. ${result.page})` : "";
       return `[${index + 1}] ${result.sourcePath}${pageSuffix}: "${result.text}"`;
     })
     .join("\n\n");
+  return `${CITATION_CONTRACT}\n\n${sources}`;
 }
 
 function normalizeBaseUrl(url: string): string {

--- a/packages/plugins/pinchy-knowledge/index.ts
+++ b/packages/plugins/pinchy-knowledge/index.ts
@@ -92,21 +92,6 @@ export function returnedDocumentIds(results: KnowledgeSearchResult[]): DocumentR
 }
 
 /**
- * Render retrieval results as a numbered, citable source list so the model
- * can cite-then-answer against a closed set of ids (the knowledge-base
- * agent template teaches this pattern in its AGENTS.md). Deterministic and
- * unit-tested: the same input always yields the same output string.
- *
- * Sources are identified by full `sourcePath`, not `docName`. A citation only
- * earns trust if the reader can FIND the document and check it: a bare
- * basename is unfindable in a deep corpus and, worse, collapses same-named
- * files from different folders into one indistinguishable citation. The model
- * can only cite what it is shown, so the path has to be in this string — the
- * tool result never reaches the browser. `docName` stays in the response shape
- * for `returnedDocumentIds`, which wants a human-readable name for the audit
- * row, not a locator.
- */
-/**
  * What the caller is expected to do with these passages, carried by the result
  * itself rather than by the agent's instructions.
  *
@@ -121,9 +106,21 @@ export function returnedDocumentIds(results: KnowledgeSearchResult[]): DocumentR
  *
  * It leads rather than trails so it reads as a directive about the passages
  * instead of one more block of text after the last quoted one.
+ *
+ * The Sources sentence is not decoration. Inline numbers alone would turn "no
+ * citation" into "unresolvable citation" — the reader never sees this tool
+ * result, so a bare `[1]` in the answer points at nothing. Pinchy's own KB
+ * graders name both halves of that failure: `gradeCitationResolution` fails an
+ * inline `[N]` with no Sources entry ("the reader hits a dead end") and a
+ * Sources entry never cited inline (a retrieved-but-unused chunk dressed up as
+ * corroboration), and `gradePathCitation` fails an entry shortened to a bare
+ * filename.
  */
 const CITATION_CONTRACT =
   "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
+  "The reader sees only your answer, never these passages, so end it with a Sources list " +
+  "giving each number you cited the document path and page exactly as written above — " +
+  "every number you cite, and no number you did not. " +
   "If they do not answer the question, say so instead of answering from memory.";
 
 /**
@@ -135,6 +132,21 @@ const NO_RESULTS =
   "No matching passages found in the knowledge base. Tell the user the knowledge base " +
   "does not cover this instead of answering from memory.";
 
+/**
+ * Render retrieval results as a numbered, citable source list so the model
+ * can cite-then-answer against a closed set of ids, prefixed by the contract
+ * that says what to do with them. Deterministic and unit-tested: the same
+ * input always yields the same output string.
+ *
+ * Sources are identified by full `sourcePath`, not `docName`. A citation only
+ * earns trust if the reader can FIND the document and check it: a bare
+ * basename is unfindable in a deep corpus and, worse, collapses same-named
+ * files from different folders into one indistinguishable citation. The model
+ * can only cite what it is shown, so the path has to be in this string — the
+ * tool result never reaches the browser. `docName` stays in the response shape
+ * for `returnedDocumentIds`, which wants a human-readable name for the audit
+ * row, not a locator.
+ */
 export function formatWithCitations(results: KnowledgeSearchResult[]): string {
   if (results.length === 0) {
     return NO_RESULTS;

--- a/packages/plugins/pinchy-knowledge/index.ts
+++ b/packages/plugins/pinchy-knowledge/index.ts
@@ -167,7 +167,7 @@ const plugin = {
           name: "knowledge_search",
           label: "Search Knowledge Base",
           description:
-            "Search the organization's knowledge base for passages relevant to a question. Returns numbered, citable source snippets — cite them by number in your answer.",
+            "Search the organization's indexed documents for passages relevant to a question. Use this FIRST for any question about document content, before reaching for file tools: it returns numbered passages together with their document path and page number, which is what makes an answer citable. Reading a file directly gives you no page anchor, so anything found that way cannot be cited. Cite the returned numbers inline in your answer.",
           parameters: {
             type: "object",
             properties: {

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -697,7 +697,15 @@ describe("POST /api/agents", () => {
     );
   });
 
-  it("should include pinchy_ls instructions in AGENTS.md for knowledge-base agents", async () => {
+  // The route-level counterpart to the generateAgentsMd unit test: the file that
+  // actually lands in the workspace must not tell a KB agent to start from the
+  // file tools. It used to prescribe "1. Always start with `pinchy_ls`", which
+  // outranked the template's own "use knowledge_search for any question" and
+  // sent the agent walking the folder tree — producing answers whose sources
+  // carried no citation numbers, because only retrieval returns page anchors.
+  // Which tool to prefer is now stated in the tool descriptions themselves.
+  // The test above already pins that the granted paths still reach the file.
+  it("should not prescribe file-tool steps in AGENTS.md for knowledge-base agents", async () => {
     const request = new NextRequest("http://localhost:7777/api/agents", {
       method: "POST",
       body: JSON.stringify({
@@ -714,7 +722,7 @@ describe("POST /api/agents", () => {
     expect(writeWorkspaceFile).toHaveBeenCalledWith(
       "new-agent-id",
       "AGENTS.md",
-      expect.stringContaining("pinchy_ls")
+      expect.not.stringContaining("pinchy_ls")
     );
   });
 

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -316,12 +316,21 @@ describe("generateAgentsMd", () => {
     expect(content).toContain("/data/hr-docs/");
   });
 
-  it("should instruct the agent to use pinchy_ls before reading files", () => {
+  // This block used to prescribe "1. Always start with pinchy_ls / 2. Use
+  // pinchy_read", which contradicted the template's own "use knowledge_search
+  // for any question" two paragraphs above — and the numbered, more specific
+  // instruction won. The generated prompt now states only WHERE the documents
+  // are (a fact, identical for every template); WHICH tool to reach for is the
+  // tools' own descriptions to declare, which is where a model looks when
+  // choosing one and which also reaches agents created without a template.
+  it("states where the documents are without prescribing a file-tool workflow", () => {
     const template = AGENT_TEMPLATES["knowledge-base"];
     const content = generateAgentsMd(template, {
       "pinchy-files": { allowed_paths: ["/data/hr-docs/"] },
     });
-    expect(content).toContain("pinchy_ls");
+    expect(content).toContain("/data/hr-docs/");
+    expect(content).not.toContain("pinchy_ls");
+    expect(content).not.toContain("pinchy_read");
   });
 
   it("should preserve the base knowledge base instructions", () => {

--- a/packages/web/src/lib/agent-templates/generate-agents-md.ts
+++ b/packages/web/src/lib/agent-templates/generate-agents-md.ts
@@ -4,9 +4,22 @@ import type { AgentTemplate } from "./types";
 /**
  * Generate the AGENTS.md content for an agent.
  *
- * For knowledge-base agents, dynamically includes the allowed paths and
- * explicit tool-use instructions so all models (including OpenAI) know
- * exactly where to look for files instead of guessing paths.
+ * For document-backed agents this appends the granted paths, so a model knows
+ * where its documents live instead of guessing at directory names.
+ *
+ * It deliberately says only WHERE the documents are, never WHICH tool to reach
+ * for. This block used to prescribe "1. Always start with `pinchy_ls`", which
+ * contradicted the knowledge-base template's own "use `knowledge_search` for
+ * any question" — and the numbered, more specific instruction won, so KB agents
+ * walked the folder tree instead of searching and produced answers whose
+ * sources had no citation numbers (retrieval yields page anchors, reading a
+ * file does not).
+ *
+ * Tool choice belongs in the tool descriptions, which is where a model looks
+ * when picking one, and which also covers agents created without a template.
+ * `knowledge_search` states its own priority; the pinchy-files tools state only
+ * what they do. That split is what keeps the document templates working, since
+ * they have no `knowledge_search` and therefore no competing option.
  */
 export function generateAgentsMd(
   template: AgentTemplate,
@@ -20,10 +33,7 @@ export function generateAgentsMd(
   ) {
     const paths = pluginConfig["pinchy-files"].allowed_paths;
     const pathList = paths.map((p) => `- \`${p}\``).join("\n");
-    return (
-      template.defaultAgentsMd +
-      `\n\n## File Access\nYour knowledge base is stored at:\n${pathList}\n\nTool use workflow:\n1. Always start with \`pinchy_ls\` on one of the paths above to discover available files\n2. Use \`pinchy_read\` to read specific files\n3. Never guess file names — always discover them first`
-    );
+    return template.defaultAgentsMd + `\n\n## Document Access\nYour documents are in:\n${pathList}`;
   }
 
   // Odoo templates render with a top-level heading derived from template.name,


### PR DESCRIPTION
Two related defects, both with the same shape: behaviour that looked like a model problem but was really instructions living in a place a from-scratch agent never gets.

## 1. The agent walked the folder tree instead of searching

On the 193-document Noack corpus a single question cost **4× `pinchy_ls`, 5× `pinchy_read` and 8× `knowledge_search`**, hung on the ninth read, and took over five minutes. The answer that came back cited `[1][3][8]` and listed a fourth source with **no number at all** — because that one had been read with `pinchy_read`, which returns no page anchor and therefore nothing citable.

The agent was following its instructions. Four places told it to, all left over from when `pinchy-files` *was* the knowledge base, before retrieval existed:

- `generateAgentsMd` appended *"1. Always start with `pinchy_ls` / 2. Use `pinchy_read`"* — two paragraphs below the template's own "use `knowledge_search` for any question". The numbered, more specific instruction won.
- `pinchy_ls`: *"Start here first … Your knowledge base is at: &lt;paths&gt;"*
- `pinchy_read`: *"… Your knowledge base is at: &lt;paths&gt;"*
- the plugin itself: *"for Pinchy Knowledge Base agents"*

Split by what each surface is for. The generated prompt now states only **where** the documents are — a fact, identical for every template. **Which** tool to reach for moved into the tool descriptions, where a model actually looks when choosing one, and which also covers agents created with **no template at all**.

That split is deliberate: the five document templates (Contract Analyzer, Resume Screener, Proposal Comparator, Compliance Checker, Onboarding Guide) have no `knowledge_search`, so there is no competing option and no priority to declare — their full-document workflow is untouched. Nothing loses a tool; a KB agent may still read a document in full once it knows which one.

## 2. Citing depended on the template too

Observed 2026-07-27 on the same corpus: the same question, the same five successful `knowledge_search` calls returning eight hits each, produced a **fully cited** answer from the agent carrying the knowledge-base template and an **uncited** one from an agent whose template slot was empty. Retrieval was identical; only the prose differed.

It first looked like a model difference — the two agents also ran different models — and fixing it that way would have meant tuning for one model. The audit trail said otherwise.

So `knowledge_search` now states the contract in its own **result**: cite the passages you use as `[1]`, `[2]` next to the claim each supports, and say so instead of answering from memory when they do not answer the question. A tool result reaches the model on every call, for every agent, whatever it was configured from.

The instruction **leads** rather than trails the passages, so it reads as a directive about them rather than as one more block of text after the last quoted one. The empty state got the same treatment — and that is the half a template is least likely to spell out: no results is a fact about the corpus, not an invitation to fall back on training data.

## On the tests

Four existing assertions covered the old strings. Their **expectation** was wrong, not their shape, so they were inverted rather than dropped, and each keeps a positive assertion — the granted paths must still reach the prompt.

The two exact-match assertions on `formatWithCitations` stay **whole-string** rather than being loosened to `toContain`. The dispatch test in particular is the only one that sees the citation contract and the sources as a single dispatched payload; a loose match there would let the contract fall out of the wiring while the formatter's own tests stayed green.

One test I wrote for this PR passed on the first run, which is not a good sign. It asserted the instruction precedes the sources via `indexOf(...) < indexOf(...)` — but `indexOf` returns `-1` when the needle is missing, and `-1` is less than any real index, so it would have passed **loudest** with the instruction absent entirely. Both anchors are now asserted present first.

`pinchy_read`'s description still names `pinchy_ls` — that one is mechanics (you need an exact path), not strategy.

## Verification

`pnpm typecheck:plugins` clean (9 packages), `pinchy-knowledge` 30 tests green, `pnpm build` (pre-push) clean.

Full-suite verification is left to CI. This machine is under sustained external load (load average 40–200) and produced timeout-shaped failures in `pinchy-files/pdf-extract.test.ts` and `pdf-render.test.ts` — files this branch does not touch. Those look environmental, but three of them still fail with a 120 s timeout, so there may be something real underneath; tracked in #947 rather than waved away here.