### PR TITLE
feat(kb): name the documents the index cannot search

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -103,7 +103,7 @@ curl -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/knowledg
 | `unsearchable` | Read without error, but the file holds no text to search — nearly always a scanned PDF (see [Scope in this release](#scope-in-this-release)). |
 | `failed`       | Couldn't be read or parsed at all. The run continues; if an earlier version of the file was indexed, that version stays searchable.           |
 
-`indexed` counts documents the agent can actually reach, not documents we processed — that's why a scanned PDF lands under `unsearchable` instead. If either of the last two numbers is above zero, part of your corpus can't answer questions yet, and it's worth knowing which part before someone asks it something.
+`indexed` counts documents the agent can actually reach, not documents we processed — that's why a scanned PDF lands under `unsearchable` instead. If either of the last two numbers is above zero, part of your corpus can't answer questions yet, and it's worth knowing which part before someone asks it something. For `unsearchable` you don't have to go looking: the **Index** section names those documents, one path per document (see [Documents that can't be searched](#documents-that-cant-be-searched)). A `failed` file can't be named there — it never got far enough to have an entry in the index — so that one you find in the run's log.
 
 A `status` of `failed` is a different thing from a `failed` file: it means something systemic stopped the whole run — the embedding model failed to load, or the database did — and `error` says what. A broken file never gets that far; it's counted and stepped over.
 
@@ -163,6 +163,18 @@ Phase 1 of the knowledge base is deliberately narrow:
 - Only **text-based PDFs** are indexed and searchable via `knowledge_search`. Scanned/image-only PDFs and Office documents (`.docx`, etc.) are on the roadmap, not indexed today.
 - There's no clickable link from a citation into the PDF viewer yet — citations are text (document path + page), not a jump-to-passage link.
 - Indexing is a manual admin action (step 7). It runs in the background and reports progress, but you still have to ask for it — a scheduled sweep and a progress UI in the app are planned for a later phase.
+
+### Documents that can't be searched
+
+A gap you can't see is worse than one you can. If an agent answers "I found nothing" about a scanned certificate, it sounds like a statement about your company — not about the index — and nobody thinks to check.
+
+So the **Index** section in the agent's Permissions tab lists the documents this applies to, by full path: everything that was indexed but produced no searchable text. It's scoped to the folders that agent is granted, exactly like search itself, so the list never mentions a document the agent isn't allowed to know about. Documents in archived folders are listed last and marked as such — they're already out of everyday search.
+
+The list covers everything in those folders, while the `unsearchable` count above it covers only the documents the last run actually touched — a file that hasn't changed since the run before is `skipped`, not counted again. So the list is usually the larger of the two, and that's them agreeing, not disagreeing.
+
+Today these are almost always scans, and reading text from scans is on the roadmap. When it lands, the list empties itself. Until then it tells you which questions your agent can't answer yet, before somebody asks one of them.
+
+If the list is empty after a run that finished, that's the whole message: every document in those folders came back with searchable text. After a run that failed we don't say it — the run stopped early, so there's nothing solid to say it about.
 
 Every retrieval and every reindex is recorded in the [audit trail](/concepts/audit-trail/) — each `knowledge_search` call as `retrieval.query` with the documents it drew on (and a flag when the search reached into archived material), and every reindex as two `knowledge.reindex` entries sharing a `jobId`: who asked for it, and how it turned out, including how many documents were archived. Both are needed, because the run finishes long after the request that started it. The search query text itself is never stored in plaintext, only a one-way hash.
 

--- a/packages/web/src/__tests__/api/knowledge-unsearchable.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-unsearchable.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Route tests for GET /api/agents/[agentId]/knowledge/unsearchable (#935).
+ *
+ * These cover the ACCESS boundary — who may ask, and which paths the question
+ * is asked about. Whether the SQL then answers it correctly is a database
+ * question, pinned against a real Postgres in
+ * lib/knowledge/unsearchable.integration.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+const mockLimit = vi.fn();
+const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+vi.mock("@/db", () => ({
+  db: { select: (...args: unknown[]) => mockSelect(...args) },
+}));
+
+vi.mock("@/db/schema", () => ({
+  activeAgents: { __table: "active_agents", id: "active_agents.id" },
+}));
+
+const mockListUnsearchableDocuments = vi.fn();
+vi.mock("@/lib/knowledge/unsearchable", () => ({
+  listUnsearchableDocuments: (...args: unknown[]) => mockListUnsearchableDocuments(...args),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
+
+const makeRequest = () =>
+  new NextRequest("http://localhost/api/agents/agent-1/knowledge/unsearchable");
+
+const agentRow = {
+  id: "agent-1",
+  name: "Smithers",
+  pluginConfig: { "pinchy-files": { allowed_paths: ["/data/hr", "/data/legal"] } },
+};
+
+describe("GET /api/agents/[agentId]/knowledge/unsearchable", () => {
+  let GET: typeof import("@/app/api/agents/[agentId]/knowledge/unsearchable/route").GET;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ user: { id: "admin-1", role: "admin" } });
+    mockLimit.mockResolvedValue([agentRow]);
+    mockListUnsearchableDocuments.mockResolvedValue({ documents: [], total: 0 });
+    GET = (await import("@/app/api/agents/[agentId]/knowledge/unsearchable/route")).GET;
+  });
+
+  it("returns 401 when unauthenticated and never queries", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+
+    const res = await GET(makeRequest(), ctx as never);
+
+    expect(res.status).toBe(401);
+    expect(mockListUnsearchableDocuments).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for an authenticated non-admin and never queries", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "user-1", role: "member" } });
+
+    const res = await GET(makeRequest(), ctx as never);
+
+    expect(res.status).toBe(403);
+    expect(mockListUnsearchableDocuments).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown agent and never queries", async () => {
+    mockLimit.mockResolvedValueOnce([]);
+
+    const res = await GET(makeRequest(), ctx as never);
+
+    expect(res.status).toBe(404);
+    expect(mockListUnsearchableDocuments).not.toHaveBeenCalled();
+  });
+
+  // The security boundary of this route: the scope comes from the agent's
+  // SAVED grants, never from the request. A route that took a path from the
+  // query string would let an admin enumerate documents an agent was never
+  // granted — the exact thing the allow-list exists to prevent.
+  it("scopes the query to the agent's granted directories", async () => {
+    await GET(makeRequest(), ctx as never);
+
+    expect(mockListUnsearchableDocuments).toHaveBeenCalledWith(DEFAULT_ORG_ID, [
+      "/data/hr",
+      "/data/legal",
+    ]);
+  });
+
+  it("scopes to nothing when the agent has no pinchy-files grants", async () => {
+    mockLimit.mockResolvedValueOnce([{ id: "agent-1", name: "Smithers", pluginConfig: null }]);
+
+    const res = await GET(makeRequest(), ctx as never);
+
+    expect(res.status).toBe(200);
+    expect(mockListUnsearchableDocuments).toHaveBeenCalledWith(DEFAULT_ORG_ID, []);
+  });
+
+  it("returns the documents and the untruncated total", async () => {
+    mockListUnsearchableDocuments.mockResolvedValueOnce({
+      documents: [
+        { sourcePath: "/data/hr/AFNOR validation.pdf", status: "active" },
+        { sourcePath: "/data/hr/OLD/Expired ISO.pdf", status: "archived" },
+      ],
+      total: 25,
+    });
+
+    const res = await GET(makeRequest(), ctx as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      documents: [
+        { sourcePath: "/data/hr/AFNOR validation.pdf", status: "active" },
+        { sourcePath: "/data/hr/OLD/Expired ISO.pdf", status: "archived" },
+      ],
+      total: 25,
+    });
+  });
+});

--- a/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-reindex-section.test.tsx
@@ -19,6 +19,25 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), message: vi.fn() },
 }));
 
+// The unsearchable-document list owns its own read (and is tested on its own in
+// knowledge-unsearchable-list.test.tsx). Stubbed here so this file keeps testing
+// ONE network conversation, with the props rendered as attributes so the
+// section's decisions about WHEN to show it stay assertable.
+vi.mock("@/components/knowledge-unsearchable-list", () => ({
+  KnowledgeUnsearchableList: (props: {
+    agentId: string;
+    announceNone: boolean;
+    reloadKey: string;
+  }) => (
+    <div
+      data-testid="unsearchable-list"
+      data-agent-id={props.agentId}
+      data-announce-none={String(props.announceNone)}
+      data-reload-key={props.reloadKey}
+    />
+  ),
+}));
+
 const mockGet = vi.mocked(apiGet);
 const mockPost = vi.mocked(apiPost);
 
@@ -204,6 +223,93 @@ describe("KnowledgeReindexSection", () => {
 
     const bar = await screen.findByRole("progressbar");
     await waitFor(() => expect(bar).toHaveAttribute("aria-valuenow", "100"));
+  });
+
+  // #935: the reindex summary counts unsearchable documents; the list beside it
+  // names them. Which documents an admin may see is the route's business — this
+  // is only about when the section asks for them at all.
+  describe("unsearchable documents", () => {
+    it("shows the list beside the counts once a run has finished, and lets it announce zero", async () => {
+      mockGet.mockResolvedValue({
+        job: job({
+          status: "succeeded",
+          counts: { indexed: 90, skipped: 5, removed: 0, unsearchable: 4, failed: 1 },
+        }),
+      });
+
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      const list = await screen.findByTestId("unsearchable-list");
+      expect(list).toHaveAttribute("data-agent-id", "a1");
+      expect(list).toHaveAttribute("data-announce-none", "true");
+    });
+
+    // The index is corpus-wide: another agent's run can have left unsearchable
+    // documents inside this agent's scope, so the list is still asked for — it
+    // just may not reassure about a zero it has no run to stand on.
+    it("still shows the list before any run of its own, but without announcing zero", async () => {
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      const list = await screen.findByTestId("unsearchable-list");
+      expect(list).toHaveAttribute("data-announce-none", "false");
+    });
+
+    // A failed run stopped somewhere; what it indexed before that is a partial
+    // corpus. Listing what it found is useful, but "every document came back
+    // with searchable text" printed under "Last reindex failed" is an all-clear
+    // about a run that never finished — the one place this panel could add a
+    // false reassurance instead of removing one.
+    it("shows the list after a failed run but never lets it announce zero", async () => {
+      mockGet.mockResolvedValue({
+        job: job({ status: "failed", error: "Embedding model failed to load" }),
+      });
+
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      const list = await screen.findByTestId("unsearchable-list");
+      expect(list).toHaveAttribute("data-announce-none", "false");
+    });
+
+    it("hides the list while a run is in flight", async () => {
+      mockGet.mockResolvedValue({ job: job({ status: "running", processed: 3, total: 10 }) });
+
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+
+      await waitFor(() => expect(screen.getByText(/indexing 3 of 10/i)).toBeInTheDocument());
+      expect(screen.queryByTestId("unsearchable-list")).not.toBeInTheDocument();
+    });
+
+    it("hides the list when no directory is granted", async () => {
+      render(<KnowledgeReindexSection agentId="a1" allowedPathCount={0} />);
+
+      await waitFor(() => expect(screen.getByRole("button", { name: /reindex/i })).toBeDisabled());
+      expect(screen.queryByTestId("unsearchable-list")).not.toBeInTheDocument();
+    });
+
+    // Both inputs that can invalidate the list: a finished run (new findings)
+    // and a changed grant count (a different scope to report on).
+    it("re-reads the list after a finished run and after a grant change", async () => {
+      mockGet.mockResolvedValue({ job: job({ id: "job-1", status: "succeeded" }) });
+      const first = render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+      const afterJob1 = (await screen.findByTestId("unsearchable-list")).getAttribute(
+        "data-reload-key"
+      );
+      first.unmount();
+
+      // A later run of its own is new evidence about the same scope.
+      mockGet.mockResolvedValue({ job: job({ id: "job-2", status: "succeeded" }) });
+      const second = render(<KnowledgeReindexSection agentId="a1" allowedPathCount={2} />);
+      const afterJob2 = (await screen.findByTestId("unsearchable-list")).getAttribute(
+        "data-reload-key"
+      );
+      expect(afterJob2).not.toBe(afterJob1);
+
+      // So is a changed grant: same run, different scope to report on.
+      second.rerender(<KnowledgeReindexSection agentId="a1" allowedPathCount={3} />);
+      expect(screen.getByTestId("unsearchable-list").getAttribute("data-reload-key")).not.toBe(
+        afterJob2
+      );
+    });
   });
 
   it("warns that a reindex uses the saved grants while directory changes are unsaved", async () => {

--- a/packages/web/src/__tests__/components/knowledge-unsearchable-list.test.tsx
+++ b/packages/web/src/__tests__/components/knowledge-unsearchable-list.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { KnowledgeUnsearchableList } from "@/components/knowledge-unsearchable-list";
+import { apiGet } from "@/lib/api-client";
+
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return { ...actual, apiGet: vi.fn() };
+});
+
+const mockGet = vi.mocked(apiGet);
+
+describe("KnowledgeUnsearchableList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ documents: [], total: 0 });
+  });
+
+  it("names the documents that can't be searched, by full path", async () => {
+    mockGet.mockResolvedValue({
+      documents: [
+        { sourcePath: "/data/certs/AFNOR validation.pdf", status: "active" },
+        { sourcePath: "/data/certs/NordVal certificate.pdf", status: "active" },
+      ],
+      total: 2,
+    });
+
+    render(<KnowledgeUnsearchableList agentId="a1" announceNone />);
+
+    await waitFor(() =>
+      expect(screen.getByText("/data/certs/AFNOR validation.pdf")).toBeInTheDocument()
+    );
+    expect(screen.getByText("/data/certs/NordVal certificate.pdf")).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith("/api/agents/a1/knowledge/unsearchable");
+  });
+
+  // The whole point of the panel: a reader must learn that "nothing found" can
+  // be a fact about the INDEX, not about the documents.
+  it("says why it matters — the agent will answer 'nothing found' for these", async () => {
+    mockGet.mockResolvedValue({
+      documents: [{ sourcePath: "/data/certs/AFNOR validation.pdf", status: "active" }],
+      total: 1,
+    });
+
+    render(<KnowledgeUnsearchableList agentId="a1" announceNone />);
+
+    await waitFor(() => expect(screen.getByText(/no searchable text/i)).toBeInTheDocument());
+    expect(screen.getByText(/won't find anything in them/i)).toBeInTheDocument();
+  });
+
+  // This number counts the whole scope; the per-run counts it renders beside
+  // only count what that run processed (an unchanged document is `skipped`, not
+  // recounted). Naming the window is what stops "4 unsearchable" above "25
+  // documents…" from reading as a contradiction — so it is asserted, not left
+  // to survive the next copy edit by luck.
+  it("names the window it is counting, so it can't be read against the run counts", async () => {
+    mockGet.mockResolvedValue({
+      documents: [{ sourcePath: "/data/certs/Scan.pdf", status: "active" }],
+      total: 25,
+    });
+
+    render(<KnowledgeUnsearchableList agentId="a1" announceNone />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/25 documents in this agent's folders/i)).toBeInTheDocument()
+    );
+  });
+
+  it("reads as good news when every document has text", async () => {
+    render(<KnowledgeUnsearchableList agentId="a1" announceNone />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/every document in this agent's folders/i)).toBeInTheDocument()
+    );
+    // Good news, not a warning: no alert role, nothing to act on.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  // Before a run has ever finished, "every document has searchable text" is
+  // trivially true of an empty index and would sit right under "Not yet
+  // indexed" — a reassurance about nothing.
+  it("stays silent about zero when no run has finished yet", async () => {
+    const { container } = render(<KnowledgeUnsearchableList agentId="a1" announceNone={false} />);
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // …but a corpus indexed by ANOTHER agent still shows up: the index is
+  // corpus-wide, so this agent's scope can hold unsearchable documents without
+  // this agent ever having run an index itself.
+  it("lists documents even when this agent has never finished a run", async () => {
+    mockGet.mockResolvedValue({
+      documents: [{ sourcePath: "/data/certs/Scan.pdf", status: "active" }],
+      total: 1,
+    });
+
+    render(<KnowledgeUnsearchableList agentId="a1" announceNone={false} />);
+
+    await waitFor(() => expect(screen.getByText("/data/certs/Scan.pdf")).toBeInTheDocument());
+  });
+
+  it("marks archived documents as archived", async () => {
+    mockGet.mockResolvedValue({
+      documents: [{ sourcePath: "/data/certs/OLD/Expired ISO.pdf", status: "archived" }],
+      total: 1,
+    });
+
+    render(<KnowledgeUnsearchableList agentId="a1" announceNone />);
+
+    await waitFor(() =>
+      expect(screen.getByText("/data/certs/OLD/Expired ISO.pdf")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/archived/i)).toBeInTheDocument();
+  });
+
+  // A truncated list that doesn't say it's truncated understates exactly the
+  // gap it exists to expose.
+  it("says how many it is not showing when the list is capped", async () => {
+    mockGet.mockResolvedValue({
+      documents: [
+        { sourcePath: "/data/certs/Scan 1.pdf", status: "active" },
+        { sourcePath: "/data/certs/Scan 2.pdf", status: "active" },
+      ],
+      total: 25,
+    });
+
+    render(<KnowledgeUnsearchableList agentId="a1" announceNone />);
+
+    await waitFor(() => expect(screen.getByText(/showing 2 of 25/i)).toBeInTheDocument());
+  });
+
+  it("reloads when the reload key changes, and not otherwise", async () => {
+    const { rerender } = render(
+      <KnowledgeUnsearchableList agentId="a1" announceNone reloadKey="job-1:succeeded" />
+    );
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1));
+
+    rerender(<KnowledgeUnsearchableList agentId="a1" announceNone reloadKey="job-1:succeeded" />);
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    rerender(<KnowledgeUnsearchableList agentId="a1" announceNone reloadKey="job-2:succeeded" />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+
+  // A failed read must not claim the corpus is clean: silence is the honest
+  // answer, and the next reload retries.
+  it("renders nothing when the read fails, rather than a false all-clear", async () => {
+    mockGet.mockRejectedValue(new Error("network down"));
+
+    const { container } = render(<KnowledgeUnsearchableList agentId="a1" announceNone />);
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/unsearchable.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/unsearchable.integration.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Real-DB integration tests for listUnsearchableDocuments() (#935): the
+ * documents an index run produced a row for but no searchable text from.
+ *
+ * These belong against a real PostgreSQL database rather than a mocked query
+ * builder, because every way this feature can be wrong is a way the SQL can be
+ * wrong: an inner join instead of a left join lists nothing (or everything) and
+ * still looks plausible, and a prefix filter that forgets to escape LIKE
+ * metacharacters silently widens an agent's scope. Neither mistake is visible
+ * from a mock that returns whatever it was told to.
+ *
+ * Rows are inserted directly (no ingest, no embedder) — a chunk's `embedding`
+ * is nullable, and nothing here ranks anything.
+ */
+import { expect, it } from "vitest";
+
+import { db } from "@/db";
+import { kbChunks, kbDocuments } from "@/db/schema";
+import { listUnsearchableDocuments } from "@/lib/knowledge/unsearchable";
+
+const ORG_ID = "org-kb-unsearchable-test";
+
+/** Inserts a kb_documents row with NO chunks — what an unsearchable (or unconverted) document looks like in the database. */
+async function seedUnsearchable(
+  sourcePath: string,
+  status: "active" | "archived" = "active"
+): Promise<string> {
+  const [doc] = await db
+    .insert(kbDocuments)
+    .values({ orgId: ORG_ID, contentHash: `hash-${sourcePath}`, sourcePath, status })
+    .returning();
+  return doc.id;
+}
+
+/** Inserts a kb_documents row WITH one chunk — a document that answers questions. */
+async function seedReadable(sourcePath: string): Promise<void> {
+  const [doc] = await db
+    .insert(kbDocuments)
+    .values({ orgId: ORG_ID, contentHash: `hash-${sourcePath}`, sourcePath })
+    .returning();
+  await db.insert(kbChunks).values({
+    documentId: doc.id,
+    orgId: ORG_ID,
+    sourcePath,
+    chunkText: "Some extracted text.",
+    page: 1,
+  });
+}
+
+const paths = (result: { documents: { sourcePath: string }[] }) =>
+  result.documents.map((d) => d.sourcePath);
+
+it("lists exactly the documents that have a row and no chunks", async () => {
+  await seedUnsearchable("/data/certs/AFNOR validation.pdf");
+  await seedReadable("/data/certs/Datasheet.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/certs"]);
+
+  expect(paths(result)).toEqual(["/data/certs/AFNOR validation.pdf"]);
+  expect(result.total).toBe(1);
+});
+
+// The left-join trap named in #935: an INNER join would list nothing at all
+// here, and an unfiltered join would list this document once per chunk. Two
+// chunks make both mistakes visible; one chunk hides the second.
+it("never lists a document that has chunks, not even once per chunk", async () => {
+  const [doc] = await db
+    .insert(kbDocuments)
+    .values({
+      orgId: ORG_ID,
+      contentHash: "hash-multi",
+      sourcePath: "/data/certs/Handbook.pdf",
+    })
+    .returning();
+  await db.insert(kbChunks).values([
+    {
+      documentId: doc.id,
+      orgId: ORG_ID,
+      sourcePath: "/data/certs/Handbook.pdf",
+      chunkText: "Page one.",
+      page: 1,
+    },
+    {
+      documentId: doc.id,
+      orgId: ORG_ID,
+      sourcePath: "/data/certs/Handbook.pdf",
+      chunkText: "Page two.",
+      page: 2,
+    },
+  ]);
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/certs"]);
+
+  expect(result.documents).toEqual([]);
+  expect(result.total).toBe(0);
+});
+
+it("does not list unsearchable documents outside the agent's granted directories", async () => {
+  await seedUnsearchable("/data/hr/Scanned contract.pdf");
+  await seedUnsearchable("/data/legal/Scanned NDA.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/hr"]);
+
+  expect(paths(result)).toEqual(["/data/hr/Scanned contract.pdf"]);
+});
+
+// Same separator-boundary reasoning as retrieval's path filter: a grant on
+// "/data/hr" must not reach into a sibling folder whose name merely starts
+// with it.
+it("treats a grant as a directory boundary, not a string prefix", async () => {
+  await seedUnsearchable("/data/hr-archive/Scan.pdf");
+  await seedUnsearchable("/data/hr/Scan.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/hr"]);
+
+  expect(paths(result)).toEqual(["/data/hr/Scan.pdf"]);
+});
+
+// "_" is a single-character LIKE wildcard. Unescaped, a grant on "/data/hr_eu"
+// would also match "/data/hrxeu" — a real folder-naming pattern turning into a
+// scope bypass.
+it("escapes LIKE metacharacters in a granted path", async () => {
+  await seedUnsearchable("/data/hr_eu/Scan.pdf");
+  await seedUnsearchable("/data/hrxeu/Scan.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/hr_eu"]);
+
+  expect(paths(result)).toEqual(["/data/hr_eu/Scan.pdf"]);
+});
+
+it("lists a document granted by its exact path, not only by its parent directory", async () => {
+  await seedUnsearchable("/data/certs/AFNOR validation.pdf");
+  await seedUnsearchable("/data/certs/NordVal.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/certs/AFNOR validation.pdf"]);
+
+  expect(paths(result)).toEqual(["/data/certs/AFNOR validation.pdf"]);
+});
+
+// Denies by default, exactly as retrieve() does: an agent granted nothing sees
+// nothing — never "everything, because there is no filter to apply".
+it("returns nothing when the agent is granted no directories", async () => {
+  await seedUnsearchable("/data/hr/Scan.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, []);
+
+  expect(result).toEqual({ documents: [], total: 0 });
+});
+
+it("never crosses the org boundary", async () => {
+  await seedUnsearchable("/data/hr/Scan.pdf");
+  await db.insert(kbDocuments).values({
+    orgId: "org-somebody-else",
+    contentHash: "hash-other",
+    sourcePath: "/data/hr/Other org scan.pdf",
+  });
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/hr"]);
+
+  expect(paths(result)).toEqual(["/data/hr/Scan.pdf"]);
+});
+
+// kb_chunks denormalizes source_path from its parent document, so "has text?"
+// could be asked by path (as the exploratory query in #935 did) or by
+// document_id. They disagree exactly when two DOCUMENTS share a path — which
+// (org_id, source_path) being unique makes an ACL duplicate across orgs. The
+// join is on document_id, and this pins it: another document's chunk must
+// never make this one look readable.
+it("decides per document, not per path", async () => {
+  const [foreignDoc] = await db
+    .insert(kbDocuments)
+    .values({
+      orgId: "org-somebody-else",
+      contentHash: "hash-shared",
+      sourcePath: "/data/certs/Shared name.pdf",
+    })
+    .returning();
+  await db.insert(kbChunks).values({
+    documentId: foreignDoc.id,
+    orgId: ORG_ID,
+    sourcePath: "/data/certs/Shared name.pdf",
+    chunkText: "Text belonging to the other document.",
+    page: 1,
+  });
+  await seedUnsearchable("/data/certs/Shared name.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/certs"]);
+
+  expect(paths(result)).toEqual(["/data/certs/Shared name.pdf"]);
+});
+
+it("orders active documents before archived ones, then by path", async () => {
+  await seedUnsearchable("/data/certs/OLD/Expired ISO.pdf", "archived");
+  await seedUnsearchable("/data/certs/NordVal.pdf");
+  await seedUnsearchable("/data/certs/AFNOR.pdf");
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/certs"]);
+
+  expect(result.documents).toEqual([
+    { sourcePath: "/data/certs/AFNOR.pdf", status: "active" },
+    { sourcePath: "/data/certs/NordVal.pdf", status: "active" },
+    { sourcePath: "/data/certs/OLD/Expired ISO.pdf", status: "archived" },
+  ]);
+});
+
+// A corpus can hold more unsearchable documents than a panel should render. The
+// cap truncates the list, never the count — a "showing 2 of 5" is honest, a
+// silent "2" would understate the gap it exists to expose.
+it("caps the returned list but reports the true total", async () => {
+  for (const n of [1, 2, 3, 4, 5]) {
+    await seedUnsearchable(`/data/certs/Scan ${n}.pdf`);
+  }
+
+  const result = await listUnsearchableDocuments(ORG_ID, ["/data/certs"], { limit: 2 });
+
+  expect(paths(result)).toEqual(["/data/certs/Scan 1.pdf", "/data/certs/Scan 2.pdf"]);
+  expect(result.total).toBe(5);
+});

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/unsearchable/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/unsearchable/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+
+import { withAdmin } from "@/lib/api-auth";
+import { db } from "@/db";
+import { activeAgents, type AgentPluginConfig } from "@/db/schema";
+import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
+import { listUnsearchableDocuments } from "@/lib/knowledge/unsearchable";
+
+type RouteContext = { params: Promise<{ agentId: string }> };
+
+/**
+ * GET /api/agents/[agentId]/knowledge/unsearchable — WHICH documents the index
+ * holds but cannot search, not just how many (#935).
+ *
+ * The reindex status route already reports `unsearchable` as a count. A count
+ * nobody can expand is the silent half of a known gap: the agent answers "I
+ * found nothing" and the reader hears a statement about the world rather than
+ * about the index. Named after that counter on purpose — this is the list
+ * behind it, and `unreadable` is the word the docs already spend on `failed`,
+ * which (see lib/knowledge/unsearchable.ts) is the one state this cannot show.
+ *
+ * Wider window than the counter, though: a run counts only what it processed,
+ * this answers for everything currently in scope. Callers rendering the two
+ * together must say which is which.
+ *
+ * Scope: the agent's SAVED `pinchy-files` grants — the same allow-list that
+ * scopes retrieval, resolved from the same place. Never from the request: a
+ * path parameter here would turn a diagnostics panel into a way to enumerate
+ * documents the agent was never granted.
+ *
+ * Admin-only, like the reindex it explains.
+ */
+// audit-exempt: read-only projection of already-stored index state, no state change.
+export const GET = withAdmin<RouteContext>(async (_request, { params }) => {
+  const { agentId } = await params;
+
+  const [agent] = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId)).limit(1);
+  if (!agent) {
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  const allowedPaths =
+    (agent.pluginConfig as AgentPluginConfig | null)?.["pinchy-files"]?.allowed_paths ?? [];
+
+  // Denies by default on an empty grant list (see listUnsearchableDocuments), so
+  // an agent granted nothing reports nothing rather than the whole corpus.
+  const { documents, total } = await listUnsearchableDocuments(DEFAULT_ORG_ID, allowedPaths);
+
+  return NextResponse.json({ documents, total });
+});

--- a/packages/web/src/components/knowledge-reindex-section.tsx
+++ b/packages/web/src/components/knowledge-reindex-section.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { KnowledgeUnsearchableList } from "@/components/knowledge-unsearchable-list";
 import { apiGet, apiPost, ApiError } from "@/lib/api-client";
 import type { IngestResult } from "@/lib/knowledge/types";
 import type { KnowledgeReindexRequest } from "@/lib/schemas/knowledge-base";
@@ -183,6 +184,26 @@ export function KnowledgeReindexSection({
         <FailedState job={job} />
       ) : (
         <p className="text-sm text-muted-foreground">Not yet indexed.</p>
+      )}
+
+      {/* Which documents the counts above mean by "unsearchable" (#935). Hidden
+          while a run is in flight — the list is about to change — and hidden
+          without a grant, where there is nothing to report on. Documents that
+          exist are listed in every other state, since the index is corpus-wide
+          and another agent's run can have filled this scope.
+
+          A zero, though, is only announced after a SUCCEEDED run. Before any
+          run, "every document came back with searchable text" is trivially true
+          of an empty index and would sit under "Not yet indexed"; after a
+          FAILED one it would sit under "Last reindex failed" and read as an
+          all-clear about a run that stopped early. Both are reassurances the
+          evidence doesn't support. */}
+      {allowedPathCount > 0 && !active && (
+        <KnowledgeUnsearchableList
+          agentId={agentId}
+          announceNone={job?.status === "succeeded"}
+          reloadKey={`${allowedPathCount}:${job?.id ?? "none"}:${job?.status ?? "none"}`}
+        />
       )}
     </div>
   );

--- a/packages/web/src/components/knowledge-unsearchable-list.tsx
+++ b/packages/web/src/components/knowledge-unsearchable-list.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { apiGet } from "@/lib/api-client";
+
+/** One document the index holds but cannot search. Mirrors the route's projection. */
+interface UnsearchableDocument {
+  sourcePath: string;
+  status: "active" | "archived";
+}
+
+interface UnsearchableResponse {
+  documents: UnsearchableDocument[];
+  /** The untruncated count — `documents` may be capped by the route. */
+  total: number;
+}
+
+export interface KnowledgeUnsearchableListProps {
+  agentId: string;
+  /**
+   * Whether "none" is worth saying out loud. Before any run has finished,
+   * "every document has searchable text" is trivially true of an empty index
+   * and would sit directly under "Not yet indexed" — a reassurance about
+   * nothing. Documents that DO exist are always listed, run or no run: the
+   * index is corpus-wide, so another agent's run can have filled this agent's
+   * scope.
+   */
+  announceNone: boolean;
+  /**
+   * Changes when the underlying index state has moved on (a finished run), to
+   * re-read the list. A plain value rather than a callback, so the parent
+   * doesn't have to hold a ref to this component.
+   */
+  reloadKey?: string;
+}
+
+/**
+ * The documents in this agent's scope that carry no searchable text (#935).
+ *
+ * The reindex summary counts them; this names them. A count nobody can expand
+ * is the silent half of a known gap — the agent answers "I found nothing" and
+ * the reader hears a statement about the world rather than about the index. On
+ * the corpus that motivated this, 19 of 25 such documents were certifications:
+ * exactly what a technical-sales team asks about all day.
+ */
+export function KnowledgeUnsearchableList({
+  agentId,
+  announceNone,
+  reloadKey,
+}: KnowledgeUnsearchableListProps) {
+  const [result, setResult] = useState<UnsearchableResponse | null>(null);
+  const url = `/api/agents/${agentId}/knowledge/unsearchable`;
+
+  // Monotonic ticket, same reasoning as the reindex section's status reads: a
+  // reload issued on a finished run must not be overwritten by a slower read
+  // from before it.
+  const fetchSeq = useRef(0);
+
+  useEffect(() => {
+    const seq = ++fetchSeq.current;
+    void (async () => {
+      try {
+        const res = await apiGet<UnsearchableResponse>(url);
+        if (seq === fetchSeq.current) setResult(res);
+      } catch {
+        // A failed read stays silent rather than claiming an all-clear. No
+        // toast either: this panel is a detail beside the reindex control, and
+        // an unreachable API already surfaces there.
+      }
+    })();
+  }, [url, reloadKey]);
+
+  if (!result) return null;
+
+  if (result.total === 0) {
+    if (!announceNone) return null;
+    return (
+      <p className="text-sm text-muted-foreground">
+        Every document in this agent&apos;s folders came back with searchable text.
+      </p>
+    );
+  }
+
+  const hidden = result.total - result.documents.length;
+
+  return (
+    <div className="space-y-2">
+      {/* "in this agent's folders" is load-bearing, not padding. The counts
+          directly above are per-RUN — a document unchanged since the last index
+          is `skipped`, not recounted as unsearchable — while this number covers
+          everything in scope. So "4 unsearchable" over "25 documents…" is the
+          normal case, and without the scope named it reads as a contradiction. */}
+      <p className="text-sm text-amber-600 dark:text-amber-500">
+        {result.total === 1
+          ? "1 document in this agent's folders is indexed but holds no searchable text"
+          : `${result.total} documents in this agent's folders are indexed but hold no searchable text`}{" "}
+        — nearly always scans. Your agent won&apos;t find anything in them, so it will answer that
+        it found nothing. Reading text from scans is on the roadmap.
+      </p>
+      <ul className="max-h-48 space-y-1 overflow-y-auto rounded-md border p-2">
+        {result.documents.map((doc) => (
+          <li key={doc.sourcePath} className="flex items-baseline gap-2 text-sm">
+            {/* The full path, not the basename: two folders can hold the same
+                filename, and the path is what lets an admin go and look. */}
+            <span className="font-mono text-xs break-all">{doc.sourcePath}</span>
+            {doc.status === "archived" && (
+              <span className="text-muted-foreground shrink-0 text-xs">archived</span>
+            )}
+          </li>
+        ))}
+      </ul>
+      {hidden > 0 && (
+        <p className="text-muted-foreground text-sm">
+          Showing {result.documents.length} of {result.total}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/knowledge/path-filter.ts
+++ b/packages/web/src/lib/knowledge/path-filter.ts
@@ -1,0 +1,44 @@
+/**
+ * The knowledge base's path allow-list, as a SQL predicate.
+ *
+ * Every read that answers "what does this agent know about?" — retrieval
+ * (./retrieve.ts) and the unsearchable-document list (./unsearchable.ts) — is
+ * scoped by the SAME admin-configured `allowed_paths` grants, so the rule that
+ * decides what is inside a grant lives once. Two copies of a boundary check are
+ * two chances to fix only one of them.
+ */
+import { sql, type SQL } from "drizzle-orm";
+import { sep } from "node:path";
+
+/**
+ * Escapes Postgres LIKE metacharacters (`\`, `%`, `_`) in a path segment
+ * before it's used as a LIKE prefix pattern. Without this, an allowed path
+ * that happens to contain a literal `_` (a single-character LIKE wildcard,
+ * common in real folder names like "my_folder") would silently widen the
+ * match to unrelated paths — a security-relevant boundary bypass.
+ */
+function escapeLikePattern(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
+/**
+ * Builds the WHERE fragment scoping a query to `allowedPaths`. A row qualifies
+ * iff `column` equals an allowed path exactly, or sits under an allowed
+ * directory. The path separator is appended to the allowed path before
+ * prefix-matching so "/data/foo" never matches "/data/foobar/x.pdf" — the same
+ * boundary reasoning as ingest.ts's removal pass.
+ *
+ * `column` is a caller-supplied SQL fragment (e.g. sql`c.source_path`) rather
+ * than a string, so the alias in play at the call site stays with the query
+ * that owns it. Callers must handle an EMPTY `allowedPaths` list themselves,
+ * by denying: this returns an empty fragment, which as a WHERE clause would
+ * mean "no restriction".
+ */
+export function buildPathFilter(allowedPaths: readonly string[], column: SQL): SQL {
+  const conditions = allowedPaths.map((allowedPath) => {
+    const prefix = allowedPath.endsWith(sep) ? allowedPath : allowedPath + sep;
+    const likePattern = `${escapeLikePattern(prefix)}%`;
+    return sql`(${column} = ${allowedPath} OR ${column} LIKE ${likePattern} ESCAPE '\\')`;
+  });
+  return sql.join(conditions, sql` OR `);
+}

--- a/packages/web/src/lib/knowledge/retrieve.ts
+++ b/packages/web/src/lib/knowledge/retrieve.ts
@@ -15,9 +15,9 @@
  * so the integration suite stays hermetic — no Ollama required.
  */
 import { sql } from "drizzle-orm";
-import { sep } from "node:path";
 
 import { db } from "@/db";
+import { buildPathFilter } from "./path-filter";
 
 export interface RetrievedChunk {
   chunkId: string;
@@ -87,34 +87,6 @@ interface RetrieveRow extends Record<string, unknown> {
 }
 
 /**
- * Escapes Postgres LIKE metacharacters (`\`, `%`, `_`) in a path segment
- * before it's used as a LIKE prefix pattern. Without this, an allowed path
- * that happens to contain a literal `_` (a single-character LIKE wildcard,
- * common in real folder names like "my_folder") would silently widen the
- * match to unrelated paths — a security-relevant boundary bypass.
- */
-function escapeLikePattern(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
-}
-
-/**
- * Builds the WHERE fragment scoping retrieval to `allowedPaths`. A chunk
- * (aliased `c` in the caller's query) qualifies iff its `source_path`
- * equals an allowed path exactly, or sits under an allowed directory. The
- * path separator is appended to the allowed path before prefix-matching so
- * "/data/foo" never matches "/data/foobar/x.pdf" — the same boundary
- * reasoning as ingest.ts's removal pass.
- */
-function buildPathFilter(allowedPaths: string[]) {
-  const conditions = allowedPaths.map((allowedPath) => {
-    const prefix = allowedPath.endsWith(sep) ? allowedPath : allowedPath + sep;
-    const likePattern = `${escapeLikePattern(prefix)}%`;
-    return sql`(c.source_path = ${allowedPath} OR c.source_path LIKE ${likePattern} ESCAPE '\\')`;
-  });
-  return sql.join(conditions, sql` OR `);
-}
-
-/**
  * Retrieves the top-`k` kb_chunks for `query`, scoped to `orgId` and
  * `allowedPaths`. An empty `allowedPaths` list denies by default and
  * returns `[]` without calling `deps.embed` — an agent granted no paths
@@ -138,7 +110,7 @@ export async function retrieve(
   // pgvector's textual literal is the same `[1,2,3]` form JSON.stringify
   // produces for a number array (see db/vector.ts's customType).
   const queryVectorLiteral = JSON.stringify(queryVector);
-  const pathFilter = buildPathFilter(allowedPaths);
+  const pathFilter = buildPathFilter(allowedPaths, sql`c.source_path`);
   const statusFilter = opts.includeArchived ? sql`` : sql`AND d.status = 'active'`;
   const baseFilter = sql`c.org_id = ${orgId} ${statusFilter} AND (${pathFilter})`;
 

--- a/packages/web/src/lib/knowledge/unsearchable.ts
+++ b/packages/web/src/lib/knowledge/unsearchable.ts
@@ -1,0 +1,103 @@
+/**
+ * The documents the index has a row for but could not make searchable (#935).
+ *
+ * A reindex reports `unsearchable` as a NUMBER, and a number nobody can expand
+ * turns a known gap into a silent one: an agent that answers "I found nothing"
+ * about a document it holds reads as a statement about the world, not about the
+ * index. On the corpus this was measured against, 19 of 25 such documents were
+ * certifications — the single most likely thing to be asked about.
+ *
+ * Read-side only, and deliberately derived rather than recorded: a document
+ * with a kb_documents row and not one kb_chunks row produced no searchable
+ * text, whatever the reason. Today that is a scan with no text layer; when
+ * Office conversion lands, a document whose conversion failed lands in this
+ * list too, with nothing to wire up.
+ *
+ * What it does NOT cover is the ingest counter of the other name: a `failed`
+ * file (unreadable/corrupt) usually has no document row at all, because ingest
+ * extracts BEFORE inserting — so it cannot appear here. The two counters
+ * describe different states and this list answers only one of them.
+ *
+ * It also answers over a WIDER window than the run summary it explains. A run's
+ * `unsearchable` counts only what THAT run processed — a document unchanged
+ * since the last index is `skipped` and never recounted — while this lists
+ * everything currently in scope. So the list is normally larger than the last
+ * run's number, and the two disagreeing is the expected case, not a bug. Any
+ * surface showing them together has to say which window it means.
+ */
+import { sql } from "drizzle-orm";
+
+import { db } from "@/db";
+
+import { buildPathFilter } from "./path-filter";
+
+export interface UnsearchableDocument {
+  /** Absolute path of the source file, as indexed. The full path, not a basename — two folders may hold the same filename. */
+  sourcePath: string;
+  /** `archived` means the document sits under an OLD/Archive folder (archive-paths.ts) and is already out of everyday search. */
+  status: "active" | "archived";
+}
+
+export interface UnsearchableDocumentsResult {
+  /** At most `limit` documents, active ones first, then by path. */
+  documents: UnsearchableDocument[];
+  /** How many there are in total — never truncated by `limit`, so a capped list can say what it is hiding. */
+  total: number;
+}
+
+/** How many documents one call returns by default. A real corpus can hold hundreds; `total` keeps the answer honest past the cap. */
+export const DEFAULT_UNSEARCHABLE_LIMIT = 100;
+
+interface UnsearchableRow extends Record<string, unknown> {
+  source_path: string;
+  status: "active" | "archived";
+  total: string | number;
+}
+
+/**
+ * Lists the unsearchable documents for `orgId`, scoped to `allowedPaths`.
+ *
+ * The scope is the SAME allow-list that scopes retrieval (path-filter.ts), for
+ * the same reason: an agent must never learn that a document exists outside the
+ * directories it was granted. An empty `allowedPaths` denies by default and
+ * returns an empty result without touching the database — an agent granted
+ * nothing sees nothing, not everything.
+ */
+export async function listUnsearchableDocuments(
+  orgId: string,
+  allowedPaths: readonly string[],
+  opts: { limit?: number } = {}
+): Promise<UnsearchableDocumentsResult> {
+  if (allowedPaths.length === 0) return { documents: [], total: 0 };
+
+  const limit = opts.limit ?? DEFAULT_UNSEARCHABLE_LIMIT;
+  const pathFilter = buildPathFilter(allowedPaths, sql`d.source_path`);
+
+  const rows = await db.execute<UnsearchableRow>(sql`
+    SELECT d.source_path,
+           d.status,
+           -- The pre-LIMIT count, in the same pass: the cap truncates the
+           -- list, never the number. A window function beats a second query
+           -- here because both would have to agree, and a separate COUNT can
+           -- disagree with the page it labels.
+           COUNT(*) OVER () AS total
+    FROM kb_documents d
+    WHERE d.org_id = ${orgId}
+      AND (${pathFilter})
+      -- "Has no chunk", correlated on document_id — NOT on source_path. The
+      -- two disagree exactly when two documents share a path, which
+      -- (org_id, source_path) being unique makes an ACL duplicate across orgs;
+      -- matching by path would let one org's text vouch for another's scan.
+      AND NOT EXISTS (SELECT 1 FROM kb_chunks c WHERE c.document_id = d.id)
+    -- Archived documents last: they are already out of everyday search
+    -- (archive-paths.ts), so a capped window should fill with the ones a
+    -- question is actually going to hit.
+    ORDER BY (d.status = 'archived'), d.source_path
+    LIMIT ${limit}
+  `);
+
+  return {
+    documents: rows.map((row) => ({ sourcePath: row.source_path, status: row.status })),
+    total: rows.length > 0 ? Number(rows[0].total) : 0,
+  };
+}


### PR DESCRIPTION
Closes #935.

A reindex reports `unsearchable` as a *number*. Nobody could see **which** documents it meant, and that turns a known gap into a silent one — the agent answers "I found nothing" and the reader hears a statement about the world, not about the index.

## What's in it

**`GET /api/agents/[agentId]/knowledge/unsearchable`** — admin-only, `// audit-exempt:` (read-only projection). Scoped to the agent's **saved** `pinchy-files` grants, never to a request parameter: a caller-supplied path would turn a diagnostics panel into a way to enumerate documents the agent was never granted.

Named after the counter it expands. `unreadable` is the word the docs already spend on `failed` — *"Couldn't be read or parsed at all"* — which is precisely the one state this list cannot show, so that name would have said the opposite of what the route returns.

**`lib/knowledge/unsearchable.ts`** — documents with a `kb_documents` row and no `kb_chunks` row. Read-side only and *derived*, so when Office conversion lands, a document whose conversion failed shows up here automatically with nothing to wire up. Active documents first, then archived (already out of everyday search), capped at 100 with an untruncated `total`.

**`components/knowledge-unsearchable-list.tsx`** — renders in the **Index** section beside the counts it explains. Full paths (two folders can hold the same filename), `archived` marked, a capped list says what it's hiding.

Two things the panel is careful about:

- **It names the window it counts.** The counts directly above are per-**run** — a document unchanged since the last index is `skipped`, not recounted — while the list covers the whole scope. "4 unsearchable" over "25 documents…" is therefore the normal case, and without the scope in the sentence it reads as a contradiction.
- **A zero is announced only after a *succeeded* run.** Under "Not yet indexed" it would be trivially true of an empty index; under "Last reindex failed" it would be an all-clear about a run that stopped early. Documents that *do* exist are listed in every state either way, since the index is corpus-wide and another agent's run can fill this scope.

**`lib/knowledge/path-filter.ts`** — `buildPathFilter` moves out of `retrieve.ts`. It's the security boundary (LIKE-metacharacter escaping, separator-bounded prefixes); two copies would be two chances to fix only one. `retrieve.ts` now calls it with its own column alias; all 66 KB integration tests stay green.

**Docs** — new *Documents that can't be searched* section in the KB guide. The pointer from the counts table says `unsearchable` explicitly: a `failed` file has no index entry to name, so pointing at the list for it would have been a promise the list can't keep.

## The two traps from the issue, pinned against a real Postgres

11 integration tests in `unsearchable.integration.test.ts`. Both failure modes are verified by mutation, not by assertion alone:

| Mutation | Result |
| --- | --- |
| `NOT EXISTS` → `EXISTS` (the inner-join mistake) | 10 of 11 red |
| path filter removed | 4 of 11 red |

Covered: a document with two chunks never appears (not even once per chunk), scoping to granted directories, `/data/hr` not matching `/data/hr-archive`, `_` escaped in a grant, exact-path grants, empty grants denying, the org boundary, per-document rather than per-path correlation, ordering, and the cap reporting the true total.

The three UI guarantees above are mutation-checked too: restoring `failed` to the announce condition, dropping the scope clause, and rewriting the empty-state copy each redden exactly their own test and nothing else.

## `failed` is deliberately not covered

Per the issue's note. Ingest extracts **before** inserting (`ingest.ts:300`), so a file that can't be read usually has no `kb_documents` row to find — the only exception is an existing zero-chunk row whose re-extract now fails. `unsearchable` is fully covered. Documented in the module header rather than left as an assumption.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm lint` | 0 errors |
| `pnpm typecheck` (incl. tests) | pass |
| `pnpm format:check` (whole tree) | pass |
| `next build` (pre-push) | pass — route present in the manifest |
| KB integration suite (5 files) | 66/66 |
| Route / list / section tests | 6 + 11 + 28 |

The full unit suite is left to CI: locally it is load-bound rather than informative on this machine.
