### PR TITLE
fix(integrations): stop the IMAP connection test from mapping the internal network

### DIFF
--- a/docker-compose.imap-test.yml
+++ b/docker-compose.imap-test.yml
@@ -80,6 +80,12 @@ services:
       # takes effect with this explicit flag, so the TLS downgrade can never
       # happen silently in production.
       - PINCHY_INSECURE_MAIL_MOCK=1
+      # GreenMail lives on the compose network, i.e. behind a private Docker IP —
+      # exactly the on-premise mail server this flag exists for. Without it the
+      # IMAP SSRF guard (mail-host-guard.ts) refuses every probe of a stored
+      # `greenmail` host. NOT an E2E-only flag: it is the same production opt-in
+      # an operator sets for an internal mail server, off by default.
+      - ALLOW_PRIVATE_MAIL_HOSTS=1
       # Emit a dummy API-key SecretRef for the local Ollama provider so
       # OpenClaw authenticates when the dispatch probe (email-imap.spec.ts)
       # swaps default_provider to ollama-local and routes to host fake-Ollama

--- a/docs/src/content/docs/guides/connect-email-imap.mdx
+++ b/docs/src/content/docs/guides/connect-email-imap.mdx
@@ -176,6 +176,8 @@ ALLOW_PRIVATE_MAIL_HOSTS=1
 
 Loopback and link-local addresses stay blocked either way — `127.0.0.1`, `::1`, `169.254.169.254` and `fd00:ec2::254`, the cloud metadata endpoints. No mail server lives there, so there's nothing to trade off.
 
+The same check runs when the connection is saved, not only when it's tested, so a blocked host can't be stored and quietly reconnected to later by an inbox sweep.
+
 ---
 
 ## Ports, TLS & cloud firewalls

--- a/docs/src/content/docs/guides/connect-email-imap.mdx
+++ b/docs/src/content/docs/guides/connect-email-imap.mdx
@@ -158,6 +158,24 @@ The **Security** setting doesn't match what the server expects. Try `TLS` for po
 
 The server didn't respond in time — usually a network issue or an incorrect host/port combination.
 
+**"Blocked: this host resolves to a private network address"**
+
+See [Mail servers on your own network](#mail-servers-on-your-own-network) below.
+
+---
+
+## Mail servers on your own network
+
+The connection test reports exactly why an attempt failed — refused, timed out, TLS error, wrong password. That's what makes it useful for fixing a mailbox, and it's also what would make it useful for mapping the network Pinchy runs in. So we only probe hosts that resolve to a public address.
+
+If your mail server genuinely lives on your own network — an on-premise Exchange or Dovecot box on `10.x`, `172.16–31.x`, `192.168.x`, or an IPv6 unique-local range — set the environment variable on the Pinchy container and restart it:
+
+```bash
+ALLOW_PRIVATE_MAIL_HOSTS=1
+```
+
+Loopback and link-local addresses stay blocked either way — `127.0.0.1`, `::1`, `169.254.169.254` and `fd00:ec2::254`, the cloud metadata endpoints. No mail server lives there, so there's nothing to trade off.
+
 ---
 
 ## Ports, TLS & cloud firewalls

--- a/packages/web/src/__tests__/api/imap-create-route.test.ts
+++ b/packages/web/src/__tests__/api/imap-create-route.test.ts
@@ -4,6 +4,16 @@ vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
 }));
 
+// The route resolves both mail hosts through the SSRF guard, so DNS is stubbed
+// here — no test in this file may depend on what the machine's resolver says
+// about example.com.
+const { mockDnsLookup } = vi.hoisted(() => ({ mockDnsLookup: vi.fn() }));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: mockDnsLookup,
+  default: { lookup: mockDnsLookup },
+}));
+
 const mockGetSession = vi.fn();
 vi.mock("@/lib/auth", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
@@ -90,6 +100,7 @@ describe("POST /api/integrations/imap", () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
     mockInsertReturning.mockResolvedValue([insertedConnection]);
+    mockDnsLookup.mockResolvedValue([{ address: "203.0.113.50", family: 4 }]);
   });
 
   it("returns 401 when not authenticated and does not insert a row", async () => {
@@ -313,6 +324,78 @@ describe("POST /api/integrations/imap", () => {
       expect(response.status).toBe(400);
       expect(mockInsertValues).not.toHaveBeenCalled();
       expect(mockAppendAuditLog).not.toHaveBeenCalled();
+    });
+  });
+
+  // The SSRF guard on POST /api/integrations/imap/test only covers the
+  // diagnostic. Storing a connection is the more durable path to the same
+  // internal address: the inbox sweep and the pinchy-email plugin reconnect to
+  // whatever host is on the row, on a schedule, and report their errors — so a
+  // saved connection is a standing oracle, not a one-shot one. The UI tests
+  // before it saves; the API is the contract (pinchy#823).
+  describe("SSRF guard", () => {
+    it("refuses to store a connection whose IMAP host resolves to loopback", async () => {
+      mockDnsLookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+      const { POST } = await import("@/app/api/integrations/imap/route");
+
+      const response = await POST(makeRequest(validBody), routeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/loopback/i);
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it("refuses to store a connection whose SMTP host resolves to cloud metadata", async () => {
+      // Only the SMTP leg is internal — the guard must check both hosts, not
+      // just the first one.
+      mockDnsLookup.mockImplementation(async (host: string) =>
+        host === "smtp.example.com"
+          ? [{ address: "169.254.169.254", family: 4 }]
+          : [{ address: "203.0.113.50", family: 4 }]
+      );
+      const { POST } = await import("@/app/api/integrations/imap/route");
+
+      const response = await POST(makeRequest(validBody), routeContext());
+
+      expect(response.status).toBe(400);
+      expect(mockInsertValues).not.toHaveBeenCalled();
+    });
+
+    it("audits the refusal as a failed integration.created without leaking identity", async () => {
+      mockDnsLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+      const { POST } = await import("@/app/api/integrations/imap/route");
+
+      await POST(makeRequest(validBody), routeContext());
+
+      expect(mockAppendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: "integration.created",
+          outcome: "failure",
+          actorType: "user",
+          actorId: "user-1",
+          detail: expect.objectContaining({ type: "imap", blocked: "host" }),
+        })
+      );
+
+      const auditCall = mockAppendAuditLog.mock.calls[0][0];
+      const serialized = JSON.stringify(auditCall);
+      expect(serialized).not.toContain("super-secret-password");
+      expect(serialized).not.toContain("support@example.com");
+    });
+
+    it("stores a connection on a private range when ALLOW_PRIVATE_MAIL_HOSTS=1", async () => {
+      // The on-premise case the flag exists for: the operator has said reaching
+      // their own network is intended, so saving must work end to end.
+      vi.stubEnv("ALLOW_PRIVATE_MAIL_HOSTS", "1");
+      mockDnsLookup.mockResolvedValue([{ address: "192.168.1.10", family: 4 }]);
+      const { POST } = await import("@/app/api/integrations/imap/route");
+
+      const response = await POST(makeRequest(validBody), routeContext());
+
+      expect(response.status).toBe(201);
+      expect(mockInsertValues).toHaveBeenCalled();
+      vi.unstubAllEnvs();
     });
   });
 });

--- a/packages/web/src/__tests__/api/imap-test-route.test.ts
+++ b/packages/web/src/__tests__/api/imap-test-route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
@@ -60,6 +60,17 @@ vi.mock("nodemailer", () => ({
   createTransport: createTransportMock,
 }));
 
+// The SSRF guard resolves both probe hosts before connecting; DNS is stubbed so
+// the route tests never depend on real name resolution. The default answer is a
+// public address (TEST-NET-3), i.e. "guard allows it" unless a test says
+// otherwise.
+const { mockDnsLookup } = vi.hoisted(() => ({ mockDnsLookup: vi.fn() }));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: mockDnsLookup,
+  default: { lookup: mockDnsLookup },
+}));
+
 // Only probeSmtpPorts is mocked here (raw TCP reachability probe) — everything
 // else in the module (testImapLogin/testSmtpVerify/classifyProbeError) runs
 // for real, driven by the imapflow/nodemailer mocks above, so the route's
@@ -98,12 +109,24 @@ function makeRequest(body?: unknown) {
 }
 
 describe("POST /api/integrations/imap/test", () => {
+  // Compile the route's whole dependency graph (better-auth, drizzle, imapflow,
+  // nodemailer, …) ONCE here rather than inside whichever test happens to run
+  // first. Every test below re-imports the module, but nothing calls
+  // vi.resetModules(), so those are cache hits — the first one was paying the
+  // transform out of the 5s per-test budget and timing out on a cold cache.
+  // The generous hook budget covers that compile on a loaded machine; it bounds
+  // setup cost only, never an assertion.
+  beforeAll(async () => {
+    await import("@/app/api/integrations/imap/test/route");
+  }, 60_000);
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockImapClient.connect.mockResolvedValue(undefined);
     mockImapClient.logout.mockResolvedValue(undefined);
     mockTransport.verify.mockResolvedValue(true);
     mockAppendAuditLog.mockResolvedValue(undefined);
+    mockDnsLookup.mockResolvedValue([{ address: "203.0.113.50", family: 4 }]);
     mockProbeSmtpPorts.mockReset();
     mockProbeSmtpPorts.mockResolvedValue([
       { port: 465, reachable: false },
@@ -344,6 +367,71 @@ describe("POST /api/integrations/imap/test", () => {
       expect(mockProbeSmtpPorts).not.toHaveBeenCalled();
       expect(body.smtpPortProbe).toBeUndefined();
       expect(body.suggestion).toBeUndefined();
+    });
+
+    // The endpoint probes an admin-supplied host:port and reports WHY the
+    // connection failed — refused vs. timeout vs. TLS vs. auth. Without a guard
+    // that is an internal port scanner with a friendly UI (pinchy#823), so a
+    // host pointing inside the network must never reach a socket at all.
+    describe("SSRF guard", () => {
+      it("blocks both legs, and never opens a socket, when the hosts resolve to loopback", async () => {
+        mockDnsLookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+        const { POST } = await import("@/app/api/integrations/imap/test/route");
+        const response = await POST(makeRequest(validBody), routeContext());
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.ok).toBe(false);
+        expect(body.imap.code).toBe("blocked");
+        expect(body.smtp.code).toBe("blocked");
+        expect(ImapFlowMock).not.toHaveBeenCalled();
+        expect(createTransportMock).not.toHaveBeenCalled();
+      });
+
+      it("does not run the SMTP port scan for a blocked host", async () => {
+        // The port scan is the sharpest edge of the oracle: three raw TCP
+        // connects per request, with the result reported back.
+        mockDnsLookup.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+        const { POST } = await import("@/app/api/integrations/imap/test/route");
+        const response = await POST(makeRequest(validBody), routeContext());
+        const body = await response.json();
+
+        expect(mockProbeSmtpPorts).not.toHaveBeenCalled();
+        expect(body.smtpPortProbe).toBeUndefined();
+        expect(body.suggestion).toBeUndefined();
+      });
+
+      it("writes a failure audit entry for a blocked host", async () => {
+        mockDnsLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+
+        const { POST } = await import("@/app/api/integrations/imap/test/route");
+        await POST(makeRequest(validBody), routeContext());
+
+        expect(mockAppendAuditLog).toHaveBeenCalledTimes(1);
+        const entry = mockAppendAuditLog.mock.calls[0][0];
+        expect(entry.outcome).toBe("failure");
+        expect(entry.detail.imapCode).toBe("blocked");
+        expect(entry.detail.smtpCode).toBe("blocked");
+      });
+
+      it("blocks the IMAP leg alone when only the IMAP host is internal", async () => {
+        mockDnsLookup.mockImplementation(async (host: string) =>
+          host === validBody.imapHost
+            ? [{ address: "192.168.1.10", family: 4 }]
+            : [{ address: "203.0.113.50", family: 4 }]
+        );
+
+        const { POST } = await import("@/app/api/integrations/imap/test/route");
+        const response = await POST(makeRequest(validBody), routeContext());
+        const body = await response.json();
+
+        expect(body.imap.code).toBe("blocked");
+        expect(body.smtp).toEqual({ ok: true });
+        expect(ImapFlowMock).not.toHaveBeenCalled();
+        expect(createTransportMock).toHaveBeenCalled();
+      });
     });
 
     it("never includes the plaintext password in the audit detail across success and failure paths", async () => {

--- a/packages/web/src/app/api/integrations/imap/route.ts
+++ b/packages/web/src/app/api/integrations/imap/route.ts
@@ -7,6 +7,7 @@ import { integrationConnections } from "@/db/schema";
 import { encrypt } from "@/lib/encryption";
 import { appendAuditLog, redactEmail, scrubEmails } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
+import { assertMailHostAllowed, MailHostBlockedError } from "@/lib/integrations/mail-host-guard";
 
 // Matches an email-shaped username so we can redact it the same way the IMAP
 // test route does (see EMAIL_LIKE in imap/test/route.ts). Not every IMAP
@@ -17,6 +18,15 @@ const EMAIL_LIKE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // credentials via POST /api/integrations/imap/test. We don't re-probe here —
 // this route's job is only to encrypt-and-store what the client already
 // confirmed works, then audit the creation.
+//
+// The one exception is the SSRF guard, which runs on BOTH routes. The test
+// route's guard stops a one-shot probe of the internal network (pinchy#823);
+// this one stops the durable version of the same thing, because nothing forces
+// a client to call /test first, and a stored row is worse than a probe: the
+// inbox sweep and the pinchy-email plugin reconnect to that host on a schedule
+// and report what they find. It resolves DNS, so it is the only network call
+// this route makes — a host that doesn't resolve is let through (see the
+// guard), so a saveable connection never turns unsaveable on a DNS hiccup.
 export const POST = withAdmin(async (request: NextRequest, _ctx, session) => {
   const parsed = await parseRequestBody(imapCreateSchema, request);
   if ("error" in parsed) return parsed.error;
@@ -27,6 +37,41 @@ export const POST = withAdmin(async (request: NextRequest, _ctx, session) => {
   // `name` is an optional label for the integrations list; default it to the
   // mailbox address so the row always has a sensible, renameable name.
   const connectionName = name ?? username;
+
+  const identity = EMAIL_LIKE.test(username) ? redactEmail(username) : undefined;
+
+  try {
+    await assertMailHostAllowed(imapHost);
+    await assertMailHostAllowed(smtpHost);
+  } catch (err) {
+    if (!(err instanceof MailHostBlockedError)) throw err;
+
+    // A refused host is security-relevant on its own — record the attempt, but
+    // say only THAT a host was blocked. The guard's message already tells the
+    // admin which tier they hit; naming the resolved address in an immutable
+    // row would just archive someone's internal topology.
+    const blockedEntry = {
+      eventType: "integration.created" as const,
+      actorType: "user" as const,
+      actorId,
+      resource: "integration",
+      outcome: "failure" as const,
+      error: { message: err.message },
+      detail: {
+        name: scrubEmails(connectionName),
+        type: "imap",
+        blocked: "host",
+        ...(identity ?? {}),
+      },
+    };
+    try {
+      await appendAuditLog(blockedEntry);
+    } catch (auditErr) {
+      recordAuditFailure(auditErr, blockedEntry);
+    }
+
+    return NextResponse.json({ error: err.message }, { status: 400 });
+  }
 
   // Store every field (including host/port/security/senderName) encrypted as
   // a single blob — never persist the password (or the sender display name,
@@ -59,7 +104,6 @@ export const POST = withAdmin(async (request: NextRequest, _ctx, session) => {
       })
       .returning();
   } catch (err) {
-    const identity = EMAIL_LIKE.test(username) ? redactEmail(username) : undefined;
     const failureEntry = {
       eventType: "integration.created" as const,
       actorType: "user" as const,

--- a/packages/web/src/lib/integrations/__tests__/imap-probe.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/imap-probe.test.ts
@@ -76,6 +76,15 @@ const { mockNetConnect, fakeSockets } = vi.hoisted(() => {
 
 vi.mock("node:net", () => ({ connect: mockNetConnect, default: { connect: mockNetConnect } }));
 
+// The SSRF guard resolves every probe host before connecting, so DNS is stubbed
+// here — no test in this file may depend on real name resolution.
+const { mockDnsLookup } = vi.hoisted(() => ({ mockDnsLookup: vi.fn() }));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: mockDnsLookup,
+  default: { lookup: mockDnsLookup },
+}));
+
 import {
   testImapLogin,
   testSmtpVerify,
@@ -84,6 +93,7 @@ import {
   probeSmtpPorts,
   tlsModeForPort,
 } from "@/lib/integrations/imap-probe";
+import { MailHostBlockedError } from "@/lib/integrations/mail-host-guard";
 
 const input = {
   imapHost: "imap.example.com",
@@ -101,6 +111,7 @@ describe("imap-probe", () => {
     mockImapClient.connect.mockResolvedValue(undefined);
     mockImapClient.logout.mockResolvedValue(undefined);
     mockTransport.verify.mockResolvedValue(true);
+    mockDnsLookup.mockResolvedValue([{ address: "203.0.113.50", family: 4 }]);
   });
 
   describe("testImapLogin", () => {
@@ -150,6 +161,21 @@ describe("imap-probe", () => {
       mockImapClient.connect.mockRejectedValue(new Error("Authentication failed"));
 
       await expect(testImapLogin(input)).rejects.toThrow("Authentication failed");
+    });
+
+    it("never opens a socket to a host resolving to an internal address", async () => {
+      mockDnsLookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+      await expect(testImapLogin(input)).rejects.toThrow(MailHostBlockedError);
+      expect(ImapFlowMock).not.toHaveBeenCalled();
+      expect(mockImapClient.connect).not.toHaveBeenCalled();
+    });
+
+    it("resolves the IMAP host, not the SMTP host", async () => {
+      await testImapLogin(input);
+
+      expect(mockDnsLookup).toHaveBeenCalledWith(input.imapHost, expect.anything());
+      expect(mockDnsLookup).not.toHaveBeenCalledWith(input.smtpHost, expect.anything());
     });
   });
 
@@ -238,6 +264,21 @@ describe("imap-probe", () => {
       await expect(testSmtpVerify(input)).rejects.toThrow("ECONNREFUSED");
       expect(mockTransport.close).toHaveBeenCalled();
     });
+
+    it("never builds a transport for a host resolving to an internal address", async () => {
+      mockDnsLookup.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+      await expect(testSmtpVerify(input)).rejects.toThrow(MailHostBlockedError);
+      expect(createTransportMock).not.toHaveBeenCalled();
+      expect(mockTransport.verify).not.toHaveBeenCalled();
+    });
+
+    it("resolves the SMTP host, not the IMAP host", async () => {
+      await testSmtpVerify(input);
+
+      expect(mockDnsLookup).toHaveBeenCalledWith(input.smtpHost, expect.anything());
+      expect(mockDnsLookup).not.toHaveBeenCalledWith(input.imapHost, expect.anything());
+    });
   });
 
   describe("friendlyError", () => {
@@ -276,6 +317,14 @@ describe("imap-probe", () => {
     it("falls back to a generic message for unrecognized errors", () => {
       expect(friendlyError(new Error("something weird"))).toMatch(/connection failed/i);
       expect(friendlyError("not an Error instance")).toMatch(/connection failed/i);
+    });
+
+    it("passes an SSRF-guard rejection through verbatim", () => {
+      // The guard's message already says what to do about it; the generic
+      // "check your settings" fallback would hide that.
+      const message = "Blocked: this host resolves to a private network address.";
+
+      expect(friendlyError(new MailHostBlockedError(message))).toBe(message);
     });
   });
 
@@ -316,6 +365,18 @@ describe("imap-probe", () => {
     it("handles a non-Error value the same way friendlyError does", () => {
       const result = classifyProbeError("not an Error instance");
       expect(result.code).toBe("unknown");
+    });
+
+    it("classifies an SSRF-guard rejection as 'blocked' and keeps its message", () => {
+      // Its own code, not "unknown": the route branches on the code to decide
+      // whether an SMTP port scan is worth running, and a blocked host must
+      // never trigger the very port scan the guard exists to prevent.
+      const error = new MailHostBlockedError("Blocked: this host resolves to something internal.");
+
+      const result = classifyProbeError(error);
+
+      expect(result.code).toBe("blocked");
+      expect(result.message).toBe("Blocked: this host resolves to something internal.");
     });
   });
 

--- a/packages/web/src/lib/integrations/__tests__/mail-host-guard.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/mail-host-guard.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { assertMailHostAllowed, MailHostBlockedError } from "../mail-host-guard";
+
+// Every test injects its own resolver, so no test in this file ever touches
+// real DNS — the guard's decision table is what's under test, not getaddrinfo.
+function resolvesTo(...addresses: string[]) {
+  return async () => addresses;
+}
+
+describe("assertMailHostAllowed", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("always blocked, regardless of ALLOW_PRIVATE_MAIL_HOSTS", () => {
+    const alwaysBlocked: Array<[string, string]> = [
+      ["IPv4 loopback", "127.0.0.1"],
+      ["IPv4 loopback, non-canonical", "127.99.42.7"],
+      ["IPv4 unspecified", "0.0.0.0"],
+      ["IPv6 loopback", "::1"],
+      ["IPv6 unspecified", "::"],
+      ["IPv4 link-local", "169.254.1.1"],
+      ["AWS/GCP/Azure IMDS", "169.254.169.254"],
+      ["IPv6 IMDS", "fd00:ec2::254"],
+      ["IPv6 IMDS, expanded", "fd00:ec2:0:0:0:0:0:254"],
+      ["IPv6 link-local", "fe80::1"],
+      ["IPv6 link-local, upper half of fe80::/10", "feb0::1"],
+      ["IPv4-mapped IPv6 loopback", "::ffff:127.0.0.1"],
+    ];
+
+    it.each(alwaysBlocked)("blocks a host resolving to %s (%s)", async (_label, address) => {
+      await expect(assertMailHostAllowed("mail.evil.test", resolvesTo(address))).rejects.toThrow(
+        MailHostBlockedError
+      );
+    });
+
+    it.each(alwaysBlocked)(
+      "still blocks %s (%s) with ALLOW_PRIVATE_MAIL_HOSTS=1",
+      async (_label, address) => {
+        vi.stubEnv("ALLOW_PRIVATE_MAIL_HOSTS", "1");
+
+        await expect(assertMailHostAllowed("mail.evil.test", resolvesTo(address))).rejects.toThrow(
+          MailHostBlockedError
+        );
+      }
+    );
+
+    it("does not name the escape hatch for an always-blocked address", async () => {
+      // The flag genuinely does not help here — advertising it would send an
+      // admin chasing a config change that cannot fix their problem.
+      const error = await assertMailHostAllowed("mail.evil.test", resolvesTo("127.0.0.1")).catch(
+        (e: unknown) => e
+      );
+
+      expect(error).toBeInstanceOf(MailHostBlockedError);
+      expect((error as Error).message).not.toContain("ALLOW_PRIVATE_MAIL_HOSTS");
+    });
+  });
+
+  describe("private ranges, gated behind ALLOW_PRIVATE_MAIL_HOSTS", () => {
+    const privateAddresses: Array<[string, string]> = [
+      ["10.0.0.0/8", "10.1.2.3"],
+      ["172.16.0.0/12 lower bound", "172.16.0.1"],
+      ["172.16.0.0/12 upper bound", "172.31.255.255"],
+      ["192.168.0.0/16", "192.168.1.10"],
+      ["IPv6 unique-local", "fd12:3456:789a::1"],
+    ];
+
+    it.each(privateAddresses)("blocks %s (%s) by default", async (_label, address) => {
+      await expect(
+        assertMailHostAllowed("mail.internal.test", resolvesTo(address))
+      ).rejects.toThrow(MailHostBlockedError);
+    });
+
+    it.each(privateAddresses)(
+      "allows %s (%s) when ALLOW_PRIVATE_MAIL_HOSTS=1",
+      async (_label, address) => {
+        vi.stubEnv("ALLOW_PRIVATE_MAIL_HOSTS", "1");
+
+        await expect(
+          assertMailHostAllowed("mail.internal.test", resolvesTo(address))
+        ).resolves.toBeUndefined();
+      }
+    );
+
+    it("names the escape hatch so an on-premise admin knows the fix", async () => {
+      await expect(
+        assertMailHostAllowed("mail.internal.test", resolvesTo("192.168.1.10"))
+      ).rejects.toThrow(/ALLOW_PRIVATE_MAIL_HOSTS/);
+    });
+  });
+
+  describe("public hosts", () => {
+    it.each([
+      ["IPv4", "203.0.113.50"],
+      ["IPv4 just outside 172.16.0.0/12", "172.32.0.1"],
+      ["IPv6", "2606:4700:4700::1111"],
+    ])("allows a host resolving to a public %s (%s)", async (_label, address) => {
+      await expect(
+        assertMailHostAllowed("imap.example.com", resolvesTo(address))
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("multi-address hosts", () => {
+    it("blocks when ANY resolved address is internal", async () => {
+      // A split-horizon or attacker-controlled zone can answer with a public
+      // address alongside an internal one; the connect() picks whichever the
+      // OS prefers, so one bad answer has to fail the whole host.
+      await expect(
+        assertMailHostAllowed("mail.evil.test", resolvesTo("203.0.113.50", "127.0.0.1"))
+      ).rejects.toThrow(MailHostBlockedError);
+    });
+
+    it("allows when every resolved address is public", async () => {
+      await expect(
+        assertMailHostAllowed("imap.example.com", resolvesTo("203.0.113.50", "198.51.100.7"))
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("resolution failures", () => {
+    it("allows the probe to proceed when the host does not resolve", async () => {
+      // No address means no connection, so there is no oracle to protect
+      // against — and letting the probe run keeps the far more common typo
+      // case reporting "could not resolve the host" instead of a security
+      // error the admin cannot act on.
+      const failing = async () => {
+        throw new Error("getaddrinfo ENOTFOUND imap.example.com");
+      };
+
+      await expect(assertMailHostAllowed("imap.example.com", failing)).resolves.toBeUndefined();
+    });
+
+    it("allows the probe to proceed when the resolver returns no addresses", async () => {
+      await expect(
+        assertMailHostAllowed("imap.example.com", resolvesTo())
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("host input handling", () => {
+    it("rejects an empty host without resolving", async () => {
+      const resolver = vi.fn(resolvesTo("203.0.113.50"));
+
+      await expect(assertMailHostAllowed("   ", resolver)).rejects.toThrow(MailHostBlockedError);
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it("strips brackets from an IPv6 literal before resolving", async () => {
+      const resolver = vi.fn(resolvesTo("2606:4700:4700::1111"));
+
+      await assertMailHostAllowed("[2606:4700:4700::1111]", resolver);
+
+      expect(resolver).toHaveBeenCalledWith("2606:4700:4700::1111");
+    });
+
+    it("blocks a bracketed IPv6 loopback literal", async () => {
+      await expect(assertMailHostAllowed("[::1]", resolvesTo("::1"))).rejects.toThrow(
+        MailHostBlockedError
+      );
+    });
+  });
+});

--- a/packages/web/src/lib/integrations/__tests__/mail-host-guard.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/mail-host-guard.test.ts
@@ -26,6 +26,7 @@ describe("assertMailHostAllowed", () => {
       ["IPv6 link-local", "fe80::1"],
       ["IPv6 link-local, upper half of fe80::/10", "feb0::1"],
       ["IPv4-mapped IPv6 loopback", "::ffff:127.0.0.1"],
+      ["IPv4-compatible IPv6 loopback", "::7f00:1"],
     ];
 
     it.each(alwaysBlocked)("blocks a host resolving to %s (%s)", async (_label, address) => {

--- a/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
@@ -40,6 +40,12 @@ describe("isPrivateUrl", () => {
     expect(isPrivateUrl("http://[::ffff:127.0.0.1]:8069")).toBe(true);
   });
 
+  it("rejects an IPv4-compatible IPv6 loopback", () => {
+    // The deprecated `::a.b.c.d` form. `URL` hands it over as [::7f00:1] —
+    // it reads as an ordinary public IPv6 address unless the tail is decoded.
+    expect(isPrivateUrl("http://[::127.0.0.1]:8069")).toBe(true);
+  });
+
   it("rejects IPv6 unique local address (fc00::/7)", () => {
     expect(isPrivateUrl("http://[fd12:3456:789a::1]:8069")).toBe(true);
   });
@@ -107,6 +113,12 @@ describe("classifyIpAddress", () => {
     ["::ffff:127.0.0.1", "loopback"],
     ["::ffff:192.168.1.10", "private"],
     ["::ffff:203.0.113.50", "public"],
+    // ::a.b.c.d, the deprecated IPv4-compatible form. ::/96 is reserved, so
+    // nothing public lives there — decode the tail rather than wave it past.
+    ["::127.0.0.1", "loopback"],
+    ["::7f00:1", "loopback"],
+    ["::169.254.169.254", "link-local"],
+    ["::192.168.1.10", "private"],
   ] as const)("classifies IPv6 %s as %s", (address, expected) => {
     expect(classifyIpAddress(address)).toBe(expected);
   });

--- a/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { validateExternalUrl, isPrivateUrl } from "../url-validation";
+import { validateExternalUrl, isPrivateUrl, classifyIpAddress } from "../url-validation";
 
 describe("isPrivateUrl", () => {
   it("rejects localhost", () => {
@@ -34,6 +34,12 @@ describe("isPrivateUrl", () => {
     expect(isPrivateUrl("http://[::1]:8069")).toBe(true);
   });
 
+  it("rejects an IPv4-mapped IPv6 loopback", () => {
+    // `URL` normalizes this to [::ffff:7f00:1], which no longer looks like a
+    // loopback address unless the mapped IPv4 is actually decoded.
+    expect(isPrivateUrl("http://[::ffff:127.0.0.1]:8069")).toBe(true);
+  });
+
   it("rejects IPv6 unique local address (fc00::/7)", () => {
     expect(isPrivateUrl("http://[fd12:3456:789a::1]:8069")).toBe(true);
   });
@@ -56,6 +62,69 @@ describe("isPrivateUrl", () => {
 
   it("does not reject 172.32.x.x (outside private range)", () => {
     expect(isPrivateUrl("http://172.32.0.1:8069")).toBe(false);
+  });
+
+  it.each(["https://fcbank.example.com", "https://fdservice.example.com", "https://fe80.co"])(
+    "accepts %s — a DNS name is not an IPv6 literal just because it starts like one",
+    (url) => {
+      expect(isPrivateUrl(url)).toBe(false);
+    }
+  );
+});
+
+describe("classifyIpAddress", () => {
+  it.each([
+    ["127.0.0.1", "loopback"],
+    ["127.99.42.7", "loopback"],
+    ["0.0.0.0", "unspecified"],
+    ["0.1.2.3", "unspecified"],
+    ["169.254.169.254", "link-local"],
+    ["10.1.2.3", "private"],
+    ["172.16.0.1", "private"],
+    ["172.31.255.255", "private"],
+    ["192.168.1.10", "private"],
+    ["172.32.0.1", "public"],
+    ["203.0.113.50", "public"],
+  ] as const)("classifies IPv4 %s as %s", (address, expected) => {
+    expect(classifyIpAddress(address)).toBe(expected);
+  });
+
+  it.each([
+    ["::1", "loopback"],
+    ["0:0:0:0:0:0:0:1", "loopback"],
+    ["::", "unspecified"],
+    ["fe80::1", "link-local"],
+    // fe80::/10 spans fe80 through febf — a prefix match on "fe80" alone
+    // would miss most of it.
+    ["feb0::1", "link-local"],
+    ["fc00::1", "private"],
+    ["fd12:3456:789a::1", "private"],
+    ["fd00:ec2::254", "private"],
+    ["2606:4700:4700::1111", "public"],
+    ["fec0::1", "public"],
+    // IPv4-mapped addresses carry an IPv4 destination; classify what they
+    // actually reach, not the IPv6 wrapper.
+    ["::ffff:127.0.0.1", "loopback"],
+    ["::ffff:192.168.1.10", "private"],
+    ["::ffff:203.0.113.50", "public"],
+  ] as const)("classifies IPv6 %s as %s", (address, expected) => {
+    expect(classifyIpAddress(address)).toBe(expected);
+  });
+
+  it.each([
+    ["imap.example.com"],
+    ["localhost"],
+    [""],
+    ["999.1.1.1"],
+    ["1.2.3"],
+    ["1.2.3.4.5"],
+    ["not:an:address"],
+  ])("returns null for %s, which is not an IP literal", (value) => {
+    expect(classifyIpAddress(value)).toBeNull();
+  });
+
+  it("ignores an IPv6 zone identifier", () => {
+    expect(classifyIpAddress("fe80::1%eth0")).toBe("link-local");
   });
 });
 

--- a/packages/web/src/lib/integrations/imap-probe.ts
+++ b/packages/web/src/lib/integrations/imap-probe.ts
@@ -2,13 +2,16 @@ import { ImapFlow } from "imapflow";
 import nodemailer from "nodemailer";
 import { connect as netConnect } from "node:net";
 import type { ImapTestInput } from "@/lib/schemas/imap";
+import { assertMailHostAllowed, MailHostBlockedError } from "@/lib/integrations/mail-host-guard";
 
 // Shared IMAP/SMTP probe logic used by BOTH:
 //   - the pre-create "Test Connection" route (packages/web/src/app/api/integrations/imap/test/route.ts)
 //   - the imap branch of probeIntegrationCredentials (packages/web/src/lib/integrations/probe.ts),
 //     which re-probes an EXISTING connection's stored credentials.
-// Kept in one place (DRY) so timeout bounds and error-message mapping never drift
-// between the two callers.
+// Kept in one place (DRY) so timeout bounds, error-message mapping and the SSRF
+// guard never drift between the two callers — the guard lives at the two entry
+// points below (testImapLogin/testSmtpVerify) precisely so neither caller can
+// forget it.
 
 // Maps low-level probe errors to short, friendly messages that never leak a
 // stack trace or the password. Order matters: unambiguous network-error CODES
@@ -17,6 +20,10 @@ import type { ImapTestInput } from "@/lib/schemas/imap";
 // A host named e.g. "smtp-auth.example.com" would otherwise turn a DNS/timeout/
 // refused failure into a bogus "authentication failed".
 export function friendlyError(error: unknown): string {
+  // The SSRF guard's own message already names the cause and the fix; the
+  // fuzzy mapping below would only bury it under "check your settings".
+  if (error instanceof MailHostBlockedError) return error.message;
+
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
 
@@ -51,13 +58,19 @@ export function friendlyError(error: unknown): string {
 // failure category — e.g. to decide whether it's worth probing raw SMTP port
 // reachability — instead of pattern-matching the friendly string again.
 // friendlyError() itself is kept unchanged/exported for its existing callers.
-export type ProbeFailureCode = "timeout" | "refused" | "dns" | "auth" | "tls" | "unknown";
+export type ProbeFailureCode =
+  "timeout" | "refused" | "dns" | "auth" | "tls" | "blocked" | "unknown";
 
 // Per-leg (IMAP or SMTP) outcome of a connection test — see ImapTestResult in
 // @/lib/schemas/imap for how the two legs combine into the full API response.
 export type LegResult = { ok: true } | { ok: false; code: ProbeFailureCode; message: string };
 
 export function classifyProbeError(error: unknown): { code: ProbeFailureCode; message: string } {
+  // Its own code, ahead of every message-shaped rule: the caller uses the code
+  // to decide whether to run the SMTP port-reachability probe, and a host the
+  // guard just refused must not be scanned on three more ports.
+  if (error instanceof MailHostBlockedError) return { code: "blocked", message: error.message };
+
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
 
@@ -136,6 +149,11 @@ function probeTcpPort(host: string, port: number, timeoutMs: number): Promise<bo
 // smtpHost on a fixed, hardcoded port list — never to a host/port derived
 // from user-controlled input beyond what the caller already validated and
 // intended to probe. Do not widen this to accept arbitrary ports/hosts.
+//
+// It is deliberately NOT guarded again here: its only caller runs it after the
+// SMTP leg failed with code "timeout"/"refused", and a host the SSRF guard
+// refuses fails with code "blocked" — so a blocked host never reaches this
+// scan. A new caller MUST call assertMailHostAllowed() first.
 export async function probeSmtpPorts(
   host: string,
   ports: number[] = [465, 587, 25]
@@ -165,6 +183,8 @@ export function tlsModeForPort(
 }
 
 export async function testImapLogin(input: ImapTestInput): Promise<void> {
+  await assertMailHostAllowed(input.imapHost);
+
   const client = new ImapFlow({
     host: input.imapHost,
     port: input.imapPort,
@@ -185,6 +205,8 @@ export async function testImapLogin(input: ImapTestInput): Promise<void> {
 }
 
 export async function testSmtpVerify(input: ImapTestInput): Promise<void> {
+  await assertMailHostAllowed(input.smtpHost);
+
   const { secure, requireTLS } = tlsModeForPort(input.smtpPort, input.security);
   const transport = nodemailer.createTransport({
     host: input.smtpHost,

--- a/packages/web/src/lib/integrations/mail-host-guard.ts
+++ b/packages/web/src/lib/integrations/mail-host-guard.ts
@@ -1,5 +1,9 @@
 import { lookup } from "node:dns/promises";
-import { canonicalizeIpAddress, classifyIpAddress } from "@/lib/integrations/url-validation";
+import {
+  canonicalizeIpAddress,
+  classifyIpAddress,
+  type IpAddressClass,
+} from "@/lib/integrations/url-validation";
 
 /**
  * SSRF guard for the IMAP/SMTP probes.
@@ -47,11 +51,24 @@ export type MailHostResolver = (host: string) => Promise<string[]>;
 // off, and reaching IMDS must not become collateral of an operator enabling
 // their on-premise mail server. Canonicalized so no alternate spelling of the
 // same address slips past the comparison.
-const ALWAYS_BLOCKED_ADDRESSES = new Set(
-  ["fd00:ec2::254"].map((address) => canonicalizeIpAddress(address))
+const ALWAYS_BLOCKED_ADDRESSES: ReadonlySet<string> = new Set(
+  ["fd00:ec2::254"].map((address) => {
+    const canonical = canonicalizeIpAddress(address);
+    // A typo in this list would canonicalize to null and silently stop
+    // blocking anything. Fail at import instead of shipping a dead entry.
+    if (canonical === null) throw new Error(`Not an IP address: ${address}`);
+    return canonical;
+  })
 );
 
-const ALWAYS_BLOCKED_CLASSES = new Set(["loopback", "unspecified", "link-local"]);
+// Typed against IpAddressClass so a misspelt class is a compile error rather
+// than an entry that never matches — the failure mode of a security list is
+// that it silently lets things through.
+const ALWAYS_BLOCKED_CLASSES: ReadonlySet<IpAddressClass> = new Set([
+  "loopback",
+  "unspecified",
+  "link-local",
+]);
 
 const INTERNAL_MESSAGE =
   "Blocked: this host resolves to a loopback, link-local, or cloud-metadata address.";
@@ -109,7 +126,7 @@ export async function assertMailHostAllowed(
 
     if (
       (canonical !== null && ALWAYS_BLOCKED_ADDRESSES.has(canonical)) ||
-      ALWAYS_BLOCKED_CLASSES.has(addressClass ?? "")
+      (addressClass !== null && ALWAYS_BLOCKED_CLASSES.has(addressClass))
     ) {
       throw new MailHostBlockedError(INTERNAL_MESSAGE);
     }

--- a/packages/web/src/lib/integrations/mail-host-guard.ts
+++ b/packages/web/src/lib/integrations/mail-host-guard.ts
@@ -1,0 +1,120 @@
+import { lookup } from "node:dns/promises";
+import { canonicalizeIpAddress, classifyIpAddress } from "@/lib/integrations/url-validation";
+
+/**
+ * SSRF guard for the IMAP/SMTP probes.
+ *
+ * The "Test connection" endpoint connects to an admin-supplied host:port and
+ * reports *why* the attempt failed — refused, timed out, TLS error, auth
+ * rejected. Those distinctions are the whole point of the diagnostic, and they
+ * are also exactly what makes an unguarded probe an internal port scanner: it
+ * answers "is there something listening on 10.0.0.5:6379, and does it speak
+ * TLS?" one request at a time (pinchy#823).
+ *
+ * Unlike `validateExternalUrl`, which checks a URL string, this guard RESOLVES
+ * the host first: a mail host is a bare name, and the interesting attack is a
+ * public DNS name with an internal A record.
+ *
+ * Two tiers, because an on-premise mail server on an RFC-1918 range is a
+ * legitimate deployment:
+ *
+ *   - Always blocked: loopback, unspecified, link-local (which is where cloud
+ *     metadata lives) and the EC2 IPv6 metadata address. No mail server lives
+ *     there, so there is nothing to trade off.
+ *   - Blocked unless `ALLOW_PRIVATE_MAIL_HOSTS=1`: the private ranges. The
+ *     opt-in is the operator's explicit statement that reaching their own
+ *     network is intended.
+ *
+ * Caveat, same as the rest of the app's SSRF checks: this resolves once and the
+ * mail library resolves again when it connects, so a DNS answer that changes
+ * between the two (rebinding) is not covered. Closing that would mean pinning
+ * the connection to the address we checked, which neither imapflow nor
+ * nodemailer exposes.
+ */
+
+export class MailHostBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MailHostBlockedError";
+  }
+}
+
+/** Resolves a host to its IP addresses. Injected in tests. */
+export type MailHostResolver = (host: string) => Promise<string[]>;
+
+// EC2's IPv6 instance-metadata endpoint. It sits inside fc00::/7, so the
+// private-range check already covers it — but only while the opt-in flag is
+// off, and reaching IMDS must not become collateral of an operator enabling
+// their on-premise mail server. Canonicalized so no alternate spelling of the
+// same address slips past the comparison.
+const ALWAYS_BLOCKED_ADDRESSES = new Set(
+  ["fd00:ec2::254"].map((address) => canonicalizeIpAddress(address))
+);
+
+const ALWAYS_BLOCKED_CLASSES = new Set(["loopback", "unspecified", "link-local"]);
+
+const INTERNAL_MESSAGE =
+  "Blocked: this host resolves to a loopback, link-local, or cloud-metadata address.";
+
+const PRIVATE_MESSAGE =
+  "Blocked: this host resolves to a private network address. " +
+  "Set ALLOW_PRIVATE_MAIL_HOSTS=1 to allow an on-premise mail server.";
+
+async function resolveViaDns(host: string): Promise<string[]> {
+  const results = await lookup(host, { all: true, verbatim: true });
+  return results.map((result) => result.address);
+}
+
+function normalizeAddress(address: string): string {
+  return address
+    .replace(/^\[|\]$/g, "")
+    .split("%")[0]
+    .toLowerCase();
+}
+
+/**
+ * Throws `MailHostBlockedError` if `host` resolves to an address the probe must
+ * not touch. Resolves silently otherwise.
+ *
+ * A host that does not resolve at all is allowed through: no address means no
+ * connection, so there is no oracle to protect — and the far more common cause
+ * is a typo, which deserves the probe's "could not resolve the host" message
+ * rather than a security error the admin cannot act on.
+ */
+export async function assertMailHostAllowed(
+  host: string,
+  resolver: MailHostResolver = resolveViaDns
+): Promise<void> {
+  const normalizedHost = normalizeAddress(host.trim());
+  if (normalizedHost.length === 0) {
+    // The schemas already require a non-empty host, so this is a belt-and-
+    // suspenders guard for a future caller — say what is actually wrong rather
+    // than reusing the internal-address wording.
+    throw new MailHostBlockedError("Blocked: no mail server host was given.");
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await resolver(normalizedHost);
+  } catch {
+    return;
+  }
+
+  const allowPrivate = process.env.ALLOW_PRIVATE_MAIL_HOSTS === "1";
+
+  for (const address of addresses) {
+    const normalized = normalizeAddress(address);
+    const addressClass = classifyIpAddress(normalized);
+    const canonical = canonicalizeIpAddress(normalized);
+
+    if (
+      (canonical !== null && ALWAYS_BLOCKED_ADDRESSES.has(canonical)) ||
+      ALWAYS_BLOCKED_CLASSES.has(addressClass ?? "")
+    ) {
+      throw new MailHostBlockedError(INTERNAL_MESSAGE);
+    }
+    if (addressClass === "private" && !allowPrivate) {
+      throw new MailHostBlockedError(PRIVATE_MESSAGE);
+    }
+  }
+}

--- a/packages/web/src/lib/integrations/url-validation.ts
+++ b/packages/web/src/lib/integrations/url-validation.ts
@@ -137,9 +137,14 @@ export function classifyIpAddress(address: string): IpAddressClass | null {
   if (groups.every((group) => group === 0)) return "unspecified";
   if (groups.slice(0, 7).every((group) => group === 0) && groups[7] === 1) return "loopback";
 
-  // IPv4-mapped (::ffff:a.b.c.d) — what it actually reaches is the IPv4
-  // address, so classify that instead of the wrapper.
-  if (groups.slice(0, 5).every((group) => group === 0) && groups[5] === 0xffff) {
+  // Both forms that carry an IPv4 address in the low 32 bits: IPv4-mapped
+  // (::ffff:a.b.c.d) and the deprecated IPv4-compatible (::a.b.c.d). Classify
+  // the address they name rather than the wrapper — `URL` hands the latter over
+  // as "[::7f00:1]", which reads as an ordinary public IPv6 address. Nothing
+  // public lives in ::/96 either way, so decoding the tail can only be safer.
+  const embedsIPv4 =
+    groups.slice(0, 5).every((group) => group === 0) && (groups[5] === 0xffff || groups[5] === 0);
+  if (embedsIPv4) {
     return classifyIPv4([groups[6] >> 8, groups[6] & 0xff, groups[7] >> 8, groups[7] & 0xff]);
   }
 

--- a/packages/web/src/lib/integrations/url-validation.ts
+++ b/packages/web/src/lib/integrations/url-validation.ts
@@ -6,49 +6,149 @@
 const PRIVATE_HOSTNAMES = new Set(["localhost", "localhost.", "ip6-localhost", "ip6-loopback"]);
 
 /**
- * Returns true if the hostname is an IPv4 address in a private/reserved range.
+ * What an IP address can reach. The categories are split finer than
+ * "private or not" because callers weigh them differently: the mail-host
+ * guard (see mail-host-guard.ts) blocks loopback/link-local/unspecified
+ * unconditionally but lets an operator opt into `private`, since an
+ * on-premise mail server legitimately lives on an RFC-1918 range.
  */
-function isPrivateIPv4(hostname: string): boolean {
-  const parts = hostname.split(".").map(Number);
-  if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255)) {
-    return false;
+export type IpAddressClass = "loopback" | "unspecified" | "link-local" | "private" | "public";
+
+/**
+ * Parses a dotted-quad IPv4 literal into its four octets, or null if the
+ * string isn't one. Deliberately strict — decimal digits only — so legacy
+ * encodings ("0x7f.0.0.1", "2130706433") are NOT silently accepted as
+ * IPv4 here. Both callers normalize before this point: `URL` rewrites those
+ * forms to dotted-quad, and the mail-host guard classifies the addresses
+ * getaddrinfo resolved rather than the raw input.
+ */
+function parseIPv4(address: string): number[] | null {
+  const parts = address.split(".");
+  if (parts.length !== 4) return null;
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    octets.push(octet);
   }
-  const [a, b] = parts;
-
-  // 0.0.0.0/8 — current network
-  if (a === 0) return true;
-  // 10.0.0.0/8 — class A private
-  if (a === 10) return true;
-  // 127.0.0.0/8 — loopback
-  if (a === 127) return true;
-  // 169.254.0.0/16 — link-local (AWS metadata lives here)
-  if (a === 169 && b === 254) return true;
-  // 172.16.0.0/12 — class B private
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  // 192.168.0.0/16 — class C private
-  if (a === 192 && b === 168) return true;
-
-  return false;
+  return octets;
 }
 
 /**
- * Returns true if the hostname is an IPv6 address in a private/reserved range.
- * Handles bracket-stripped addresses (e.g. "::1", "fd12:3456:789a::1").
+ * Parses an IPv6 literal into its eight 16-bit groups, or null if the string
+ * isn't one. Handles "::" compression, an embedded IPv4 tail
+ * ("::ffff:127.0.0.1"), a zone identifier ("fe80::1%eth0") and surrounding
+ * brackets.
  */
-function isPrivateIPv6(hostname: string): boolean {
-  // Strip brackets if present
-  const addr = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+function parseIPv6(address: string): number[] | null {
+  // Strip brackets and any zone id — neither changes which host is reached.
+  const addr = address
+    .replace(/^\[|\]$/g, "")
+    .split("%")[0]
+    .toLowerCase();
+  if (!addr.includes(":")) return null;
 
-  // ::1 — loopback
-  if (addr === "::1" || addr === "0:0:0:0:0:0:0:1") return true;
-  // :: — unspecified
-  if (addr === "::" || addr === "0:0:0:0:0:0:0:0") return true;
-  // fc00::/7 — unique local addresses (fc00:: and fd00::)
-  if (addr.startsWith("fc") || addr.startsWith("fd")) return true;
-  // fe80::/10 — link-local
-  if (addr.startsWith("fe80")) return true;
+  const [head, tail, ...extra] = addr.split("::");
+  if (extra.length > 0) return null; // "::" may appear at most once
 
-  return false;
+  const parseGroups = (segment: string): number[] | null => {
+    if (segment === "") return [];
+    const groups: number[] = [];
+    const parts = segment.split(":");
+    for (const [index, part] of parts.entries()) {
+      // An embedded IPv4 tail is only legal as the very last part.
+      if (part.includes(".")) {
+        if (index !== parts.length - 1) return null;
+        const octets = parseIPv4(part);
+        if (!octets) return null;
+        groups.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
+        continue;
+      }
+      if (!/^[0-9a-f]{1,4}$/.test(part)) return null;
+      groups.push(parseInt(part, 16));
+    }
+    return groups;
+  };
+
+  const headGroups = parseGroups(head);
+  if (!headGroups) return null;
+
+  if (tail === undefined) {
+    return headGroups.length === 8 ? headGroups : null;
+  }
+
+  const tailGroups = parseGroups(tail);
+  if (!tailGroups) return null;
+
+  const missing = 8 - headGroups.length - tailGroups.length;
+  if (missing < 1) return null; // "::" must stand for at least one group
+  return [...headGroups, ...Array(missing).fill(0), ...tailGroups];
+}
+
+function classifyIPv4(octets: number[]): IpAddressClass {
+  const [a, b] = octets;
+
+  // 0.0.0.0/8 — "this network"; 0.0.0.0 itself routes to the local host
+  if (a === 0) return "unspecified";
+  // 127.0.0.0/8 — loopback
+  if (a === 127) return "loopback";
+  // 169.254.0.0/16 — link-local (cloud metadata lives at 169.254.169.254)
+  if (a === 169 && b === 254) return "link-local";
+  // 10.0.0.0/8 — class A private
+  if (a === 10) return "private";
+  // 172.16.0.0/12 — class B private
+  if (a === 172 && b >= 16 && b <= 31) return "private";
+  // 192.168.0.0/16 — class C private
+  if (a === 192 && b === 168) return "private";
+
+  return "public";
+}
+
+/**
+ * Rewrites an IP address literal into a single canonical spelling — dotted-quad
+ * for IPv4, eight zero-padded hex groups for IPv6 — or returns null when the
+ * string isn't an address. Lets callers compare against a specific address
+ * ("fd00:ec2::254") without having to enumerate its spellings.
+ */
+export function canonicalizeIpAddress(address: string): string | null {
+  const octets = parseIPv4(address);
+  if (octets) return octets.join(".");
+
+  const groups = parseIPv6(address);
+  if (!groups) return null;
+
+  return groups.map((group) => group.toString(16).padStart(4, "0")).join(":");
+}
+
+/**
+ * Classifies an IP address literal, or returns null when the string isn't one
+ * (a DNS name, a typo, an empty string). Callers that must decide about a
+ * hostname have to resolve it first — this function never touches DNS.
+ */
+export function classifyIpAddress(address: string): IpAddressClass | null {
+  const octets = parseIPv4(address);
+  if (octets) return classifyIPv4(octets);
+
+  const groups = parseIPv6(address);
+  if (!groups) return null;
+
+  if (groups.every((group) => group === 0)) return "unspecified";
+  if (groups.slice(0, 7).every((group) => group === 0) && groups[7] === 1) return "loopback";
+
+  // IPv4-mapped (::ffff:a.b.c.d) — what it actually reaches is the IPv4
+  // address, so classify that instead of the wrapper.
+  if (groups.slice(0, 5).every((group) => group === 0) && groups[5] === 0xffff) {
+    return classifyIPv4([groups[6] >> 8, groups[6] & 0xff, groups[7] >> 8, groups[7] & 0xff]);
+  }
+
+  // fc00::/7 — unique local addresses
+  if ((groups[0] & 0xfe00) === 0xfc00) return "private";
+  // fe80::/10 — link-local (spans fe80 through febf)
+  if ((groups[0] & 0xffc0) === 0xfe80) return "link-local";
+
+  return "public";
 }
 
 /**
@@ -70,13 +170,12 @@ export function isPrivateUrl(urlString: string): boolean {
   // Check well-known private hostnames
   if (PRIVATE_HOSTNAMES.has(hostname.toLowerCase())) return true;
 
-  // Check IPv4 private ranges
-  if (isPrivateIPv4(hostname)) return true;
-
-  // Check IPv6 private ranges (URL class strips brackets from hostname)
-  if (isPrivateIPv6(hostname)) return true;
-
-  return false;
+  // Everything else is decided by the address ranges. A hostname that is not
+  // an IP literal classifies as null and passes — see the DNS caveat above.
+  // (`URL.hostname` keeps the brackets around an IPv6 literal; classifyIpAddress
+  // strips them.)
+  const addressClass = classifyIpAddress(hostname);
+  return addressClass !== null && addressClass !== "public";
 }
 
 type ValidationResult = { valid: true; url: string } | { valid: false; error: string };


### PR DESCRIPTION
Closes #823.

## The problem

`POST /api/integrations/imap/test` connected to any admin-supplied `host:port` and reported exactly **why** the attempt failed — refused, timed out, TLS error, auth rejected. Those distinctions are the point of the diagnostic; they also turn the endpoint into an internal port scanner with a friendly UI, one request at a time: loopback services inside the container, `169.254.169.254`, anything on the deployment's own network. `probeIntegrationCredentials` reused the same unguarded probe when re-testing a stored connection.

## The guard

New `packages/web/src/lib/integrations/mail-host-guard.ts`. It **resolves the host first** — a mail server is a bare name, and the interesting attack is a public DNS name with an internal A record, which `validateExternalUrl` (URL-string only) cannot see. Blocks if **any** resolved address is internal.

Two tiers, because an on-premise mail server on an RFC-1918 range is a legitimate deployment:

| | default | `ALLOW_PRIVATE_MAIL_HOSTS=1` |
| --- | --- | --- |
| loopback, unspecified, link-local (incl. IMDS), `fd00:ec2::254` | blocked | **still blocked** |
| `10/8`, `172.16/12`, `192.168/16`, `fc00::/7` | blocked | allowed |
| public | allowed | allowed |

A host that does **not** resolve is let through: no address means no connection and no oracle, and the common cause is a typo that deserves "could not resolve the host" rather than a security error nobody can act on.

Placement matters twice:

- It sits in `testImapLogin`/`testSmtpVerify`, the two shared entry points, so neither caller can forget it.
- A refusal classifies as its own code `"blocked"` — never `"timeout"`/`"refused"`, which is precisely what would otherwise trigger the three-port SMTP scan the guard exists to prevent.

## Drive-by fixes in `url-validation`

It now decides by **parsing** addresses instead of matching prefixes, which fixes two real bugs:

- `isPrivateUrl` treated every hostname starting `fc`/`fd`/`fe80` as private — `https://fcbank.example.com` was blocked outright.
- It missed the upper half of `fe80::/10` and IPv4-mapped loopback, which `URL` hands over as `[::ffff:7f00:1]`.

`isPrivateUrl`'s contract is unchanged; strict decimal-only IPv4 parsing is safe because `URL` already normalizes `0x7f.0.0.1` / `2130706433` / `0177.0.0.1` to dotted-quad (verified).

## Tests

- `mail-host-guard.test.ts` — 40 cases over the decision table, always-blocked vs. gated, multi-address, resolution failure, bracketed literals. Every test injects its resolver; no test touches real DNS.
- `imap-probe.test.ts` — no socket is opened for a blocked host, per-leg host resolution, `blocked` classification.
- `imap-test-route.test.ts` — both legs blocked, no port scan, failure audit row, and the IMAP-only-blocked case.
- `url-validation.test.ts` — `classifyIpAddress` table plus the two bug regressions.

`docker-compose.imap-test.yml` sets `ALLOW_PRIVATE_MAIL_HOSTS=1`: GreenMail lives on the compose network, which is exactly the on-premise case the flag is for. It is **not** an E2E-only flag.

## Out of scope

The inbox-sweep IMAP port (`lib/email-workflows/ports/imap.ts`) opens stored credentials on a schedule and is deliberately not guarded here — it reports nothing back to a requester, so it is not an oracle. Worth a follow-up decision if we ever want a blanket "every mail connect goes through the guard" drift guard.

## Verification

- `pnpm -C packages/web vitest run src/__tests__/api/ src/lib/integrations/__tests__/` — green (2 flakes on first pass were 5s timeouts on a loaded machine; green on rerun).
- `pnpm -C packages/web typecheck` — green. `pnpm -C packages/web lint` — green. `prettier --check` on the touched files — green.
- Note: `use-ws-runtime-active-run-anchor.test.ts` and `boot-inits.test.ts` fail on this branch's tip **before** this change (mock drift); neither has an import path to anything touched here.

---

## Review follow-up (246d6685c)

**The save route bypassed the guard.** `POST /api/integrations/imap` stored any host without probing. The UI tests before it saves, but the API is the contract — and a stored row is the *worse* half of #823, because the inbox sweep and the pinchy-email plugin reconnect to that host on a schedule and report what they find. Both hosts now pass the guard before the insert; a refusal is a 400 and an audited failed `integration.created` (`blocked: "host"`, no resolved address in the row).

Two smaller ones:

- `::a.b.c.d` (deprecated IPv4-compatible) classified as **public** — `URL` normalizes `[::127.0.0.1]` to `[::7f00:1]`, which reads as an ordinary public address unless the tail is decoded. Now decoded like the IPv4-mapped form beside it. Not exploitable in practice (Linux doesn't translate `::/96`), but a guard shouldn't leave the question open.
- `ALWAYS_BLOCKED_CLASSES` was a `Set<string>` matched against `class ?? ""`, so a misspelt class name would have compiled and silently never matched. Typed against `IpAddressClass`; a malformed always-blocked address now throws at import rather than shipping as a dead entry.
