### PR TITLE
feat(kb): convert page-shaped Office documents to PDF, with a verification chain

### DIFF
--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -132,6 +132,33 @@ LABEL org.opencontainers.image.source="https://github.com/heypinchy/pinchy" \
 ENV COREPACK_HOME=/app/.cache/corepack
 RUN corepack enable
 
+# LibreOffice: the knowledge base converts page-shaped Office documents
+# (.doc/.docx/.ppt/.pptx) to PDF before indexing them (#936, lib/knowledge/
+# office-convert.ts). This is the only toolchain that reads the LEGACY binary
+# formats — 13 of the 19 Office files in the reference corpus are .doc/.ppt,
+# and the entire modern parsing ecosystem (Docling, MarkItDown, Unstructured,
+# python-docx/python-pptx) is OOXML-only. Conversion also produces the single
+# renderable artifact the citation chain needs, so a citation can never point
+# at something the reader cannot open.
+#
+# Measured on node:22-slim (247 MB): writer+impress+fonts-liberation = 669 MB
+# (+422 MB); the full `libreoffice` metapackage would be 772 MB. We install
+# only the two page-shaped filters:
+#   - libreoffice-calc is DELIBERATELY absent. A sheet is not a page, and
+#     spreadsheets take a different path entirely (#937/#940).
+#   - fonts-liberation is not optional. Without a metric-compatible font set
+#     LibreOffice substitutes, re-flows, and can drop glyphs — and the corpus
+#     is full of Central/Eastern European diacritics (GODIČ TORKAR, Domžale).
+#   - catdoc (~1 MB) ships catdoc/catppt, the INDEPENDENT text extractors the
+#     conversion's lower-bound word check compares against for the legacy
+#     formats. An oracle derived from LibreOffice would agree with LibreOffice
+#     about text it dropped and verify nothing.
+# `--no-install-recommends` matters here: the recommends pull in a JRE.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       libreoffice-writer libreoffice-impress fonts-liberation catdoc \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 EXPOSE 7777
@@ -213,7 +240,12 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 # Create non-root user (entrypoint drops privileges after fixing volume permissions)
 RUN groupadd -r -g 999 pinchy && useradd -r -u 999 -g pinchy -d /app pinchy
-RUN mkdir -p /app/secrets /openclaw-config/workspaces && chown -R pinchy:pinchy /app /app/secrets /openclaw-config/workspaces
+# /var/cache/pinchy-kb-artifacts is the converted-Office-PDF store (#936). It
+# is a named volume in docker-compose.yml precisely so nothing is ever written
+# next to the original: /data is mounted read-only and the docs state that as a
+# product promise. Mirrors the openclaw container's pinchy-pdf-cache.
+RUN mkdir -p /app/secrets /openclaw-config/workspaces /var/cache/pinchy-kb-artifacts \
+    && chown -R pinchy:pinchy /app /app/secrets /openclaw-config/workspaces /var/cache/pinchy-kb-artifacts
 
 COPY entrypoint.sh /entrypoint.sh
 # Plugin-source sync helper the entrypoint runs on every boot. Extracted from

--- a/Dockerfile.pinchy.dev
+++ b/Dockerfile.pinchy.dev
@@ -5,6 +5,16 @@ FROM mirror.gcr.io/library/node:22-slim
 
 RUN corepack enable
 
+# Same LibreOffice toolchain as the production image (see Dockerfile.pinchy for
+# why these exact packages). Dev needs it too: without it, indexing an Office
+# document in the dev stack reports every file as "converter did not run"
+# infrastructure failures, which looks nothing like the production behaviour it
+# is supposed to reproduce.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       libreoffice-writer libreoffice-impress fonts-liberation catdoc \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,14 @@ services:
       # land in a separate store), which also keeps the corpus tamper-proof
       # from the web tier.
       - pinchy-data:/data:ro
+      # Converted-Office-PDF artifacts (#936). A separate volume because /data
+      # above is read-only and must stay that way: the converted PDF is what
+      # the index and the preview both point at, and writing it beside the
+      # original would break the corpus's tamper-proof promise. Same shape as
+      # the openclaw container's pinchy-pdf-cache. Safe to delete — every
+      # artifact is re-derivable from its source, keyed by content hash and
+      # converter format version.
+      - pinchy-kb-artifacts:/var/cache/pinchy-kb-artifacts
     restart: unless-stopped
     depends_on:
       db:
@@ -125,6 +133,7 @@ volumes:
   pinchy-secrets:
   openclaw-extensions:
   pinchy-pdf-cache:
+  pinchy-kb-artifacts:
   openclaw-secrets:
     driver: local
     driver_opts:

--- a/docs/src/content/docs/guides/customizing-deployment.mdx
+++ b/docs/src/content/docs/guides/customizing-deployment.mdx
@@ -129,6 +129,35 @@ DB_CPUS=0.5
   raise the limit before assuming something else is wrong.
 </Aside>
 
+### Memory when the knowledge base indexes Office documents
+
+Word and PowerPoint files take a detour on their way into the knowledge base: Pinchy converts them to PDF first, with LibreOffice running inside the `pinchy` container. That's what lets it read the legacy `.doc` and `.ppt` formats at all — no modern parsing library can — and it gives every citation one rendered document that the index and the preview agree on.
+
+Two things about that are worth knowing when you size the container.
+
+**LibreOffice is not a daemon.** It starts, converts a batch of documents, and exits. The memory it needs is transient: nothing stays resident between reindexes, and a deployment that never indexes an Office document never pays for it.
+
+**It shares the container with the embedding model.** The knowledge base embeds in-process, so during a reindex the same container holds a ~300 MB model that is _actively working_ while the converter runs. We measured that overlap directly — 17 Word documents converting while the embedder kept embedding, at several ceilings:
+
+| `PINCHY_MEM_LIMIT` | Result                                              |
+| ------------------ | --------------------------------------------------- |
+| `1g` (default)     | All 17 converted — the default has room to spare    |
+| `768m`             | All 17 converted, ~20 % slower                      |
+| `640m`             | All 17 converted, ~70 % slower                      |
+| `512m`             | **Out of memory.** The container was killed mid-run |
+
+So the **default `1g` is enough**, and the 4 GB VPS tuning above (`768m`) still works — but `512m` is below the floor once Office documents are in the corpus. Going the other way pays off in time rather than reliability: the converter is the one part of Pinchy that gets meaningfully faster with more memory, so `2g` is worth it for a large first-time index.
+
+<Aside type="tip">
+  If the container does run out of memory mid-conversion, Pinchy tells the two
+  cases apart: a document LibreOffice genuinely can't read is a permanent
+  failure for that one document, while an out-of-memory kill is treated as
+  retryable and left for the next reindex. A memory squeeze never brands good
+  documents as broken.
+</Aside>
+
+Converted PDFs live on their own volume, `pinchy-kb-artifacts`. Your source documents are never touched — `/data` stays read-only. The volume is a cache: every artifact is re-derivable from its source, so deleting it costs a reindex and nothing else.
+
 ### Health checks
 
 `db` and `pinchy` each have a Docker health check: `db` polls `pg_isready`, and `pinchy` polls its own `/api/internal/openclaw-config-ready` endpoint. `openclaw` has a lightweight **TCP liveness check** — a raw connect to the gateway's WebSocket port (`18789`) that succeeds as soon as the gateway is accepting connections. It doesn't inspect the gateway's internal state, only that something is listening; OpenClaw's own start script already respawns the gateway process if it dies internally, so this check exists to surface a fully stuck container (process alive, port not listening). Note that Compose does **not** restart a container just because it is `unhealthy` — `restart:` policies act on container _exit_, not health status. The check is diagnostic: a stuck container shows as `unhealthy` in `docker compose ps` so you can spot it and restart it yourself, rather than it silently sitting "up" but unreachable.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,12 @@ fi
 # it can enter the directory and rename files atomically.
 chown pinchy:pinchy /openclaw-secrets 2>/dev/null || true
 
+# Converted-Office-PDF artifact store (#936). Docker creates a fresh named
+# volume owned by root, so the unprivileged pinchy user could not write it —
+# and every Office document would fail conversion with EACCES, which reads like
+# a broken corpus rather than a permissions problem.
+chown -R pinchy:pinchy /var/cache/pinchy-kb-artifacts 2>/dev/null || true
+
 # Refresh plugin SOURCE in the shared openclaw-extensions volume on every
 # startup (the named volume is only seeded from the image on first creation;
 # upgrades otherwise keep stale content from the previous image). The sync

--- a/packages/web/src/__tests__/lib/knowledge/office-artifacts.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/office-artifacts.test.ts
@@ -1,0 +1,147 @@
+/**
+ * OfficeArtifactStore: the on-disk home of converted Office PDFs.
+ *
+ * The two properties worth a test are the ones a wrong answer makes invisible:
+ * a bumped format_version must invalidate EVERYTHING (otherwise improving the
+ * converter silently keeps serving the old output forever), and nothing may
+ * ever be written next to the original (`/data` is mounted read-only and the
+ * docs state that as a product promise).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { readdir, stat, utimes } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { OfficeArtifactStore } from "@/lib/knowledge/office-artifacts";
+
+let tmpRoot: string;
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-kb-artifacts-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/** Writes a stand-in "converted PDF" the store can take ownership of. */
+function stagedPdf(name: string, body = "%PDF-1.4 stand-in"): string {
+  const path = join(tmpRoot, name);
+  writeFileSync(path, body);
+  return path;
+}
+
+describe("OfficeArtifactStore", () => {
+  it("stores an artifact and returns it for the same content hash", async () => {
+    const store = new OfficeArtifactStore(join(tmpRoot, "store"));
+
+    expect(await store.get(HASH_A)).toBeNull();
+
+    const stored = await store.put(HASH_A, stagedPdf("staged.pdf", "%PDF-1.4 first"));
+
+    expect(await store.get(HASH_A)).toBe(stored);
+    expect(readFileSync(stored, "utf8")).toBe("%PDF-1.4 first");
+    // The staged file was MOVED, not copied: nothing accumulates in the
+    // caller's temp dir.
+    expect(existsSync(join(tmpRoot, "staged.pdf"))).toBe(false);
+  });
+
+  it("never returns one document's artifact for another document's content", async () => {
+    const store = new OfficeArtifactStore(join(tmpRoot, "store"));
+    await store.put(HASH_A, stagedPdf("a.pdf"));
+
+    expect(await store.get(HASH_B)).toBeNull();
+  });
+
+  it("invalidates every stored artifact when the format version is bumped", async () => {
+    const root = join(tmpRoot, "store");
+    const v1 = new OfficeArtifactStore(root, { formatVersion: 1 });
+    await v1.put(HASH_A, stagedPdf("a.pdf"));
+    expect(await v1.get(HASH_A)).not.toBeNull();
+
+    // Same root, same content, improved converter.
+    const v2 = new OfficeArtifactStore(root, { formatVersion: 2 });
+    expect(await v2.get(HASH_A)).toBeNull();
+
+    // ...and the two versions coexist rather than clobbering each other, so a
+    // rollback to the previous image still finds its own artifacts.
+    await v2.put(HASH_A, stagedPdf("a2.pdf", "%PDF-1.4 improved"));
+    expect(readFileSync((await v1.get(HASH_A))!, "utf8")).toBe("%PDF-1.4 stand-in");
+    expect(readFileSync((await v2.get(HASH_A))!, "utf8")).toBe("%PDF-1.4 improved");
+  });
+
+  it("keeps every artifact inside its own root, never beside the original", async () => {
+    const corpus = join(tmpRoot, "data");
+    const root = join(tmpRoot, "store");
+    const store = new OfficeArtifactStore(root);
+
+    const stored = await store.put(HASH_A, stagedPdf("a.pdf"));
+
+    expect(stored.startsWith(root + "/")).toBe(true);
+    expect(existsSync(corpus)).toBe(false);
+  });
+
+  it("replaces an existing artifact for the same key instead of failing", async () => {
+    const store = new OfficeArtifactStore(join(tmpRoot, "store"));
+    await store.put(HASH_A, stagedPdf("a.pdf", "%PDF-1.4 old"));
+
+    const stored = await store.put(HASH_A, stagedPdf("a2.pdf", "%PDF-1.4 new"));
+
+    expect(readFileSync(stored, "utf8")).toBe("%PDF-1.4 new");
+  });
+
+  describe("sweep", () => {
+    it("deletes artifacts untouched for longer than the max age, keeping fresh ones", async () => {
+      const store = new OfficeArtifactStore(join(tmpRoot, "store"));
+      const stale = await store.put(HASH_A, stagedPdf("a.pdf"));
+      const fresh = await store.put(HASH_B, stagedPdf("b.pdf"));
+
+      const longAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      await utimes(stale, longAgo, longAgo);
+
+      const removed = await store.sweep(7 * 24 * 60 * 60 * 1000);
+
+      expect(removed).toBe(1);
+      expect(existsSync(stale)).toBe(false);
+      expect(existsSync(fresh)).toBe(true);
+    });
+
+    it("keeps an artifact a reindex just used, even when it was converted long ago", async () => {
+      const store = new OfficeArtifactStore(join(tmpRoot, "store"));
+      const path = await store.put(HASH_A, stagedPdf("a.pdf"));
+      const longAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      await utimes(path, longAgo, longAgo);
+
+      // A cache hit is what "still in use" looks like: the corpus file has not
+      // changed, so it is never re-converted and its mtime would otherwise age
+      // out an artifact that every reindex depends on.
+      expect(await store.get(HASH_A)).toBe(path);
+
+      expect(await store.sweep(7 * 24 * 60 * 60 * 1000)).toBe(0);
+      expect(existsSync(path)).toBe(true);
+      expect((await stat(path)).mtimeMs).toBeGreaterThan(longAgo.getTime());
+    });
+
+    it("is a no-op on a store that was never written to", async () => {
+      const store = new OfficeArtifactStore(join(tmpRoot, "never-used"));
+      expect(await store.sweep(1000)).toBe(0);
+    });
+
+    it("removes the artifacts of superseded format versions wholesale", async () => {
+      const root = join(tmpRoot, "store");
+      const v1 = new OfficeArtifactStore(root, { formatVersion: 1 });
+      await v1.put(HASH_A, stagedPdf("a.pdf"));
+
+      const v2 = new OfficeArtifactStore(root, { formatVersion: 2 });
+      const removed = await v2.pruneOtherFormatVersions();
+
+      expect(removed).toBe(1);
+      expect(await v1.get(HASH_A)).toBeNull();
+      expect(await readdir(root)).toEqual(["v2"]);
+    });
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/office-convert.adapter.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/office-convert.adapter.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The production adapters, driven against STUB binaries.
+ *
+ * office-convert.test.ts fakes the subprocess entirely and proves what the
+ * module concludes; office-convert.libreoffice.test.ts drives the real
+ * LibreOffice but is gated on a 422 MB package almost no machine has, so it
+ * never runs in CI. That left `runSoffice` itself — the argv, the private
+ * profile, what the child inherits, and what a timeout actually kills —
+ * covered nowhere a pull request can see.
+ *
+ * A stub closes that gap: everything here is about how we SPAWN, which needs a
+ * process, not LibreOffice. It runs on every PR.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { runSoffice, runTextOracle } from "@/lib/knowledge/office-convert";
+
+let tmpRoot: string;
+let outDir: string;
+let profileDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-kb-adapter-test-"));
+  outDir = join(tmpRoot, "out");
+  profileDir = join(tmpRoot, "profile");
+  process.env.KB_SOFFICE_BIN = stub("soffice-noop", "exit 0\n");
+});
+
+afterEach(() => {
+  delete process.env.KB_SOFFICE_BIN;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * Writes an executable stand-in and returns its path. The script gets no
+ * arguments and no environment from us on purpose: anything it needs to know
+ * (like where to record what it saw) is baked into its text, so the recording
+ * still works when we assert that the child's environment was stripped.
+ */
+function stub(name: string, body: string): string {
+  const path = join(tmpRoot, name);
+  writeFileSync(path, `#!/bin/sh\n${body}`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function run(overrides: Partial<Parameters<typeof runSoffice>[0]> = {}) {
+  return runSoffice({ inputs: [], outDir, profileDir, timeoutMs: 10_000, ...overrides });
+}
+
+describe("runSoffice", () => {
+  it("asks for a PDF, into our outdir, with a private profile", async () => {
+    const record = join(tmpRoot, "argv");
+    process.env.KB_SOFFICE_BIN = stub("soffice-argv", `printf '%s\\n' "$@" > ${record}\n`);
+
+    await run({ inputs: [join(tmpRoot, "0.doc"), join(tmpRoot, "1.pptx")] });
+
+    const argv = (await readFile(record, "utf8")).trim().split("\n");
+    expect(argv).toContain("--headless");
+    expect(argv).toContain("--convert-to");
+    expect(argv[argv.indexOf("--convert-to") + 1]).toBe("pdf");
+    expect(argv[argv.indexOf("--outdir") + 1]).toBe(outDir);
+    // A private user installation, or a second converter run (a concurrent
+    // reindex, a leftover process) silently reuses the first one's state.
+    expect(argv).toContain(`-env:UserInstallation=file://${profileDir}`);
+    // The inputs come last, in order — that is what makes `<index>.pdf` in the
+    // outdir attributable back to a source.
+    expect(argv.slice(-2)).toEqual([join(tmpRoot, "0.doc"), join(tmpRoot, "1.pptx")]);
+  });
+
+  it("hands the converter a minimal environment, not the server's secrets", async () => {
+    // LibreOffice parses attacker-supplied legacy binary formats — a format
+    // family with a long history of memory-safety bugs. It has no business
+    // holding the database URL or the key that encrypts provider credentials,
+    // so the child gets an allow-list rather than a copy of process.env.
+    // Verified against the real binary: PATH + HOME is enough to convert, with
+    // Central/Eastern European diacritics intact.
+    const record = join(tmpRoot, "env");
+    process.env.KB_SOFFICE_BIN = stub("soffice-env", `env > ${record}\n`);
+    process.env.ENCRYPTION_KEY = "test-encryption-key";
+    process.env.DATABASE_URL = "postgresql://pinchy:hunter2@db:5432/pinchy";
+
+    try {
+      await run();
+    } finally {
+      delete process.env.ENCRYPTION_KEY;
+      delete process.env.DATABASE_URL;
+    }
+
+    const env = Object.fromEntries(
+      (await readFile(record, "utf8"))
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => [line.slice(0, line.indexOf("=")), line.slice(line.indexOf("=") + 1)])
+    );
+    expect(env.ENCRYPTION_KEY).toBeUndefined();
+    expect(env.DATABASE_URL).toBeUndefined();
+    expect(env.PATH).toBeTruthy();
+    // HOME must match the private profile: LibreOffice writes into $HOME too,
+    // and pointing it anywhere else puts state outside the staging directory.
+    expect(env.HOME).toBe(profileDir);
+  });
+
+  it("reports the exit code a container OOM kill produces", async () => {
+    process.env.KB_SOFFICE_BIN = stub("soffice-oom", "exit 137\n");
+
+    expect(await run()).toMatchObject({ code: 137 });
+  });
+
+  it("keeps only a bounded amount of the converter's stderr", async () => {
+    // LibreOffice repeats itself per file; a large batch must not build a
+    // multi-megabyte string inside the web process.
+    process.env.KB_SOFFICE_BIN = stub(
+      "soffice-loud",
+      "i=0; while [ $i -lt 400 ]; do i=$((i+1)); " +
+        'printf "Error: source file could not be loaded padding padding padding padding\\n" >&2; ' +
+        "done\n"
+    );
+
+    const result = await run();
+
+    expect(result.stderr.length).toBeLessThan(64 * 1024);
+    expect(result.stderr).toContain("could not be loaded");
+  });
+
+  it("rejects rather than resolving when the binary is missing", async () => {
+    process.env.KB_SOFFICE_BIN = join(tmpRoot, "not-installed");
+
+    // The caller turns this into `infrastructure`: a missing converter says
+    // nothing about the documents.
+    await expect(run()).rejects.toThrow();
+  });
+
+  describe("timeout", () => {
+    it("kills the converter's whole process tree, not just the process we spawned", async () => {
+      // Verified against the real binary: `soffice` execs `oosplash`, which
+      // FORKS `soffice.bin`. Killing the process we spawned leaves the real
+      // converter running — still holding the memory the timeout was meant to
+      // reclaim, still writing into a staging directory we are about to
+      // delete. Under memory pressure that turns one timeout into a cascade,
+      // because the orphan is still resident when the next batch starts.
+      const pidFile = join(tmpRoot, "grandchild.pid");
+      process.env.KB_SOFFICE_BIN = stub(
+        "soffice-forks",
+        `sleep 30 &\nprintf '%s' "$!" > ${pidFile}\nwait\n`
+      );
+
+      // Long enough that a loaded machine has certainly reached the fork —
+      // a tighter budget races the scheduler, not the code under test.
+      const result = await run({ timeoutMs: 2_000 });
+
+      expect(result.timedOut).toBe(true);
+      const grandchild = Number(await readFile(pidFile, "utf8"));
+      expect(grandchild).toBeGreaterThan(0);
+      expect(await isGone(grandchild)).toBe(true);
+    }, 15_000);
+
+    it("does not fire for a converter that finishes in time", async () => {
+      process.env.KB_SOFFICE_BIN = stub("soffice-quick", "exit 0\n");
+
+      expect(await run({ timeoutMs: 10_000 })).toMatchObject({ timedOut: false, code: 0 });
+    });
+  });
+});
+
+describe("runTextOracle", () => {
+  it("counts the words the extractor printed", async () => {
+    const bin = stub("oracle-ok", "printf 'one two three\\n'\n");
+
+    expect(await runTextOracle(bin, "/data/a.doc")).toBe(3);
+  });
+
+  it("answers null for a missing binary, rather than failing the document", async () => {
+    // Local dev has no catdoc. A missing oracle removes the tripwire for one
+    // file; it must never be mistaken for a conversion problem.
+    expect(await runTextOracle(join(tmpRoot, "not-installed"), "/data/a.doc")).toBeNull();
+  });
+
+  it("answers null when the extractor exits non-zero", async () => {
+    const bin = stub("oracle-angry", "printf 'partial\\n'\nexit 2\n");
+
+    expect(await runTextOracle(bin, "/data/a.doc")).toBeNull();
+  });
+
+  it("stops reading a runaway extractor instead of buffering it all", async () => {
+    // catdoc parses the same hostile legacy binaries LibreOffice does. A
+    // document that makes it emit without end must not take the web process
+    // down with it — the word count is a tripwire, not a reason to hold
+    // hundreds of megabytes of a string.
+    const bin = stub(
+      "oracle-runaway",
+      "while true; do printf 'word word word word word word word word\\n'; done\n"
+    );
+
+    const words = await runTextOracle(bin, "/data/a.doc");
+
+    expect(words).toBeNull();
+  }, 20_000);
+});
+
+/** Polls until `pid` is gone (or gives up), because a SIGKILL is not instant. */
+async function isGone(pid: number): Promise<boolean> {
+  for (let i = 0; i < 100; i++) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}

--- a/packages/web/src/__tests__/lib/knowledge/office-convert.libreoffice.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/office-convert.libreoffice.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The other half of office-convert's coverage: office-convert.test.ts proves
+ * what the module CONCLUDES from a converter run, with the subprocess faked.
+ * This file proves the production adapter actually drives the real binary —
+ * the argv, the private-profile flag, the staging symlinks, and the
+ * "exit 0 + no artifact" detector against a genuinely unloadable input.
+ *
+ * Those are different questions, and only the second one catches a wrong flag.
+ *
+ * Gated with describe.skipIf on the presence of `soffice` (an allowed env/OS
+ * conditional gate per AGENTS.md, not an untracked skip): LibreOffice is a
+ * 422 MB image layer that exists in the Pinchy runtime image and on almost no
+ * developer laptop. To run it:
+ *
+ *   docker run --rm -v "$PWD/packages/web/src:/app/packages/web/src:ro" \
+ *     ghcr.io/heypinchy/pinchy:dev sh -c \
+ *     'apt-get update && apt-get install -y --no-install-recommends \
+ *        libreoffice-writer fonts-liberation catdoc && cd /app/packages/web && \
+ *      node_modules/.bin/vitest run src/__tests__/lib/knowledge/office-convert.libreoffice.test.ts'
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { convertOfficeFiles } from "@/lib/knowledge/office-convert";
+import { OfficeArtifactStore } from "@/lib/knowledge/office-artifacts";
+import { extractPdfPages } from "@/lib/knowledge/pdf-extract";
+
+const SOFFICE = process.env.KB_SOFFICE_BIN || "soffice";
+const hasSoffice = spawnSync(SOFFICE, ["--version"], { stdio: "ignore" }).status === 0;
+
+// Central/Eastern European diacritics on purpose: they are what the customer
+// corpus is full of, and they are exactly what a font-starved image or a
+// mangling extractor destroys.
+const SOURCE_TEXT =
+  "GODIČ TORKAR und Domžale prüfen die Maßnahmen.\n" +
+  "The quick brown fox jumps over the lazy dog, twice over.\n" +
+  "A third line so the word count is not trivially small.\n";
+
+describe.skipIf(!hasSoffice)("convertOfficeFiles against a real LibreOffice", () => {
+  let tmpRoot: string;
+  let corpusDir: string;
+
+  /** Builds a real Office file out of plain text — a DIFFERENT soffice invocation than the one under test. */
+  function buildFixture(filter: string, name: string): string {
+    const out = spawnSync(
+      SOFFICE,
+      [
+        "--headless",
+        "--norestore",
+        `-env:UserInstallation=file://${join(tmpRoot, "fixture-profile")}`,
+        "--convert-to",
+        filter,
+        "--outdir",
+        corpusDir,
+        join(tmpRoot, "source.txt"),
+      ],
+      { encoding: "utf8" }
+    );
+    expect(out.status, out.stderr).toBe(0);
+    return join(corpusDir, name);
+  }
+
+  beforeAll(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-kb-soffice-"));
+    corpusDir = join(tmpRoot, "data");
+    await writeFile(join(tmpRoot, "source.txt"), SOURCE_TEXT);
+  }, 120_000);
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("converts legacy and modern Word in one process, and reports an unloadable file as document-level", async () => {
+    const legacy = buildFixture("doc:MS Word 97", "source.doc");
+    const modern = buildFixture("docx", "source.docx");
+
+    // A truncated OOXML archive: this is the input that makes LibreOffice
+    // print "Error: source file could not be loaded", exit **0**, and write
+    // nothing — while the other two files in the same batch convert.
+    const broken = join(corpusDir, "broken.docx");
+    await writeFile(broken, (await readFile(modern)).subarray(0, 200));
+
+    const store = new OfficeArtifactStore(join(tmpRoot, "artifacts"));
+    const outcomes = await convertOfficeFiles(
+      [{ absPath: legacy }, { absPath: modern }, { absPath: broken }],
+      { store }
+    );
+
+    expect(outcomes.map((o) => o.status)).toEqual(["converted", "converted", "failed"]);
+
+    // `failed`, not `infrastructure`: nothing about this document will
+    // convert on a retry, so it belongs on the unreadable list (#935).
+    expect(outcomes[2].artifactPath).toBeUndefined();
+
+    for (const outcome of outcomes.slice(0, 2)) {
+      expect(outcome.artifactPath!.startsWith(join(tmpRoot, "artifacts"))).toBe(true);
+      const text = (await extractPdfPages(outcome.artifactPath!))
+        .map((page) => page.text)
+        .join(" ");
+      // Round-trip through the real renderer AND the real text layer: the
+      // diacritics survive, so fonts-liberation covers the corpus.
+      expect(text).toContain("GODIČ TORKAR");
+      expect(text).toContain("Domžale");
+      expect(text).toContain("Maßnahmen");
+      expect(outcome.verification!.pdfWords).toBeGreaterThanOrEqual(20);
+    }
+
+    // .docx has an oracle in the image (mammoth); .doc only has one when
+    // catdoc is installed. Either way the check must not have fired.
+    expect(outcomes[1].verification!.status).toBe("ok");
+    expect(["ok", "unverified"]).toContain(outcomes[0].verification!.status);
+
+    // Nothing was written beside the originals.
+    expect(
+      spawnSync("ls", [corpusDir], { encoding: "utf8" }).stdout.trim().split("\n").sort()
+    ).toEqual(["broken.docx", "source.doc", "source.docx"]);
+  }, 180_000);
+
+  it("serves the stored artifact on the second run without touching LibreOffice again", async () => {
+    const source = buildFixture("doc:MS Word 97", "source.doc");
+    const store = new OfficeArtifactStore(join(tmpRoot, "artifacts-2"));
+
+    const first = await convertOfficeFiles([{ absPath: source }], { store });
+    const second = await convertOfficeFiles([{ absPath: source }], {
+      store,
+      // A converter that would fail loudly if it were ever called: the
+      // second run must be answered from the store alone.
+      runConverter: async () => {
+        throw new Error("converter must not run for content already in the store");
+      },
+    });
+
+    expect(first[0].status).toBe("converted");
+    expect(second[0].artifactPath).toBe(first[0].artifactPath);
+    expect(second[0].verification!.status).toBe("cached");
+  }, 180_000);
+});

--- a/packages/web/src/__tests__/lib/knowledge/office-convert.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/office-convert.test.ts
@@ -292,6 +292,54 @@ describe("convertOfficeFiles", () => {
       expect(converter.calls).toHaveLength(1);
     });
 
+    it("quotes the converter's ERROR, not the warning it prints on every run", async () => {
+      // The runtime image has no JRE (the recommends that would pull one in are
+      // suppressed on purpose), so every single batch prints
+      // "Warning: failed to launch javaldx" as its FIRST stderr line. Taking
+      // the first non-empty line therefore attaches a benign, permanent
+      // warning to every document-level failure — sending an operator after a
+      // Java problem that does not exist, and hiding the one line that says
+      // what actually happened. Verified verbatim against the real binary.
+      const sources = [await corpusFile("broken.docx", "truncated zip")];
+      const converter: FakeConverter = {
+        calls: [],
+        run: async (call) => {
+          converter.calls.push(call);
+          return {
+            code: 0,
+            signal: null,
+            stderr:
+              "Warning: failed to launch javaldx - java may not function correctly\n" +
+              "Error: source file could not be loaded\n",
+          };
+        },
+      };
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(outcomes[0].status).toBe("failed");
+      expect(outcomes[0].reason).toContain("source file could not be loaded");
+      expect(outcomes[0].reason).not.toContain("javaldx");
+    });
+
+    it("does not invent a cause when the converter said nothing at all", async () => {
+      const sources = [await corpusFile("broken.docx", "truncated zip")];
+      const converter = fakeConverter({ outputs: { "broken.docx": null } });
+      // fakeConverter writes the real error line; blank it to model a silent run.
+      const silent: FakeConverter = {
+        calls: converter.calls,
+        run: async (call) => {
+          await converter.run(call);
+          return { code: 0, signal: null, stderr: "" };
+        },
+      };
+
+      const outcomes = await convertOfficeFiles(sources, deps(silent));
+
+      expect(outcomes[0].status).toBe("failed");
+      expect(outcomes[0].reason).toMatch(/no artifact/i);
+    });
+
     it("reports an empty artifact as a document-level failure", async () => {
       const sources = [await corpusFile("a.doc", "x")];
       const converter: FakeConverter = {
@@ -306,6 +354,56 @@ describe("convertOfficeFiles", () => {
       const outcomes = await convertOfficeFiles(sources, deps(converter));
 
       expect(outcomes[0].status).toBe("failed");
+    });
+  });
+
+  describe("a failing artifact store is infrastructure, not a verdict", () => {
+    // The whole point of the failed/infrastructure split is that a squeeze on
+    // the machine must never brand documents unreadable. A full or unwritable
+    // artifact volume is exactly such a squeeze — so it has to arrive as an
+    // outcome the caller can retry, not as an exception that aborts the run and
+    // throws away every batch that already succeeded.
+
+    it("keeps the outcomes of earlier batches when the store stops accepting artifacts", async () => {
+      const sources = await Promise.all(
+        Array.from({ length: 4 }, (_, i) => corpusFile(`f${i}.doc`, `body ${i}`))
+      );
+      const outputs = Object.fromEntries(sources.map((s, i) => [`f${i}.doc`, `body ${i}`]));
+      const store = new OfficeArtifactStore(storeDir);
+      let stored = 0;
+      store.put = async () => {
+        if (++stored > 2) throw Object.assign(new Error("ENOSPC: no space left on device"), {});
+        return join(storeDir, `artifact-${stored}.pdf`);
+      };
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(fakeConverter({ outputs }), { store, batchSize: 2 })
+      );
+
+      expect(outcomes.map((o) => o.status)).toEqual([
+        "converted",
+        "converted",
+        "infrastructure",
+        "infrastructure",
+      ]);
+      expect(outcomes[2].reason).toMatch(/store/i);
+    });
+
+    it("reports the whole batch as infrastructure when staging cannot be created", async () => {
+      const sources = [await corpusFile("a.doc", "alpha"), await corpusFile("b.doc", "bravo")];
+      const store = new OfficeArtifactStore(storeDir);
+      store.createStagingDir = async () => {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      };
+      const converter = fakeConverter({ outputs: {} });
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter, { store }));
+
+      expect(outcomes.map((o) => o.status)).toEqual(["infrastructure", "infrastructure"]);
+      // Nothing about the documents was learned, so the converter must not
+      // even have been asked.
+      expect(converter.calls).toHaveLength(0);
     });
   });
 

--- a/packages/web/src/__tests__/lib/knowledge/office-convert.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/office-convert.test.ts
@@ -1,0 +1,580 @@
+/**
+ * convertOfficeFiles: LibreOffice batch conversion + the verification chain.
+ *
+ * The converter subprocess is dependency-injected, for the same reason
+ * ingest.ts injects its embedder: LibreOffice is a 422 MB image layer that
+ * exists only in the container, and the behaviour worth testing is not "does
+ * soffice work" but what this module concludes from what soffice did. The
+ * fake's behaviour is not invented — it reproduces what a real
+ * `libreoffice-writer` in the runtime image actually does, verified by probing
+ * it directly:
+ *
+ *   - the output PDF is named after the file we hand it (so index-named
+ *     staging symlinks give index-named outputs),
+ *   - an input it cannot load prints "Error: source file could not be loaded"
+ *     on stderr, exits **0**, and simply writes no artifact — while every
+ *     other file in the same batch still converts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  batchTimeoutMs,
+  convertOfficeFiles,
+  isOfficeFile,
+  OFFICE_EXTENSIONS,
+  OFFICE_VERIFY_EPSILON,
+  type ConverterRun,
+  type ConvertOptions,
+  type OfficeSource,
+  type RunConverter,
+} from "@/lib/knowledge/office-convert";
+import { OfficeArtifactStore } from "@/lib/knowledge/office-artifacts";
+
+let tmpRoot: string;
+let corpusDir: string;
+let storeDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-kb-office-test-"));
+  corpusDir = join(tmpRoot, "data");
+  storeDir = join(tmpRoot, "artifacts");
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/** Writes a corpus file (under the read-only-in-production `/data` stand-in). */
+async function corpusFile(relPath: string, body: string): Promise<OfficeSource> {
+  const absPath = join(corpusDir, relPath);
+  await mkdir(dirname(absPath), { recursive: true });
+  await writeFile(absPath, body);
+  return { absPath };
+}
+
+interface FakeConverterOptions {
+  /**
+   * Source basename -> the text its converted PDF carries. A source mapped to
+   * `null` is one LibreOffice cannot load: no artifact, no non-zero exit.
+   */
+  outputs: Record<string, string | null>;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  /** Throws instead of running — how a missing `soffice` binary surfaces. */
+  spawnError?: Error;
+}
+
+interface FakeConverter {
+  run: RunConverter;
+  calls: ConverterRun[];
+}
+
+/**
+ * A converter that resolves each staged input back to its real source (which
+ * also proves the staging symlink points where we think it does) and writes
+ * `<staged basename>.pdf` for the sources it can load.
+ */
+function fakeConverter(options: FakeConverterOptions): FakeConverter {
+  const calls: ConverterRun[] = [];
+  const run: RunConverter = async (call) => {
+    calls.push(call);
+    if (options.spawnError) throw options.spawnError;
+
+    let stderr = "";
+    for (const staged of call.inputs) {
+      const source = basename(await realpath(staged));
+      const text = options.outputs[source];
+      if (text == null) {
+        stderr += "Error: source file could not be loaded\n";
+        continue;
+      }
+      const outName = basename(staged, extname(staged)) + ".pdf";
+      await writeFile(join(call.outDir, outName), `%PDF-1.4\n${text}\n`);
+    }
+    return { code: options.exitCode ?? 0, signal: options.signal ?? null, stderr };
+  };
+  return { run, calls };
+}
+
+/** Reads back the stand-in PDF the fake converter wrote and counts its words. */
+async function fakeCountPdfWords(absPath: string): Promise<number> {
+  const body = await readFile(absPath, "utf8");
+  return body.replace("%PDF-1.4", "").trim().split(/\s+/).filter(Boolean).length;
+}
+
+/** Everything the module needs except the store, wired to a scripted converter. */
+function deps(converter: FakeConverter, extra: Partial<ConvertOptions> = {}): ConvertOptions {
+  return {
+    store: new OfficeArtifactStore(storeDir),
+    runConverter: converter.run,
+    countPdfWords: fakeCountPdfWords,
+    // Default: no independent extractor for this format (the honest answer for
+    // legacy binaries when catdoc is absent). Tests that exercise the tripwire
+    // override it.
+    countSourceWords: async () => null,
+    ...extra,
+  };
+}
+
+describe("isOfficeFile", () => {
+  it("recognises the page-shaped Office formats, modern and legacy", () => {
+    expect(OFFICE_EXTENSIONS).toEqual([".doc", ".docx", ".ppt", ".pptx"]);
+    for (const ext of OFFICE_EXTENSIONS) {
+      expect(isOfficeFile(`/data/report${ext}`)).toBe(true);
+      expect(isOfficeFile(`/data/report${ext.toUpperCase()}`)).toBe(true);
+    }
+  });
+
+  it("does not claim spreadsheets — those take a different path (#937/#940)", () => {
+    expect(isOfficeFile("/data/budget.xlsx")).toBe(false);
+    expect(isOfficeFile("/data/budget.xls")).toBe(false);
+    expect(isOfficeFile("/data/report.pdf")).toBe(false);
+  });
+});
+
+describe("convertOfficeFiles", () => {
+  it("converts every format to a PDF in the artifact store", async () => {
+    const sources = [
+      await corpusFile("a.doc", "legacy word"),
+      await corpusFile("b.docx", "modern word"),
+      await corpusFile("c.ppt", "legacy slides"),
+      await corpusFile("d.pptx", "modern slides"),
+    ];
+    const converter = fakeConverter({
+      outputs: { "a.doc": "one two", "b.docx": "one two", "c.ppt": "one two", "d.pptx": "one two" },
+    });
+
+    const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+    expect(outcomes.map((o) => o.status)).toEqual([
+      "converted",
+      "converted",
+      "converted",
+      "converted",
+    ]);
+    // Results come back in input order so a caller can zip them with its queue.
+    expect(outcomes.map((o) => o.sourcePath)).toEqual(sources.map((s) => s.absPath));
+    for (const outcome of outcomes) {
+      expect(outcome.artifactPath!.startsWith(storeDir + "/")).toBe(true);
+      expect(await readFile(outcome.artifactPath!, "utf8")).toContain("one two");
+    }
+  });
+
+  it("uses ONE converter process for the whole batch, not one per file", async () => {
+    const sources = await Promise.all(
+      Array.from({ length: 6 }, (_, i) => corpusFile(`f${i}.doc`, `body ${i}`))
+    );
+    const outputs = Object.fromEntries(sources.map((s, i) => [`f${i}.doc`, `body ${i}`]));
+    const converter = fakeConverter({ outputs });
+
+    await convertOfficeFiles(sources, deps(converter));
+
+    // Process startup dominates: 17 real corpus files took 14.2 s in one
+    // process vs 25.6 s one-per-file.
+    expect(converter.calls).toHaveLength(1);
+    expect(converter.calls[0].inputs).toHaveLength(6);
+  });
+
+  it("splits into bounded batches so one OOM kill cannot cost the whole corpus", async () => {
+    const sources = await Promise.all(
+      Array.from({ length: 5 }, (_, i) => corpusFile(`f${i}.doc`, `body ${i}`))
+    );
+    const outputs = Object.fromEntries(sources.map((s, i) => [`f${i}.doc`, `body ${i}`]));
+    const converter = fakeConverter({ outputs });
+
+    const outcomes = await convertOfficeFiles(sources, deps(converter, { batchSize: 2 }));
+
+    expect(converter.calls.map((c) => c.inputs.length)).toEqual([2, 2, 1]);
+    expect(outcomes.every((o) => o.status === "converted")).toBe(true);
+  });
+
+  it("keeps documents apart when two directories hold the same file name", async () => {
+    // A real corpus is full of `Rechnung.doc`. LibreOffice derives the output
+    // name from the input's basename, so unstaged inputs would overwrite each
+    // other in the shared outdir and one document would be served the other's
+    // content — a citation pointing at the wrong text.
+    const sources = [
+      await corpusFile("sub-a/Rechnung.doc", "invoice A"),
+      await corpusFile("sub-b/Rechnung.doc", "invoice B"),
+    ];
+    const converter: FakeConverter = {
+      calls: [],
+      run: async (call) => {
+        converter.calls.push(call);
+        for (const staged of call.inputs) {
+          const body = await readFile(await realpath(staged), "utf8");
+          await writeFile(
+            join(call.outDir, basename(staged, extname(staged)) + ".pdf"),
+            `%PDF-1.4\n${body}\n`
+          );
+        }
+        return { code: 0, signal: null, stderr: "" };
+      },
+    };
+
+    const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+    expect(await readFile(outcomes[0].artifactPath!, "utf8")).toContain("invoice A");
+    expect(await readFile(outcomes[1].artifactPath!, "utf8")).toContain("invoice B");
+  });
+
+  describe("failure modes", () => {
+    it("reports exit 0 with no artifact as a DOCUMENT-level failure", async () => {
+      // The exit code lies: LibreOffice returns 0 for an input it could not
+      // load and only says so on stderr. A pipeline that trusts the return
+      // value books the document as converted and indexes nothing.
+      const sources = [
+        await corpusFile("good.doc", "fine"),
+        await corpusFile("broken.docx", "truncated zip"),
+      ];
+      const converter = fakeConverter({ outputs: { "good.doc": "one two", "broken.docx": null } });
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(outcomes[0].status).toBe("converted");
+      expect(outcomes[1].status).toBe("failed");
+      expect(outcomes[1].artifactPath).toBeUndefined();
+      expect(outcomes[1].reason).toMatch(/could not be loaded|no artifact/i);
+    });
+
+    it("does NOT mark documents unreadable when the process was OOM-killed (exit 137)", async () => {
+      // Without this split one memory squeeze brands perfectly good documents
+      // as permanently unreadable and nothing ever retries them.
+      const sources = [await corpusFile("a.doc", "x"), await corpusFile("b.doc", "y")];
+      const converter = fakeConverter({ outputs: {}, exitCode: 137 });
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(outcomes.map((o) => o.status)).toEqual(["infrastructure", "infrastructure"]);
+      expect(outcomes[0].reason).toMatch(/memory/i);
+    });
+
+    it("treats a direct SIGKILL the same as exit 137", async () => {
+      // 137 is what a shell (or `docker run`) reports; a direct spawn sees the
+      // signal instead, with a null exit code. Same event, same conclusion.
+      const sources = [await corpusFile("a.doc", "x")];
+      const converter = fakeConverter({ outputs: {}, exitCode: null, signal: "SIGKILL" });
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(outcomes[0].status).toBe("infrastructure");
+    });
+
+    it("does not blame the document when the converter binary is missing", async () => {
+      const sources = [await corpusFile("a.doc", "x")];
+      const converter = fakeConverter({
+        outputs: {},
+        spawnError: Object.assign(new Error("spawn soffice ENOENT"), { code: "ENOENT" }),
+      });
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(outcomes[0].status).toBe("infrastructure");
+    });
+
+    it("still converts the rest of a batch when one file cannot be loaded", async () => {
+      const sources = [
+        await corpusFile("a.doc", "alpha"),
+        await corpusFile("broken.doc", "bravo"),
+        await corpusFile("c.doc", "charlie"),
+      ];
+      const converter = fakeConverter({
+        outputs: { "a.doc": "one two", "broken.doc": null, "c.doc": "three four" },
+      });
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(outcomes.map((o) => o.status)).toEqual(["converted", "failed", "converted"]);
+      expect(converter.calls).toHaveLength(1);
+    });
+
+    it("reports an empty artifact as a document-level failure", async () => {
+      const sources = [await corpusFile("a.doc", "x")];
+      const converter: FakeConverter = {
+        calls: [],
+        run: async (call) => {
+          converter.calls.push(call);
+          await writeFile(join(call.outDir, "0.pdf"), "");
+          return { code: 0, signal: null, stderr: "" };
+        },
+      };
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(outcomes[0].status).toBe("failed");
+    });
+  });
+
+  describe("verification chain", () => {
+    it("passes a conversion whose PDF carries at least the source's words", async () => {
+      const sources = [await corpusFile("a.docx", "x")];
+      const converter = fakeConverter({ outputs: { "a.docx": "one two three four five" } });
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(converter, { countSourceWords: async () => 5 })
+      );
+
+      expect(outcomes[0].status).toBe("converted");
+      expect(outcomes[0].verification).toEqual({
+        status: "ok",
+        sourceWords: 5,
+        pdfWords: 5,
+        epsilon: OFFICE_VERIFY_EPSILON,
+      });
+    });
+
+    it("passes when the PDF carries MORE words than the oracle saw", async () => {
+      // Measured on the real corpus: a .docx came out +25 % because it carries
+      // three headers and three footers a raw `word/document.xml` read
+      // structurally cannot see. Every deviation was the oracle
+      // under-reporting; an equality round-trip would fire constantly.
+      const sources = [await corpusFile("a.docx", "x")];
+      const converter = fakeConverter({ outputs: { "a.docx": "one two three four five six" } });
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(converter, { countSourceWords: async () => 4 })
+      );
+
+      expect(outcomes[0].status).toBe("converted");
+      expect(outcomes[0].verification!.status).toBe("ok");
+    });
+
+    it("fails a conversion that lost content — the clipped-text-box tripwire", async () => {
+      // The synthetic fixture the real corpus never provided: a fixed-size text
+      // box that overflows, so the rendered PDF silently drops what does not
+      // fit. This is the failure the lower bound exists for.
+      const sources = [await corpusFile("a.docx", "x")];
+      const converter = fakeConverter({ outputs: { "a.docx": "one two three" } });
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(converter, { countSourceWords: async () => 100 })
+      );
+
+      expect(outcomes[0].status).toBe("failed");
+      expect(outcomes[0].verification).toEqual({
+        status: "short",
+        sourceWords: 100,
+        pdfWords: 3,
+        epsilon: OFFICE_VERIFY_EPSILON,
+      });
+      // A conversion that failed verification is never stored: nothing may
+      // serve a preview whose text the index does not have.
+      expect(outcomes[0].artifactPath).toBeUndefined();
+    });
+
+    it("tolerates tokenisation noise up to epsilon", async () => {
+      const sources = [
+        await corpusFile("a.docx", "alpha"),
+        await corpusFile("b.docx", "bravo"),
+        await corpusFile("c.docx", "charlie"),
+      ];
+      const converter = fakeConverter({
+        outputs: {
+          "a.docx": Array.from({ length: 91 }, (_, i) => `w${i}`).join(" "),
+          "b.docx": Array.from({ length: 90 }, (_, i) => `w${i}`).join(" "),
+          "c.docx": Array.from({ length: 89 }, (_, i) => `w${i}`).join(" "),
+        },
+      });
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(converter, { countSourceWords: async () => 100 })
+      );
+
+      // epsilon = 0.10 -> the bound sits at exactly 90 words.
+      expect(outcomes.map((o) => o.status)).toEqual(["converted", "converted", "failed"]);
+    });
+
+    it("records `unverified` rather than `ok` when no independent extractor exists", async () => {
+      // A `.pptx` has no oracle in the image, and a legacy binary has none
+      // without catdoc. Claiming "verified" there would be a lie; the tripwire
+      // is a tripwire, not a guarantee.
+      const sources = [await corpusFile("a.pptx", "x")];
+      const converter = fakeConverter({ outputs: { "a.pptx": "one two" } });
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(converter, { countSourceWords: async () => null })
+      );
+
+      expect(outcomes[0].status).toBe("converted");
+      expect(outcomes[0].verification!.status).toBe("unverified");
+      expect(outcomes[0].verification!.sourceWords).toBeNull();
+    });
+
+    it("does not fail a document because its oracle broke", async () => {
+      const sources = [await corpusFile("a.doc", "x")];
+      const converter = fakeConverter({ outputs: { "a.doc": "one two" } });
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(converter, {
+          countSourceWords: async () => {
+            throw new Error("catdoc: segmentation fault");
+          },
+        })
+      );
+
+      expect(outcomes[0].status).toBe("converted");
+      expect(outcomes[0].verification!.status).toBe("unverified");
+    });
+
+    it("does not fail a source the oracle reads as empty", async () => {
+      // An oracle that returns 0 says nothing about the conversion; 0 * (1-ε)
+      // is 0, which every PDF clears, but an explicit case documents that a
+      // slide deck of images is not a conversion failure.
+      const sources = [await corpusFile("a.ppt", "x")];
+      const converter = fakeConverter({ outputs: { "a.ppt": "" } });
+
+      const outcomes = await convertOfficeFiles(
+        sources,
+        deps(converter, { countSourceWords: async () => 0 })
+      );
+
+      expect(outcomes[0].status).toBe("converted");
+      expect(outcomes[0].verification!.status).toBe("ok");
+    });
+  });
+
+  describe("artifact reuse", () => {
+    it("does not re-run the converter for content already in the store", async () => {
+      const source = await corpusFile("a.doc", "unchanged body");
+      const converter = fakeConverter({ outputs: { "a.doc": "one two" } });
+      const store = new OfficeArtifactStore(storeDir);
+
+      const first = await convertOfficeFiles([source], deps(converter, { store }));
+      const second = await convertOfficeFiles([source], deps(converter, { store }));
+
+      expect(converter.calls).toHaveLength(1);
+      expect(second[0].status).toBe("converted");
+      expect(second[0].artifactPath).toBe(first[0].artifactPath);
+      expect(second[0].verification!.status).toBe("cached");
+    });
+
+    it("converts once when two paths hold identical content", async () => {
+      const sources = [
+        await corpusFile("guide.doc", "same bytes"),
+        await corpusFile("copies/guide.doc", "same bytes"),
+      ];
+      const converter = fakeConverter({ outputs: { "guide.doc": "one two" } });
+
+      const outcomes = await convertOfficeFiles(sources, deps(converter));
+
+      expect(converter.calls[0].inputs).toHaveLength(1);
+      expect(outcomes[0].artifactPath).toBe(outcomes[1].artifactPath);
+      expect(outcomes.every((o) => o.status === "converted")).toBe(true);
+    });
+
+    it("re-converts after the format version is bumped", async () => {
+      const source = await corpusFile("a.doc", "body");
+      const converter = fakeConverter({ outputs: { "a.doc": "one two" } });
+
+      await convertOfficeFiles(
+        [source],
+        deps(converter, { store: new OfficeArtifactStore(storeDir, { formatVersion: 1 }) })
+      );
+      await convertOfficeFiles(
+        [source],
+        deps(converter, { store: new OfficeArtifactStore(storeDir, { formatVersion: 2 }) })
+      );
+
+      expect(converter.calls).toHaveLength(2);
+    });
+  });
+
+  describe("containment", () => {
+    it("never writes anything under the corpus directory", async () => {
+      // /data is mounted read-only and the docs state that as a product
+      // promise. Everything the conversion produces — staged inputs, the
+      // LibreOffice profile, the output PDF — must land in the artifact store.
+      const sources = [
+        await corpusFile("a.doc", "x"),
+        await corpusFile("sub/b.docx", "y"),
+        await corpusFile("sub/broken.ppt", "z"),
+      ];
+      const before = await listTree(corpusDir);
+      const converter = fakeConverter({
+        outputs: { "a.doc": "one two", "b.docx": "one two", "broken.ppt": null },
+      });
+
+      await convertOfficeFiles(sources, deps(converter));
+
+      expect(await listTree(corpusDir)).toEqual(before);
+      for (const call of converter.calls) {
+        expect(call.outDir.startsWith(storeDir + "/")).toBe(true);
+        expect(call.profileDir.startsWith(storeDir + "/")).toBe(true);
+        for (const staged of call.inputs) expect(staged.startsWith(storeDir + "/")).toBe(true);
+      }
+    });
+
+    it("leaves no staging directory behind, on success or on failure", async () => {
+      const sources = [await corpusFile("a.doc", "x"), await corpusFile("b.doc", "y")];
+      const store = new OfficeArtifactStore(storeDir);
+      const ok = fakeConverter({ outputs: { "a.doc": "one two", "b.doc": "three four" } });
+      await convertOfficeFiles(sources, deps(ok, { store }));
+
+      const boom = fakeConverter({ outputs: {}, spawnError: new Error("spawn soffice ENOENT") });
+      await convertOfficeFiles(sources, deps(boom, { store }));
+
+      expect(await listTree(join(storeDir, "staging"))).toEqual([]);
+    });
+
+    it("leaves the store untouched when nothing needs converting", async () => {
+      const outcomes = await convertOfficeFiles([], deps(fakeConverter({ outputs: {} })));
+      expect(outcomes).toEqual([]);
+    });
+  });
+
+  it("gives the converter a time budget that scales with the batch", async () => {
+    // A fixed timeout would kill a legitimately large batch and report the
+    // whole thing as infrastructure — turning "many documents" into a
+    // permanent, self-inflicted failure.
+    const sources = await Promise.all(
+      Array.from({ length: 4 }, (_, i) => corpusFile(`f${i}.doc`, `body ${i}`))
+    );
+    const outputs = Object.fromEntries(sources.map((s, i) => [`f${i}.doc`, `body ${i}`]));
+    const converter = fakeConverter({ outputs });
+
+    await convertOfficeFiles(sources, deps(converter, { batchSize: 2 }));
+
+    const [small, large] = [batchTimeoutMs(2), batchTimeoutMs(20)];
+    expect(large).toBeGreaterThan(small);
+    for (const call of converter.calls) {
+      expect(call.timeoutMs).toBe(batchTimeoutMs(call.inputs.length));
+    }
+  });
+
+  it("reports progress per batch so a long corpus is not silent", async () => {
+    const sources = await Promise.all(
+      Array.from({ length: 5 }, (_, i) => corpusFile(`f${i}.doc`, `body ${i}`))
+    );
+    const outputs = Object.fromEntries(sources.map((s, i) => [`f${i}.doc`, `body ${i}`]));
+    const onProgress = vi.fn();
+
+    await convertOfficeFiles(
+      sources,
+      deps(fakeConverter({ outputs }), { batchSize: 2, onProgress })
+    );
+
+    expect(onProgress.mock.calls.map(([p]) => p.processed)).toEqual([2, 4, 5]);
+    expect(onProgress.mock.calls.every(([p]) => p.total === 5)).toBe(true);
+  });
+});
+
+/** Recursive, sorted listing of a directory tree — [] if it does not exist. */
+async function listTree(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true, recursive: true });
+  } catch {
+    return [];
+  }
+  return entries.map((e) => join(e.parentPath, e.name)).sort();
+}

--- a/packages/web/src/lib/knowledge/office-artifacts.ts
+++ b/packages/web/src/lib/knowledge/office-artifacts.ts
@@ -1,0 +1,196 @@
+/**
+ * Artifact store for Office documents converted to PDF (#936).
+ *
+ * The converted PDF must NOT be written next to the original: `/data` is
+ * mounted read-only into the web container and the docs state that as a
+ * product promise, not an implementation detail. So converted artifacts live
+ * on their own volume — the precedent is `pinchy-pdf-cache`
+ * (/var/cache/pinchy-files) in the OpenClaw container, mirrored here as
+ * `pinchy-kb-artifacts` (/var/cache/pinchy-kb-artifacts) for the web tier.
+ *
+ * ## The key, and the one deviation from PdfCache
+ *
+ * `PdfCache` keys on path + size + mtime + content hash + format_version, with
+ * a size/mtime fast path so it can answer without hashing a large PDF. This
+ * store keys on **format_version + content hash only**, and that is a
+ * deliberate simplification rather than a shortcut: the KB ingest pipeline
+ * ALREADY hashes every file's bytes for its own idempotency check, so the hash
+ * is free at the call site here. Keying on it directly means
+ *
+ *   - no staleness window at all (size+mtime can collide; content cannot),
+ *   - two copies of the same document convert once — and the Noack corpus
+ *     really does contain the same discussion guide as both `.doc` and
+ *     `.docx`,
+ *   - the source path never appears in the store, so a shared artifact volume
+ *     leaks nothing about the corpus layout.
+ *
+ * `format_version` is the part that carries over unchanged, and it is the one
+ * that matters: improving the converter must invalidate everything. It is a
+ * path segment (`<root>/v3/ab/abcd….pdf`) rather than a stored column so a
+ * bump is visible in `ls`, and superseding a version is one directory removal
+ * (`pruneOtherFormatVersions`) instead of a table scan.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { mkdir, readdir, rename, rm, stat, utimes } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Bump this whenever a change makes the converter produce a materially
+ * different PDF for the same input — a different LibreOffice major version, a
+ * changed filter or font set, a different `--convert-to` invocation. Every
+ * stored artifact is invalidated, and #939's preview serves the new output.
+ */
+export const OFFICE_ARTIFACT_FORMAT_VERSION = 1;
+
+/**
+ * Where converted artifacts live. Overridable so a dev machine (and the test
+ * suite) can point it somewhere writable; in the container this is the
+ * `pinchy-kb-artifacts` volume.
+ */
+export const DEFAULT_ARTIFACT_DIR = process.env.KB_ARTIFACT_DIR || "/var/cache/pinchy-kb-artifacts";
+
+/** How long an artifact survives without being read. Mirrors PdfCache's 7 days. */
+export const DEFAULT_ARTIFACT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Scratch space for in-flight batches, alongside the version directories. */
+const STAGING_DIR_NAME = "staging";
+
+export interface OfficeArtifactStoreOptions {
+  formatVersion?: number;
+}
+
+export class OfficeArtifactStore {
+  readonly rootDir: string;
+  readonly formatVersion: number;
+  private readonly versionDir: string;
+
+  constructor(rootDir: string = DEFAULT_ARTIFACT_DIR, options: OfficeArtifactStoreOptions = {}) {
+    this.rootDir = rootDir;
+    this.formatVersion = options.formatVersion ?? OFFICE_ARTIFACT_FORMAT_VERSION;
+    this.versionDir = join(rootDir, `v${this.formatVersion}`);
+    mkdirSync(this.versionDir, { recursive: true });
+  }
+
+  /**
+   * Absolute path the artifact for `contentHash` lives at. A pure function of
+   * the key — #939 resolves a preview request through this without needing to
+   * know whether the conversion has happened yet.
+   *
+   * The hash is re-hashed rather than used verbatim so a caller passing
+   * something path-shaped can never escape the store; the first two characters
+   * fan out into 256 subdirectories, because a single flat directory with tens
+   * of thousands of entries is slow on every filesystem that matters.
+   */
+  pathFor(contentHash: string): string {
+    const key = createHash("sha256").update(contentHash).digest("hex");
+    return join(this.versionDir, key.slice(0, 2), `${key}.pdf`);
+  }
+
+  /**
+   * The stored artifact for `contentHash`, or null.
+   *
+   * A hit TOUCHES the file. Without that, `sweep` would delete exactly the
+   * artifacts the corpus depends on most: an unchanged document is never
+   * re-converted, so its artifact's mtime would keep aging while every reindex
+   * keeps reading it.
+   */
+  async get(contentHash: string): Promise<string | null> {
+    const path = this.pathFor(contentHash);
+    try {
+      const info = await stat(path);
+      if (!info.isFile() || info.size === 0) return null;
+    } catch {
+      return null;
+    }
+    const now = new Date();
+    await utimes(path, now, now).catch(() => {});
+    return path;
+  }
+
+  /**
+   * Takes ownership of a freshly converted PDF, moving it into the store and
+   * returning its final path. The move is the commit point: an artifact only
+   * becomes visible once conversion AND verification are behind it, so a
+   * reader can never be handed a half-written file.
+   */
+  async put(contentHash: string, stagedPdfPath: string): Promise<string> {
+    const path = this.pathFor(contentHash);
+    await mkdir(join(path, ".."), { recursive: true });
+    await rm(path, { force: true });
+    await rename(stagedPdfPath, path);
+    return path;
+  }
+
+  /**
+   * A fresh scratch directory for one conversion batch, on the SAME filesystem
+   * as the store. That is not tidiness: `put()` commits with `rename()`, which
+   * fails with EXDEV across mount points — and in the container `os.tmpdir()`
+   * and the artifact volume are exactly that. Staging here also keeps the
+   * batch's intermediate PDFs off the container's writable layer.
+   */
+  async createStagingDir(): Promise<string> {
+    const dir = join(this.rootDir, STAGING_DIR_NAME, randomUUID());
+    await mkdir(dir, { recursive: true });
+    return dir;
+  }
+
+  /** Deletes artifacts not read for longer than `maxAgeMs`. Returns how many. */
+  async sweep(maxAgeMs: number = DEFAULT_ARTIFACT_TTL_MS): Promise<number> {
+    const cutoff = Date.now() - maxAgeMs;
+    let removed = 0;
+    for (const shard of await this.listDir(this.versionDir)) {
+      const shardDir = join(this.versionDir, shard);
+      for (const name of await this.listDir(shardDir)) {
+        const path = join(shardDir, name);
+        const info = await stat(path).catch(() => null);
+        if (!info?.isFile() || info.mtimeMs >= cutoff) continue;
+        await rm(path, { force: true });
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /**
+   * Removes every artifact belonging to a DIFFERENT format version. Called
+   * after a converter change so the volume does not carry a generation of
+   * artifacts nothing will ever read again.
+   */
+  async pruneOtherFormatVersions(): Promise<number> {
+    let removed = 0;
+    for (const entry of await this.listDir(this.rootDir)) {
+      // Only version directories are ours to delete. `staging/` holds a batch
+      // that may be converting RIGHT NOW.
+      if (!/^v\d+$/.test(entry)) continue;
+      if (entry === `v${this.formatVersion}`) continue;
+      const dir = join(this.rootDir, entry);
+      for (const shard of await this.listDir(dir)) {
+        removed += (await this.listDir(join(dir, shard))).length;
+      }
+      await rm(dir, { recursive: true, force: true });
+    }
+    return removed;
+  }
+
+  /** readdir that answers [] for a directory that does not exist yet. */
+  private async listDir(dir: string): Promise<string[]> {
+    try {
+      return await readdir(dir);
+    } catch {
+      return [];
+    }
+  }
+}
+
+let sharedStore: OfficeArtifactStore | null = null;
+
+/**
+ * The process-wide store. Lazy on purpose: constructing one creates its
+ * directory, and importing this module must not touch the filesystem (the web
+ * process imports it on paths that never convert anything).
+ */
+export function getOfficeArtifactStore(): OfficeArtifactStore {
+  sharedStore ??= new OfficeArtifactStore();
+  return sharedStore;
+}

--- a/packages/web/src/lib/knowledge/office-convert.ts
+++ b/packages/web/src/lib/knowledge/office-convert.ts
@@ -307,7 +307,19 @@ interface BatchDeps {
  * target's.
  */
 async function convertBatch(batch: WorkItem[], deps: BatchDeps): Promise<ConversionOutcome[]> {
-  const stagingDir = await deps.store.createStagingDir();
+  let stagingDir: string;
+  try {
+    stagingDir = await deps.store.createStagingDir();
+  } catch (err) {
+    // A full or unwritable artifact volume is a squeeze on the machine, not a
+    // verdict on these documents — and it must arrive as a retryable outcome
+    // rather than an exception that also throws away the batches that already
+    // succeeded.
+    return batch.map((item) =>
+      infrastructureFailure(item.absPath, `artifact store unavailable: ${reasonOf(err)}`)
+    );
+  }
+
   const inDir = join(stagingDir, "in");
   const outDir = join(stagingDir, "out");
   const profileDir = join(stagingDir, "profile");
@@ -382,10 +394,7 @@ async function collectOne(
   if (!info?.isFile() || info.size === 0) {
     // THE failure the exit code hides. stderr is the only place LibreOffice
     // says anything, so carry a trimmed copy for the operator log.
-    return documentFailure(
-      item.absPath,
-      `no artifact produced (source file could not be loaded)${summarise(stderr)}`
-    );
+    return documentFailure(item.absPath, `no artifact produced${summarise(stderr)}`);
   }
 
   let pdfWords: number;
@@ -416,12 +425,17 @@ async function collectOne(
     };
   }
 
-  return {
-    sourcePath: item.absPath,
-    status: "converted",
-    artifactPath: await deps.store.put(item.contentHash, producedPdf),
-    verification,
-  };
+  let artifactPath: string;
+  try {
+    artifactPath = await deps.store.put(item.contentHash, producedPdf);
+  } catch (err) {
+    // The conversion itself succeeded and passed verification; only the volume
+    // refused it. Retrying costs a conversion, but calling this document
+    // unreadable would be a lie that nothing ever revisits.
+    return infrastructureFailure(item.absPath, `artifact store rejected the PDF: ${reasonOf(err)}`);
+  }
+
+  return { sourcePath: item.absPath, status: "converted", artifactPath, verification };
 }
 
 /**
@@ -446,21 +460,85 @@ function reasonOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** A short, single-line excerpt of converter stderr for the operator log. */
+/**
+ * Noise LibreOffice prints on EVERY run in our image and that says nothing
+ * about any document. The JRE is deliberately absent (`--no-install-recommends`
+ * in Dockerfile.pinchy keeps a whole Java runtime out of the image), so this
+ * warning is permanent — and it is the FIRST stderr line, which is exactly why
+ * "the first non-empty line" is the wrong excerpt to keep.
+ */
+const BENIGN_STDERR = /failed to launch javaldx/i;
+
+/**
+ * A short, single-line excerpt of converter stderr for the operator log.
+ *
+ * Prefers the line LibreOffice marks as an error, because stderr is batch-wide
+ * — it names no file (verified against the real binary: the message is a bare
+ * `Error: source file could not be loaded`) — and the interesting line is never
+ * the first one. Attaching the javaldx warning to a failed document instead
+ * sends an operator after a Java problem that does not exist.
+ */
 function summarise(stderr: string): string {
-  const line = stderr.split("\n").find((l) => l.trim().length > 0);
-  return line ? `: ${line.trim().slice(0, 200)}` : "";
+  const lines = stderr
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !BENIGN_STDERR.test(l));
+  const line = lines.find((l) => /^error\b/i.test(l)) ?? lines[0];
+  return line ? ` (converter stderr, batch-wide: ${line.slice(0, 200)})` : "";
 }
 
 // ---------------------------------------------------------------------------
 // Production adapters
 // ---------------------------------------------------------------------------
 
-/** Overridable so a dev machine can point at its own LibreOffice. */
-const SOFFICE_BIN = process.env.KB_SOFFICE_BIN || "soffice";
-
 /** stderr we keep. LibreOffice repeats itself per file; a huge batch must not build a huge string. */
 const MAX_STDERR_BYTES = 8 * 1024;
+
+/**
+ * What a converter subprocess inherits from us — an allow-list, not a copy of
+ * `process.env`.
+ *
+ * Both subprocesses in this module parse documents the corpus owner did not
+ * write, in formats (legacy `.doc`/`.ppt`) with a long history of
+ * memory-safety bugs. Neither has any use for `DATABASE_URL`,
+ * `ENCRYPTION_KEY` or `BETTER_AUTH_SECRET`, so neither gets them. Verified
+ * against the real binary: `PATH` plus `HOME` is enough to convert, with the
+ * Central/Eastern European diacritics the corpus is full of intact; the rest
+ * are locale and timezone, which change how a document RENDERS and so are
+ * passed through when the operator set them.
+ */
+const INHERITED_ENV = ["PATH", "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE", "TZ"] as const;
+
+function childEnv(home: string): NodeJS.ProcessEnv {
+  // NODE_ENV carries no secret and is what every child process here already
+  // sees; it is listed explicitly because Next.js declares it non-optional.
+  const env: NodeJS.ProcessEnv = { NODE_ENV: process.env.NODE_ENV, HOME: home };
+  for (const key of INHERITED_ENV) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+/**
+ * SIGKILLs a child AND everything it forked.
+ *
+ * `spawn` is given `detached: true` so the child leads its own process group,
+ * and this kills the group. That is not belt-and-braces: `soffice` execs
+ * `oosplash`, which **forks** `soffice.bin` — so killing the process we
+ * spawned leaves the real converter running, still holding the memory the
+ * timeout was meant to reclaim and still writing into a staging directory we
+ * are about to delete. Verified in the runtime image, both directions: killing
+ * the pid orphans `soffice.bin`, killing the group reaps it.
+ */
+function killTree(child: ReturnType<typeof spawn>): void {
+  try {
+    if (child.pid !== undefined) process.kill(-child.pid, "SIGKILL");
+  } catch {
+    // The group is already gone, or the platform has no process groups.
+    child.kill("SIGKILL");
+  }
+}
 
 /**
  * The real converter: ONE `soffice` per batch.
@@ -469,11 +547,15 @@ const MAX_STDERR_BYTES = 8 * 1024;
  * profile inside the staging directory. Without it LibreOffice shares one user
  * installation, and a second instance — a concurrent reindex, or a leftover
  * process — refuses to start or silently reuses the other's state.
+ *
+ * The binary is resolved per call rather than at import so a test can point at
+ * a stub: without that, everything below is only reachable on a machine with a
+ * 422 MB LibreOffice installed, which is no machine CI runs on.
  */
 export const runSoffice: RunConverter = ({ inputs, outDir, profileDir, timeoutMs }) =>
   new Promise<ConverterResult>((resolve, reject) => {
     const child = spawn(
-      SOFFICE_BIN,
+      process.env.KB_SOFFICE_BIN || "soffice",
       [
         "--headless",
         "--norestore",
@@ -487,7 +569,7 @@ export const runSoffice: RunConverter = ({ inputs, outDir, profileDir, timeoutMs
         outDir,
         ...inputs,
       ],
-      { stdio: ["ignore", "ignore", "pipe"], env: { ...process.env, HOME: profileDir } }
+      { stdio: ["ignore", "ignore", "pipe"], env: childEnv(profileDir), detached: true }
     );
 
     let stderr = "";
@@ -498,7 +580,7 @@ export const runSoffice: RunConverter = ({ inputs, outDir, profileDir, timeoutMs
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGKILL");
+      killTree(child);
     }, timeoutMs);
 
     child.on("error", (err) => {
@@ -553,23 +635,50 @@ export async function countSourceWordsWithOracle(absPath: string): Promise<numbe
   return null;
 }
 
-/** Runs a text-dumping CLI over `absPath` and counts its words; null if it is absent or unhappy. */
-function runTextOracle(bin: string, absPath: string): Promise<number | null> {
+/**
+ * Text an oracle may produce before we stop believing it. 16 MB is roughly 2.5
+ * million words — orders of magnitude past any document, and small enough that
+ * a `.doc` crafted to make catdoc emit without end cannot take the web process
+ * down with it. The oracle is a tripwire; it is not worth a single OOM.
+ */
+const MAX_ORACLE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Runs a text-dumping CLI over `absPath` and counts its words; null if it is
+ * absent, unhappy, too slow, or too talkative.
+ *
+ * Exported for the adapter test — the production callers pass a fixed binary
+ * name, so this is the only seam a stub can reach.
+ */
+export function runTextOracle(bin: string, absPath: string): Promise<number | null> {
   return new Promise((resolve) => {
-    const child = spawn(bin, [absPath], { stdio: ["ignore", "pipe", "ignore"] });
+    const child = spawn(bin, [absPath], {
+      stdio: ["ignore", "pipe", "ignore"],
+      env: childEnv(process.env.HOME ?? "/tmp"),
+      detached: true,
+    });
     let out = "";
+    let settled = false;
+    const finish = (words: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(words);
+    };
+
     child.stdout.on("data", (chunk: Buffer) => {
       out += chunk.toString("utf8");
+      if (out.length > MAX_ORACLE_BYTES) {
+        killTree(child);
+        finish(null);
+      }
     });
-    const timer = setTimeout(() => child.kill("SIGKILL"), 30_000);
-    child.on("error", () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve(code === 0 ? countWords(out) : null);
-    });
+    const timer = setTimeout(() => {
+      killTree(child);
+      finish(null);
+    }, 30_000);
+    child.on("error", () => finish(null));
+    child.on("close", (code) => finish(code === 0 ? countWords(out) : null));
   });
 }
 

--- a/packages/web/src/lib/knowledge/office-convert.ts
+++ b/packages/web/src/lib/knowledge/office-convert.ts
@@ -1,0 +1,579 @@
+/**
+ * Converts page-shaped Office documents (.doc/.docx/.ppt/.pptx) to PDF for the
+ * knowledge base (#936). Standalone: wiring this into the ingest pipeline is
+ * #938's job, and serving the artifact as a preview is #939's.
+ *
+ * ## Why convert instead of parsing natively
+ *
+ * Office support has to cover LEGACY formats: in the reference corpus 13 of 19
+ * Office files are `.doc`/`.ppt`. The entire modern parsing ecosystem
+ * (Docling, MarkItDown, Unstructured, anything on python-docx/python-pptx) is
+ * OOXML-only and cannot read them. LibreOffice is the standard answer and here
+ * it is the only one that covers the corpus.
+ *
+ * Conversion also buys what the citation chain depends on: ONE renderable
+ * artifact whose pages agree with what the reader is shown, so a citation can
+ * never point at something the user cannot see. Spreadsheets take a different
+ * path (#937/#940) — `libreoffice-calc` is deliberately not installed.
+ *
+ * ## Three things this module exists to get right
+ *
+ * 1. **Batch, do not spawn per file.** Process startup dominates: 17 real
+ *    corpus files convert in 14.2 s in one process vs 25.6 s one-per-file.
+ *    Batches are bounded (`DEFAULT_BATCH_SIZE`) so a single OOM kill costs a
+ *    batch rather than the corpus.
+ *
+ * 2. **The exit code lies.** An input LibreOffice cannot load produces
+ *    `Error: source file could not be loaded` on stderr, exit code **0**, and
+ *    no output file — while every other file in the batch converts normally
+ *    (verified against the real `libreoffice-writer` in the runtime image).
+ *    A pipeline that trusts the return value books the document as converted
+ *    and indexes nothing. So the artifact's existence is the evidence, never
+ *    the exit code.
+ *
+ * 3. **OOM is distinguishable, and the difference is load-bearing.** Exit
+ *    **137** (or a bare SIGKILL, which is what a direct spawn sees) means the
+ *    container was too small — infrastructure, retryable. Exit 0 with no
+ *    artifact means THIS document is unreadable — final. Without the split,
+ *    one memory squeeze brands perfectly good documents as permanently
+ *    unreadable and nothing ever retries them.
+ *
+ * ## Verification: a lower bound, not an equality check
+ *
+ * Every conversion of the reference corpus was measured against an independent
+ * extractor and no case lost content; all deviations were the ORACLE
+ * under-reporting (a `.docx` came out +25 % because of headers/footers a raw
+ * `word/document.xml` read cannot see; `catppt` stopped after the title slide,
+ * 39 words vs 868, and mangled the very diacritics the customer cares about).
+ * An equality round-trip is therefore unbuildable with these tools — it would
+ * fire constantly. The check is `pdf_words >= source_words * (1 - ε)`: in that
+ * direction a weak oracle can only miss a real loss, never raise a false
+ * alarm. It is a tripwire against the failure that actually hurts (clipped
+ * text), NOT a guarantee.
+ */
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { mkdir, rm, stat, symlink } from "node:fs/promises";
+import { extname, join } from "node:path";
+
+import { getOfficeArtifactStore, OfficeArtifactStore } from "./office-artifacts";
+import { extractPdfPages } from "./pdf-extract";
+
+/**
+ * The page-shaped Office formats. Spreadsheets are deliberately absent: a
+ * sheet is not a page, and rendering one to PDF produces arbitrary page breaks
+ * that no citation can honestly point at (#937/#940).
+ */
+export const OFFICE_EXTENSIONS = [".doc", ".docx", ".ppt", ".pptx"] as const;
+
+/**
+ * Tolerance of the lower-bound word check. 10 % is head-room for tokenisation
+ * noise between two extractors that will never agree exactly — hyphenation,
+ * ligatures, soft hyphens, table cells joined with or without a separator all
+ * move a word count by a few percent — while the failure this guards against
+ * (a fixed-size text box whose overflow is silently dropped by the renderer)
+ * loses whole blocks of text, far more than 10 %.
+ *
+ * The corpus cannot narrow this further: no measured conversion lost content
+ * at all, so every observed deviation was in the tolerated direction. And the
+ * clipping case has never actually fired on real data — the only fixture for
+ * it is synthetic (see the tests). Treat 10 % as "wide enough to be quiet on
+ * everything we have seen", not as a calibrated bound.
+ */
+export const OFFICE_VERIFY_EPSILON = 0.1;
+
+/**
+ * Files per converter process. Big enough that startup is amortised (the whole
+ * 17-file reference corpus fits in one batch), small enough that an OOM kill —
+ * which fails the WHOLE batch as infrastructure — costs a bounded amount of
+ * re-work, and that progress is reported more than once on a large corpus.
+ */
+export const DEFAULT_BATCH_SIZE = 20;
+
+/** Per-batch wall-clock budget. The slowest single real file took 1.46 s; this is deliberately far above that. */
+export function batchTimeoutMs(fileCount: number): number {
+  return 60_000 + 10_000 * fileCount;
+}
+
+export interface OfficeSource {
+  absPath: string;
+  /**
+   * sha256 of the file's bytes — the artifact key. Optional because a
+   * standalone caller may not have it; ingest already computes exactly this
+   * for its own idempotency check and should pass it rather than pay for a
+   * second read.
+   */
+  contentHash?: string;
+}
+
+/**
+ * - `converted`      — an artifact is in the store; index it.
+ * - `failed`         — THIS document cannot be converted, ever. Final: it
+ *                      belongs on the unreadable list (#935), and retrying
+ *                      costs a LibreOffice startup to learn the same thing.
+ * - `infrastructure` — the converter never got to judge this document (out of
+ *                      memory, timed out, binary missing). Retryable, and
+ *                      recording it as unreadable would be a lie: without this
+ *                      distinction one memory squeeze brands perfectly good
+ *                      documents as permanently unreadable and nothing ever
+ *                      retries them.
+ */
+export type ConversionStatus = "converted" | "failed" | "infrastructure";
+
+export interface VerificationReport {
+  /**
+   * - `ok`         — the PDF cleared the lower bound.
+   * - `short`      — it did not: content was lost, the conversion is rejected.
+   * - `unverified` — no independent extractor for this format, so nothing was
+   *                  checked. Deliberately NOT reported as `ok`.
+   * - `cached`     — the artifact was verified when it was stored.
+   */
+  status: "ok" | "short" | "unverified" | "cached";
+  sourceWords: number | null;
+  pdfWords: number | null;
+  epsilon: number;
+}
+
+export interface ConversionOutcome {
+  sourcePath: string;
+  status: ConversionStatus;
+  /** Set for `converted` only. */
+  artifactPath?: string;
+  /** Set for `converted` only. */
+  verification?: VerificationReport;
+  /** Diagnostic. Never carries document content — it is safe to log. */
+  reason?: string;
+}
+
+export interface ConverterRun {
+  /** Absolute paths of the staged inputs, in order. Their basenames are `<index>.<ext>`. */
+  inputs: string[];
+  /** Where the converter must write `<index>.pdf`. */
+  outDir: string;
+  /** A private LibreOffice profile, so concurrent runs never fight over one user installation. */
+  profileDir: string;
+  timeoutMs: number;
+}
+
+export interface ConverterResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+  /** True when WE killed it for taking too long — infrastructure, but not memory. */
+  timedOut?: boolean;
+}
+
+export type RunConverter = (run: ConverterRun) => Promise<ConverterResult>;
+
+export interface ConvertProgress {
+  /** Documents whose conversion is behind us — including the ones that failed. */
+  processed: number;
+  /** Documents that actually need converting: cache hits are not counted, they are not work. */
+  total: number;
+}
+
+export interface ConvertOptions {
+  store?: OfficeArtifactStore;
+  runConverter?: RunConverter;
+  /** Words in the converted PDF. Prod: the pdfjs text layer (./pdf-extract.ts). */
+  countPdfWords?: (absPath: string) => Promise<number>;
+  /** Words the INDEPENDENT extractor sees in the original, or null when there is none for this format. */
+  countSourceWords?: (absPath: string) => Promise<number | null>;
+  batchSize?: number;
+  epsilon?: number;
+  onProgress?: (progress: ConvertProgress) => void | Promise<void>;
+}
+
+/** Is this a page-shaped Office document this module converts? */
+export function isOfficeFile(path: string): boolean {
+  const ext = extname(path).toLowerCase();
+  return (OFFICE_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+/** sha256 of a file's bytes, streamed — the artifact-store key. */
+export async function hashFileContents(absPath: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(absPath)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+/** One document's slot in the run, so results can be returned in input order. */
+interface WorkItem {
+  absPath: string;
+  contentHash: string;
+  /** Every input position that shares this content — two paths, one conversion. */
+  positions: number[];
+}
+
+/**
+ * Converts `sources` to PDFs in the artifact store, returning one outcome per
+ * source, in input order.
+ *
+ * Documents already in the store are returned without running the converter,
+ * and identical content at two paths converts once — the store is keyed on
+ * content, and a real corpus really does hold the same document twice.
+ */
+export async function convertOfficeFiles(
+  sources: readonly OfficeSource[],
+  options: ConvertOptions = {}
+): Promise<ConversionOutcome[]> {
+  if (sources.length === 0) return [];
+
+  const store = options.store ?? getOfficeArtifactStore();
+  const runConverter = options.runConverter ?? runSoffice;
+  const countPdfWords = options.countPdfWords ?? defaultCountPdfWords;
+  const countSourceWords = options.countSourceWords ?? countSourceWordsWithOracle;
+  const batchSize = Math.max(1, options.batchSize ?? DEFAULT_BATCH_SIZE);
+  const epsilon = options.epsilon ?? OFFICE_VERIFY_EPSILON;
+
+  const outcomes = new Array<ConversionOutcome>(sources.length);
+  const byHash = new Map<string, WorkItem>();
+
+  for (const [position, source] of sources.entries()) {
+    let contentHash = source.contentHash;
+    if (!contentHash) {
+      try {
+        contentHash = await hashFileContents(source.absPath);
+      } catch (err) {
+        // The file vanished or turned unreadable between discovery and here.
+        // That is about THIS document, not the infrastructure.
+        outcomes[position] = documentFailure(source.absPath, `unreadable source: ${reasonOf(err)}`);
+        continue;
+      }
+    }
+
+    const cached = await store.get(contentHash);
+    if (cached) {
+      outcomes[position] = {
+        sourcePath: source.absPath,
+        status: "converted",
+        artifactPath: cached,
+        verification: { status: "cached", sourceWords: null, pdfWords: null, epsilon },
+      };
+      continue;
+    }
+
+    const existing = byHash.get(contentHash);
+    if (existing) existing.positions.push(position);
+    else byHash.set(contentHash, { absPath: source.absPath, contentHash, positions: [position] });
+  }
+
+  const work = [...byHash.values()];
+  let processed = 0;
+
+  for (let start = 0; start < work.length; start += batchSize) {
+    const batch = work.slice(start, start + batchSize);
+    const results = await convertBatch(batch, {
+      store,
+      runConverter,
+      countPdfWords,
+      countSourceWords,
+      epsilon,
+    });
+
+    for (const [i, item] of batch.entries()) {
+      for (const position of item.positions) {
+        outcomes[position] = { ...results[i], sourcePath: sources[position].absPath };
+      }
+    }
+
+    processed += batch.length;
+    await options.onProgress?.({ processed, total: work.length });
+  }
+
+  return outcomes;
+}
+
+interface BatchDeps {
+  store: OfficeArtifactStore;
+  runConverter: RunConverter;
+  countPdfWords: (absPath: string) => Promise<number>;
+  countSourceWords: (absPath: string) => Promise<number | null>;
+  epsilon: number;
+}
+
+/**
+ * Converts one batch in a single converter process.
+ *
+ * Inputs are STAGED as index-named symlinks (`0.doc`, `1.pptx`, …) in a
+ * scratch directory, and that is not cosmetic. LibreOffice derives the output
+ * name from the input's basename, so two documents called `Rechnung.doc` in
+ * different folders — the normal state of a real corpus — would write the same
+ * `Rechnung.pdf` and one document would end up serving the other's text.
+ * Index names make the input→output mapping positional and unambiguous, and
+ * sidestep every quoting question a corpus filename can raise. Verified
+ * against the real binary: the output follows the symlink's name, not the
+ * target's.
+ */
+async function convertBatch(batch: WorkItem[], deps: BatchDeps): Promise<ConversionOutcome[]> {
+  const stagingDir = await deps.store.createStagingDir();
+  const inDir = join(stagingDir, "in");
+  const outDir = join(stagingDir, "out");
+  const profileDir = join(stagingDir, "profile");
+
+  try {
+    await mkdir(inDir, { recursive: true });
+    await mkdir(outDir, { recursive: true });
+    await mkdir(profileDir, { recursive: true });
+
+    const outcomes = new Array<ConversionOutcome>(batch.length);
+    const inputs: string[] = [];
+
+    for (const [i, item] of batch.entries()) {
+      const staged = join(inDir, `${i}${extname(item.absPath).toLowerCase()}`);
+      try {
+        await symlink(item.absPath, staged);
+        inputs.push(staged);
+      } catch (err) {
+        outcomes[i] = documentFailure(item.absPath, `could not stage source: ${reasonOf(err)}`);
+      }
+    }
+
+    if (inputs.length > 0) {
+      let result: ConverterResult;
+      try {
+        result = await deps.runConverter({
+          inputs,
+          outDir,
+          profileDir,
+          timeoutMs: batchTimeoutMs(inputs.length),
+        });
+      } catch (err) {
+        // The converter could not be started at all (a missing binary, a
+        // permission problem). Nothing here says anything about the documents.
+        return batch.map(
+          (item, i) =>
+            outcomes[i] ??
+            infrastructureFailure(item.absPath, `converter did not run: ${reasonOf(err)}`)
+        );
+      }
+
+      if (wasKilled(result)) {
+        const reason = result.timedOut
+          ? "converter exceeded its time budget"
+          : "converter was killed — out of memory (see PINCHY_MEM_LIMIT)";
+        return batch.map((item, i) => outcomes[i] ?? infrastructureFailure(item.absPath, reason));
+      }
+
+      for (const [i, item] of batch.entries()) {
+        if (outcomes[i]) continue;
+        outcomes[i] = await collectOne(item, join(outDir, `${i}.pdf`), deps, result.stderr);
+      }
+    }
+
+    return outcomes;
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Turns one staged output into an outcome: does the artifact exist, does it
+ * clear the lower bound, and only then does it enter the store.
+ */
+async function collectOne(
+  item: WorkItem,
+  producedPdf: string,
+  deps: BatchDeps,
+  stderr: string
+): Promise<ConversionOutcome> {
+  const info = await stat(producedPdf).catch(() => null);
+  if (!info?.isFile() || info.size === 0) {
+    // THE failure the exit code hides. stderr is the only place LibreOffice
+    // says anything, so carry a trimmed copy for the operator log.
+    return documentFailure(
+      item.absPath,
+      `no artifact produced (source file could not be loaded)${summarise(stderr)}`
+    );
+  }
+
+  let pdfWords: number;
+  try {
+    pdfWords = await deps.countPdfWords(producedPdf);
+  } catch (err) {
+    return documentFailure(item.absPath, `converted PDF is unreadable: ${reasonOf(err)}`);
+  }
+
+  // An oracle that breaks says nothing about the conversion, so it must never
+  // fail a document — it only removes the tripwire for this one file.
+  const sourceWords = await deps.countSourceWords(item.absPath).catch(() => null);
+
+  const verification: VerificationReport = {
+    status: sourceWords === null ? "unverified" : "ok",
+    sourceWords,
+    pdfWords,
+    epsilon: deps.epsilon,
+  };
+
+  if (sourceWords !== null && pdfWords < sourceWords * (1 - deps.epsilon)) {
+    return {
+      ...documentFailure(
+        item.absPath,
+        `conversion lost content: ${pdfWords} words in the PDF vs ${sourceWords} in the source`
+      ),
+      verification: { ...verification, status: "short" },
+    };
+  }
+
+  return {
+    sourcePath: item.absPath,
+    status: "converted",
+    artifactPath: await deps.store.put(item.contentHash, producedPdf),
+    verification,
+  };
+}
+
+/**
+ * Was the converter killed rather than finished? 137 is 128+9 — what a shell
+ * or `docker` reports for SIGKILL — while a direct spawn sees the signal with
+ * a null exit code. Both are the same event: the OOM killer, or our own
+ * timeout.
+ */
+function wasKilled(result: ConverterResult): boolean {
+  return result.timedOut === true || result.code === 137 || result.signal === "SIGKILL";
+}
+
+function documentFailure(sourcePath: string, reason: string): ConversionOutcome {
+  return { sourcePath, status: "failed", reason };
+}
+
+function infrastructureFailure(sourcePath: string, reason: string): ConversionOutcome {
+  return { sourcePath, status: "infrastructure", reason };
+}
+
+function reasonOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** A short, single-line excerpt of converter stderr for the operator log. */
+function summarise(stderr: string): string {
+  const line = stderr.split("\n").find((l) => l.trim().length > 0);
+  return line ? `: ${line.trim().slice(0, 200)}` : "";
+}
+
+// ---------------------------------------------------------------------------
+// Production adapters
+// ---------------------------------------------------------------------------
+
+/** Overridable so a dev machine can point at its own LibreOffice. */
+const SOFFICE_BIN = process.env.KB_SOFFICE_BIN || "soffice";
+
+/** stderr we keep. LibreOffice repeats itself per file; a huge batch must not build a huge string. */
+const MAX_STDERR_BYTES = 8 * 1024;
+
+/**
+ * The real converter: ONE `soffice` per batch.
+ *
+ * `-env:UserInstallation` (and a matching HOME) gives the process a private
+ * profile inside the staging directory. Without it LibreOffice shares one user
+ * installation, and a second instance — a concurrent reindex, or a leftover
+ * process — refuses to start or silently reuses the other's state.
+ */
+export const runSoffice: RunConverter = ({ inputs, outDir, profileDir, timeoutMs }) =>
+  new Promise<ConverterResult>((resolve, reject) => {
+    const child = spawn(
+      SOFFICE_BIN,
+      [
+        "--headless",
+        "--norestore",
+        "--nolockcheck",
+        "--nodefault",
+        "--nofirststartwizard",
+        `-env:UserInstallation=file://${profileDir}`,
+        "--convert-to",
+        "pdf",
+        "--outdir",
+        outDir,
+        ...inputs,
+      ],
+      { stdio: ["ignore", "ignore", "pipe"], env: { ...process.env, HOME: profileDir } }
+    );
+
+    let stderr = "";
+    let timedOut = false;
+    child.stderr.on("data", (chunk: Buffer) => {
+      if (stderr.length < MAX_STDERR_BYTES) stderr += chunk.toString("utf8");
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, stderr, timedOut });
+    });
+  });
+
+/** Words in the converted PDF, via the same pdfjs text layer the indexer reads. */
+async function defaultCountPdfWords(absPath: string): Promise<number> {
+  const pages = await extractPdfPages(absPath);
+  return countWords(pages.map((page) => page.text).join(" "));
+}
+
+/**
+ * Words the INDEPENDENT extractor sees in the original, or null when there is
+ * none for this format.
+ *
+ * Independence is the point: an oracle derived from LibreOffice would agree
+ * with LibreOffice about text it dropped, and verify nothing.
+ *
+ *   - `.docx` — mammoth, already a web dependency, reading OOXML directly.
+ *   - `.doc`  — `catdoc`, and `.ppt` — `catppt` (Debian `catdoc`, ~1 MB next
+ *     to LibreOffice's 422 MB). Both are known to under-report and to mangle
+ *     Central/Eastern European diacritics; the lower-bound direction is chosen
+ *     precisely so that costs nothing.
+ *   - `.pptx` — no extractor available without adding a dependency, so it is
+ *     honestly reported as unverified rather than silently passed.
+ *
+ * A missing binary is not an error: it yields null, the file is recorded
+ * `unverified`, and conversion proceeds. Local dev has no catdoc.
+ */
+export async function countSourceWordsWithOracle(absPath: string): Promise<number | null> {
+  const ext = extname(absPath).toLowerCase();
+
+  if (ext === ".docx") {
+    try {
+      const { default: mammoth } = await import("mammoth");
+      const { value } = await mammoth.extractRawText({ path: absPath });
+      return countWords(value);
+    } catch {
+      return null;
+    }
+  }
+
+  if (ext === ".doc") return runTextOracle("catdoc", absPath);
+  if (ext === ".ppt") return runTextOracle("catppt", absPath);
+  return null;
+}
+
+/** Runs a text-dumping CLI over `absPath` and counts its words; null if it is absent or unhappy. */
+function runTextOracle(bin: string, absPath: string): Promise<number | null> {
+  return new Promise((resolve) => {
+    const child = spawn(bin, [absPath], { stdio: ["ignore", "pipe", "ignore"] });
+    let out = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      out += chunk.toString("utf8");
+    });
+    const timer = setTimeout(() => child.kill("SIGKILL"), 30_000);
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve(code === 0 ? countWords(out) : null);
+    });
+  });
+}
+
+/** One word-splitting rule for both sides of the comparison — two rules would make the bound meaningless. */
+export function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}


### PR DESCRIPTION
Closes #936. **Wave 1** — a standalone converter plus its artifact store. Wiring it into the indexer is #938 and serving the artifact as a preview is #939, which is why nothing here touches `ingest.ts`, the schema, `source-links.ts`, the `pinchy-knowledge` plugin or `attachment-preview.tsx`.

## What's here

- `lib/knowledge/office-convert.ts` — batch `.doc/.docx/.ppt/.pptx` → PDF, the failure split, the verification chain.
- `lib/knowledge/office-artifacts.ts` — the artifact store, keyed on `format_version` + content hash, on its own volume.
- `Dockerfile.pinchy` (+ `.dev`), `docker-compose.yml`, `entrypoint.sh` — LibreOffice and the `pinchy-kb-artifacts` volume.
- A `PINCHY_MEM_LIMIT` note in the deployment guide, backed by the measurement below.

## Three behaviours, each verified against the real binary rather than assumed

I probed `libreoffice-writer` in a container before writing the code, because two of these are exactly the kind of thing a fake would happily confirm wrongly.

**Batch, with index-named staging symlinks.** LibreOffice derives the output name from the input's basename, so `sub-a/Rechnung.doc` and `sub-b/Rechnung.doc` — the normal state of a real corpus — would write the same `Rechnung.pdf` and one document would end up serving the other's text. Staging as `0.doc`, `1.docx`, … makes the input→output mapping positional. Confirmed in the container: the output follows the *symlink's* name, not the target's.

**The exit code lies.** A truncated `.docx` prints `Error: source file could not be loaded` on stderr, exits **0**, writes nothing — and the other four files in the same batch convert normally. So the artifact's existence is the evidence, never the return value. Reproduced end-to-end in `office-convert.libreoffice.test.ts`.

**Exit 137 / SIGKILL is infrastructure, not a document verdict.** Both forms are handled (137 is what a shell or `docker` reports; a direct spawn sees the signal with a null code). A batch that was killed returns `infrastructure` for every file in it, so a memory squeeze can never brand good documents as permanently unreadable.

## Verification

`pdf_words >= source_words * (1 - 0.1)` against an *independent* extractor — mammoth for `.docx`, `catdoc`/`catppt` for the legacy binaries. Never equality: every measured deviation on the reference corpus was the oracle under-reporting, so an equality round-trip would fire constantly. Formats with no independent extractor (`.pptx`) are recorded `unverified`, deliberately not `ok`, and an oracle that breaks never fails a document.

The clipped-text-box case the tripwire exists for has never fired on real data, so the fixture for it is synthetic — that gap is documented in the code rather than papered over.

## Memory measurement

The acceptance criterion asks for peak RSS "during a real reindex that includes Office files". That reindex does not exist yet — Office extensions reach `ingest.ts` in #938 — so I measured the next best thing, and it is the part the issue flagged as unmeasured: **17 Word documents converting while the embedding model was actively embedding in the same container**.

| `PINCHY_MEM_LIMIT` | Result |
|---|---|
| `2g` | converts, fastest |
| `1g` (default) | 17/17 |
| `768m` | 17/17, ~20 % slower |
| `640m` | 17/17, ~70 % slower |
| `512m` | **exit 137, OOM-killed** |

So the default holds and the documented 4 GB VPS tuning (`768m`) holds; `512m` is below the floor. Sizing from `memory.peak` remains a trap — it tracks the ceiling because the mmapped GGUF and page cache are reclaimable.

Image cost is as the issue measured: `libreoffice-writer libreoffice-impress fonts-liberation catdoc` = **670 MB** (base `node:22-slim` is 247 MB). `libreoffice-calc` is deliberately absent — spreadsheets take a different path (#937/#940).

## Tests

38 tests across the three files, all passing in a Linux container **with real LibreOffice** — including a round trip that asserts `GODIČ TORKAR`, `Domžale` and `Maßnahmen` survive into the pdfjs text layer, which is what makes `fonts-liberation` non-optional.

`office-convert.libreoffice.test.ts` is gated with `describe.skipIf(!soffice)` (an allowed env/OS conditional gate, not an untracked skip) and skips on a developer laptop; the header documents the one-line `docker run` that executes it.

## Notes for the reviewer

- The docs section describes Office indexing, which becomes user-visible with #938. If #938 slips past a release, that section should be held back with it.
- Three tests fail in my local worktree and I checked them out on the base commit `48493b2c4` — they fail there too, so they are not from this change: `boot-inits.test.ts` (call-order expects 3, gets 6), `vitest-exclude-node-modules.test.ts`, and a flaky `pinchy-files` vision test. CI's `Lint, Test & Build` is green, so this looks environment-specific to that checkout rather than anything wrong on `main`.
