### PR TITLE
fix(config): judge the plaintext guard on what a write adds, not what it inherits

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -4493,6 +4493,72 @@ describe("regenerateOpenClawConfig", () => {
         vi.useRealTimers();
       }
     });
+
+    it("still applies when the payload carries a plaintext key the on-disk config already had (#884)", async () => {
+      // The WS path is where the inherited-secret abort hurt most: the guard
+      // runs inside the fire-and-forget coroutine, so a throw did not surface
+      // to the caller at all — the config change was simply lost. The
+      // restart-class seed and updateTelegramChannelConfig both push through
+      // here carrying the whole on-disk config, legacy `env` block included.
+      const legacyKey = "d09762adf39c4d1cbdca5f5fc7ca13d5.JyGHlyB0m9yYcpIVkavQIBH7";
+      const onDisk = {
+        gateway: { mode: "local", bind: "lan" },
+        env: { OLLAMA_CLOUD_API_KEY: legacyKey },
+      };
+      mockedReadFileSync.mockReturnValue(JSON.stringify(onDisk));
+      mockConfigGet.mockResolvedValue({ hash: "h1", config: onDisk });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+
+      pushConfigInBackground(JSON.stringify({ ...onDisk, update: { checkOnStart: false } }));
+
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      await drainBackgroundCoroutine();
+
+      const applied = JSON.parse(String(mockConfigApply.mock.calls[0][0]));
+      expect(applied.update).toEqual({ checkOnStart: false });
+    });
+
+    it("refuses a newly introduced plaintext key without crashing the process (#884)", async () => {
+      // The other half of the contract: a Pinchy regression that routes a
+      // secret around SecretRef must still never reach OpenClaw. It must not
+      // take the server down doing so either — the guard throws inside a
+      // voided coroutine, and Node ≥15 turns an unhandled rejection into an
+      // uncaught exception that terminates the process.
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on("unhandledRejection", onUnhandled);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        mockedReadFileSync.mockReturnValue(JSON.stringify({ gateway: { mode: "local" } }));
+        mockConfigGet.mockResolvedValue({ hash: "h1", config: { gateway: { mode: "local" } } });
+        mockConfigApply.mockResolvedValue(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(
+          JSON.stringify({
+            gateway: { mode: "local" },
+            models: { providers: { anthropic: { apiKey: "sk-ant-regression1234567890" } } },
+          })
+        );
+        await drainBackgroundCoroutine();
+        await drainBackgroundCoroutine();
+
+        expect(mockConfigApply).not.toHaveBeenCalled();
+        expect(unhandled).toEqual([]);
+        const logged = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+        expect(logged).toMatch(/plaintext secret detected/);
+        // Never the value itself, not even on the refusal path.
+        expect(logged).not.toContain("sk-ant-regression1234567890");
+      } finally {
+        errorSpy.mockRestore();
+        process.off("unhandledRejection", onUnhandled);
+      }
+    });
   });
 });
 

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -4709,6 +4709,46 @@ describe("seedRestartClassOverridesIfMissing", () => {
     expect(written.agents).toEqual(existing.agents);
     expect(written.plugins).toEqual(existing.plugins);
   });
+
+  it("still seeds when the on-disk config carries a legacy plaintext provider key (#884)", () => {
+    // Installs upgraded from a pre-SecretRef Pinchy (which wrote a top-level
+    // `env` block holding raw provider keys) still carry that block, and keep
+    // a plaintext models.providers.*.apiKey whenever the healing regenerate
+    // never completes — e.g. the apsa box, whose regenerate died on an
+    // unmounted secrets volume (#878).
+    //
+    // The seed spreads the whole on-disk config through verbatim, so the
+    // absolute plaintext guard rejected the entire write:
+    //   [pinchy] Failed to seed restart-class overrides: plaintext secret
+    //   detected in config: env.OLLAMA_CLOUD_API_KEY matches ollama-cloud
+    // Rejecting it never removed the secret — it only meant the four
+    // restart-class overrides were silently never applied, on every boot.
+    // The guard judges what a write INTRODUCES, not what it inherits.
+    const legacyKey = "d09762adf39c4d1cbdca5f5fc7ca13d5.JyGHlyB0m9yYcpIVkavQIBH7";
+    const existing = {
+      gateway: { mode: "local", bind: "lan" },
+      env: { OLLAMA_CLOUD_API_KEY: legacyKey },
+      models: { providers: { "ollama-cloud": { apiKey: legacyKey } } },
+    };
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing));
+
+    const changed = seedRestartClassOverridesIfMissing();
+
+    expect(changed).toBe(true);
+    const writtenAtomic = findOpenClawConfigWrite(mockedWriteFileSync);
+    expect(writtenAtomic).toBeDefined();
+    const written = JSON.parse(String(writtenAtomic![1]));
+    expect(written.gateway.controlUi.enabled).toBe(false);
+    expect(written.gateway.terminal.enabled).toBe(false);
+    expect(written.discovery.mdns.mode).toBe("off");
+    expect(written.update.checkOnStart).toBe(false);
+    expect(written.canvasHost.enabled).toBe(false);
+
+    // The pre-existing blocks ride through untouched — the seed heals the
+    // restart-class fields, it does not silently drop provider config.
+    expect(written.env).toEqual(existing.env);
+    expect(written.models).toEqual(existing.models);
+  });
 });
 
 describe("seedGatewayTokenIfMissing", () => {

--- a/packages/web/src/__tests__/lib/openclaw-plaintext-scanner.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-plaintext-scanner.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { assertNoPlaintextSecrets, findPlaintextSecrets } from "@/lib/openclaw-plaintext-scanner";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  assertNoPlaintextSecrets,
+  findNewPlaintextSecrets,
+  findPlaintextSecrets,
+} from "@/lib/openclaw-plaintext-scanner";
+
+// Shape-accurate Ollama Cloud key: 32 hex + "." + ≥16 base62.
+const LEGACY_KEY = "d09762adf39c4d1cbdca5f5fc7ca13d5.JyGHlyB0m9yYcpIVkavQIBH7";
+const OTHER_KEY = "1a2b3c4d5e6f70718293a4b5c6d7e8f9.ZqWx0EcRvTyBnUmIoPlK9876";
 
 describe("findPlaintextSecrets", () => {
   it("flags Anthropic-style keys", () => {
@@ -102,7 +110,59 @@ describe("findPlaintextSecrets", () => {
   });
 });
 
+// #884: a write is only a leak when it INTRODUCES the plaintext. Installs
+// upgraded from a pre-SecretRef Pinchy still carry a top-level `env` block with
+// plaintext provider keys, and targeted writers (the boot seeds, the Telegram
+// channel writer) spread the whole on-disk config through verbatim. Judging
+// those writes by the absolute scan permanently wedged them — the write was
+// rejected, the secret stayed on disk anyway, and the restart-class overrides
+// were never seeded.
+describe("findNewPlaintextSecrets", () => {
+  it("ignores a secret the previous config already carried at the same path", () => {
+    const previous = {
+      env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY },
+      models: { providers: { "ollama-cloud": { apiKey: LEGACY_KEY } } },
+    };
+    const next = { ...previous, update: { checkOnStart: false } };
+
+    expect(findNewPlaintextSecrets(next, previous)).toEqual([]);
+  });
+
+  it("flags a different value at a path that already leaked", () => {
+    const previous = { env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY } };
+    const next = { env: { OLLAMA_CLOUD_API_KEY: OTHER_KEY } };
+
+    expect(findNewPlaintextSecrets(next, previous)).toEqual([
+      { path: "env.OLLAMA_CLOUD_API_KEY", pattern: "ollama-cloud" },
+    ]);
+  });
+
+  it("flags a secret at a path the previous config did not carry", () => {
+    const previous = { env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY } };
+    const next = {
+      env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY },
+      models: { providers: { "ollama-cloud": { apiKey: LEGACY_KEY } } },
+    };
+
+    expect(findNewPlaintextSecrets(next, previous)).toEqual([
+      { path: "models.providers.ollama-cloud.apiKey", pattern: "ollama-cloud" },
+    ]);
+  });
+
+  it("flags everything when there is no previous config (cold start)", () => {
+    const next = { env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY } };
+
+    expect(findNewPlaintextSecrets(next, undefined)).toEqual([
+      { path: "env.OLLAMA_CLOUD_API_KEY", pattern: "ollama-cloud" },
+    ]);
+  });
+});
+
 describe("assertNoPlaintextSecrets", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("throws when plaintext found", () => {
     expect(() =>
       assertNoPlaintextSecrets({ env: { ANTHROPIC_API_KEY: "sk-ant-leaked1234567890" } })
@@ -113,5 +173,37 @@ describe("assertNoPlaintextSecrets", () => {
     expect(() =>
       assertNoPlaintextSecrets({ gateway: { mode: "local", bind: "lan" } })
     ).not.toThrow();
+  });
+
+  it("does not throw when every finding is carried over from the previous config", () => {
+    const previous = { env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY } };
+    const next = { ...previous, update: { checkOnStart: false } };
+
+    expect(() => assertNoPlaintextSecrets(next, () => previous)).not.toThrow();
+  });
+
+  it("reports the carried-over leak instead of swallowing it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previous = { env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY } };
+
+    assertNoPlaintextSecrets({ ...previous, update: { checkOnStart: false } }, () => previous);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0][0]);
+    expect(message).toContain("env.OLLAMA_CLOUD_API_KEY");
+    // The value itself must never reach the logs.
+    expect(message).not.toContain(LEGACY_KEY);
+  });
+
+  it("still throws for a newly introduced secret even when another one is carried over", () => {
+    const previous = { env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY } };
+    const next = {
+      env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY },
+      models: { providers: { anthropic: { apiKey: "sk-ant-regression1234567890" } } },
+    };
+
+    expect(() => assertNoPlaintextSecrets(next, () => previous)).toThrow(
+      /models\.providers\.anthropic\.apiKey/
+    );
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-plaintext-scanner.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-plaintext-scanner.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   assertNoPlaintextSecrets,
   findNewPlaintextSecrets,
   findPlaintextSecrets,
+  _resetInheritedSecretReports,
 } from "@/lib/openclaw-plaintext-scanner";
 
 // Shape-accurate Ollama Cloud key: 32 hex + "." + ≥16 base62.
@@ -159,6 +160,12 @@ describe("findNewPlaintextSecrets", () => {
 });
 
 describe("assertNoPlaintextSecrets", () => {
+  // The once-per-process report dedup is module state; clear it so the tests
+  // below don't silence each other through it.
+  beforeEach(() => {
+    _resetInheritedSecretReports();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -193,6 +200,32 @@ describe("assertNoPlaintextSecrets", () => {
     expect(message).toContain("env.OLLAMA_CLOUD_API_KEY");
     // The value itself must never reach the logs.
     expect(message).not.toContain(LEGACY_KEY);
+  });
+
+  it("reports a carried-over leak once per process, not on every config write", () => {
+    // The message is a one-time instruction ("rotate that key and delete the
+    // entry"), but config writes are not one-time: boot seeds, every settings
+    // save, every agent create. Repeating a four-line paragraph on each of
+    // them is how an actionable warning turns into background noise nobody
+    // reads. A leak at a NEW path still gets its own report.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previous = { env: { OLLAMA_CLOUD_API_KEY: LEGACY_KEY } };
+    const next = { ...previous, update: { checkOnStart: false } };
+
+    assertNoPlaintextSecrets(next, () => previous);
+    assertNoPlaintextSecrets(next, () => previous);
+    assertNoPlaintextSecrets(next, () => previous);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    const widened = {
+      ...previous,
+      models: { providers: { "ollama-cloud": { apiKey: LEGACY_KEY } } },
+    };
+    assertNoPlaintextSecrets(widened, () => widened);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[1][0])).toContain("models.providers.ollama-cloud.apiKey");
   });
 
   it("still throws for a newly introduced secret even when another one is carried over", () => {

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -26,7 +26,8 @@ export function writeConfigAtomic(content: string) {
     }
   }
   // Defense-in-depth: never let a plaintext secret land in openclaw.json.
-  assertNoPlaintextSecrets(JSON.parse(content));
+  // Judged against what is already on disk — see readSecretBaseline.
+  assertNoPlaintextSecrets(JSON.parse(content), readSecretBaseline);
   const tmpPath = CONFIG_PATH + ".tmp";
   // Mode 0o666: Pinchy and OpenClaw both need read/write access. OpenClaw
   // rewrites the file as root:0600 on every internal SIGUSR1 restart and
@@ -37,6 +38,36 @@ export function writeConfigAtomic(content: string) {
   // because the volume itself is namespaced inside Docker; not exposed.)
   writeFileSync(tmpPath, content, { encoding: "utf-8", mode: 0o666 });
   renameSync(tmpPath, CONFIG_PATH);
+}
+
+/**
+ * The config currently on disk, as the baseline the plaintext-secret guard
+ * judges a write against. Best-effort: a missing, unreadable or corrupt file
+ * yields nothing to inherit, so the guard scans the whole payload — the strict
+ * reading, and the right one for a cold start.
+ *
+ * Why a baseline at all: Pinchy's targeted writers (`seedRestartClass-
+ * OverridesIfMissing`, `seedGatewayTokenIfMissing`, `sanitizeOpenClawConfig`,
+ * `updateTelegramChannelConfig`) spread the whole on-disk config through so
+ * OpenClaw-enriched fields survive. On an install that already carries a
+ * plaintext provider key — the legacy top-level `env` block written by a
+ * pre-SecretRef Pinchy, or a `models.providers.*.apiKey` left un-healed
+ * because regenerate itself is failing (#878) — the absolute scan rejected
+ * every one of those writes forever. That never removed the secret; it only
+ * meant the write's actual payload was silently dropped, which is how #884
+ * left the restart-class overrides unseeded on every boot of the apsa box.
+ *
+ * Passed to the guard as a thunk, so a clean payload — nearly every write —
+ * pays neither this read nor the comparison.
+ */
+function readSecretBaseline(): Record<string, unknown> | undefined {
+  // Reuses readExistingConfig for its EACCES retry (OC's 0600 restart-write
+  // race). A persistent EACCES throws there; here it just means "no baseline".
+  try {
+    return readExistingConfig();
+  } catch {
+    return undefined;
+  }
 }
 
 export function readExistingConfig(): Record<string, unknown> {
@@ -232,7 +263,12 @@ export function pushConfigInBackground(newContent: string, options: PushConfigOp
     // tries to write with a stale initialSnapshotRead hash.
     // Without the prior file write, currentCompareConfig stays as startup_source;
     // config.apply's output only differs in agents/plugins/secrets — no restart.
-    assertNoPlaintextSecrets(JSON.parse(newContent));
+    // Same on-disk baseline as writeConfigAtomic: `newContent` can be a
+    // targeted writer's payload, which carries the whole existing config
+    // through. Throwing here would reject the change in a background
+    // coroutine — an unhandled rejection, and the channel update lost with
+    // it (#884).
+    assertNoPlaintextSecrets(JSON.parse(newContent), readSecretBaseline);
 
     // Brief retry across transient WS disconnects. Beyond ~3.5 s the WS is
     // probably down due to the cold-start cascade, and inotify will catch

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -464,5 +464,21 @@ export function pushConfigInBackground(newContent: string, options: PushConfigOp
         await new Promise((resolve) => setTimeout(resolve, backoffsMs[i]));
       }
     }
-  })().finally(trackConfigPushSettled);
+  })()
+    .finally(trackConfigPushSettled)
+    .catch((err: unknown) => {
+      // Terminal safety net. Everything inside the retry loop already handles
+      // its own errors, but the pre-loop section does not: the plaintext guard
+      // throws by design, and `writeConfigAtomic` can throw on a full or
+      // read-only volume. This coroutine is voided, so such a throw becomes an
+      // unhandled rejection — which Node ≥ 15 escalates to an uncaught
+      // exception and terminates the Pinchy server with it. Refusing the push
+      // is the correct outcome; taking the process down with it is not.
+      // `.finally` before `.catch` so the pending-push counter settles either
+      // way (the health endpoint's `configPushesPending` must not leak).
+      console.error(
+        `[openclaw-config] push gen=${String(generation)}: aborted before delivery —`,
+        err instanceof Error ? err.message : String(err)
+      );
+    });
 }

--- a/packages/web/src/lib/openclaw-plaintext-scanner.ts
+++ b/packages/web/src/lib/openclaw-plaintext-scanner.ts
@@ -16,38 +16,120 @@ const PATTERNS: Array<{ name: string; regex: RegExp }> = [
 
 export type Finding = { path: string; pattern: string };
 
+/** Internal: a finding plus the matched value, used to compare two configs. */
+type Hit = Finding & { value: string };
+
 export function findPlaintextSecrets(config: unknown, prefix = ""): Finding[] {
-  const findings: Finding[] = [];
-  walk(config, prefix, findings);
-  return findings;
+  return collectHits(config, prefix).map(({ path, pattern }) => ({ path, pattern }));
 }
 
-function walk(value: unknown, path: string, findings: Finding[]): void {
+/**
+ * Findings that `config` INTRODUCES relative to `previous` — a hit counts as
+ * carried over only when the previous config held the very same value at the
+ * very same path.
+ *
+ * The absolute scan answers "does this tree contain a plaintext secret", which
+ * is the wrong question for a writer that spreads the on-disk config through
+ * verbatim (the boot seeds, the Telegram channel writer). On an install that
+ * already has a plaintext key on disk, every such write was rejected forever —
+ * which never removed the secret, it only meant the write's actual payload
+ * (Pinchy's restart-class overrides) was silently never applied (#884).
+ *
+ * The guard's job is to catch a Pinchy regression that routes a secret around
+ * SecretRef, and that still holds: such a regression writes a value the file
+ * did not previously carry at that path, so it is reported as new.
+ */
+export function findNewPlaintextSecrets(config: unknown, previous: unknown): Finding[] {
+  return partition(collectHits(config), previous).introduced;
+}
+
+/**
+ * Split `hits` by whether `previous` already carried them. An absent
+ * `previous` carries nothing, so everything counts as introduced — which is
+ * exactly the absolute scan.
+ */
+function partition(
+  hits: Hit[],
+  previous: unknown
+): { introduced: Finding[]; inherited: Finding[] } {
+  const carriedOver = new Set(collectHits(previous).map(keyOf));
+  const introduced: Finding[] = [];
+  const inherited: Finding[] = [];
+  for (const hit of hits) {
+    const finding = { path: hit.path, pattern: hit.pattern };
+    (carriedOver.has(keyOf(hit)) ? inherited : introduced).push(finding);
+  }
+  return { introduced, inherited };
+}
+
+function keyOf(hit: Hit): string {
+  // NUL separator: a path can contain dots and a value can contain anything,
+  // so any printable delimiter risks two different (path, value) pairs
+  // colliding onto one key.
+  return `${hit.path}\u0000${hit.value}`;
+}
+
+function collectHits(config: unknown, prefix = ""): Hit[] {
+  const hits: Hit[] = [];
+  walk(config, prefix, hits);
+  return hits;
+}
+
+function walk(value: unknown, path: string, hits: Hit[]): void {
   if (value === null || value === undefined) return;
   if (typeof value === "string") {
     for (const { name, regex } of PATTERNS) {
       if (regex.test(value)) {
-        findings.push({ path, pattern: name });
+        hits.push({ path, pattern: name, value });
         return;
       }
     }
     return;
   }
   if (Array.isArray(value)) {
-    value.forEach((v, i) => walk(v, `${path}[${i}]`, findings));
+    value.forEach((v, i) => walk(v, `${path}[${i}]`, hits));
     return;
   }
   if (typeof value === "object") {
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      walk(v, path ? `${path}.${k}` : k, findings);
+      walk(v, path ? `${path}.${k}` : k, hits);
     }
   }
 }
 
-export function assertNoPlaintextSecrets(config: unknown): void {
-  const hits = findPlaintextSecrets(config);
-  if (hits.length > 0) {
-    const msg = hits.map((h) => `  ${h.path} matches ${h.pattern}`).join("\n");
+/**
+ * Throw if `config` introduces a plaintext secret.
+ *
+ * `readPrevious` supplies the config currently on disk, for writes that spread
+ * existing content through; omit it to judge the whole tree, which is the right
+ * call for a payload Pinchy built from scratch. It is a thunk because a clean
+ * config — the overwhelmingly common case — has nothing to exempt: no baseline
+ * is read and no second tree is walked unless the payload actually matched.
+ */
+export function assertNoPlaintextSecrets(config: unknown, readPrevious?: () => unknown): void {
+  const hits = collectHits(config);
+  if (hits.length === 0) return;
+
+  const { introduced, inherited } = partition(hits, readPrevious?.());
+
+  // Report before throwing: an inherited leak is still a leak, and staying
+  // quiet about it is how it survived every upgrade so far. Paths and pattern
+  // names only — never the value.
+  if (inherited.length > 0) {
+    console.warn(
+      "[openclaw-config] Carrying pre-existing plaintext secrets through this " +
+        "config write (Pinchy did not add them; refusing the write would not " +
+        "remove them):\n" +
+        inherited.map((h) => `  ${h.path} matches ${h.pattern}`).join("\n") +
+        "\nInstalls upgraded from a pre-SecretRef Pinchy still carry a top-level " +
+        "`env` block holding raw provider keys. Pinchy resolves provider keys " +
+        "from the secrets file, so an entry whose provider is configured under " +
+        "Settings is obsolete: rotate that key and delete the entry to clear this."
+    );
+  }
+
+  if (introduced.length > 0) {
+    const msg = introduced.map((h) => `  ${h.path} matches ${h.pattern}`).join("\n");
     throw new Error(`plaintext secret detected in config:\n${msg}`);
   }
 }

--- a/packages/web/src/lib/openclaw-plaintext-scanner.ts
+++ b/packages/web/src/lib/openclaw-plaintext-scanner.ts
@@ -98,6 +98,19 @@ function walk(value: unknown, path: string, hits: Hit[]): void {
 }
 
 /**
+ * Paths already reported as carrying a pre-existing plaintext secret, so the
+ * warning below fires once per process instead of once per config write. Holds
+ * `path` and pattern name only — never a value; the point of the report is that
+ * the value must not be logged.
+ */
+const reportedInheritedPaths = new Set<string>();
+
+/** Exposed only for unit-testing the once-per-process report; do not call in app code. */
+export function _resetInheritedSecretReports(): void {
+  reportedInheritedPaths.clear();
+}
+
+/**
  * Throw if `config` introduces a plaintext secret.
  *
  * `readPrevious` supplies the config currently on disk, for writes that spread
@@ -114,13 +127,17 @@ export function assertNoPlaintextSecrets(config: unknown, readPrevious?: () => u
 
   // Report before throwing: an inherited leak is still a leak, and staying
   // quiet about it is how it survived every upgrade so far. Paths and pattern
-  // names only — never the value.
-  if (inherited.length > 0) {
+  // names only — never the value. Once per process per path: an affected
+  // install writes this config on every boot seed, settings save and agent
+  // create, and a paragraph repeated that often stops being read.
+  const unreported = inherited.filter((h) => !reportedInheritedPaths.has(`${h.path}|${h.pattern}`));
+  if (unreported.length > 0) {
+    for (const h of unreported) reportedInheritedPaths.add(`${h.path}|${h.pattern}`);
     console.warn(
       "[openclaw-config] Carrying pre-existing plaintext secrets through this " +
         "config write (Pinchy did not add them; refusing the write would not " +
         "remove them):\n" +
-        inherited.map((h) => `  ${h.path} matches ${h.pattern}`).join("\n") +
+        unreported.map((h) => `  ${h.path} matches ${h.pattern}`).join("\n") +
         "\nInstalls upgraded from a pre-SecretRef Pinchy still carry a top-level " +
         "`env` block holding raw provider keys. Pinchy resolves provider keys " +
         "from the secrets file, so an entry whose provider is configured under " +


### PR DESCRIPTION
Closes #884.

## What was happening

`seedRestartClassOverridesIfMissing` aborted on every boot with

```
[pinchy] Failed to seed restart-class overrides: plaintext secret detected in config:
  env.OLLAMA_CLOUD_API_KEY matches ollama-cloud
  models.providers.ollama-cloud.apiKey matches ollama-cloud
```

so `controlUi.enabled` / `update` / `discovery` / `canvasHost` were silently never seeded.

## Why

The issue guessed the scanner was reading resolved values. It wasn't — those two strings really are plaintext in the on-disk `openclaw.json`, and Pinchy put neither of them there *in that write*:

- **`env.OLLAMA_CLOUD_API_KEY`** — a pre-SecretRef Pinchy (`4bf353132`, before `f1f66d8da`) emitted a top-level `env` block holding raw provider keys. `regenerateOpenClawConfig` doesn't spread `env`, so it never re-emits it — but nothing removes it either, and OpenClaw's merge carries it through `config.apply` forever.
- **`models.providers.ollama-cloud.apiKey`** — stays plaintext for as long as the healing regenerate keeps failing. On the apsa box that's #878, the unmounted secrets volume.

The seed spreads the whole on-disk config through so OpenClaw-enriched fields survive a targeted write. `assertNoPlaintextSecrets` scanned that whole tree, found the inherited secret, and rejected the write — which never removed the secret. It only threw away the seed's own payload.

## The fix

The guard now judges what a write **introduces**: a hit counts as inherited only when the previous config held the identical value at the identical path. Anything else throws exactly as before, which is what keeps the guard's real job intact — a Pinchy regression that routes a secret around SecretRef writes a value the file did not previously carry at that path, so it is still fatal.

Both call sites in `write.ts` pass the on-disk config as the baseline. The one in `pushConfigInBackground` matters as much as the one in `writeConfigAtomic`: it runs inside a background coroutine, so a throw there is an unhandled rejection that takes the channel update with it. Every targeted writer has the same spread-through shape — `seedGatewayTokenIfMissing`, `sanitizeOpenClawConfig`, `updateTelegramChannelConfig` — so this closes the class, not one caller.

The baseline is passed as a thunk. A clean config — nearly every write — pays neither the file read nor a second tree walk; a microbenchmark on a realistically sized config showed the eager version doubling the walk on the hot path.

Inherited hits are no longer swallowed: they're logged with path and pattern (never the value), naming the legacy `env` block as the likely source and what to do about it.

## Not in scope

The inherited secret still sits on disk. Purging the legacy `env` entries automatically is a separate call: if a provider key isn't in Pinchy's settings, that entry may be the only thing keeping the provider working, so deleting it could break a running install. The warning surfaces it and leaves the decision with the operator.

## Tests

- `openclaw-plaintext-scanner.test.ts` — `findNewPlaintextSecrets` unit coverage: carried-over hit ignored, changed value at a leaked path flagged, new path flagged, no-baseline judges everything; plus the assert's report-don't-swallow behaviour and that a newly introduced secret still throws when another is carried over.
- `openclaw-config.test.ts` — regression test seeding against a config that carries the legacy `env` block and a plaintext provider apiKey. Without the fix it reproduces the issue's error message verbatim.

Verified green: `openclaw-config.test.ts` (235/235), `openclaw-plaintext-scanner.test.ts` (17/17), `pnpm -C packages/web typecheck`, `pnpm -C packages/web lint`, `pnpm format:check`.