### PR TITLE
fix(audit): stop the verify sweep from stepping over rows written while it ran

### DIFF
--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -265,6 +265,7 @@ A background job re-verifies the hash chain on a schedule, so a break introduced
 
 - verifies only the rows appended since the last run — an incremental checkpoint keeps this cheap as the log grows — and seeds the check with the previous run's last signature, so the boundary link between two runs is never left unchecked;
 - writes an `audit.integrity_check` entry recording the scanned range and any violations found;
+- holds its checkpoint back when entries were written while it was running, so those entries are verified by the following run instead of being stepped over — every entry gets checked by the background job, not only the ones that happened to sit still;
 - on a detected break, also emits a structured `audit_integrity_violation` line to stderr, so an external log monitor can alert on it even if no admin is watching the UI.
 
 The job runs shortly after startup and then every 6 hours by default; set the `AUDIT_VERIFY_INTERVAL_MS` environment variable (in milliseconds) to change the cadence. It is enabled by default and needs no configuration.

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -265,7 +265,7 @@ A background job re-verifies the hash chain on a schedule, so a break introduced
 
 - verifies only the rows appended since the last run — an incremental checkpoint keeps this cheap as the log grows — and seeds the check with the previous run's last signature, so the boundary link between two runs is never left unchecked;
 - writes an `audit.integrity_check` entry recording the scanned range and any violations found;
-- holds its checkpoint back when entries were written while it was running, so those entries are verified by the following run instead of being stepped over — every entry gets checked by the background job, not only the ones that happened to sit still;
+- holds its checkpoint back when entries were written while it was running, so those entries are verified by the following run instead of being stepped over — every entry is covered by the background job, not only the ones written between runs;
 - on a detected break, also emits a structured `audit_integrity_violation` line to stderr, so an external log monitor can alert on it even if no admin is watching the UI.
 
 The job runs shortly after startup and then every 6 hours by default; set the `AUDIT_VERIFY_INTERVAL_MS` environment variable (in milliseconds) to change the cadence. It is enabled by default and needs no configuration.

--- a/packages/web/src/__tests__/server/audit-verify-job.integration.test.ts
+++ b/packages/web/src/__tests__/server/audit-verify-job.integration.test.ts
@@ -7,14 +7,45 @@
 // `audit_verify_state` table and the real `verifyIntegrity` seedPrevHmac
 // option, genuinely closes the boundary-link gap against a real DB. That
 // proof — plus a control assertion that the same attack slips through
-// WITHOUT the seed — lives here.
+// WITHOUT the seed — lives here. So does the #698 proof that a row appended
+// concurrently with a sweep is picked up by the NEXT sweep instead of falling
+// through the checkpoint fold, which likewise only means something against
+// real ids and a real chain.
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { asc, eq, sql } from "drizzle-orm";
 import { appendAuditLog, verifyIntegrity } from "@/lib/audit";
 import { db } from "@/db";
 import { auditLog, auditVerifyState } from "@/db/schema";
 import { sweepAuditVerify } from "@/server/audit-verify-job";
+
+// Hook for the #698 concurrency test: when armed, one real audit row is
+// appended right BEFORE the sweep writes its own report row — i.e. inside the
+// window between the sweep's MAX(id) snapshot and its report. That window is
+// milliseconds wide in production and can't be hit reliably from the outside,
+// so we interpose on the sweep's own append instead of racing it. Everything
+// else stays real: real DB, real hash chain, real verifyIntegrity.
+const { raceState } = vi.hoisted(() => ({ raceState: { armed: false } }));
+
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return {
+    ...actual,
+    appendAuditLog: async (entry: Parameters<typeof actual.appendAuditLog>[0]) => {
+      if (raceState.armed && entry.eventType === "audit.integrity_check") {
+        raceState.armed = false;
+        await actual.appendAuditLog({
+          actorType: "user",
+          actorId: "racer",
+          eventType: "auth.login",
+          resource: "user:racer",
+          outcome: "success",
+        });
+      }
+      return actual.appendAuditLog(entry);
+    },
+  };
+});
 
 async function appendRow(actorId: string) {
   await appendAuditLog({
@@ -61,6 +92,9 @@ async function deleteRowPastTrigger(id: number) {
 
 describe("audit-verify-job (integration)", () => {
   beforeEach(async () => {
+    // Only the #698 test arms the concurrent-append interposer; make sure a
+    // leftover arming can never bleed into another test's row sequence.
+    raceState.armed = false;
     // Fresh checkpoint per test — the shared per-test TRUNCATE in
     // src/test-helpers/integration/setup.ts already resets audit_verify_state,
     // this is just documentation of that assumption.
@@ -183,6 +217,50 @@ describe("audit-verify-job (integration)", () => {
 
     const checkpointAfterSecondSweep = await readCheckpointRow();
     expect(checkpointAfterSecondSweep!.lastStatus).toBe("violation");
+  });
+
+  it("CONCURRENT APPEND during the sweep: the raced row is verified by the next sweep, not skipped forever (#698)", async () => {
+    await appendRow("u1");
+    await appendRow("u2");
+    const rowsBeforeSweep = await allRowsById();
+    const lastPreSweepRow = rowsBeforeSweep[rowsBeforeSweep.length - 1];
+
+    // Arm the interposer: one real row lands between the sweep's MAX(id)
+    // snapshot and its own report row, i.e. in the (toId, reportId) window
+    // that neither this sweep (> toId) nor a report-folded checkpoint
+    // (< reportId + 1) would ever cover.
+    raceState.armed = true;
+    const firstSweep = await sweepAuditVerify();
+    expect(firstSweep.scanned).toBe(true);
+    expect(firstSweep.scannedTo).toBe(lastPreSweepRow.id);
+
+    const rowsAfterSweep = await allRowsById();
+    const racedRow = rowsAfterSweep[rowsAfterSweep.length - 2];
+    const reportRow = rowsAfterSweep[rowsAfterSweep.length - 1];
+    // Sanity: the interposer really produced the (toId, reportId) window.
+    expect(racedRow.id).toBeGreaterThan(lastPreSweepRow.id);
+    expect(racedRow.id).toBeLessThan(reportRow.id);
+
+    // The fix: because a row exists in that window, the checkpoint is folded
+    // only to the window actually scanned instead of past the report row.
+    const checkpoint = await readCheckpointRow();
+    expect(checkpoint!.lastVerifiedId).toBe(lastPreSweepRow.id);
+    expect(checkpoint!.lastVerifiedHmac).toBe(lastPreSweepRow.rowHmac);
+    expect(checkpoint!.lastStatus).toBe("ok");
+
+    // Self-healing: the next sweep re-scans the raced row AND the previous
+    // sweep's own report row — with the chain seeded from the checkpoint, so
+    // the boundary link into the raced row is checked too.
+    const secondSweep = await sweepAuditVerify();
+    expect(secondSweep.scanned).toBe(true);
+    expect(secondSweep.valid).toBe(true);
+    expect(secondSweep.scannedFrom).toBe(lastPreSweepRow.id + 1);
+    expect(secondSweep.scannedTo).toBe(reportRow.id);
+
+    // …and converges: nothing raced the second sweep, so it folded past its
+    // own report and the third sweep is a genuine no-op again.
+    const third = await sweepAuditVerify();
+    expect(third.scanned).toBe(false);
   });
 
   it("SEQUENCE GAP: scannedTo reflects the true highest scanned id, not fromId + count - 1", async () => {

--- a/packages/web/src/__tests__/server/audit-verify-job.test.ts
+++ b/packages/web/src/__tests__/server/audit-verify-job.test.ts
@@ -55,10 +55,10 @@ const {
   // A single db.select() stub serves both tables the module queries,
   // routing on which table object .from(...) is called with (identity
   // comparison against the __marker tag the @/db/schema mock below attaches).
-  // For auditLog there are two distinct call shapes: a bare await (MAX(id)
-  // snapshot) and .where().orderBy().limit() (last-scanned-row lookup). They're
-  // distinguished by which chain method is called first, exactly like the real
-  // query builder — this mock never calls .where() with no follow-on chain.
+  // For auditLog there are three distinct call shapes: a bare await (MAX(id)
+  // snapshot), .where().orderBy().limit() (last-scanned-row lookup) and
+  // .where().limit() (the #698 concurrency probe). They're distinguished by
+  // which chain method follows, exactly like the real query builder.
   const mockSelect = vi.fn((..._args: unknown[]) => ({
     from: (table: unknown) => {
       const isCheckpointTable =
@@ -402,6 +402,37 @@ describe("sweepAuditVerify", () => {
     expect(mockInsertValues).toHaveBeenCalledWith(
       expect.objectContaining({ lastVerifiedId: 14, lastVerifiedHmac: "hmac-14" })
     );
+  });
+
+  it("concurrency probe query fails: still advances the checkpoint, folding conservatively to the scanned window", async () => {
+    // The probe runs AFTER the report row is already written, so letting its
+    // error escape would leave the checkpoint behind entirely — and the next
+    // sweep would re-scan and re-report the very same window. Treat an
+    // unanswerable probe as "assume someone raced us": never skips a row.
+    mockCheckpointRow({ lastVerifiedId: 10, lastVerifiedHmac: "hmac-10" });
+    mockCurrentMaxId(13);
+    mockVerifyIntegrity.mockResolvedValue({
+      valid: true,
+      totalChecked: 3,
+      invalidIds: [],
+      chainBreakIds: [],
+    });
+    mockLastScannedRow({ id: 13, rowHmac: "hmac-13" });
+    mockOwnReportRow(16, "hmac-16");
+    mockRacedRowLimit.mockRejectedValueOnce(new Error("db blip"));
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(sweepAuditVerify()).resolves.toBeDefined();
+
+    expect(mockRacedRowLimit).toHaveBeenCalled();
+    expect(mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ lastVerifiedId: 13, lastVerifiedHmac: "hmac-13", lastStatus: "ok" })
+    );
+    // A failed probe is not an audit-write failure — the audit row went in.
+    expect(mockRecordAuditFailure).not.toHaveBeenCalled();
+    // …but it is not swallowed silently either.
+    expect(stderrSpy).toHaveBeenCalled();
+    stderrSpy.mockRestore();
   });
 
   it("violation: advances the checkpoint anyway, sets lastStatus='violation', emits failure audit + stderr + increments counter", async () => {

--- a/packages/web/src/__tests__/server/audit-verify-job.test.ts
+++ b/packages/web/src/__tests__/server/audit-verify-job.test.ts
@@ -13,6 +13,7 @@ const {
   mockCheckpointWhere,
   mockMaxIdThen,
   mockLastScannedLimit,
+  mockRacedRowLimit,
   mockInsertValues,
   mockOnConflictDoUpdate,
   mockInsert,
@@ -30,8 +31,17 @@ const {
   // db.select(...).from(auditLog).where(...).orderBy(desc(...)).limit(1) ->
   // the highest real row actually scanned in [fromId, toId]
   const mockLastScannedLimit = vi.fn();
+  // db.select(...).from(auditLog).where(...).limit(1) -> the #698 concurrency
+  // probe: any row another request appended in (toId, reportId). Shares the
+  // `where` stub with the last-scanned lookup above and is told apart by which
+  // chain method follows — .orderBy().limit() vs a bare .limit() — exactly
+  // like the real query builder.
+  const mockRacedRowLimit = vi.fn().mockResolvedValue([]);
   const mockLastScannedOrderBy = vi.fn().mockReturnValue({ limit: mockLastScannedLimit });
-  const mockLastScannedWhere = vi.fn().mockReturnValue({ orderBy: mockLastScannedOrderBy });
+  const mockLastScannedWhere = vi.fn().mockReturnValue({
+    orderBy: mockLastScannedOrderBy,
+    limit: mockRacedRowLimit,
+  });
   // NOTE: there is deliberately no "own report row" query stub any more. The
   // sweep folds its own audit.integrity_check row into the checkpoint from the
   // {id, rowHmac} that appendAuditLog RETURNS (INSERT ... RETURNING), not from
@@ -70,6 +80,7 @@ const {
     mockCheckpointWhere,
     mockMaxIdThen,
     mockLastScannedLimit,
+    mockRacedRowLimit,
     mockInsertValues,
     mockOnConflictDoUpdate,
     mockInsert,
@@ -135,6 +146,13 @@ function mockOwnReportRow(id: number, rowHmac: string) {
   mockAppendAuditLog.mockResolvedValue({ id, rowHmac });
 }
 
+// Whether another request appended a row in (toId, reportId) — the #698 window
+// between the sweep's MAX(id) snapshot and its own report row. `null` is the
+// normal case (nobody raced us).
+function mockRacedRow(row: { id: number } | null) {
+  mockRacedRowLimit.mockResolvedValue(row ? [row] : []);
+}
+
 describe("sweepAuditVerify", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -146,6 +164,7 @@ describe("sweepAuditVerify", () => {
     // keeps implementations, so a prior test's mockOwnReportRow could leak in).
     // Tests that reach the append override this via mockOwnReportRow.
     mockAppendAuditLog.mockResolvedValue(undefined);
+    mockRacedRow(null);
   });
 
   it("no new rows since the checkpoint (toId < fromId): no-op, verifyIntegrity never called", async () => {
@@ -299,6 +318,89 @@ describe("sweepAuditVerify", () => {
 
     expect(mockInsertValues).toHaveBeenCalledWith(
       expect.objectContaining({ lastVerifiedId: 14, lastVerifiedHmac: "hmac-14", lastStatus: "ok" })
+    );
+  });
+
+  it("concurrent append during the verify pass: folds only to the scanned window so the raced rows are re-scanned (#698)", async () => {
+    // Another request appended row 14 between the toId=13 snapshot and this
+    // sweep's own report row (id 16). Row 14 is outside the scanned window
+    // (> toId) — and folding the checkpoint to 16 would put it BELOW the next
+    // sweep's start too, so the incremental job would never verify it. The
+    // sweep therefore folds only to the window it really scanned.
+    mockCheckpointRow({ lastVerifiedId: 10, lastVerifiedHmac: "hmac-10" });
+    mockCurrentMaxId(13);
+    mockVerifyIntegrity.mockResolvedValue({
+      valid: true,
+      totalChecked: 3,
+      invalidIds: [],
+      chainBreakIds: [],
+    });
+    mockLastScannedRow({ id: 13, rowHmac: "hmac-13" });
+    mockOwnReportRow(16, "hmac-16");
+    mockRacedRow({ id: 14 });
+
+    const result = await sweepAuditVerify();
+
+    // The report itself still describes the window that was actually scanned.
+    expect(result.scannedTo).toBe(13);
+    // Checkpoint stays at row 13, so the next sweep re-scans [14, …] — the
+    // raced rows AND this sweep's own report row. One extra non-converged
+    // sweep, then the steady state is a no-op again.
+    expect(mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ lastVerifiedId: 13, lastVerifiedHmac: "hmac-13", lastStatus: "ok" })
+    );
+    expect(mockOnConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({ lastVerifiedId: 13, lastVerifiedHmac: "hmac-13" }),
+      })
+    );
+    // The append succeeded — a deferred fold is not an audit-write failure.
+    expect(mockRecordAuditFailure).not.toHaveBeenCalled();
+  });
+
+  it("report row not adjacent to the snapshot but the gap is empty (sequence gap): still folds past its own report", async () => {
+    // A rolled-back transaction burned ids 14–15, so the report row lands at
+    // 16 without anyone racing us. The probe finds nothing, so this is the
+    // normal converging fold — a sequence gap must not be mistaken for
+    // concurrency and cost a redundant re-scan every sweep.
+    mockCheckpointRow({ lastVerifiedId: 10, lastVerifiedHmac: "hmac-10" });
+    mockCurrentMaxId(13);
+    mockVerifyIntegrity.mockResolvedValue({
+      valid: true,
+      totalChecked: 3,
+      invalidIds: [],
+      chainBreakIds: [],
+    });
+    mockLastScannedRow({ id: 13, rowHmac: "hmac-13" });
+    mockOwnReportRow(16, "hmac-16");
+    mockRacedRow(null);
+
+    await sweepAuditVerify();
+
+    expect(mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ lastVerifiedId: 16, lastVerifiedHmac: "hmac-16", lastStatus: "ok" })
+    );
+  });
+
+  it("report row immediately follows the snapshot: no concurrency probe query is issued at all", async () => {
+    // reportId === toId + 1 leaves no id strictly between the two, so the
+    // common (uncontended) case must not pay for an extra round trip.
+    mockCheckpointRow({ lastVerifiedId: 10, lastVerifiedHmac: "hmac-10" });
+    mockCurrentMaxId(13);
+    mockVerifyIntegrity.mockResolvedValue({
+      valid: true,
+      totalChecked: 3,
+      invalidIds: [],
+      chainBreakIds: [],
+    });
+    mockLastScannedRow({ id: 13, rowHmac: "hmac-13" });
+    mockOwnReportRow(14, "hmac-14");
+
+    await sweepAuditVerify();
+
+    expect(mockRacedRowLimit).not.toHaveBeenCalled();
+    expect(mockInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ lastVerifiedId: 14, lastVerifiedHmac: "hmac-14" })
     );
   });
 

--- a/packages/web/src/server/audit-verify-job.ts
+++ b/packages/web/src/server/audit-verify-job.ts
@@ -110,17 +110,29 @@ async function writeCheckpoint(
  *
  * Adjacent ids leave no room for a row in between, so the common uncontended
  * case (report row directly after the snapshot) answers without a query.
+ *
+ * An unanswerable probe answers "yes". This runs AFTER the report row is
+ * already written, so letting the error escape would leave the checkpoint
+ * behind entirely and make the next sweep re-scan and re-report the identical
+ * window. "Assume someone raced us" costs at most a redundant re-scan and can
+ * never skip a row — the same conservative direction as the audit-write
+ * failure fallback below.
  */
 async function hasRowsBetween(afterId: number, beforeId: number): Promise<boolean> {
   if (beforeId <= afterId + 1) return false;
 
-  const [row] = await db
-    .select({ id: auditLog.id })
-    .from(auditLog)
-    .where(and(gt(auditLog.id, afterId), lt(auditLog.id, beforeId)))
-    .limit(1);
+  try {
+    const [row] = await db
+      .select({ id: auditLog.id })
+      .from(auditLog)
+      .where(and(gt(auditLog.id, afterId), lt(auditLog.id, beforeId)))
+      .limit(1);
 
-  return row !== undefined;
+    return row !== undefined;
+  } catch (err) {
+    console.error("[audit-verify-job] concurrency probe failed, folding conservatively:", err);
+    return true;
+  }
 }
 
 export interface AuditVerifySweepResult {

--- a/packages/web/src/server/audit-verify-job.ts
+++ b/packages/web/src/server/audit-verify-job.ts
@@ -25,7 +25,7 @@
  * passed as `seedPrevHmac`, forcing that boundary link to be checked on every
  * run.
  */
-import { eq, desc, and, gte, lte, sql } from "drizzle-orm";
+import { eq, desc, and, gt, gte, lt, lte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { auditVerifyState, auditLog } from "@/db/schema";
 import { verifyIntegrity, appendAuditLog } from "@/lib/audit";
@@ -96,6 +96,31 @@ async function writeCheckpoint(
       target: auditVerifyState.id,
       set: { lastVerifiedId, lastVerifiedHmac, lastStatus, updatedAt: new Date() },
     });
+}
+
+/**
+ * Did another writer land a row in the open interval (afterId, beforeId)?
+ *
+ * Used to detect a concurrent append that happened between this sweep's
+ * MAX(id) snapshot and its own report row (#698). The answer is trustworthy
+ * despite the read happening outside any of those transactions: appendAuditLog
+ * allocates the id and commits while holding the chain's advisory xact lock,
+ * so id order IS commit order — once the report row at `beforeId` is visible,
+ * every row below it that will ever exist is committed and visible too.
+ *
+ * Adjacent ids leave no room for a row in between, so the common uncontended
+ * case (report row directly after the snapshot) answers without a query.
+ */
+async function hasRowsBetween(afterId: number, beforeId: number): Promise<boolean> {
+  if (beforeId <= afterId + 1) return false;
+
+  const [row] = await db
+    .select({ id: auditLog.id })
+    .from(auditLog)
+    .where(and(gt(auditLog.id, afterId), lt(auditLog.id, beforeId)))
+    .limit(1);
+
+  return row !== undefined;
 }
 
 export interface AuditVerifySweepResult {
@@ -190,20 +215,32 @@ export async function sweepAuditVerify(): Promise<AuditVerifySweepResult> {
   // is what makes this race-free: a separate "current highest row" query could
   // observe a row another request appended concurrently right after our report
   // and mis-fold THAT into the checkpoint, silently skipping the rows between
-  // on the next sweep. (A smaller residual remains: rows appended DURING the
-  // verify pass, in (toId, reportId), are caught by the full GET
-  // /api/audit/verify scan but skipped by this incremental job — see #698.)
+  // on the next sweep.
+  //
+  // Folding past the report is only safe when nothing else wrote while this
+  // sweep was running. Rows another request appends between the toId snapshot
+  // and the report land in (toId, reportId): outside this sweep's window
+  // (> toId) AND below the next sweep's start (reportId + 1) — never verified
+  // incrementally at all (#698). So probe that interval, and when it isn't
+  // empty fold only to the window actually scanned: the next sweep re-scans
+  // the raced rows together with this report row and converges again. One
+  // extra non-converged sweep, paid only when concurrency really happened.
   //
   // Advancing even on violation is intentional: re-scanning the same tampered
   // window forever would just re-alarm on every cycle without surfacing new
   // information — the violation is recorded (audit row + stderr + counter)
   // exactly once. On an audit-write failure there is no report row to fold, so
   // fall back to the window actually scanned.
+  let ownRow: { id: number; rowHmac: string } | null = null;
   try {
-    const ownRow = await appendAuditLog(entry);
-    await writeCheckpoint(ownRow.id, ownRow.rowHmac, status);
+    ownRow = await appendAuditLog(entry);
   } catch (err) {
     recordAuditFailure(err, entry);
+  }
+
+  if (ownRow && !(await hasRowsBetween(toId, ownRow.id))) {
+    await writeCheckpoint(ownRow.id, ownRow.rowHmac, status);
+  } else {
     await writeCheckpoint(scannedTo, lastVerifiedHmac, status);
   }
 


### PR DESCRIPTION
Closes #698.

## The gap

A sweep snapshots `toId = MAX(id)`, verifies `[fromId, toId]`, then appends its own `audit.integrity_check` row at id `R` and folds `R` into the checkpoint so the steady state converges to a no-op.

Rows another request appends **between the snapshot and the report** land in `(toId, R)`: above this sweep's window, below the next sweep's start. The incremental job never verified them at all — only the full `GET /api/audit/verify` scan did. Milliseconds wide, but non-zero under load.

## The fix

After appending, probe that interval. When it isn't empty, fold only to the window actually scanned, so the next sweep re-scans the raced rows together with this report row and converges again — one extra non-converged sweep, paid only when concurrency really happened.

Adjacent ids leave no room for a row in between, so the uncontended case (report row directly after the snapshot) answers without a query. A sequence gap with an empty interval is correctly *not* read as concurrency.

The probe is trustworthy despite reading outside those transactions: `appendAuditLog` allocates the id and commits while holding the chain's advisory xact lock, so id order **is** commit order — once `R` is visible, every row below it that will ever exist is committed and visible too.

## Tests

- **Unit** (`audit-verify-job.test.ts`): the fold decision — raced row present → fold to `scannedTo`; empty gap → fold past the report; adjacent ids → no probe query at all.
- **Integration** (`audit-verify-job.integration.test.ts`): interposes a **real** concurrent append on the real chain inside the real window, then asserts the checkpoint stays at the scanned window, the next sweep re-scans the raced row *and* the previous report row cleanly (chain seeded, so the boundary link is checked), and the third sweep is a genuine no-op again.

Both fail without the fix (verified by reverting the source and re-running).

Docs updated: the coverage guarantee is now stated in the Automatic verification section of the audit-trail concept page.

## Gates

`pnpm -C packages/web test src/__tests__/server/audit-verify-job.test.ts` 15/15 · `test:db` on that file 6/6 · `pnpm format:check` · `pnpm -C packages/web typecheck` · `pnpm -C packages/web lint` (0 errors).

The full `pnpm -C packages/web test` run left 21 unrelated failures, all `Test timed out in 5000ms` in component suites — this machine was at load ~150 from parallel sessions and those files took 26–73s each. None touch the audit job.
