### PR TITLE
feat(kb): read spreadsheets into row-wise chunks anchored on sheet and row range

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -51,6 +51,7 @@
     "cmdk": "^1.1.1",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
+    "exceljs": "^4.4.0",
     "file-type": "^22.0.1",
     "i18n-iso-countries": "^7.14.0",
     "imapflow": "^1.4.6",

--- a/packages/web/src/__tests__/lib/knowledge/xlsx-extract.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/xlsx-extract.test.ts
@@ -1,0 +1,456 @@
+/**
+ * extractXlsx against real workbooks written on the fly with exceljs (the same
+ * library the extractor reads with, and already a web dependency), so this is a
+ * true round-trip without a checked-in binary fixture — same approach as
+ * pdf-extract.test.ts.
+ *
+ * The two real corpus files named in the issue are NOT committed: they are a
+ * customer's 3M vendor data, and this repository is public. They are exercised
+ * by the opt-in block at the bottom, pointed at a local corpus via
+ * KB_XLSX_CORPUS_DIR.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import ExcelJS from "exceljs";
+
+import { extractXlsx, XlsxExtractionError } from "@/lib/knowledge/xlsx-extract";
+
+/** The first 8 bytes of every legacy BIFF .xls: the OLE2 compound-file magic. */
+const OLE2_MAGIC = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-kb-xlsx-extract-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/** Writes a workbook built by `build` into the test tmp dir and returns its path. */
+async function buildWorkbook(
+  name: string,
+  build: (workbook: ExcelJS.Workbook) => void
+): Promise<string> {
+  const workbook = new ExcelJS.Workbook();
+  build(workbook);
+  const path = join(tmpRoot, name);
+  await workbook.xlsx.writeFile(path);
+  return path;
+}
+
+/** Every row line of a chunk (i.e. everything below the `Sheet: …` preamble). */
+function rowLines(text: string): string[] {
+  return text.split("\n").slice(1);
+}
+
+describe("sheets and row anchors", () => {
+  it("extracts rows with their sheet name and Excel row numbers", async () => {
+    const path = await buildWorkbook("multi-sheet.xlsx", (workbook) => {
+      const products = workbook.addWorksheet("Products");
+      products.addRow(["Article", "Description"]);
+      products.addRow(["A-1", "Petrifilm plate"]);
+      products.addRow(["A-2", "Aqua plate"]);
+
+      const storage = workbook.addWorksheet("Storage");
+      storage.addRow(["Article", "Condition"]);
+      storage.addRow(["A-1", "2-8 degrees C"]);
+    });
+
+    const { chunks, sheets } = await extractXlsx(path);
+
+    expect(sheets).toEqual(["Products", "Storage"]);
+    expect(chunks).toEqual([
+      {
+        sheet: "Products",
+        startRow: 2,
+        endRow: 3,
+        text: "Sheet: Products\nArticle: A-1; Description: Petrifilm plate\nArticle: A-2; Description: Aqua plate",
+      },
+      {
+        sheet: "Storage",
+        startRow: 2,
+        endRow: 2,
+        text: "Sheet: Storage\nArticle: A-1; Condition: 2-8 degrees C",
+      },
+    ]);
+  });
+
+  it("never puts two sheets in one chunk, even when both would fit the budget", async () => {
+    const path = await buildWorkbook("tiny-sheets.xlsx", (workbook) => {
+      for (const name of ["One", "Two", "Three"]) {
+        const sheet = workbook.addWorksheet(name);
+        sheet.addRow(["Key"]);
+        sheet.addRow([`value for ${name}`]);
+      }
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks.map((chunk) => chunk.sheet)).toEqual(["One", "Two", "Three"]);
+  });
+
+  it("keeps Excel's own row numbers across skipped rows", async () => {
+    const path = await buildWorkbook("gaps.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Gaps");
+      sheet.addRow(["Key", "Value"]);
+      sheet.addRow(["first", 1]);
+      sheet.addRow([]);
+      sheet.addRow([]);
+      sheet.addRow(["last", 2]);
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    // Rows 3 and 4 are blank and drop out, but row 5 stays row 5 — the anchor
+    // has to match what the reader sees in Excel's row gutter, not a
+    // re-numbering of the rows we happened to keep.
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({ startRow: 2, endRow: 5 });
+    expect(rowLines(chunks[0].text)).toEqual(["Key: first; Value: 1", "Key: last; Value: 2"]);
+  });
+
+  it("falls back to column letters when the sheet has no header row", async () => {
+    const path = await buildWorkbook("no-header.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Raw");
+      // First row already carries data (a number), so it is not a header.
+      sheet.addRow([1, "first"]);
+      sheet.addRow([2, "second"]);
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    expect(rowLines(chunks[0].text)).toEqual(["A: 1; B: first", "A: 2; B: second"]);
+    expect(chunks[0].startRow).toBe(1);
+  });
+});
+
+describe("cell values", () => {
+  it("uses a formula's cached result, never the formula text", async () => {
+    const path = await buildWorkbook("formulas.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Calc");
+      sheet.addRow(["Item", "Qty", "Total"]);
+      sheet.addRow(["Hammer", 2, { formula: "B2*10", result: 20 }]);
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    expect(rowLines(chunks[0].text)).toEqual(["Item: Hammer; Qty: 2; Total: 20"]);
+    expect(chunks[0].text).not.toContain("B2*10");
+  });
+
+  it("drops a formula cell that was never calculated instead of indexing its source", async () => {
+    const path = await buildWorkbook("uncalculated.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Calc");
+      sheet.addRow(["Item", "Total"]);
+      const row = sheet.addRow(["Hammer", null]);
+      row.getCell(2).value = { formula: "A1" } as ExcelJS.CellFormulaValue;
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    expect(rowLines(chunks[0].text)).toEqual(["Item: Hammer"]);
+  });
+
+  it("carries a merged cell's value into every row it spans", async () => {
+    const path = await buildWorkbook("merged.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Catalog");
+      sheet.addRow(["Category", "Product"]);
+      sheet.addRow(["Petrifilm Rapid", "Coliform Count Plate"]);
+      sheet.addRow([null, "E. coli Count Plate"]);
+      sheet.mergeCells("A2:A3");
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    // The category lives in the merged master cell only. A row-shaped chunk
+    // has to stand on its own, so the second row must still say which
+    // category it belongs to.
+    expect(rowLines(chunks[0].text)).toEqual([
+      "Category: Petrifilm Rapid; Product: Coliform Count Plate",
+      "Category: Petrifilm Rapid; Product: E. coli Count Plate",
+    ]);
+  });
+
+  it("flattens rich text, hyperlinks, dates and booleans into readable values", async () => {
+    const path = await buildWorkbook("value-shapes.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Shapes");
+      sheet.addRow(["Kind", "Value"]);
+      const rich = sheet.addRow(["rich", null]);
+      rich.getCell(2).value = { richText: [{ text: "Hello " }, { text: "world" }] };
+      const link = sheet.addRow(["link", null]);
+      link.getCell(2).value = { text: "Pinchy", hyperlink: "https://heypinchy.com" };
+      sheet.addRow(["date", new Date(Date.UTC(2026, 0, 2))]);
+      sheet.addRow(["bool", true]);
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    expect(rowLines(chunks[0].text)).toEqual([
+      "Kind: rich; Value: Hello world",
+      "Kind: link; Value: Pinchy (https://heypinchy.com)",
+      "Kind: date; Value: 2026-01-02",
+      "Kind: bool; Value: true",
+    ]);
+  });
+
+  it("drops error cells and collapses newlines inside a cell", async () => {
+    const path = await buildWorkbook("noise.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Noise");
+      const header = sheet.addRow(["Material\nSAP Number", "Broken", "Note"]);
+      header.getCell(1).alignment = { wrapText: true };
+      const row = sheet.addRow(["7100039311", null, "line one\nline two"]);
+      row.getCell(2).value = { error: "#DIV/0!" } as ExcelJS.CellErrorValue;
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    // A row must stay a single line — the chunker groups whole rows, and a
+    // stray newline would make one row look like two.
+    expect(rowLines(chunks[0].text)).toEqual([
+      "Material SAP Number: 7100039311; Note: line one line two",
+    ]);
+  });
+});
+
+describe("hidden content is excluded by default", () => {
+  it("excludes hidden and very-hidden sheets, and reports that it did", async () => {
+    const path = await buildWorkbook("hidden-sheets.xlsx", (workbook) => {
+      const visible = workbook.addWorksheet("Visible");
+      visible.addRow(["Key"]);
+      visible.addRow(["public value"]);
+
+      const hidden = workbook.addWorksheet("Draft");
+      hidden.addRow(["Key"]);
+      hidden.addRow(["internal draft value"]);
+      hidden.state = "hidden";
+
+      const veryHidden = workbook.addWorksheet("Scratch");
+      veryHidden.addRow(["Key"]);
+      veryHidden.addRow(["scratch value"]);
+      veryHidden.state = "veryHidden";
+    });
+
+    const result = await extractXlsx(path);
+
+    expect(result.sheets).toEqual(["Visible"]);
+    expect(result.hiddenSheets).toEqual(["Draft", "Scratch"]);
+    expect(result.chunks.map((chunk) => chunk.sheet)).toEqual(["Visible"]);
+    const allText = result.chunks.map((chunk) => chunk.text).join("\n");
+    expect(allText).not.toContain("internal draft");
+    expect(allText).not.toContain("scratch value");
+  });
+
+  it("excludes hidden rows and hidden columns, and reports the row count", async () => {
+    const path = await buildWorkbook("hidden-rows.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Prices");
+      sheet.addRow(["Article", "List price", "Purchase price"]);
+      sheet.addRow(["A-1", 100, 42]);
+      sheet.addRow(["A-2", 200, 84]);
+      sheet.getRow(3).hidden = true;
+      sheet.getColumn(3).hidden = true;
+    });
+
+    const result = await extractXlsx(path);
+
+    expect(result.hiddenRows).toBe(1);
+    expect(rowLines(result.chunks[0].text)).toEqual(["Article: A-1; List price: 100"]);
+    expect(result.chunks[0].text).not.toContain("42");
+  });
+
+  it("reports zero chunks with a reason when every sheet is hidden", async () => {
+    const path = await buildWorkbook("all-hidden.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Draft");
+      sheet.addRow(["Key"]);
+      sheet.addRow(["value"]);
+      sheet.state = "hidden";
+    });
+
+    const result = await extractXlsx(path);
+
+    // Nothing to index, but this is a governance decision rather than an
+    // unreadable file — the caller has to be able to tell the two apart.
+    expect(result.chunks).toEqual([]);
+    expect(result.sheets).toEqual([]);
+    expect(result.hiddenSheets).toEqual(["Draft"]);
+  });
+});
+
+describe("chunking", () => {
+  it("splits a long sheet into chunks that respect the token bound", async () => {
+    const path = await buildWorkbook("long.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Packaging");
+      sheet.addRow(["Material", "Unit"]);
+      for (let i = 1; i <= 40; i++) {
+        sheet.addRow([`70000018${String(i).padStart(2, "0")}`, "CV"]);
+      }
+    });
+
+    // 20 tokens ~ 80 chars: small enough to force several chunks over 40 rows.
+    const { chunks } = await extractXlsx(path, { targetTokens: 20 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(20 * 4);
+      expect(chunk.sheet).toBe("Packaging");
+    }
+  });
+
+  it("emits every row exactly once, in order, across the chunk boundaries", async () => {
+    const path = await buildWorkbook("coverage.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Packaging");
+      sheet.addRow(["Material"]);
+      for (let i = 1; i <= 40; i++) sheet.addRow([`row-${i}`]);
+    });
+
+    const { chunks } = await extractXlsx(path, { targetTokens: 20 });
+
+    // Rows are the atomic unit here, so chunks do NOT overlap the way the PDF
+    // chunker does: a duplicated row would be a duplicated fact and would make
+    // the row-range anchor ambiguous.
+    const emitted = chunks.flatMap((chunk) => rowLines(chunk.text));
+    expect(emitted).toEqual(Array.from({ length: 40 }, (_, i) => `Material: row-${i + 1}`));
+
+    // Anchors have to tile the sheet: each chunk starts right after the
+    // previous one ends.
+    expect(chunks[0].startRow).toBe(2);
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i].startRow).toBeGreaterThan(chunks[i - 1].endRow);
+    }
+    expect(chunks.at(-1)!.endRow).toBe(41);
+  });
+
+  it("emits a row that alone exceeds the budget as its own chunk rather than cutting it", async () => {
+    const path = await buildWorkbook("oversized.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Wide");
+      sheet.addRow(["Description"]);
+      sheet.addRow(["x".repeat(500)]);
+      sheet.addRow(["short"]);
+    });
+
+    const { chunks } = await extractXlsx(path, { targetTokens: 20 });
+
+    expect(chunks[0].text).toContain("x".repeat(500));
+    expect(chunks[0]).toMatchObject({ startRow: 2, endRow: 2 });
+    expect(chunks[1]).toMatchObject({ startRow: 3, endRow: 3 });
+  });
+
+  it("returns no chunks for a sheet that holds only a header row", async () => {
+    const path = await buildWorkbook("header-only.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Empty");
+      sheet.addRow(["Article", "Description"]);
+    });
+
+    const { chunks, sheets } = await extractXlsx(path);
+
+    expect(sheets).toEqual(["Empty"]);
+    expect(chunks).toEqual([]);
+  });
+});
+
+describe("unreadable files fail at document level", () => {
+  it("throws with a reason for a file that is not a zip at all", async () => {
+    const path = join(tmpRoot, "corrupt.xlsx");
+    await writeFile(path, "this is plain text, not a workbook");
+
+    await expect(extractXlsx(path)).rejects.toThrow(XlsxExtractionError);
+    await expect(extractXlsx(path)).rejects.toThrow(/corrupt\.xlsx/);
+  });
+
+  it("throws for a legacy binary .xls, which exceljs cannot read", async () => {
+    // exceljs reads .xlsx as a zip, so no OLE2 container gets past the opener,
+    // whatever its BIFF payload — legacy Excel is out of scope for this
+    // extractor and has to say so loudly.
+    const path = join(tmpRoot, "legacy.xls");
+    await writeFile(path, Buffer.concat([OLE2_MAGIC, Buffer.alloc(512)]));
+
+    await expect(extractXlsx(path)).rejects.toThrow(XlsxExtractionError);
+  });
+
+  it("throws for a missing file", async () => {
+    await expect(extractXlsx(join(tmpRoot, "nope.xlsx"))).rejects.toThrow(XlsxExtractionError);
+  });
+
+  it("throws for a valid zip that holds no worksheets", async () => {
+    // This is the silent-zero trap: a .docx renamed .xlsx unzips fine and
+    // exceljs resolves happily with zero worksheets. Returning [] here would
+    // book a document nobody can read as a successfully indexed empty one.
+    const path = await buildWorkbook("no-sheets.xlsx", () => {});
+
+    await expect(extractXlsx(path)).rejects.toThrow(XlsxExtractionError);
+    await expect(extractXlsx(path)).rejects.toThrow(/no worksheets/i);
+  });
+
+  it("keeps the source path on the error so the caller can name the document", async () => {
+    const path = join(tmpRoot, "corrupt.xlsx");
+    await writeFile(path, "nope");
+
+    const error = await extractXlsx(path).catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(XlsxExtractionError);
+    expect((error as XlsxExtractionError).sourcePath).toBe(path);
+    expect((error as XlsxExtractionError).cause).toBeInstanceOf(Error);
+  });
+});
+
+/**
+ * The two real corpus files from the issue. They are a customer's 3M vendor
+ * data and this repository is public, so they are not committed; point
+ * KB_XLSX_CORPUS_DIR at a directory holding them to run this block:
+ *
+ *   KB_XLSX_CORPUS_DIR="/path/to/Technical Information" pnpm -C packages/web test xlsx-extract
+ */
+const CORPUS_DIR = process.env.KB_XLSX_CORPUS_DIR;
+const CORPUS_FILES = {
+  storage: "3M Products ALL - Storage Conditions 01_2019.xlsx",
+  packaging: "3M_Packaging_Dimensions_export_pack_levels_by_ean_code_-_2022.xlsx",
+} as const;
+
+describe.skipIf(
+  !CORPUS_DIR || !Object.values(CORPUS_FILES).every((f) => existsSync(join(CORPUS_DIR, f)))
+)("real corpus files (opt-in via KB_XLSX_CORPUS_DIR)", () => {
+  it("reads the storage-conditions sheet, carrying its merged category down", async () => {
+    const { chunks, sheets } = await extractXlsx(join(CORPUS_DIR!, CORPUS_FILES.storage));
+
+    expect(sheets).toEqual(["FSD Storage"]);
+    expect(chunks.length).toBeGreaterThan(0);
+
+    // Column A holds the product family in a cell merged over rows 3-10, so
+    // only row 3 physically carries the text. Asserted on the ROW line rather
+    // than the chunk: a chunk-level match would also pass if the category came
+    // from a neighbouring row that happens to share the chunk.
+    const line = chunks
+      .flatMap((chunk) => rowLines(chunk.text))
+      .find((row) => row.includes("7100039395"));
+    expect(line).toBeDefined();
+    expect(line).toContain("Petrifilm Rapid");
+    expect(line).toContain("2-8°C");
+  }, 30_000);
+
+  it("reads every data row of the packaging export without losing one", async () => {
+    const { chunks } = await extractXlsx(join(CORPUS_DIR!, CORPUS_FILES.packaging));
+
+    // The sheet reports 1394 rows: one header, 1392 data rows, and a trailing
+    // ghost row 1394 that the SAP export left behind — it holds 32 cells, all
+    // of them the empty string. It is dropped like any other blank row, which
+    // is why the last anchor is 1393 and not 1394.
+    const rowCount = chunks.reduce((sum, chunk) => sum + rowLines(chunk.text).length, 0);
+    expect(rowCount).toBe(1392);
+    expect(chunks[0].startRow).toBe(2);
+    expect(chunks.at(-1)!.endRow).toBe(1393);
+
+    // Header labels ride along with their value, so a column that is blank for
+    // a given row costs that row nothing. This export has 31 columns and most
+    // rows fill a dozen — labelling the blanks too would roughly double the
+    // token bill for no added meaning.
+    expect(chunks[0].text).toContain("EAN/UPC: 50021200186634");
+    expect(rowLines(chunks[0].text)[2]).not.toContain("Unit of Dimension");
+    // exceljs's own readFile costs ~4.5 s on this 192 KB / 43k-cell workbook;
+    // walking and rendering it afterwards costs ~0.2 s. The default 5 s test
+    // timeout is not enough for a file of this size.
+  }, 30_000);
+});

--- a/packages/web/src/__tests__/lib/knowledge/xlsx-extract.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/xlsx-extract.test.ts
@@ -9,7 +9,7 @@
  * by the opt-in block at the bottom, pointed at a local corpus via
  * KB_XLSX_CORPUS_DIR.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -199,6 +199,61 @@ describe("cell values", () => {
     ]);
   });
 
+  it("reads a hyperlink whose label is rich text", async () => {
+    const path = await buildWorkbook("rich-hyperlink.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Links");
+      sheet.addRow(["Kind", "Value"]);
+      sheet.addRow([
+        "richlink",
+        // exceljs types `text` as a string, but a hyperlink cell whose label
+        // carries mixed formatting — the normal case for a styled link — reads
+        // back with a richText OBJECT there. Its own typings do not model that.
+        {
+          text: { richText: [{ text: "Rich " }, { text: "link" }] },
+          hyperlink: "https://example.com/rich",
+        } as unknown as ExcelJS.CellHyperlinkValue,
+      ]);
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    expect(rowLines(chunks[0].text)).toEqual([
+      "Kind: richlink; Value: Rich link (https://example.com/rich)",
+    ]);
+  });
+
+  it("renders a percent-formatted cell the way the sheet displays it", async () => {
+    const path = await buildWorkbook("percent.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Margins");
+      sheet.addRow(["Product", "Margin", "Discount"]);
+      const row = sheet.addRow(["A-1", 0.15, 0.075]);
+      row.getCell(2).numFmt = "0%";
+      row.getCell(3).numFmt = "0.0%;[Red]-0.0%";
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    // Excel's `%` multiplies by 100 for display. Indexing the stored 0.15 would
+    // make the document answer "15%" with "0.15" — a wrong number, not merely
+    // an unformatted one, and exactly the failure the formula rule avoids.
+    expect(rowLines(chunks[0].text)).toEqual(["Product: A-1; Margin: 15%; Discount: 7.5%"]);
+  });
+
+  it("does not scale a value whose format only contains a quoted percent sign", async () => {
+    const path = await buildWorkbook("quoted-percent.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Literal");
+      sheet.addRow(["Kind", "Value"]);
+      const row = sheet.addRow(["literal", 0.15]);
+      // A quoted % is a literal suffix in Excel's format language and carries
+      // no multiplier — the cell reads 0.15%, so the value must stay 0.15.
+      row.getCell(2).numFmt = '0.00"%"';
+    });
+
+    const { chunks } = await extractXlsx(path);
+
+    expect(rowLines(chunks[0].text)).toEqual(["Kind: literal; Value: 0.15"]);
+  });
+
   it("drops error cells and collapses newlines inside a cell", async () => {
     const path = await buildWorkbook("noise.xlsx", (workbook) => {
       const sheet = workbook.addWorksheet("Noise");
@@ -384,6 +439,27 @@ describe("unreadable files fail at document level", () => {
 
     await expect(extractXlsx(path)).rejects.toThrow(XlsxExtractionError);
     await expect(extractXlsx(path)).rejects.toThrow(/no worksheets/i);
+  });
+
+  it("reports a failure raised while walking the workbook as a document-level failure", async () => {
+    const path = await buildWorkbook("walk-explodes.xlsx", (workbook) => {
+      const sheet = workbook.addWorksheet("Data");
+      sheet.addRow(["Key"]);
+      sheet.addRow(["value"]);
+    });
+
+    // The file opens fine and only the walk fails. Without a net that surfaces
+    // as a raw TypeError from library internals, which the caller cannot tell
+    // apart from a systemic fault — so a per-file problem would look like a
+    // reason to abort the whole ingest run.
+    const spy = vi.spyOn(ExcelJS.Workbook.prototype, "worksheets", "get").mockImplementation(() => {
+      throw new TypeError("value.text.replace is not a function");
+    });
+    try {
+      await expect(extractXlsx(path)).rejects.toThrow(XlsxExtractionError);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("keeps the source path on the error so the caller can name the document", async () => {

--- a/packages/web/src/lib/knowledge/xlsx-extract.ts
+++ b/packages/web/src/lib/knowledge/xlsx-extract.ts
@@ -1,0 +1,305 @@
+/**
+ * Spreadsheet extractor for the knowledge-base ingest pipeline.
+ *
+ * Spreadsheets deliberately do NOT go through the Office→PDF conversion path
+ * its sibling formats take. Three reasons, in order of weight:
+ *
+ *  - The anchor would be meaningless. A 40-column sheet laid out onto pages
+ *    becomes dozens of unreadable pages, and a citation saying "page 17" gives
+ *    the reader nothing to verify. Sheet + row range is intrinsic to the
+ *    document rather than to a renderer, so it is both meaningful and stable.
+ *  - Page-fitting is the step that silently clips: text too wide for its
+ *    column is cut when the sheet is paginated. Reading cells skips that step
+ *    entirely, so reading is HIGHER fidelity here, not lower.
+ *  - It saves installing `libreoffice-calc` (~103 MB) in the image.
+ *
+ * The chunk shape follows current practice for tabular RAG (structure-aware
+ * chunking): each row becomes a self-contained `Label: value` block, and whole
+ * rows are grouped under a token bound. Fixed-size text chunking is documented
+ * to tear row structure apart, and the sheet+row-range anchor falls out of the
+ * row-wise shape for free.
+ *
+ *  - Structure-Aware Chunking for Tabular Data in RAG — arxiv.org/pdf/2605.00318
+ *  - Sheet as Token: multi-sheet spreadsheet understanding — arxiv.org/pdf/2605.05811
+ *
+ * Wiring this into ingest.ts is a separate change; this module is standalone
+ * and knows nothing about documents, chunk rows or embeddings.
+ */
+import ExcelJS from "exceljs";
+
+/** A group of whole rows from ONE sheet, anchored on the sheet name and an inclusive row range. */
+export interface XlsxChunk {
+  text: string;
+  /** Sheet name exactly as the workbook spells it — half of the citation anchor. */
+  sheet: string;
+  /** First row in the chunk, 1-based, as Excel's own row gutter numbers it. */
+  startRow: number;
+  /** Last row in the chunk, inclusive, 1-based. */
+  endRow: number;
+}
+
+export interface XlsxExtraction {
+  chunks: XlsxChunk[];
+  /** Sheets that were read, in workbook order. */
+  sheets: string[];
+  /**
+   * Sheets excluded because their author hid them. Reported rather than merely
+   * skipped: without it, a workbook whose every sheet is hidden is
+   * indistinguishable from an empty one, and "0 chunks" is exactly the answer
+   * an unreadable file gives.
+   */
+  hiddenSheets: string[];
+  /** Rows excluded across all read sheets because their author hid them. */
+  hiddenRows: number;
+}
+
+export interface XlsxExtractOptions {
+  /** Approximate chunk size bound in tokens. Defaults to 512, matching chunk.ts. */
+  targetTokens?: number;
+}
+
+/**
+ * This spreadsheet could not be read at all — not a zip, not a workbook, gone
+ * from disk. Deliberately an exception rather than an empty result: a silent
+ * zero looks exactly like a successfully indexed empty document, and a
+ * document nobody can read must never be booked as one nobody wrote anything
+ * in.
+ */
+export class XlsxExtractionError extends Error {
+  constructor(
+    readonly sourcePath: string,
+    reason: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`Cannot read spreadsheet ${sourcePath}: ${reason}`, options);
+    this.name = "XlsxExtractionError";
+  }
+}
+
+// Same char-per-token heuristic and default target as chunk.ts, so a mixed
+// corpus produces comparably-sized chunks whatever the source format.
+const CHARS_PER_TOKEN = 4;
+const DEFAULT_TARGET_TOKENS = 512;
+
+/** One kept row: its Excel row number and its rendered single-line key-value block. */
+interface SheetRow {
+  number: number;
+  text: string;
+}
+
+interface SheetContent {
+  name: string;
+  rows: SheetRow[];
+}
+
+/** Collapses every whitespace run — newlines included — so one cell can never turn one row into two lines. */
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/** A date-only cell renders as its calendar date; anything with a time keeps the full ISO stamp. */
+function renderDate(value: Date): string {
+  const iso = value.toISOString();
+  return iso.endsWith("T00:00:00.000Z") ? iso.slice(0, 10) : iso;
+}
+
+/**
+ * Renders a cell the way its reader sees it, or "" for a cell that carries no
+ * readable content.
+ *
+ * Formula cells contribute their CACHED RESULT, never the formula source: the
+ * reader sees `20`, not `=B2*10`, and indexing the source would make the
+ * document answer questions with text that appears nowhere on screen. A
+ * formula the writer never calculated has no result to show and contributes
+ * nothing — same rule, applied honestly.
+ */
+function renderCellValue(value: ExcelJS.CellValue): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return normalizeWhitespace(value);
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value instanceof Date) return renderDate(value);
+  if (typeof value !== "object") return "";
+
+  // An error cell (#DIV/0!, #N/A) is a broken cell, not knowledge. Indexing
+  // the code would put hundreds of identical error strings into the corpus.
+  if ("error" in value) return "";
+
+  if ("richText" in value) {
+    return normalizeWhitespace(value.richText.map((run) => run.text).join(""));
+  }
+  if ("hyperlink" in value) {
+    const text = normalizeWhitespace(value.text ?? "");
+    const href = normalizeWhitespace(value.hyperlink ?? "");
+    if (!href || href === text) return text;
+    return text ? `${text} (${href})` : href;
+  }
+  if ("formula" in value || "sharedFormula" in value) {
+    return renderCellValue(value.result ?? null);
+  }
+  return "";
+}
+
+/** "B7" -> "B". The fallback label for a column with no header cell. */
+function columnLetter(address: string): string {
+  return address.replace(/\d+$/, "");
+}
+
+/** Is this cell's raw value a text value? Only an all-text row can be a header row. */
+function isTextCell(value: ExcelJS.CellValue): boolean {
+  return (
+    typeof value === "string" ||
+    (typeof value === "object" && value !== null && "richText" in value)
+  );
+}
+
+/**
+ * Reads one worksheet into rendered rows, applying the two exclusions this
+ * module makes on governance grounds (hidden rows, hidden columns) and turning
+ * the first row into column labels when it looks like a header.
+ */
+function readSheet(worksheet: ExcelJS.Worksheet): { rows: SheetRow[]; hiddenRows: number } {
+  const isHiddenColumn = (col: number) => worksheet.getColumn(col).hidden === true;
+
+  const rows: SheetRow[] = [];
+  let hiddenRows = 0;
+  let headers: Map<number, string> | null = null;
+  let headerDecided = false;
+
+  worksheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+    if (row.hidden) {
+      hiddenRows++;
+      return;
+    }
+
+    // Collect the row's visible, non-empty cells once; both the header
+    // decision and the rendered block are built from this.
+    const cells: Array<{ column: number; letter: string; raw: ExcelJS.CellValue; text: string }> =
+      [];
+    row.eachCell({ includeEmpty: false }, (cell, colNumber) => {
+      if (isHiddenColumn(colNumber)) return;
+      const text = renderCellValue(cell.value);
+      if (!text) return;
+      cells.push({ column: colNumber, letter: columnLetter(cell.address), raw: cell.value, text });
+    });
+
+    if (cells.length === 0) return;
+
+    // The first row with content decides: an all-text row is the header and
+    // becomes the labels; anything else (a number, a date, a formula) means
+    // the sheet starts straight into data and columns are labelled by letter.
+    if (!headerDecided) {
+      headerDecided = true;
+      if (cells.every((cell) => isTextCell(cell.raw))) {
+        headers = new Map(cells.map((cell) => [cell.column, cell.text]));
+        return;
+      }
+    }
+
+    const text = cells
+      .map((cell) => `${headers?.get(cell.column) ?? cell.letter}: ${cell.text}`)
+      .join("; ");
+    rows.push({ number: rowNumber, text });
+  });
+
+  return { rows, hiddenRows };
+}
+
+/**
+ * Groups whole rows of one sheet into chunks under `targetChars`.
+ *
+ * Unlike the PDF chunker there is NO overlap between consecutive chunks: a row
+ * is the atomic unit of a spreadsheet, so repeating one would duplicate a fact
+ * and leave the row-range anchor ambiguous about where that fact lives. A row
+ * that alone exceeds the bound is emitted intact as its own oversized chunk
+ * rather than being cut — a half row is a wrong row, not a smaller one.
+ */
+function chunkSheet(sheet: SheetContent, targetChars: number): XlsxChunk[] {
+  const prefix = `Sheet: ${sheet.name}`;
+  const chunks: XlsxChunk[] = [];
+
+  let rows: string[] = [];
+  let startRow = 0;
+  let endRow = 0;
+  let length = 0;
+
+  const flush = () => {
+    if (rows.length === 0) return;
+    chunks.push({ text: [prefix, ...rows].join("\n"), sheet: sheet.name, startRow, endRow });
+    rows = [];
+  };
+
+  for (const row of sheet.rows) {
+    if (rows.length > 0 && length + 1 + row.text.length <= targetChars) {
+      rows.push(row.text);
+      endRow = row.number;
+      length += 1 + row.text.length;
+      continue;
+    }
+    flush();
+    rows = [row.text];
+    startRow = row.number;
+    endRow = row.number;
+    length = prefix.length + 1 + row.text.length;
+  }
+  flush();
+
+  return chunks;
+}
+
+/**
+ * Extracts row-wise chunks from the spreadsheet at `absPath`, anchored on sheet
+ * name and row range.
+ *
+ * Hidden sheets, rows and columns are excluded. That is a governance decision,
+ * not a formatting one: indexing what the author hid makes the citation
+ * unverifiable for the reader, who opens the file and does not see it. The
+ * result reports what was excluded so a zero-chunk workbook can still explain
+ * itself.
+ *
+ * Only OOXML `.xlsx` is readable — exceljs has no BIFF reader, so a legacy
+ * binary `.xls` (an OLE2 container, not a zip) fails at the opener like any
+ * other unreadable file. That is the intended outcome: loud, with a reason.
+ *
+ * @throws XlsxExtractionError if the file cannot be read as a workbook.
+ */
+export async function extractXlsx(
+  absPath: string,
+  opts: XlsxExtractOptions = {}
+): Promise<XlsxExtraction> {
+  const workbook = new ExcelJS.Workbook();
+  try {
+    await workbook.xlsx.readFile(absPath);
+  } catch (err) {
+    throw new XlsxExtractionError(absPath, "the file could not be opened as a workbook", {
+      cause: err,
+    });
+  }
+
+  // Excel cannot save a workbook without a sheet, so zero worksheets means we
+  // opened something that merely LOOKS like one — a .docx renamed .xlsx unzips
+  // fine and lands exactly here. exceljs reports that as a clean, empty
+  // success, which is the silent-zero this extractor exists to refuse.
+  if (workbook.worksheets.length === 0) {
+    throw new XlsxExtractionError(absPath, "the file opened but contains no worksheets");
+  }
+
+  const targetChars = (opts.targetTokens ?? DEFAULT_TARGET_TOKENS) * CHARS_PER_TOKEN;
+
+  const sheets: string[] = [];
+  const hiddenSheets: string[] = [];
+  const chunks: XlsxChunk[] = [];
+  let hiddenRows = 0;
+
+  for (const worksheet of workbook.worksheets) {
+    if (worksheet.state === "hidden" || worksheet.state === "veryHidden") {
+      hiddenSheets.push(worksheet.name);
+      continue;
+    }
+    sheets.push(worksheet.name);
+    const sheet = readSheet(worksheet);
+    hiddenRows += sheet.hiddenRows;
+    chunks.push(...chunkSheet({ name: worksheet.name, rows: sheet.rows }, targetChars));
+  }
+
+  return { chunks, sheets, hiddenSheets, hiddenRows };
+}

--- a/packages/web/src/lib/knowledge/xlsx-extract.ts
+++ b/packages/web/src/lib/knowledge/xlsx-extract.ts
@@ -104,6 +104,45 @@ function renderDate(value: Date): string {
 }
 
 /**
+ * Removes everything in a number-format section that is a literal rather than a
+ * directive: quoted runs, backslash-escaped characters, and the bracketed
+ * blocks Excel uses for colours and conditions.
+ */
+function stripFormatLiterals(section: string): string {
+  return section
+    .replace(/"[^"]*"/g, "")
+    .replace(/\\./g, "")
+    .replace(/\[[^\]]*\]/g, "");
+}
+
+/**
+ * Does this number format scale its value by 100? An unquoted `%` is Excel's
+ * multiplier directive; a quoted or escaped one is just a character to print.
+ * Only the first section is consulted — it governs positive numbers, and a
+ * format that switches the multiplier between sections does not occur in
+ * practice.
+ */
+function isPercentFormat(numFmt: string | undefined): boolean {
+  if (!numFmt) return false;
+  return stripFormatLiterals(numFmt.split(";")[0]).includes("%");
+}
+
+/**
+ * A percent-formatted cell stores 0.15 and shows `15%`. Indexing the stored
+ * number would answer with a value that is wrong by two orders of magnitude,
+ * not merely unformatted, so the multiplier is applied. Other formats
+ * (currency, thousands separators) only change how the same number looks and
+ * are deliberately left alone.
+ */
+function renderNumber(value: number, numFmt: string | undefined): string {
+  if (!isPercentFormat(numFmt)) return String(value);
+  // 0.15 * 100 is 15.000000000000002 in binary floating point. Re-rounding to
+  // the ~15 significant digits a double actually carries drops the artefact
+  // without touching a legitimately long value.
+  return `${Number.parseFloat((value * 100).toPrecision(15))}%`;
+}
+
+/**
  * Renders a cell the way its reader sees it, or "" for a cell that carries no
  * readable content.
  *
@@ -113,10 +152,11 @@ function renderDate(value: Date): string {
  * formula the writer never calculated has no result to show and contributes
  * nothing — same rule, applied honestly.
  */
-function renderCellValue(value: ExcelJS.CellValue): string {
+function renderCellValue(value: ExcelJS.CellValue, numFmt?: string): string {
   if (value === null || value === undefined) return "";
   if (typeof value === "string") return normalizeWhitespace(value);
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (typeof value === "number") return renderNumber(value, numFmt);
+  if (typeof value === "boolean") return String(value);
   if (value instanceof Date) return renderDate(value);
   if (typeof value !== "object") return "";
 
@@ -128,13 +168,17 @@ function renderCellValue(value: ExcelJS.CellValue): string {
     return normalizeWhitespace(value.richText.map((run) => run.text).join(""));
   }
   if ("hyperlink" in value) {
-    const text = normalizeWhitespace(value.text ?? "");
-    const href = normalizeWhitespace(value.hyperlink ?? "");
+    // `text` is typed as a string but is not always one: a link whose label
+    // carries mixed formatting reads back as a richText object, and a link on a
+    // numeric cell as a number. Recursing renders every one of those shapes
+    // instead of assuming the declared type and throwing on the rest.
+    const text = renderCellValue(value.text ?? null, numFmt);
+    const href = normalizeWhitespace(String(value.hyperlink ?? ""));
     if (!href || href === text) return text;
     return text ? `${text} (${href})` : href;
   }
   if ("formula" in value || "sharedFormula" in value) {
-    return renderCellValue(value.result ?? null);
+    return renderCellValue(value.result ?? null, numFmt);
   }
   return "";
 }
@@ -177,7 +221,7 @@ function readSheet(worksheet: ExcelJS.Worksheet): { rows: SheetRow[]; hiddenRows
       [];
     row.eachCell({ includeEmpty: false }, (cell, colNumber) => {
       if (isHiddenColumn(colNumber)) return;
-      const text = renderCellValue(cell.value);
+      const text = renderCellValue(cell.value, cell.numFmt);
       if (!text) return;
       cells.push({ column: colNumber, letter: columnLetter(cell.address), raw: cell.value, text });
     });
@@ -275,14 +319,6 @@ export async function extractXlsx(
     });
   }
 
-  // Excel cannot save a workbook without a sheet, so zero worksheets means we
-  // opened something that merely LOOKS like one — a .docx renamed .xlsx unzips
-  // fine and lands exactly here. exceljs reports that as a clean, empty
-  // success, which is the silent-zero this extractor exists to refuse.
-  if (workbook.worksheets.length === 0) {
-    throw new XlsxExtractionError(absPath, "the file opened but contains no worksheets");
-  }
-
   const targetChars = (opts.targetTokens ?? DEFAULT_TARGET_TOKENS) * CHARS_PER_TOKEN;
 
   const sheets: string[] = [];
@@ -290,15 +326,36 @@ export async function extractXlsx(
   const chunks: XlsxChunk[] = [];
   let hiddenRows = 0;
 
-  for (const worksheet of workbook.worksheets) {
-    if (worksheet.state === "hidden" || worksheet.state === "veryHidden") {
-      hiddenSheets.push(worksheet.name);
-      continue;
+  // The walk runs on shapes exceljs's own typings understate (see the hyperlink
+  // branch), so an unexpected cell can still raise from library internals. That
+  // is a fault of THIS document and has to read as one: an unwrapped TypeError
+  // is indistinguishable from a systemic fault, which a caller would reasonably
+  // treat as a reason to abort the whole run rather than skip one file.
+  try {
+    // Excel cannot save a workbook without a sheet, so zero worksheets means we
+    // opened something that merely LOOKS like one — a .docx renamed .xlsx unzips
+    // fine and lands exactly here. exceljs reports that as a clean, empty
+    // success, which is the silent-zero this extractor exists to refuse.
+    if (workbook.worksheets.length === 0) {
+      throw new XlsxExtractionError(absPath, "the file opened but contains no worksheets");
     }
-    sheets.push(worksheet.name);
-    const sheet = readSheet(worksheet);
-    hiddenRows += sheet.hiddenRows;
-    chunks.push(...chunkSheet({ name: worksheet.name, rows: sheet.rows }, targetChars));
+
+    for (const worksheet of workbook.worksheets) {
+      if (worksheet.state === "hidden" || worksheet.state === "veryHidden") {
+        hiddenSheets.push(worksheet.name);
+        continue;
+      }
+      sheets.push(worksheet.name);
+      const sheet = readSheet(worksheet);
+      hiddenRows += sheet.hiddenRows;
+      chunks.push(...chunkSheet({ name: worksheet.name, rows: sheet.rows }, targetChars));
+    }
+  } catch (err) {
+    // A diagnosis we already made keeps its own, more specific reason.
+    if (err instanceof XlsxExtractionError) throw err;
+    throw new XlsxExtractionError(absPath, "the workbook could not be read to the end", {
+      cause: err,
+    });
   }
 
   return { chunks, sheets, hiddenSheets, hiddenRows };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(kysely@0.29.2)(postgres@3.4.9)
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       file-type:
         specifier: ^22.0.1
         version: 22.0.1


### PR DESCRIPTION
Closes #937.

Wave 1, standalone. `extractXlsx()` reads an `.xlsx` into row-wise chunks anchored on **sheet + inclusive row range**. Nothing imports it yet — wiring into `ingest.ts` is Wave 2, which is what keeps this out of the file two sibling issues also touch.

## What it does

Each row becomes a self-contained `Label: value` block under its sheet's header row; whole rows are grouped under a **~512-token bound** (chunk.ts's char heuristic, so a mixed corpus stays comparable); a chunk never spans two sheets.

```
Sheet: FSD Storage
Indicators: Petrifilm Rapid; Material SAP Number: 7100039311; Product Description: 6402 PETRIFILM RAPD COLIFRM CT PLT 50EA/; Storage Conditions: 2-8°C
```

**No overlap between consecutive chunks**, unlike the PDF chunker. A row is the atomic unit of a spreadsheet, so repeating one would duplicate a fact and leave the row range ambiguous about where that fact lives. A row that alone exceeds the bound is emitted intact — half a row is a wrong row, not a smaller one.

## Three things worth reviewing

**The silent-zero trap is real, and it is not the one the issue named.** A `.docx` renamed `.xlsx` unzips fine, and exceljs resolves it as a clean, empty success with zero worksheets — byte-for-byte the answer a successfully indexed empty document gives. Excel cannot save a workbook without a sheet, so zero worksheets can only mean we opened something else. That now throws too, not just an unopenable file.

**Formula cells contribute their cached result, never the source.** The reader sees `20`, not `=B2*10`; indexing the source would answer questions with text that appears nowhere on screen. A formula nobody ever calculated has no result and contributes nothing — the same rule applied honestly, rather than falling back to the formula text.

**Merged cells needed no special case.** exceljs hands the master's value to every spanned cell, so a category merged over rows 3–10 lands in each of those rows and every row block stands on its own. That is exactly the row-tree shape the prior art asks for, for free.

Hidden sheets, rows **and columns** are excluded — governance, not formatting. Indexing what an author hid makes the citation unverifiable for a reader who opens the file and does not see it. The result reports `hiddenSheets` / `hiddenRows`, so a workbook whose every sheet is hidden explains its zero chunks instead of looking like an empty document.

Legacy `.xls` is **not** readable: exceljs has no BIFF reader and an OLE2 container is not a zip. Verified, not assumed — it fails as a document-level failure with a reason.

## Fixtures — a deliberate deviation

The issue lists the two real 3M corpus files as fixtures. **They are not committed**: they are a customer's vendor data and this repository is public, which is not a call I should make alone. Instead:

- Workbooks are built with exceljs on the fly, the same way `pdf-extract.test.ts` uses pdfkit and `pinchy-files` generates its PDF/DOCX fixtures.
- Both real files run **opt-in** via `KB_XLSX_CORPUS_DIR`, and are green locally (23/23).

Say the word and I will add them.

Running them earned its keep: the packaging export reports 1394 rows, but **row 1394 is a ghost** the SAP export left behind — 32 cells, every one the empty string. A synthetic fixture would never have produced that. Note also that both corpus files are single-sheet, so the multi-sheet acceptance criterion is covered by a generated fixture.

## For Wave 2

`exceljs.readFile` costs **~4.5 s** on the 192 KB / 43k-cell packaging export; walking and rendering it afterwards costs ~0.2 s. The cost is the library, not the extractor.

## Gates

`typecheck` (incl. tests), `lint`, `prettier --check .` (whole tree), `test:scripts` (390/390), and the full web suite (9890 passed) are green. `test:db` was not run: this change touches neither the schema, nor ingest, nor any module mocked in an `*.integration.test.ts`, and the default port belongs to another worktree's stack.

One unrelated pre-existing flake surfaced: `vitest-exclude-node-modules.test.ts` spawns a nested vitest process and runs on the default 5 s budget (3.67 s idle, 5162 ms under load). Flagged separately rather than touched here.

---

## Review pass — three defects found and fixed (368322d)

**A percent cell was indexed as a number wrong by two orders of magnitude.** Excel stores `0.15` and displays `15%`. Indexing the stored value makes the document answer `0.15` to a sheet that says `15%` — the same "text that appears nowhere on screen" failure the formula rule exists to prevent, except here the *number* is wrong, not just its formatting. The multiplier is now applied, honouring Excel's rule that a quoted or escaped `%` is a literal rather than a directive. Currency symbols and thousands separators are deliberately still dropped: those change how the same number looks, not what it is.

**A styled hyperlink crashed the extractor.** exceljs types `CellHyperlinkValue.text` as a string, but a link whose label carries mixed formatting — the normal case for a styled link — reads back with a **richText object** there. `normalizeWhitespace` called `.replace` on it and threw. Verified against exceljs 4.4.0, not inferred from the typings. The label now goes back through the renderer, which already handles every value shape.

**That TypeError escaped unwrapped**, so a fault in one document was indistinguishable from a systemic one — and a caller would reasonably read the latter as a reason to abort the whole ingest run rather than skip one file. The workbook walk now reports as the document-level failure it is, while a diagnosis already made keeps its own more specific reason.

Three new tests, each confirmed red before the fix. The safety net is pinned by making the library throw mid-walk rather than by trusting it never will.

**Checked and found sound, so left alone:** date rendering is timezone-independent. `cell.value` is anchored to the Excel serial (46024 for 2026-01-02 in UTC, New York and Sydney alike) — it is `cell.text` that drifts with `TZ`, and the extractor does not use it. Neither vitest nor CI pins `TZ`, so this was worth proving rather than assuming.

**Known limitation, documented not fixed:** the header heuristic takes the first row with content as labels when every cell in it is text. A sheet whose first data row happens to be all-text loses that row to the header. Any alternative trades this case for a worse one (a title row above the real header), so the heuristic stays as the documented behaviour.

Gates re-run after the fix: `typecheck` ✅, `lint` (0 errors) ✅, `prettier --check .` ✅, knowledge suite 97 ✅ — including all 25 spreadsheet tests. The full web suite was not re-run: the module still has **zero importers**, so its blast radius is exactly the one test file. The opt-in corpus tests could not be re-run — the 3M files are not on this machine. They are unaffected by design: the percent fix only changes numeric cells carrying a `%` format, and neither asserted value is one, nor can it change a row count.
