### PR TITLE
docs: mount data directories via docker-compose.override.yml

### DIFF
--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -195,7 +195,7 @@ All permission changes are logged in the [audit trail](/concepts/audit-trail/). 
 
 ## The `/data/` convention
 
-All agent-accessible files live under `/data/` inside the Pinchy container. This is mounted as a Docker volume, and you can bind-mount host directories into subdirectories of `/data/`.
+All agent-accessible files live under `/data/`, at the same path in both Pinchy containers. A named Docker volume is mounted there, and you can bind-mount host directories into subdirectories of `/data/` from a `docker-compose.override.yml`.
 
 For example, if you mount your company's HR policies at `/data/hr-policies`, an agent configured to access that directory can read those documents — and nothing else.
 

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -16,7 +16,7 @@ The knowledge base embeds your documents with a local model (`embeddinggemma`) t
 
 ## 1. Mount your data directories
 
-Before creating a Knowledge Base agent, make sure the documents you want the agent to access are mounted under `/data/` in the Pinchy container. See the [Mount Data Directories](/guides/mount-data-directories/) guide for detailed instructions.
+Before creating a Knowledge Base agent, make sure the documents you want the agent to access are mounted under `/data/` — on **both** the `openclaw` and the `pinchy` service, since indexing reads them in the `pinchy` container. See the [Mount Data Directories](/guides/mount-data-directories/) guide for detailed instructions.
 
 ## 2. Navigate to "New Agent"
 

--- a/docs/src/content/docs/guides/customizing-deployment.mdx
+++ b/docs/src/content/docs/guides/customizing-deployment.mdx
@@ -80,7 +80,7 @@ services:
       - /srv/docs/hr:/data/hr:ro
 ```
 
-The `- pinchy-data:/data` line re-declares that mount without the base file's `:ro`, which Docker needs before it can create a mount point underneath it. [Mount Data Directories](/guides/mount-data-directories/) covers the details, including how the directories show up in the agent permissions picker.
+The `- pinchy-data:/data` line re-declares that mount without the base file's `:ro`, which Docker needs before it can create a mount point underneath it — at the cost of the read-only protection that line carried. [Mount Data Directories](/guides/mount-data-directories/) covers the details and the trade-off, including how the directories show up in the agent permissions picker.
 
 ## What's not supported
 

--- a/docs/src/content/docs/guides/customizing-deployment.mdx
+++ b/docs/src/content/docs/guides/customizing-deployment.mdx
@@ -63,6 +63,25 @@ services:
 
 Mount read-only (`:ro`) when possible — OpenClaw reads extensions at startup; it doesn't need write access.
 
+## Recipe 4: Mount your own document directories
+
+Host directories you want agents to read belong under `/data/`, on both the `openclaw` and the `pinchy` service:
+
+```yaml
+# docker-compose.override.yml
+services:
+  openclaw:
+    volumes:
+      - /srv/docs/hr:/data/hr:ro
+
+  pinchy:
+    volumes:
+      - pinchy-data:/data
+      - /srv/docs/hr:/data/hr:ro
+```
+
+The `- pinchy-data:/data` line re-declares that mount without the base file's `:ro`, which Docker needs before it can create a mount point underneath it. [Mount Data Directories](/guides/mount-data-directories/) covers the details, including how the directories show up in the agent permissions picker.
+
 ## What's not supported
 
 The override file is for _additions_, not _replacements_. The following are outside the supported surface and may break on any release:

--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -1,54 +1,83 @@
 ---
 title: Mount Data Directories
-description: How to make files available to Pinchy agents by mounting directories into the container.
+description: How to make files available to Pinchy agents by mounting directories into the containers.
 ---
 
-Pinchy agents can only access files inside the `/data/` directory in the container. To make your documents available, you mount host directories into subdirectories of `/data/` using Docker volumes.
+import { Aside } from "@astrojs/starlight/components";
+
+Pinchy agents can only access files inside the `/data/` directory. To make your documents available, you mount host directories into subdirectories of `/data/` — in a `docker-compose.override.yml`, so upgrades never touch them.
 
 ## The `/data/` convention
 
 ![Agent permissions with directory picker — select which directories each agent can access](/screenshots/agent-settings-permissions.png)
 
-All agent-accessible files live under `/data/` inside the **OpenClaw** container. Pinchy's `pinchy-files` plugin runs inside OpenClaw and reads files from that path. The `pinchy-data` named volume is mounted there by default, but you can bind-mount additional host directories as subdirectories.
+All agent-accessible files live under `/data/`. The `pinchy-data` named volume is mounted there in **both** the `openclaw` and the `pinchy` container, at the same path, so a directory you grant an agent resolves identically wherever Pinchy reads it. You can bind-mount additional host directories as subdirectories.
 
 This convention provides a clear boundary: anything under `/data/` is potentially accessible to agents (depending on their permissions), and nothing outside `/data/` is.
 
-## Adding volumes in `docker-compose.yml`
+## Put your mounts in `docker-compose.override.yml`
 
-To mount a local folder, add a bind mount under the **`openclaw`** service's `volumes` section:
+`docker-compose.yml` belongs to the Pinchy project and gets replaced whenever you upgrade — mounts you add there are gone after the next `curl -o docker-compose.yml ...`. `docker-compose.override.yml` is yours: Docker Compose merges it on top of the base file on every `docker compose up`, and upgrades leave it alone. See [Customizing your deployment](/guides/customizing-deployment/) for the full picture.
+
+Create the file next to `docker-compose.yml`:
 
 ```yaml
+# docker-compose.override.yml
 services:
   openclaw:
     volumes:
-      - openclaw-config:/root/.openclaw
-      - openclaw-secrets:/openclaw-secrets
-      - pinchy-workspaces:/root/.openclaw/workspaces
-      - openclaw-extensions:/root/.openclaw/extensions
+      - /path/on/host/hr-policies:/data/hr-policies:ro
+      - /path/on/host/engineering-docs:/data/engineering-docs:ro
+
+  pinchy:
+    volumes:
+      # Keep this line first — see the note below.
       - pinchy-data:/data
-      - pinchy-pdf-cache:/var/cache/pinchy-files
-      # Add your data directories here:
       - /path/on/host/hr-policies:/data/hr-policies:ro
       - /path/on/host/engineering-docs:/data/engineering-docs:ro
 ```
 
+Compose merges volumes by mount path, so you only list what you're adding — the mounts already in `docker-compose.yml` stay as they are.
+
 The `:ro` suffix mounts the directory as read-only, which is recommended since agents only need to read files.
 
-After updating `docker-compose.yml`, restart the OpenClaw container:
+Then apply the change:
 
 ```bash
-docker compose up -d --no-deps openclaw
+docker compose up -d
 ```
 
+<Aside type="caution">
+  **The `- pinchy-data:/data` line on `pinchy` is required**, not decoration.
+  The base file mounts `/data` read-only in that container, and Docker can't
+  create a `/data/hr-policies` mount point inside a read-only mount — the
+  container refuses to start with `error mounting ... read-only file system`.
+  Re-declaring the same mount without `:ro` makes `/data` writable and the
+  nested mounts work. Your own directories stay read-only either way, because
+  each one carries its own `:ro`.
+</Aside>
+
+## Why both services
+
+Two containers read `/data`, for different jobs:
+
+| Service    | Reads `/data` for                                                         | Needed when                                     |
+| ---------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
+| `openclaw` | Agent file access, and the directory list shown in the permissions picker | Always                                          |
+| `pinchy`   | Knowledge Base indexing                                                   | You index those documents into a knowledge base |
+
+Mounting in both is the simple path, and it's what we recommend: the paths stay identical, and a directory you later point a [Knowledge Base agent](/guides/create-knowledge-base-agent/) at is already there. A directory mounted only on `openclaw` shows up in the picker and agents can read it, but indexing it finds nothing.
+
 ## Examples
+
+Each example shows the mount line to add. Add the same line to **both** services in your override file.
 
 ### Local folder
 
 Mount a folder from your host machine:
 
 ```yaml
-volumes:
-  - /home/admin/company-docs:/data/company-docs:ro
+- /home/admin/company-docs:/data/company-docs:ro
 ```
 
 ### NAS or network drive
@@ -56,9 +85,8 @@ volumes:
 If your NAS is mounted on the host at `/mnt/nas/shared`, mount a subdirectory:
 
 ```yaml
-volumes:
-  - /mnt/nas/shared/legal:/data/legal:ro
-  - /mnt/nas/shared/finance:/data/finance:ro
+- /mnt/nas/shared/legal:/data/legal:ro
+- /mnt/nas/shared/finance:/data/finance:ro
 ```
 
 ### Multiple directories
@@ -66,10 +94,9 @@ volumes:
 You can mount as many directories as you need:
 
 ```yaml
-volumes:
-  - /srv/docs/hr:/data/hr:ro
-  - /srv/docs/engineering:/data/engineering:ro
-  - /srv/docs/compliance:/data/compliance:ro
+- /srv/docs/hr:/data/hr:ro
+- /srv/docs/engineering:/data/engineering:ro
+- /srv/docs/compliance:/data/compliance:ro
 ```
 
 Each mounted directory appears as a separate selectable option in the Permissions tab when configuring an agent.
@@ -78,17 +105,39 @@ Each mounted directory appears as a separate selectable option in the Permission
 
 When you configure an agent's permissions in the **Permissions tab** of Agent Settings, Pinchy scans `/data/` for subdirectories and displays them as selectable options. Each mounted directory shows up by name — for example, `/data/hr-policies` appears as "hr-policies".
 
+The scan runs when the `openclaw` container starts, so a new mount appears in the picker after `docker compose up -d`, not before.
+
 Only top-level subdirectories of `/data/` are listed. Nested directories within those are accessible to the agent but are not listed separately in the directory picker.
 
 ## Verifying your mounts
 
-To check that your directories are correctly mounted, you can exec into the running container:
+Check the merged configuration before starting anything:
+
+```bash
+docker compose config
+```
+
+Then confirm both containers see your directories:
 
 ```bash
 docker compose exec openclaw ls /data/
 ```
 
-You should see your mounted directories listed.
+```bash
+docker compose exec pinchy ls /data/
+```
+
+Both should list your mounted directories.
+
+## Moving mounts out of `docker-compose.yml`
+
+If you added your mounts to `docker-compose.yml` directly, move them now — before the next upgrade overwrites them:
+
+1. Copy your `- /host/path:/data/name:ro` lines into `docker-compose.override.yml`, under both services as shown above (don't forget the `- pinchy-data:/data` line on `pinchy`).
+2. Delete those lines from `docker-compose.yml`, leaving the rest of the file untouched.
+3. Run `docker compose config` to confirm the merged result still has every mount, then `docker compose up -d`.
+
+Nothing is re-indexed or re-uploaded by this — the mounts point at the same host directories as before, and your knowledge base index lives in Postgres.
 
 ## Supported file types
 

--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -31,7 +31,7 @@ services:
 
   pinchy:
     volumes:
-      # Keep this line first — see the note below.
+      # Required — see the note below.
       - pinchy-data:/data
       - /path/on/host/hr-policies:/data/hr-policies:ro
       - /path/on/host/engineering-docs:/data/engineering-docs:ro
@@ -55,6 +55,14 @@ docker compose up -d
   Re-declaring the same mount without `:ro` makes `/data` writable and the
   nested mounts work. Your own directories stay read-only either way, because
   each one carries its own `:ro`.
+
+What you trade away is one layer of defence in depth: the `pinchy-data` volume
+itself is no longer read-only from the web container. Nothing in Pinchy writes
+to it — the agent runtime already mounts it writable, and user uploads go to a
+different store — but a compromised web tier could. If that trade isn't one
+you want to make, mount your directories on `openclaw` only; agents can still
+read them, you just can't index them into a knowledge base.
+
 </Aside>
 
 ## Why both services

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -214,8 +214,10 @@ Your data is safe across the image swap: it's the same PostgreSQL 17 on the same
 <Aside type="caution">
   **If you edited `docker-compose.yml` to [mount data
   directories](/guides/mount-data-directories/)**, re-apply those `volumes:`
-  lines after re-fetching — the download overwrites them. Keeping custom mounts
-  in a `docker-compose.override.yml` instead makes future upgrades hands-off.
+  lines after re-fetching — the download overwrites them. Better: [move them
+  into a
+  `docker-compose.override.yml`](/guides/mount-data-directories/#moving-mounts-out-of-docker-composeyml)
+  while you're there, and no upgrade touches them again.
 </Aside>
 
 <Aside type="note">

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -133,8 +133,9 @@ curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%
 docker compose up -d
 ```
 
-Re-apply any custom `volumes:` mounts afterwards (or keep them in a
-`docker-compose.override.yml` so upgrades stay hands-off).
+Re-apply any custom `volumes:` mounts afterwards — or better, [move them into a
+`docker-compose.override.yml`](/guides/mount-data-directories/#moving-mounts-out-of-docker-composeyml)
+so no upgrade can overwrite them again.
 
 </Aside>
 


### PR DESCRIPTION
Closes #835

## Problem

The mount guide told operators to add their bind mounts directly to `docker-compose.yml` — the one file every upgrade overwrites. Anyone who followed it silently lost their KB mounts on the next release, which is exactly what v0.9.0's compose re-fetch (db image → pgvector) triggers.

## What changed

The guide now uses `docker-compose.override.yml`, which Compose merges on top of the base file and upgrades never touch.

Two things the old guide got wrong beyond the file it named:

**1. It only showed the `openclaw` service.** The KB ingest pipeline reads `/data` in the `pinchy` (web) container, so a directory mounted only on `openclaw` appears in the permissions picker and agents can read it — but indexing it finds nothing.

**2. Adding a nested `/data/<name>` mount to the `pinchy` service the obvious way does not start.** The base file mounts `pinchy-data:/data` **read-only** there, and Docker cannot create a mount point inside a read-only mount:

```
error mounting ".../hostdocs" to rootfs at "/data/hr": create mountpoint for /data/hr mount:
make mountpoint "/data/hr": mkdirat .../merged/data/hr: read-only file system
```

The override has to re-declare `- pinchy-data:/data` first — the same workaround `docker-compose.dev.yml` already documents for `sample-data`. The guide now carries that as a `caution` Aside with the reason, so it doesn't read as boilerplate to be trimmed.

## Verification

Not derived from the docs — reproduced against Docker:

- Ran the naive two-service override with alpine stand-ins: `openclaw` starts and reads the mount, `pinchy` **fails to start** with the error above.
- Ran the documented override: both containers start, both see `/data/hr/policy.md`, the nested bind stays `:ro`.
- Merged the documented override against the **real** `docker-compose.yml` with `docker compose config`: the `- pinchy-data:/data` entry replaces `read_only: true` on that one mount, every base mount survives, and both services end up with identical `/data` paths.

Also traced who actually reads `/data` in which container, to get the table right: the permissions-picker list comes from `config/start-openclaw.sh`'s scan (openclaw, at startup), agent file access from `pinchy-files` (openclaw), and KB indexing from `packages/web/src/lib/knowledge/ingest.ts` (pinchy).

## Also in this PR

- New section for moving existing mounts out of `docker-compose.yml` (no re-download needed — just delete the lines you added).
- `Recipe 4: Mount your own document directories` in the customizing-deployment guide.
- Fixed the KB guide's claim that `/data` lives in "the Pinchy container" — it's both.
- The `upgrading.mdx` Aside now links straight to the migration section instead of only mentioning override files in passing.

## Gates

- `pnpm dlx prettier@3.9.5 --check` on all four files — clean
- `pnpm -C docs check:tables` — "No indented tables found."
- `pnpm -C docs build` — 66 pages, `Complete!`, version placeholders restored