### PR TITLE
fix(usage): stop logging an absent trajectory as an error every poll

### DIFF
--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -12,12 +12,22 @@ vi.mock("@/db/schema", () => ({
   usageRecords: { _table: "usage_records", sessionKey: "session_key", runId: "run_id" },
 }));
 
-vi.mock("@/lib/diagnostics/jsonl-reader", () => ({
-  resolveSessionId: (...args: unknown[]) => mockResolveSessionId(...args),
-  readTrajectoryJsonl: (...args: unknown[]) => mockReadTrajectoryJsonl(...args),
-}));
+// Partial mock: only the two readers are stubbed. `TrajectoryFileNotFoundError`
+// stays the REAL class so the `instanceof` branch under test is exercised
+// against the same identity production code sees.
+vi.mock("@/lib/diagnostics/jsonl-reader", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/diagnostics/jsonl-reader")>(
+    "@/lib/diagnostics/jsonl-reader"
+  );
+  return {
+    ...actual,
+    resolveSessionId: (...args: unknown[]) => mockResolveSessionId(...args),
+    readTrajectoryJsonl: (...args: unknown[]) => mockReadTrajectoryJsonl(...args),
+  };
+});
 
 import { buildUsageRows, recordSessionTurnsUsage } from "@/lib/usage-per-turn";
+import { TrajectoryFileNotFoundError } from "@/lib/diagnostics/jsonl-reader";
 import { _resetPricingCacheForTest } from "@/lib/usage";
 import type { PerTurnUsage } from "@/lib/usage-from-trajectory";
 
@@ -214,6 +224,57 @@ describe("recordSessionTurnsUsage cost wiring", () => {
     expect(recorded).toBe(1);
     const rows = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
     expect(rows[0].estimatedCostUsd).toBeNull();
+  });
+});
+
+// #885: a session whose run never wrote a trajectory (e.g. it failed on a
+// retired model) is an EXPECTED state, not an error — but the poller re-scans
+// it forever, so logging it as an error floods the container logs and evicts
+// real signal from log-capture's 100-entry diagnostics ring.
+describe("recordSessionTurnsUsage with no trajectory file", () => {
+  function client() {
+    return {
+      config: { get: vi.fn().mockResolvedValue({ config: {} }) },
+    } as unknown as Parameters<typeof recordSessionTurnsUsage>[0]["openclawClient"];
+  }
+
+  const params = () => ({
+    openclawClient: client(),
+    agentId: "a1",
+    userId: "u1",
+    agentName: "Ada",
+    sessionKey: "agent:a1:direct:u1",
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetPricingCacheForTest();
+    mockResolveSessionId.mockResolvedValue("sess-1");
+  });
+
+  it("returns 0 without logging an error when the trajectory file is absent", async () => {
+    mockReadTrajectoryJsonl.mockRejectedValue(
+      new TrajectoryFileNotFoundError("/openclaw-config/agents/a1/sessions/sess-1.trajectory.jsonl")
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const recorded = await recordSessionTurnsUsage(params());
+
+    expect(recorded).toBe(0);
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("still logs an error for a real IO failure, so genuine breakage stays visible", async () => {
+    const ioError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    mockReadTrajectoryJsonl.mockRejectedValue(ioError);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const recorded = await recordSessionTurnsUsage(params());
+
+    expect(recorded).toBe(0);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
   });
 });
 

--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -266,6 +266,9 @@ describe("recordSessionTurnsUsage with no trajectory file", () => {
   });
 
   it("still logs an error for a real IO failure, so genuine breakage stays visible", async () => {
+    // EACCES is the transient case `readFileResilient` already retries against
+    // OpenClaw's chmod window — reaching the recorder means those retries are
+    // exhausted, so this is real breakage and must NOT join the silent branch.
     const ioError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
     mockReadTrajectoryJsonl.mockRejectedValue(ioError);
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -274,6 +277,9 @@ describe("recordSessionTurnsUsage with no trajectory file", () => {
 
     expect(recorded).toBe(0);
     expect(consoleError).toHaveBeenCalledTimes(1);
+    // The original error must reach the log, not a rewrapped stand-in — the
+    // `code`/stack is what an operator diagnoses the volume mount from.
+    expect(consoleError).toHaveBeenCalledWith(expect.any(String), ioError);
     consoleError.mockRestore();
   });
 });

--- a/packages/web/src/lib/usage-per-turn.ts
+++ b/packages/web/src/lib/usage-per-turn.ts
@@ -2,7 +2,11 @@ import { db } from "@/db";
 import { usageRecords } from "@/db/schema";
 import type { OpenClawClient } from "openclaw-node";
 import { parseJsonlLines } from "@/lib/diagnostics/jsonl-parser";
-import { resolveSessionId, readTrajectoryJsonl } from "@/lib/diagnostics/jsonl-reader";
+import {
+  resolveSessionId,
+  readTrajectoryJsonl,
+  TrajectoryFileNotFoundError,
+} from "@/lib/diagnostics/jsonl-reader";
 import { extractPerTurnUsage, type PerTurnUsage } from "@/lib/usage-from-trajectory";
 import { getModelPricing } from "@/lib/usage";
 import { estimateTurnCostUsd, type ModelPricing } from "@/lib/usage-cost";
@@ -152,8 +156,16 @@ export async function recordSessionTurnsUsage(params: RecordSessionTurnsParams):
     );
     return await insertPerTurnUsage(priced);
   } catch (error) {
-    // Trajectory missing / unreadable / DB hiccup — never throw into the
-    // poller or chat path. The next scan retries; dedup keeps it safe.
+    // A session with no trajectory file is an EXPECTED state, not a failure:
+    // the run may have died before OpenClaw wrote one (e.g. its model was
+    // retired), and there is simply nothing to record. Logging it would repeat
+    // on every poll cycle forever (#885) — flooding the container logs and
+    // evicting real signal from log-capture's bounded diagnostics ring. Stay
+    // quiet; a trajectory that appears later is picked up by the next scan.
+    if (error instanceof TrajectoryFileNotFoundError) return 0;
+    // Everything else (unreadable file, DB hiccup) is real breakage worth
+    // surfacing — but still never thrown into the poller or chat path. The
+    // next scan retries; dedup keeps it safe.
     console.error("[usage-per-turn] Failed to record session turns:", error);
     return 0;
   }


### PR DESCRIPTION
## What

A chat session whose run never produced a trajectory file — the run died before OpenClaw wrote one, e.g. because its model was retired — is an **expected** state, not a failure. `recordSessionTurnsUsage` caught every error alike and logged it, so the usage poller re-reported the same missing file on every cycle, forever (apsa v0.8.0: two agents spamming continuously).

That is not only noise: `log-capture` mirrors `console.error` into a 100-entry ring that the diagnostics export reads, so the repeat drowns real signal in the one buffer an operator looks at when something breaks.

## How

`readTrajectoryJsonl` already throws a typed `TrajectoryFileNotFoundError` for ENOENT, and `/api/diagnostics/export` already distinguishes it — the recorder just had to honour it. Missing trajectory now returns `0` quietly; every other error (unreadable file, DB hiccup) still logs, so genuine breakage stays visible.

## Tests

Two new cases in `usage-per-turn.test.ts`, one per branch — the second one is what keeps the fix from degenerating into a blanket silence. The jsonl-reader mock became partial (`importActual`) so the real error class drives the `instanceof` check.

## Verification

Run locally on a heavily loaded machine, so the full-suite noise was traced rather than assumed:

- `usage-per-turn.test.ts` — 11/11 green (red before the fix, on the new assertion)
- `pnpm -C packages/web typecheck`, root `prettier --check .`, eslint on the changed files — green
- `pnpm test:scripts` (390 pass), `pnpm typecheck:plugins` (9/9) — green
- `test:db` — 47/48 files green; the two `email-sweep` failures are 30 s timeouts that reproduce identically with the change stashed
- Full unit suite — remaining failures are 5 s timeouts under load average ~137 (each file green in isolation) plus a `better-sqlite3` ABI mismatch from installing under Node 25 and running under Node 22. None touch the changed code.

Fixes #885