### PR TITLE
fix(audit): keep the raw user id out of the workspace-file audit detail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,7 @@ Audit logging rules:
 - Include resource names in delete-event details because deleted rows may no longer be queryable.
 - Keep audit `detail` under 2048 bytes. Summarize bulk operations.
 - Never write plaintext email addresses or other PII into audit `detail`. Use `redactEmail()` from `@/lib/audit` when email identity is required.
+- Never mirror the **acting** user's raw `users.id` into `detail`. `appendAuditLog` pseudonymizes the `actorId` **column** (`resolveActorId`) so GDPR crypto-erasure can reach it, while `detail` is stored verbatim in an immutable, HMAC-chained row that cannot be rewritten. The actor is already on the row; to filter audit rows by a known user, resolve `actorId` through `resolveActorIdMatchSet` on the read side (#824).
 - For batched maintenance operations (e.g. GC sweeps), include a `sweepId` UUID in every emitted audit row so analysts can correlate the full sweep from one drill-down query.
 
 Checklist for state-changing routes:
@@ -277,7 +278,7 @@ Checklist for state-changing routes:
 6. Referenced entities are snapshotted as `{ id, name }`.
 7. A test verifies the audit call and payload.
 8. `outcome` is set correctly.
-9. No plaintext PII appears in audit `detail`.
+9. No plaintext PII appears in audit `detail`, and the acting user's raw id is carried by `actorId` alone.
 
 ## Shared Schemas And Typed Client
 

--- a/packages/web/src/__tests__/api/agent-workspace-file.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file.test.ts
@@ -92,13 +92,40 @@ describe("GET /api/agents/[agentId]/workspace-file", () => {
     expect(entry.outcome).toBe("success");
     expect(entry.actorId).toBe("user-1");
     expect(entry.detail).toMatchObject({
-      userId: "user-1",
       agent: { id: "agent-1", name: "Smithers" },
       document: { name: "handbook.pdf" },
     });
     // The full path (which could embed a username) must never land in the
     // audit detail — only the basename.
     expect(JSON.stringify(entry.detail)).not.toContain(tmpRoot);
+    // Nor may the raw users.id (#824): appendAuditLog pseudonymizes the
+    // actorId COLUMN only, `detail` is stored verbatim. An id written here
+    // would sit un-erasable in an HMAC-chained row and defeat crypto-erasure
+    // — and it is redundant with the (pseudonymized) actorId anyway.
+    expect(entry.detail).not.toHaveProperty("userId");
+    expect(JSON.stringify(entry.detail)).not.toContain("user-1");
+  });
+
+  it("keeps the raw user id out of the detail on failure rows too", async () => {
+    // Same crypto-erasure rule as the success row above (#824) — every audit
+    // path this route writes goes through the same detail builder, so a
+    // regression on any of them is a regression on all.
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, SECRET_BYTES);
+
+    const res = await callGET("agent-1", secretPath);
+
+    expect(res.status).toBe(403);
+    expect(mockDeferAuditLog).toHaveBeenCalledTimes(1);
+    const entry = mockDeferAuditLog.mock.calls[0][0];
+    expect(entry.eventType).toBe("knowledge.source_viewed");
+    expect(entry.outcome).toBe("failure");
+    expect(entry.detail).toMatchObject({ reason: "outside_allowed_paths" });
+    // The actor is still attributable — through the column that gets
+    // pseudonymized, which is the whole point.
+    expect(entry.actorId).toBe("user-1");
+    expect(entry.detail).not.toHaveProperty("userId");
+    expect(JSON.stringify(entry.detail)).not.toContain("user-1");
   });
 
   it("sanitizes a filename containing a quote/backslash so it cannot break out of the quoted Content-Disposition value", async () => {

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -62,6 +62,24 @@ describe("AuditLogEntry email_workflow.updated / .deleted (Automations managemen
   });
 });
 
+describe("AuditLogEntry knowledge.source_viewed (#824)", () => {
+  it("types the detail shape without a raw user id", () => {
+    // `detail` is stored verbatim — appendAuditLog pseudonymizes the actorId
+    // COLUMN only (resolveActorId). A `userId` field here would put a raw
+    // users.id into an immutable, HMAC-chained row that crypto-erasure cannot
+    // reach, and it duplicates the actor the row already carries. Pinned at
+    // compile time so it cannot come back through the type.
+    expectTypeOf<
+      Extract<AuditLogEntry, { eventType: "knowledge.source_viewed" }>["detail"]
+    >().toEqualTypeOf<{
+      agent: { id: string; name: string };
+      document: { name: string };
+      reason?: string;
+    }>();
+    expectTypeOf<"knowledge.source_viewed">().toExtend<AuditEventType>();
+  });
+});
+
 describe("AuditEventType is a subset of AuditLogEntry['eventType']", () => {
   it("every curated event type is one appendAuditLog can record", () => {
     // Intentionally NOT equal (the entry type is strictly broader), but the

--- a/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
@@ -36,8 +36,11 @@ function sourceViewedAuditEntry(args: {
     eventType: "knowledge.source_viewed",
     resource: `agent:${args.agentId}`,
     outcome: args.outcome,
+    // The actor lives in `actorId` ONLY — appendAuditLog pseudonymizes that
+    // column (resolveActorId) for GDPR crypto-erasure, while `detail` is
+    // stored verbatim. A raw users.id repeated here would be un-erasable in
+    // an HMAC-chained row, and redundant besides (#824).
     detail: {
-      userId: args.userId,
       agent: { id: args.agentId, name: args.agentName ?? args.agentId },
       document: { name: args.documentName },
       ...(args.reason !== undefined ? { reason: args.reason } : {}),

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -618,15 +618,17 @@ export type AuditLogEntry =
       // (KB citation source PDFs today; the shared "agent, give me file X"
       // serve mechanism later). Audited deliberately even though it's
       // read-only (governance: which documents did a user actually open).
-      // `userId` mirrors the top-level `actorId` for detail-query
-      // convenience (same redundancy as `retrieval.query`'s `agent` field).
+      // The actor is carried by the top-level `actorId` ALONE: that column is
+      // pseudonymized on write (resolveActorId) so crypto-erasure can reach
+      // it, whereas `detail` is stored verbatim. Never mirror a raw users.id
+      // in here for query convenience (#824) — filter by actorId through
+      // `resolveActorIdMatchSet` instead.
       // `document.name` is a basename ONLY — never the full path, which
       // could embed a username (AGENTS.md PII rule). `reason` is present on
       // failure rows only (outside allowed_paths, traversal/symlink escape,
       // missing file, not a regular file, oversized).
       eventType: "knowledge.source_viewed";
       detail: {
-        userId: string;
         agent: EntityRef;
         document: { name: string };
         reason?: string;


### PR DESCRIPTION
Closes #824.

## Problem

The `knowledge.source_viewed` row written by `GET /api/agents/[agentId]/workspace-file` mirrored the **raw** `users.id` into `detail`, defeating the pseudonymization `1ac5249e` introduced for GDPR crypto-erasure.

`appendAuditLog` pseudonymizes the **actorId column** (via `resolveActorId`); `detail` is stored verbatim (`truncateDetail` only, no scrub). The mirrored id therefore sat un-erasable in an immutable, HMAC-chained row — and it was redundant, since the actor is already captured (pseudonymized) in `actorId`. Sibling routes don't do this.

## Fix

Drop the field, from the route's detail builder **and** from the `AuditLogEntry` union in `audit.ts`. Callers that need to filter audit rows by a known user go through `resolveActorIdMatchSet` on `actorId` — the read-side counterpart built for exactly this.

## Guardrails (three layers)

- The route test asserts no raw id reaches the detail on the **success** row.
- A new test asserts the same on a **failure** row — every audit path in this route shares one detail builder, so a regression on one is a regression on all.
- A compile-time test in `audit-types.test.ts` pins the detail shape. With the field gone from the union, TypeScript's excess-property check now rejects it at the write site.

## Verification

- `pnpm -C packages/web typecheck` (incl. test files) — green
- `pnpm format:check` — green
- `pnpm -C packages/web lint` — 0 errors
- Full vitest suite — 9848 passed. Note for reviewers: local runs on this machine surface two *environment* failure classes that CI does not have, and they are mutually exclusive: under Node 25 the jsdom `localStorage` tests fail, under Node 22 (CI's version) the `better-sqlite3` tests fail because the native bindings were compiled for Node 25. Every test in the intersection passes; the touched paths are green on both.