### PR TITLE
fix(settings): finish the "AI Provider" rename on the card heading

### DIFF
--- a/packages/web/src/__tests__/app/settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/settings-page.test.tsx
@@ -241,7 +241,7 @@ describe("Settings Page", () => {
     it("should render AI Provider section with ProviderKeyForm", async () => {
       setupAdminFetchMocks();
 
-      const { container } = render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+      render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
 
       await waitFor(() => {
         expect(screen.getByTestId("mock-provider-form")).toBeInTheDocument();
@@ -251,7 +251,13 @@ describe("Settings Page", () => {
       // error hint ("Go to Settings > AI Provider…"), which both already say
       // "AI Provider". 3966c06b renamed the tab and missed this heading, so a
       // user following that hint landed on a card still titled "LLM Provider".
-      expect(container.querySelector('[data-slot="card-title"]')).toHaveTextContent("AI Provider");
+      // Scoped to the card that holds the provider form — several tabs stay
+      // mounted, so the first card-title in the container is not necessarily
+      // this one.
+      const providerCard = screen.getByTestId("mock-provider-form").closest('[data-slot="card"]');
+      expect(providerCard?.querySelector('[data-slot="card-title"]')).toHaveTextContent(
+        "AI Provider"
+      );
     });
 
     it("should show loading state while fetching provider status", () => {

--- a/packages/web/src/__tests__/app/settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/settings-page.test.tsx
@@ -238,14 +238,20 @@ describe("Settings Page", () => {
       expect(contextTab).toHaveAttribute("data-state", "active");
     });
 
-    it("should render LLM Provider section with ProviderKeyForm", async () => {
+    it("should render AI Provider section with ProviderKeyForm", async () => {
       setupAdminFetchMocks();
 
-      render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+      const { container } = render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
 
       await waitFor(() => {
         expect(screen.getByTestId("mock-provider-form")).toBeInTheDocument();
       });
+
+      // The card heading must agree with the tab label and with the chat
+      // error hint ("Go to Settings > AI Provider…"), which both already say
+      // "AI Provider". 3966c06b renamed the tab and missed this heading, so a
+      // user following that hint landed on a card still titled "LLM Provider".
+      expect(container.querySelector('[data-slot="card-title"]')).toHaveTextContent("AI Provider");
     });
 
     it("should show loading state while fetching provider status", () => {

--- a/packages/web/src/__tests__/app/setup-provider-page.test.tsx
+++ b/packages/web/src/__tests__/app/setup-provider-page.test.tsx
@@ -70,11 +70,12 @@ describe("Setup Provider Page", () => {
     expect(screen.getByText("Connect your AI provider")).toBeInTheDocument();
   });
 
+  // Same rename as the settings card heading: the wizard card says "AI
+  // provider" in its title, so the description right below it must not fall
+  // back to the old "LLM provider" wording.
   it("should display page description", () => {
     render(<SetupProviderPage />);
-    expect(
-      screen.getByText(/choose your llm provider and enter your api key/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/choose your ai provider and enter your api key/i)).toBeInTheDocument();
   });
 
   it("should render the ProviderKeyForm", () => {

--- a/packages/web/src/app/setup/provider/page.tsx
+++ b/packages/web/src/app/setup/provider/page.tsx
@@ -71,7 +71,7 @@ export default function SetupProviderPage() {
           <CardHeader>
             <CardTitle>Connect your AI provider</CardTitle>
             <CardDescription>
-              Choose your LLM provider and enter your API key. This is used to power your agents.
+              Choose your AI provider and enter your API key. This is used to power your agents.
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -288,7 +288,7 @@ export function SettingsPageContent({
                 <div className="space-y-6">
                   <Card>
                     <CardHeader>
-                      <CardTitle>LLM Provider</CardTitle>
+                      <CardTitle>AI Provider</CardTitle>
                     </CardHeader>
                     <CardContent>
                       {loading ? (


### PR DESCRIPTION
The settings tab was renamed from "LLM Provider" to "AI Provider" in `3966c06b` — disambiguating the model provider from OAuth "providers" (Google/Microsoft) — and the chat error hint already sends users to **Settings > AI Provider**. The card heading on that very tab was missed and still read "LLM Provider", so a user following that hint landed on a card with the old wording.

One string, plus an assertion in the existing provider-section test so the tab label and the card heading cannot drift apart again.

**Docs deliberately unchanged.** They use "LLM Providers" as both the page title and the route (`/guides/llm-providers/`), cross-linked from eight files. Renaming a docs route is a separate decision, not a stray rename to bundle here.

Found during 0.9.0 Flow-4 testing. Will be cherry-picked onto `release/0.9` so 0.9.0 does not ship the rename half-done — it is that release that introduces the new wording.