### PR TITLE
fix(chat): put a deadline on the wait for the initial history frame

### DIFF
--- a/docs/src/content/docs/explanation/chat-states.mdx
+++ b/docs/src/content/docs/explanation/chat-states.mdx
@@ -5,15 +5,16 @@ description: How Pinchy tracks the health of the agent connection and what each 
 
 Pinchy tracks the health of the agent connection in real time so you always know what's happening — and what to do if something goes wrong.
 
-## The five states
+## The states
 
-| State           | Indicator     | What it means                                         |
-| --------------- | ------------- | ----------------------------------------------------- |
-| Starting        | Yellow        | Pinchy is loading your conversation history.          |
-| Ready           | Green         | The agent is available and waiting for your message.  |
-| Responding      | Green         | The agent is generating a reply. You can still type.  |
-| Unavailable     | Red or Yellow | The agent can't be reached right now.                 |
-| Image too large | Red           | An attachment you tried to send exceeds the size cap. |
+| State            | Indicator     | What it means                                         |
+| ---------------- | ------------- | ----------------------------------------------------- |
+| Starting         | Yellow        | Pinchy is loading your conversation history.          |
+| Ready            | Green         | The agent is available and waiting for your message.  |
+| Responding       | Green         | The agent is generating a reply. You can still type.  |
+| Unavailable      | Red or Yellow | The agent can't be reached right now.                 |
+| Chat didn't load | Red           | Your conversation history didn't arrive in time.      |
+| Image too large  | Red           | An attachment you tried to send exceeds the size cap. |
 
 When an attachment is rejected, the indicator reads **Image too large** and a banner asks you to send a smaller file before you can keep chatting.
 
@@ -24,6 +25,15 @@ When the state is Unavailable, the indicator and status message explain why:
 - **Disconnected** (red): The connection dropped. Pinchy is trying to reconnect automatically.
 - **Configuring** (yellow): You recently changed agent settings. Pinchy is applying the changes and will be ready in a moment.
 - **Exhausted** (red): Reconnection attempts failed. You need to reload the page to resume.
+- **Chat didn't load** (red): Your conversation history didn't arrive within 20 seconds. See below.
+
+## When the conversation doesn't load
+
+Opening a chat starts with one request: Pinchy asks the server for your conversation history and shows the Starting state until it arrives. That request has a deadline. If nothing comes back within 20 seconds — a dropped connection, a mobile device waking from sleep with a socket that quietly died — Pinchy stops waiting instead of leaving you on a loading indicator.
+
+Two things happen at once. Pinchy reconnects by itself and asks again, which fixes the common case without you doing anything. And the chat tells you what's going on, with a **Try again** button that reconnects on demand. Whichever gets there first wins: as soon as your history arrives, the message disappears and the conversation is back.
+
+You never have to reload the page to get out of this state.
 
 ## Auto-recovery
 

--- a/docs/src/content/docs/explanation/chat-states.mdx
+++ b/docs/src/content/docs/explanation/chat-states.mdx
@@ -5,16 +5,15 @@ description: How Pinchy tracks the health of the agent connection and what each 
 
 Pinchy tracks the health of the agent connection in real time so you always know what's happening — and what to do if something goes wrong.
 
-## The states
+## The five states
 
-| State            | Indicator     | What it means                                         |
-| ---------------- | ------------- | ----------------------------------------------------- |
-| Starting         | Yellow        | Pinchy is loading your conversation history.          |
-| Ready            | Green         | The agent is available and waiting for your message.  |
-| Responding       | Green         | The agent is generating a reply. You can still type.  |
-| Unavailable      | Red or Yellow | The agent can't be reached right now.                 |
-| Chat didn't load | Red           | Your conversation history didn't arrive in time.      |
-| Image too large  | Red           | An attachment you tried to send exceeds the size cap. |
+| State           | Indicator     | What it means                                         |
+| --------------- | ------------- | ----------------------------------------------------- |
+| Starting        | Yellow        | Pinchy is loading your conversation history.          |
+| Ready           | Green         | The agent is available and waiting for your message.  |
+| Responding      | Green         | The agent is generating a reply. You can still type.  |
+| Unavailable     | Red or Yellow | The agent can't be reached right now.                 |
+| Image too large | Red           | An attachment you tried to send exceeds the size cap. |
 
 When an attachment is rejected, the indicator reads **Image too large** and a banner asks you to send a smaller file before you can keep chatting.
 
@@ -25,7 +24,7 @@ When the state is Unavailable, the indicator and status message explain why:
 - **Disconnected** (red): The connection dropped. Pinchy is trying to reconnect automatically.
 - **Configuring** (yellow): You recently changed agent settings. Pinchy is applying the changes and will be ready in a moment.
 - **Exhausted** (red): Reconnection attempts failed. You need to reload the page to resume.
-- **Chat didn't load** (red): Your conversation history didn't arrive within 20 seconds. See below.
+- **Chat didn't load** (red): Your conversation history didn't arrive within 20 seconds of opening the chat. See below.
 
 ## When the conversation doesn't load
 

--- a/packages/web/e2e/22-history-timeout.spec.ts
+++ b/packages/web/e2e/22-history-timeout.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Stalled initial history — Issue #956.
+ *
+ * Every other E2E in this suite runs against a server that answers the client's
+ * `history` request, so nothing covered the case the user actually hit in
+ * production: the frame never arrives. Before the deadline landed, the chat
+ * waited for it forever — loading indicator, no error, no retry, no way out
+ * except knowing to reload the page.
+ *
+ * This spec makes the frame disappear and asserts the two behaviours that
+ * replace the dead end:
+ *
+ *   1. The wait ends: the chat says it didn't load and offers "Try again".
+ *   2. The retry actually works: it reconnects, the (now cooperative) server
+ *      answers, and the chat becomes usable — no page reload involved.
+ *
+ * Mock WebSocket strategy: identical to `15-model-error-ux.spec.ts` — a
+ * MockWebSocket injected via `page.addInitScript()` before the page loads,
+ * forwarding Next.js dev sockets and other agents to the real implementation.
+ * The one difference is what it does with a `history` frame: the first
+ * connection swallows it, later connections answer normally. The mock is
+ * deliberately not shared from a helper module — addInitScript serializes the
+ * function, so imports and outer-scope references are unavailable inside it.
+ */
+
+import { test, expect } from "@playwright/test";
+import { seedProviderConfig } from "./helpers";
+
+// The client's deadline (HISTORY_TIMEOUT_MS in use-ws-runtime.ts) plus room for
+// the self-heal reconnect and render. Real time, so keep the test's own budget
+// well above it.
+const DEADLINE_WAIT_MS = 35_000;
+
+test.describe("stalled initial history (#956)", () => {
+  test("surfaces a retry when the history frame never arrives, and recovers on retry", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+
+    const setupRes = await request.post("/api/setup", {
+      data: {
+        name: "Test Admin",
+        email: "admin@test.local",
+        password: "test-password-123",
+      },
+    });
+    expect([201, 403]).toContain(setupRes.status());
+
+    await seedProviderConfig();
+
+    await page.goto("/login");
+    await page.getByLabel(/email/i).fill("admin@test.local");
+    await page.getByLabel("Password", { exact: true }).fill("test-password-123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+    // Generous: the redirect chain (/login → / → /chat/<id>) compiles three
+    // routes on a cold dev server, and this spec's own budget is long anyway.
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 30_000 });
+
+    const agentIdMatch = page.url().match(/\/chat\/([^/?#]+)/);
+    expect(agentIdMatch).toBeTruthy();
+    const agentId = agentIdMatch![1];
+
+    await page.addInitScript(
+      ({ targetAgentId }: { targetAgentId: string }) => {
+        const RealWebSocket = window.WebSocket;
+        // The server's willingness to answer is a page-level switch rather than
+        // a per-connection counter: React's dev-mode double-mount opens two
+        // sockets per page load, so "the first connection is the broken one"
+        // would already be over by the time the chat renders. The test flips
+        // this to true when it wants a healthy server.
+        (window as unknown as { __answerHistory: boolean }).__answerHistory = false;
+
+        class MockWebSocket {
+          static CONNECTING = 0;
+          static OPEN = 1;
+          static CLOSING = 2;
+          static CLOSED = 3;
+
+          CONNECTING = 0;
+          OPEN = 1;
+          CLOSING = 2;
+          CLOSED = 3;
+
+          onopen: (() => void) | null = null;
+          onmessage: ((event: { data: string }) => void) | null = null;
+          onclose: (() => void) | null = null;
+          onerror: (() => void) | null = null;
+          readyState = 1;
+          binaryType: string = "blob";
+
+          constructor(url: string) {
+            if (url.includes("/_next/")) {
+              return new RealWebSocket(url) as unknown as MockWebSocket;
+            }
+            if (!url.includes(targetAgentId)) {
+              return new RealWebSocket(url) as unknown as MockWebSocket;
+            }
+            queueMicrotask(() => this.onopen?.());
+          }
+
+          addEventListener() {}
+          removeEventListener() {}
+
+          send(raw: string) {
+            const message = JSON.parse(raw) as { type?: string };
+
+            if (message.type === "history") {
+              setTimeout(() => {
+                this.onmessage?.({
+                  data: JSON.stringify({ type: "openclaw_status", connected: true }),
+                });
+              }, 0);
+              // The reported fault: the request goes into a void (or its answer
+              // is lost) and nothing ever comes back.
+              if (!(window as unknown as { __answerHistory: boolean }).__answerHistory) return;
+              setTimeout(() => {
+                this.onmessage?.({
+                  data: JSON.stringify({
+                    type: "history",
+                    messages: [{ role: "assistant", content: "Back from the deep." }],
+                  }),
+                });
+              }, 5);
+            }
+          }
+
+          close() {
+            this.readyState = 3;
+            this.onclose?.();
+          }
+        }
+
+        Object.defineProperty(window, "WebSocket", {
+          configurable: true,
+          writable: true,
+          value: MockWebSocket,
+        });
+      },
+      { targetAgentId: agentId }
+    );
+
+    await page.goto(`/chat/${agentId}`);
+
+    // While inside the deadline the chat still shows the loading state — the
+    // watchdog must not fire early on a merely slow server.
+    await expect(page.getByTestId("welcome-skeleton")).toBeVisible({ timeout: 15_000 });
+
+    // The wait ends with an explanation and a way out, not an endless spinner.
+    const stalled = page.getByTestId("history-timeout");
+    await expect(stalled).toBeVisible({ timeout: DEADLINE_WAIT_MS });
+    await expect(stalled).toContainText(/didn't load/i);
+
+    // Make the server healthy, then use the affordance the user is offered.
+    // The recovery window is deliberately shorter than the deadline: the next
+    // self-heal reconnect is a full deadline away, so nothing but the click can
+    // produce the message below inside it.
+    await page.evaluate(() => {
+      (window as unknown as { __answerHistory: boolean }).__answerHistory = true;
+    });
+    await page.getByRole("button", { name: /try again/i }).click();
+    await expect(page.getByText("Back from the deep.")).toBeVisible({ timeout: 15_000 });
+    await expect(stalled).toBeHidden();
+  });
+});

--- a/packages/web/src/__tests__/components/thread-welcome.test.tsx
+++ b/packages/web/src/__tests__/components/thread-welcome.test.tsx
@@ -84,11 +84,18 @@ vi.mock("@/components/chat", async () => {
   return {
     AgentAvatarContext: React.createContext<string | null>(null),
     AgentIdContext: React.createContext<string | null>(null),
+    ChatIdContext: React.createContext<string | null>(null),
     RetryResendContext: React.createContext<(messageId: string) => void>(() => {}),
     RetryContinueContext: React.createContext<() => void>(() => {}),
     ChatStatusContext: React.createContext<{ kind: string; reason?: string }>({ kind: "starting" }),
   };
 });
+
+// The stalled-load retry (#956) is read from the session store, not a context.
+const mockRetryHistory = vi.fn();
+vi.mock("@/components/chat-session-provider", () => ({
+  useChatSessionRetryHistory: () => mockRetryHistory,
+}));
 
 // ThreadWelcome reads the agent's starterPrompts via useAgentsContext (#570).
 // Mock it per-test via the returned object's getAgent.
@@ -247,5 +254,30 @@ describe("ThreadWelcome — disconnected state (kind=unavailable, reason=disconn
       </ChatStatusContext.Provider>
     );
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  });
+});
+
+describe("ThreadWelcome — stalled load (kind=unavailable, reason=historyTimeout)", () => {
+  // Issue #956: the chat used to sit on the loading indicator forever when the
+  // history frame never arrived. The user's only way out was knowing to reload.
+  it("explains the stall instead of showing the endless loading indicator", () => {
+    render(
+      <ChatStatusContext.Provider value={{ kind: "unavailable", reason: "historyTimeout" }}>
+        <ThreadWelcome />
+      </ChatStatusContext.Provider>
+    );
+    expect(screen.getByText(/didn't load/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("startup-message")).not.toBeInTheDocument();
+  });
+
+  it("offers a retry that reconnects and re-requests history", () => {
+    mockRetryHistory.mockClear();
+    render(
+      <ChatStatusContext.Provider value={{ kind: "unavailable", reason: "historyTimeout" }}>
+        <ThreadWelcome />
+      </ChatStatusContext.Provider>
+    );
+    screen.getByRole("button", { name: /try again/i }).click();
+    expect(mockRetryHistory).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -1555,10 +1555,17 @@ describe("useWsRuntime", () => {
     // parked the chat on the loading indicator forever — no error, no retry,
     // no way out but a manual reload. These tests pin the deadline, the
     // self-heal, and the escape hatch.
+    //
+    // The literal is deliberately NOT imported from the hook: it pins the
+    // agreed contract (20s, sized off the server's own worst case) instead of
+    // tracking whatever the implementation currently says. A change to
+    // HISTORY_TIMEOUT_MS is supposed to fail here and be argued for.
     const DEADLINE_MS = 20_000;
 
-    function openWithoutHistory() {
-      const rendered = renderHook(() => useWsRuntime("agent-1"));
+    function openWithoutHistory(agentId = "agent-1") {
+      const rendered = renderHook(({ id }) => useWsRuntime(id), {
+        initialProps: { id: agentId },
+      });
       const ws = wsInstances[0];
       act(() => {
         ws.simulateOpen();
@@ -1732,6 +1739,55 @@ describe("useWsRuntime", () => {
 
       expect(result.current.historyTimedOut).toBe(false);
       expect(ws.close).not.toHaveBeenCalled();
+    });
+
+    it("does not let one chat's pending deadline fire into the next", () => {
+      // Switch away while the first chat's deadline is STILL RUNNING, and let
+      // the new chat's socket never open — so it never sends a request of its
+      // own and never arms a deadline of its own. Anything that fires now is
+      // the abandoned timer, and it would pin a stall on a chat that has not
+      // yet asked the server anything (whose honest state is "connecting").
+      const { result, rerender } = openWithoutHistory();
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS / 4);
+      });
+      expect(result.current.historyTimedOut).toBe(false);
+
+      act(() => {
+        rerender({ id: "agent-2" });
+      });
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS * 2);
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+    });
+
+    it("does not carry a stall into the next chat", () => {
+      const { result, rerender } = openWithoutHistory();
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS);
+      });
+      expect(result.current.historyTimedOut).toBe(true);
+
+      act(() => {
+        rerender({ id: "agent-2" });
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+    });
+
+    it("disarms the deadline on unmount", () => {
+      // Asserted on the timer itself rather than on an observable side effect:
+      // an unmounted hook has no socket and no connect() left to call, so a
+      // leaked watchdog produces no visible damage — it just holds the whole
+      // closure alive for another 20 seconds per chat the user opens.
+      const { unmount } = openWithoutHistory();
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+      unmount();
+
+      expect(vi.getTimerCount()).toBe(0);
     });
 
     it("does not fire while the page is backgrounded", () => {

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -1494,6 +1494,7 @@ describe("useWsRuntime", () => {
           isRunning: ws.isRunning,
           reconnectExhausted: ws.reconnectExhausted,
           payloadRejected: ws.payloadRejected,
+          historyTimedOut: ws.historyTimedOut,
           configuring: false,
         });
         return { ws, status };
@@ -1545,6 +1546,217 @@ describe("useWsRuntime", () => {
       });
 
       expect(result.current.hasInitialContent).toBe(false);
+    });
+  });
+
+  describe("initial history deadline (#956)", () => {
+    // The client used to wait for the `history` frame with no deadline at all:
+    // every timer in the hook covers SENDING. So a frame lost for any reason
+    // parked the chat on the loading indicator forever — no error, no retry,
+    // no way out but a manual reload. These tests pin the deadline, the
+    // self-heal, and the escape hatch.
+    const DEADLINE_MS = 20_000;
+
+    function openWithoutHistory() {
+      const rendered = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+      act(() => {
+        ws.simulateOpen();
+        ws.simulateMessage({ type: "openclaw_status", connected: true });
+      });
+      return { ...rendered, ws };
+    }
+
+    it("stays quiet while the server is still within the deadline", () => {
+      const { result } = openWithoutHistory();
+
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS - 1000);
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+    });
+
+    it("reports a timeout when the history frame never arrives", () => {
+      const { result } = openWithoutHistory();
+
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS);
+      });
+
+      expect(result.current.historyTimedOut).toBe(true);
+    });
+
+    it("forces a reconnect on expiry so a silently dead socket self-heals", () => {
+      // The leading candidate cause: a backgrounded PWA socket torn down by the
+      // OS without a `close` event reaching the page. The client believes it is
+      // connected and sends the request into a void — only closing the socket
+      // ourselves gets a live one back.
+      const { ws } = openWithoutHistory();
+
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS);
+      });
+
+      expect(ws.close).toHaveBeenCalled();
+
+      act(() => {
+        ws.simulateClose();
+      });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(wsInstances).toHaveLength(2);
+    });
+
+    it("re-arms the deadline for the reconnected socket's own request", () => {
+      const { result, ws } = openWithoutHistory();
+
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS);
+      });
+      act(() => {
+        ws.simulateClose();
+      });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // Second socket answers → the dead end is over, without user action.
+      const ws2 = latestWs();
+      act(() => {
+        ws2.simulateOpen();
+        ws2.simulateMessage({
+          type: "history",
+          messages: [{ role: "assistant", content: "Hello!" }],
+        });
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+      expect(result.current.hasInitialContent).toBe(true);
+    });
+
+    it("clears the timeout when a late history frame lands on the same socket", () => {
+      const { result, ws } = openWithoutHistory();
+
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS);
+      });
+      expect(result.current.historyTimedOut).toBe(true);
+
+      act(() => {
+        ws.simulateMessage({ type: "history", messages: [], sessionKnown: true });
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+    });
+
+    it("stops self-healing after a bounded number of attempts", () => {
+      // A permanently unanswering server must not turn into an endless
+      // reconnect loop. The retry button stays as the way forward.
+      const { result } = openWithoutHistory();
+
+      for (let attempt = 0; attempt < 6; attempt++) {
+        act(() => {
+          vi.advanceTimersByTime(DEADLINE_MS);
+        });
+        const ws = latestWs();
+        if (!ws.close.mock.calls.length) break;
+        act(() => {
+          ws.simulateClose();
+        });
+        act(() => {
+          vi.advanceTimersByTime(5000);
+        });
+        act(() => {
+          latestWs().simulateOpen();
+        });
+      }
+
+      expect(result.current.historyTimedOut).toBe(true);
+      expect(wsInstances.length).toBeLessThanOrEqual(3);
+    });
+
+    it("retryHistory reconnects and re-arms a fresh self-heal budget", () => {
+      const { result } = openWithoutHistory();
+
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS);
+      });
+      const timedOutWs = latestWs();
+      act(() => {
+        timedOutWs.simulateClose();
+      });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      const socketsBeforeRetry = wsInstances.length;
+
+      act(() => {
+        result.current.retryHistory();
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+
+      act(() => {
+        latestWs().simulateClose();
+      });
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(wsInstances.length).toBeGreaterThan(socketsBeforeRetry);
+
+      const fresh = latestWs();
+      act(() => {
+        fresh.simulateOpen();
+        fresh.simulateMessage({ type: "history", messages: [], sessionKnown: true });
+      });
+      expect(result.current.historyTimedOut).toBe(false);
+      expect(result.current.hasInitialContent).toBe(true);
+    });
+
+    it("does not fire while a turn is streaming", () => {
+      // A user send disarms the pre-history buffer; the deadline must go with
+      // it, or the watchdog would tear down a healthy mid-stream socket.
+      const { result, ws } = openWithoutHistory();
+      act(() => {
+        ws.simulateMessage({ type: "history", messages: [], sessionKnown: true });
+      });
+
+      act(() => {
+        void store(result.current.runtime).onNew(makeUserMessage("hi"));
+      });
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS * 2);
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+      expect(ws.close).not.toHaveBeenCalled();
+    });
+
+    it("does not fire while the page is backgrounded", () => {
+      // The tab is suspended: the socket was closed on purpose and no history
+      // is pending. A watchdog firing here would reconnect a hidden tab.
+      const { result, ws } = openWithoutHistory();
+
+      act(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "hidden",
+          configurable: true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      act(() => {
+        vi.advanceTimersByTime(DEADLINE_MS * 2);
+      });
+
+      expect(result.current.historyTimedOut).toBe(false);
+
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      });
+      expect(ws).toBeDefined();
     });
   });
 
@@ -2285,6 +2497,7 @@ describe("useWsRuntime", () => {
           isRunning: ws.isRunning,
           reconnectExhausted: ws.reconnectExhausted,
           payloadRejected: ws.payloadRejected,
+          historyTimedOut: ws.historyTimedOut,
           configuring: false,
         });
         return { ws, status };

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -54,6 +54,7 @@ import {
   RetryPendingUploadContext,
   FileSourceContext,
 } from "@/components/chat";
+import { useChatSessionRetryHistory } from "@/components/chat-session-provider";
 import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog";
 import { useAgentsContext } from "@/components/agents-provider";
 import { normalizeStarterPrompts } from "@/lib/schemas/starter-prompts";
@@ -163,6 +164,8 @@ const ROTATION_INTERVAL_MS = 3000;
 export const ThreadWelcome: FC = () => {
   const chatStatus = useContext(ChatStatusContext);
   const agentId = useContext(AgentIdContext);
+  const chatId = useContext(ChatIdContext);
+  const retryHistory = useChatSessionRetryHistory(agentId ?? "", chatId ?? undefined);
   const { getAgent } = useAgentsContext();
   const agent = agentId ? getAgent(agentId) : undefined;
   // Normalize (trim, drop blanks, de-duplicate) so `key={prompt}` chips never
@@ -224,6 +227,30 @@ export const ThreadWelcome: FC = () => {
           <p className="text-sm font-medium text-muted-foreground">
             Image too large. Send a smaller file to keep chatting.
           </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (chatStatus.kind === "unavailable" && chatStatus.reason === "historyTimeout") {
+    // Issue #956: the wait for the initial history frame ran out. Say so and
+    // offer the way out — the chat used to sit on the loading indicator
+    // indefinitely, and only a page reload got the user unstuck.
+    return (
+      <div
+        data-testid="history-timeout"
+        className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-(--thread-max-width) grow flex-col"
+      >
+        <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-center">
+          <div className="flex flex-col items-center gap-3 px-4 text-center">
+            <p className="text-sm font-medium text-muted-foreground">
+              This chat didn&apos;t load. The connection may have dropped.
+            </p>
+            <Button variant="outline" size="sm" onClick={retryHistory}>
+              <RotateCw className="size-4" />
+              Try again
+            </Button>
+          </div>
         </div>
       </div>
     );

--- a/packages/web/src/components/chat-session-mounts.tsx
+++ b/packages/web/src/components/chat-session-mounts.tsx
@@ -160,6 +160,7 @@ function ChatSessionInstance({
   const {
     onRetryContinue,
     onRetryResend,
+    retryHistory,
     addPendingUpload,
     removePendingUpload,
     retryPendingUpload,
@@ -186,9 +187,11 @@ function ChatSessionInstance({
       isDelayed: bundle.isDelayed,
       reconnectExhausted: bundle.reconnectExhausted,
       payloadRejected: bundle.payloadRejected,
+      historyTimedOut: bundle.historyTimedOut,
       hasInlineError: bundle.hasInlineError,
       onRetryContinue,
       onRetryResend,
+      retryHistory,
       lastError,
       pendingUploads: bundle.pendingUploads,
       addPendingUpload,
@@ -210,6 +213,7 @@ function ChatSessionInstance({
     bundle.isDelayed,
     bundle.reconnectExhausted,
     bundle.payloadRejected,
+    bundle.historyTimedOut,
     bundle.hasInlineError,
     bundle.pendingUploads,
   ]);

--- a/packages/web/src/components/chat-session-provider.tsx
+++ b/packages/web/src/components/chat-session-provider.tsx
@@ -34,6 +34,13 @@ export interface RuntimeBundle {
   reconnectExhausted: boolean;
   payloadRejected: boolean;
   /**
+   * The wait for the initial history frame ran out of time (#956). Optional so
+   * the placeholder bundle and legacy publishers stay valid; absent ≙ false.
+   */
+  historyTimedOut?: boolean;
+  /** Reconnect and re-request history after a stalled load (#956). */
+  retryHistory?: () => void;
+  /**
    * The thread currently shows an inline turn-failure bubble (#583). Optional
    * so the placeholder bundle and legacy publishers stay valid; absent ≙ false.
    * Read by the durable paused-error banner to suppress itself when the same
@@ -166,6 +173,22 @@ export function useChatSessionHasInlineError(agentId: string, chatId?: string): 
   const store = useContext(ChatSessionStoreContext) ?? fallbackStore;
   const key = chatSessionKey(agentId, chatId);
   return useStore(store, (s) => s.bundles[key]?.hasInlineError ?? false);
+}
+
+/** Stable no-op so the selector below keeps a referentially stable snapshot. */
+const noop = () => {};
+
+/**
+ * Non-throwing subscription to the given chat's "reconnect and re-request
+ * history" action (#956), for the stalled-load state deep inside the thread.
+ * Read from the store rather than threaded down as yet another context provider
+ * — `<Chat>` already nests eight of them, and a ninth would re-indent the whole
+ * subtree for one callback. Same fallback-store pattern as its siblings.
+ */
+export function useChatSessionRetryHistory(agentId: string, chatId?: string): () => void {
+  const store = useContext(ChatSessionStoreContext) ?? fallbackStore;
+  const key = chatSessionKey(agentId, chatId);
+  return useStore(store, (s) => s.bundles[key]?.retryHistory ?? noop);
 }
 
 /**

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -38,6 +38,8 @@ function getStatusIndicator(status: ChatStatus): { colorClass: string; label: st
           return { colorClass: "bg-destructive", label: "Reconnecting..." };
         case "exhausted":
           return { colorClass: "bg-destructive", label: "Please reload the page" };
+        case "historyTimeout":
+          return { colorClass: "bg-destructive", label: "Chat didn't load" };
         default: {
           const _: never = status.reason;
           return { colorClass: "bg-destructive", label: "Unknown" };
@@ -208,6 +210,7 @@ export function Chat({
   const isOpenClawConnected = chatBundle?.isOpenClawConnected ?? false;
   const reconnectExhausted = chatBundle?.reconnectExhausted ?? false;
   const payloadRejected = chatBundle?.payloadRejected ?? false;
+  const historyTimedOut = chatBundle?.historyTimedOut ?? false;
   const onRetryContinue = chatBundle?.onRetryContinue ?? (() => {});
   const onRetryResend = chatBundle?.onRetryResend ?? (() => {});
   const pendingUploads = chatBundle?.pendingUploads ?? [];
@@ -223,6 +226,7 @@ export function Chat({
     isRunning,
     reconnectExhausted,
     payloadRejected,
+    historyTimedOut,
     configuring,
   });
 

--- a/packages/web/src/hooks/__tests__/use-chat-status.test.ts
+++ b/packages/web/src/hooks/__tests__/use-chat-status.test.ts
@@ -10,6 +10,7 @@ const base = {
   isRunning: false,
   reconnectExhausted: false,
   payloadRejected: false,
+  historyTimedOut: false,
   configuring: false,
 };
 
@@ -68,13 +69,59 @@ describe("useChatStatus", () => {
     expect(result.current).toEqual({ kind: "payloadRejected" });
   });
 
-  it("priority: exhausted > configuring > payloadRejected > disconnected > starting > responding > ready", () => {
+  it("returns 'unavailable' with reason 'historyTimeout' when the initial history never arrived", () => {
+    // Issue #956: the wait for the first history frame has a deadline. Once it
+    // expires with nothing renderable on screen, the chat must stop pretending
+    // to start and offer a way out instead.
+    const { result } = renderHook(() =>
+      useChatStatus({
+        ...base,
+        isHistoryLoaded: false,
+        hasInitialContent: false,
+        historyTimedOut: true,
+      })
+    );
+    expect(result.current).toEqual({ kind: "unavailable", reason: "historyTimeout" });
+  });
+
+  it("ignores a history timeout once there is content on screen", () => {
+    // A catch-up re-pull can time out mid-conversation. The transcript is still
+    // there, so the chat is not in a dead end — don't blank it with an error.
+    const { result } = renderHook(() =>
+      useChatStatus({ ...base, historyTimedOut: true, hasInitialContent: true })
+    );
+    expect(result.current).toEqual({ kind: "ready" });
+  });
+
+  it("prefers the history timeout over the generic 'disconnected' state", () => {
+    // The self-heal closes the socket, so isConnected drops right after the
+    // deadline. "Reconnecting..." would hide the retry the user needs.
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useChatStatus({
+        ...base,
+        isConnected: false,
+        isHistoryLoaded: false,
+        hasInitialContent: false,
+        historyTimedOut: true,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    expect(result.current).toEqual({ kind: "unavailable", reason: "historyTimeout" });
+    vi.useRealTimers();
+  });
+
+  it("priority: exhausted > configuring > payloadRejected > historyTimeout > disconnected > starting > responding > ready", () => {
     const { result } = renderHook(() =>
       useChatStatus({
         ...base,
         reconnectExhausted: true,
         configuring: true,
         payloadRejected: true,
+        historyTimedOut: true,
+        hasInitialContent: false,
         isConnected: false,
         isHistoryLoaded: false,
         isRunning: true,

--- a/packages/web/src/hooks/use-chat-status.ts
+++ b/packages/web/src/hooks/use-chat-status.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export type UnavailableReason = "disconnected" | "configuring" | "exhausted";
+export type UnavailableReason = "disconnected" | "configuring" | "exhausted" | "historyTimeout";
 export type ChatStatus =
   | { kind: "starting" }
   | { kind: "ready" }
@@ -22,6 +22,15 @@ export interface ChatStatusInputs {
   isRunning: boolean;
   reconnectExhausted: boolean;
   payloadRejected: boolean;
+  /**
+   * The deadline on the wait for a `history` frame expired (issue #956). Only
+   * meaningful while `hasInitialContent` is false: that combination is the dead
+   * end the user reported — a chat parked on the loading indicator with no
+   * error, no timeout and no way out but a manual reload. Once anything is
+   * renderable, a late/lost catch-up pull is not worth blanking the transcript
+   * for, so it is ignored.
+   */
+  historyTimedOut: boolean;
   configuring: boolean;
 }
 
@@ -49,6 +58,13 @@ export function useChatStatus(inputs: ChatStatusInputs): ChatStatus {
   if (inputs.reconnectExhausted) return { kind: "unavailable", reason: "exhausted" };
   if (inputs.configuring) return { kind: "unavailable", reason: "configuring" };
   if (inputs.payloadRejected) return { kind: "payloadRejected" };
+  // Ranked ABOVE "disconnected": the self-heal that follows the deadline closes
+  // the socket, so isConnected drops moments later. Letting the generic
+  // "Reconnecting..." win would hide the retry affordance behind exactly the
+  // recovery attempt the user is waiting on.
+  if (inputs.historyTimedOut && !inputs.hasInitialContent) {
+    return { kind: "unavailable", reason: "historyTimeout" };
+  }
   if (!fullyConnected && delayedDisconnect) return { kind: "unavailable", reason: "disconnected" };
   if (!inputs.isHistoryLoaded || !inputs.hasInitialContent) return { kind: "starting" };
   if (inputs.isRunning) return { kind: "responding" };

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -295,6 +295,28 @@ export const attachmentAdapter = new CompositeAttachmentAdapter([
 const MAX_RECONNECT_ATTEMPTS = 10;
 const MAX_BUNDLED_MESSAGES = 200;
 
+/**
+ * Deadline for the server's answer to a `history` request (#956).
+ *
+ * The server answers on every branch of `ClientRouter.handleHistory` — with
+ * messages, with the authoritative `sessionKnown: true` empty signal, or with a
+ * greeting — so silence past this point means the request or the response was
+ * lost in transit, not that the server declined. Sized off that handler's own
+ * worst case: `waitForConnection` gives up after 10s, the catch path then sleeps
+ * 2s and refetches. 20s leaves room for that plus the RPC round trips, so a slow
+ * server is never mistaken for a dead socket.
+ */
+const HISTORY_TIMEOUT_MS = 20_000;
+
+/**
+ * How many times an expired deadline may drop the socket and reconnect by
+ * itself. One is usually enough — the reported failure is a socket the OS tore
+ * down without a `close` event, which a fresh connection cures. The cap keeps a
+ * server that genuinely never answers from turning into an endless reconnect
+ * loop; past it the user's Retry is the way forward.
+ */
+const MAX_HISTORY_SELF_HEALS = 2;
+
 function capMessages<T>(messages: T[]): T[] {
   if (messages.length <= MAX_BUNDLED_MESSAGES) return messages;
   return messages.slice(messages.length - MAX_BUNDLED_MESSAGES);
@@ -500,6 +522,16 @@ export function useWsRuntime(
   reconnectExhausted: boolean;
   payloadRejected: boolean;
   /**
+   * The client's deadline for the server's answer to a `history` request
+   * expired (issue #956). Combined with `hasInitialContent === false` this is
+   * the dead end users hit: a chat parked on the loading indicator forever.
+   * Cleared the moment any history frame lands, including one produced by the
+   * self-heal reconnect the expiry triggers.
+   */
+  historyTimedOut: boolean;
+  /** Reconnect and re-request history after a stalled load (#956). */
+  retryHistory: () => void;
+  /**
    * True while an inline turn-failure bubble is in the thread (#583). Lets the
    * durable paused-error banner suppress itself as a fallback rather than
    * duplicate a failure that is already visible inline.
@@ -546,6 +578,16 @@ export function useWsRuntime(
    * messages that won't arrive. Reset on every reconnect/agent-switch.
    */
   const [knownEmptyHistory, setKnownEmptyHistory] = useState(false);
+  /**
+   * The deadline on an outstanding `history` request expired (#956). Before
+   * this existed, a lost history frame parked the chat on the loading indicator
+   * with no error, no retry and no way out but a manual reload — every other
+   * timer in this hook covers SENDING, nothing covered the initial load.
+   */
+  const [historyTimedOut, setHistoryTimedOut] = useState(false);
+  const historyWatchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Self-heal reconnects spent on the current stall; reset by an answer. */
+  const historySelfHealsRef = useRef(0);
   const [isOpenClawConnected, setIsOpenClawConnected] = useState(false);
   const [reconnectExhausted, setReconnectExhausted] = useState(false);
   const [payloadRejected, setPayloadRejected] = useState(false);
@@ -647,6 +689,7 @@ export function useWsRuntime(
     setIsHistoryLoaded(false);
     setIsReconcilingMessages(false);
     setKnownEmptyHistory(false);
+    setHistoryTimedOut(false);
     setPayloadRejected(false);
     // Multi-device live-sync: drop the poke-dedup identity so the newly-opened
     // session's first poke always re-pulls — its messageIds are unrelated to the
@@ -670,6 +713,17 @@ export function useWsRuntime(
       // eslint-disable-next-line react-hooks/refs
       reconcileFinishTimerRef.current = null;
     }
+    // The previous session's history deadline must not fire into the new one —
+    // it would drop a healthy socket the new session just opened (#956).
+    // eslint-disable-next-line react-hooks/refs
+    if (historyWatchdogRef.current) {
+      // eslint-disable-next-line react-hooks/refs
+      clearTimeout(historyWatchdogRef.current);
+      // eslint-disable-next-line react-hooks/refs
+      historyWatchdogRef.current = null;
+    }
+    // eslint-disable-next-line react-hooks/refs
+    historySelfHealsRef.current = 0;
     // Revoke object URLs from previous agent's pending uploads and clear the list.
     setPendingUploads((prev) => {
       for (const u of prev) {
@@ -712,6 +766,66 @@ export function useWsRuntime(
     livenessRef.current = livenessReducer(livenessRef.current, event);
   }, []);
 
+  const clearHistoryWatchdog = useCallback(() => {
+    if (historyWatchdogRef.current) {
+      clearTimeout(historyWatchdogRef.current);
+      historyWatchdogRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Throw away the current socket and get a live one. Closing it ourselves is
+   * the point: the socket we hold may be dead without having said so (a
+   * backgrounded PWA torn down by the OS never fires `close`), so it still
+   * reports OPEN while everything we send goes nowhere. `onclose` then drives
+   * the normal reconnect, whose `onopen` re-requests history.
+   */
+  const forceReconnect = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    shouldRecoverFromHistoryRef.current = true;
+    const ws = wsRef.current;
+    if (ws && ws.readyState !== WebSocket.CLOSED) {
+      ws.close();
+    } else {
+      connectRef.current?.();
+    }
+  }, []);
+
+  /**
+   * Start the clock on an outstanding history request (#956). Every path that
+   * sends one arms this, so no request can wait without a deadline.
+   */
+  const armHistoryWatchdog = useCallback(() => {
+    clearHistoryWatchdog();
+    historyWatchdogRef.current = setTimeout(() => {
+      historyWatchdogRef.current = null;
+      // Surface the stall immediately rather than after the self-heal has had
+      // its turn: the user has already been staring at a spinner for the whole
+      // deadline. If the reconnect below works, the history frame clears this
+      // again on its own and the retry affordance disappears unused.
+      setHistoryTimedOut(true);
+      if (historySelfHealsRef.current >= MAX_HISTORY_SELF_HEALS) return;
+      historySelfHealsRef.current++;
+      forceReconnect();
+    }, HISTORY_TIMEOUT_MS);
+  }, [clearHistoryWatchdog, forceReconnect]);
+
+  /**
+   * User-triggered escape from a stalled load (#956): reconnect with a fresh
+   * self-heal and reconnect budget, so a chat that gave up can be revived
+   * without reloading the page.
+   */
+  const retryHistory = useCallback(() => {
+    setHistoryTimedOut(false);
+    historySelfHealsRef.current = 0;
+    reconnectAttemptRef.current = 0;
+    setReconnectExhausted(false);
+    forceReconnect();
+  }, [forceReconnect]);
+
   useEffect(() => {
     // Update before connect() so stale handlers from the previous agent see
     // the new agentId as soon as the cleanup's ws.close() fires asynchronously.
@@ -737,9 +851,31 @@ export function useWsRuntime(
       }
     }
 
+    /**
+     * How this hook asks for history when the answer is something the UI waits
+     * on. Arms the pre-history frame buffer (Tier 2b) and the response deadline
+     * (#956) together, so the two can't drift apart: anything that waits for a
+     * history frame also has a clock on it.
+     *
+     * The one request that does NOT come through here is the OpenClaw
+     * rising-edge catch-up below, which fires only once history is already
+     * loaded — nothing is waiting on it, so it needs neither the buffer nor a
+     * deadline.
+     */
+    function sendHistoryRequest(ws: WebSocket) {
+      pendingHistoryRef.current = true;
+      frameBufferRef.current = [];
+      // #508: scope the history request to the active chat's session.
+      ws.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
+      armHistoryWatchdog();
+    }
+
     function clearUiTimers() {
       clearReconcileTimers();
       setIsReconcilingMessages(false);
+      // A suspended tab is not stalled — it closed its socket on purpose. Let
+      // the deadline fire here and it would reconnect a backgrounded page.
+      clearHistoryWatchdog();
       if (delayTimerRef.current) {
         clearTimeout(delayTimerRef.current);
         delayTimerRef.current = null;
@@ -780,13 +916,12 @@ export function useWsRuntime(
       if (!lifecycleSuspendedRef.current) return;
       lifecycleSuspendedRef.current = false;
       shouldRecoverFromHistoryRef.current = true;
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
         // Tier 2b: same buffer-then-drain protocol as ws.onopen — the
         // server may broadcast in-flight chunks between the addListener
         // (which runs in handleHistory) and the history-response send.
-        pendingHistoryRef.current = true;
-        frameBufferRef.current = [];
-        wsRef.current.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
+        sendHistoryRequest(ws);
       } else {
         connect();
       }
@@ -814,10 +949,9 @@ export function useWsRuntime(
       // the SENDING device double-renders its own just-streamed turn (the CI
       // integration E2E caught exactly this).
       shouldRecoverFromHistoryRef.current = true;
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        pendingHistoryRef.current = true;
-        frameBufferRef.current = [];
-        wsRef.current.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
+        sendHistoryRequest(ws);
       } else {
         connect();
       }
@@ -885,10 +1019,7 @@ export function useWsRuntime(
         // also missed the multi-tab case. Arming unconditionally is safe: on a
         // genuinely fresh load nothing is streaming, so the buffer drains empty
         // on the (always-sent) history response — no stall, no benefit lost.
-        pendingHistoryRef.current = true;
-        frameBufferRef.current = [];
-        // #508: scope the history request to the active chat's session.
-        ws.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
+        sendHistoryRequest(ws);
 
         // Flush any message that was queued while disconnected/connecting
         if (pendingMessageRef.current) {
@@ -907,6 +1038,11 @@ export function useWsRuntime(
         // re-arms pendingHistoryRef before sending its own history req.
         pendingHistoryRef.current = false;
         frameBufferRef.current = [];
+        // Nothing is outstanding on a dead socket. The next onopen sends its
+        // own request and arms its own deadline (#956); `historyTimedOut`
+        // deliberately survives, so a stall stays visible across the reconnect
+        // until a history frame actually lands.
+        clearHistoryWatchdog();
         if (delayTimerRef.current) {
           clearTimeout(delayTimerRef.current);
           delayTimerRef.current = null;
@@ -1052,6 +1188,13 @@ export function useWsRuntime(
         }
 
         if (data.type === "history") {
+          // The wait is over: disarm the deadline and clear any stall it
+          // already surfaced (#956). A frame that arrives late — on this
+          // socket or on a self-healed one — recovers the chat on its own,
+          // and the retry affordance disappears unused.
+          clearHistoryWatchdog();
+          historySelfHealsRef.current = 0;
+          setHistoryTimedOut(false);
           const serverMessages: Array<{
             role: string;
             content: string;
@@ -1560,6 +1703,7 @@ export function useWsRuntime(
         reconnectTimerRef.current = null;
       }
       clearReconcileTimers();
+      clearHistoryWatchdog();
       if (delayTimerRef.current) {
         clearTimeout(delayTimerRef.current);
       }
@@ -1603,34 +1747,41 @@ export function useWsRuntime(
    * handshake (see `connect()` in the main effect — it flushes
    * pendingMessageRef on open).
    */
-  const sendOrQueue = useCallback((payload: string) => {
-    const ws = wsRef.current;
-    if (ws?.readyState === WebSocket.OPEN) {
-      // A user-initiated send proves the client is interactive — i.e. past the
-      // initial history-load window (the composer is gated on isHistoryLoaded).
-      // The pre-history buffer (armed on every open) must therefore be disarmed
-      // now so THIS turn's chunks stream straight through instead of waiting for
-      // a history response that won't come mid-turn. A resuming reload never
-      // sends, so its buffer stays armed until the history response drains the
-      // raced-ahead deltas onto the anchored prefix. Only disarm when nothing is
-      // buffered — the gated composer can't produce a real pre-history backlog,
-      // and this guarantees such a backlog is never silently dropped.
-      if (pendingHistoryRef.current && frameBufferRef.current.length === 0) {
-        pendingHistoryRef.current = false;
+  const sendOrQueue = useCallback(
+    (payload: string) => {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
+        // A user-initiated send proves the client is interactive — i.e. past the
+        // initial history-load window (the composer is gated on isHistoryLoaded).
+        // The pre-history buffer (armed on every open) must therefore be disarmed
+        // now so THIS turn's chunks stream straight through instead of waiting for
+        // a history response that won't come mid-turn. A resuming reload never
+        // sends, so its buffer stays armed until the history response drains the
+        // raced-ahead deltas onto the anchored prefix. Only disarm when nothing is
+        // buffered — the gated composer can't produce a real pre-history backlog,
+        // and this guarantees such a backlog is never silently dropped.
+        if (pendingHistoryRef.current && frameBufferRef.current.length === 0) {
+          pendingHistoryRef.current = false;
+          // The deadline goes with the buffer (#956): nothing is waiting on a
+          // history frame any more, and a watchdog left armed would tear down a
+          // perfectly healthy socket in the middle of this turn.
+          clearHistoryWatchdog();
+        }
+        ws.send(payload);
+      } else {
+        pendingMessageRef.current = payload;
+        if (
+          ws?.readyState === WebSocket.CONNECTING ||
+          ws?.readyState === WebSocket.CLOSING ||
+          reconnectTimerRef.current
+        ) {
+          return;
+        }
+        connectRef.current?.();
       }
-      ws.send(payload);
-    } else {
-      pendingMessageRef.current = payload;
-      if (
-        ws?.readyState === WebSocket.CONNECTING ||
-        ws?.readyState === WebSocket.CLOSING ||
-        reconnectTimerRef.current
-      ) {
-        return;
-      }
-      connectRef.current?.();
-    }
-  }, []);
+    },
+    [clearHistoryWatchdog]
+  );
 
   const onNew = useCallback(
     async (message: AppendMessage) => {
@@ -2134,6 +2285,8 @@ export function useWsRuntime(
     isOpenClawConnected,
     reconnectExhausted,
     payloadRejected,
+    historyTimedOut,
+    retryHistory,
     // #583: whether an inline turn-failure bubble is currently in the thread.
     // The durable paused-error banner reads this (via the published bundle) to
     // suppress itself when the same failure is already shown inline.


### PR DESCRIPTION
Closes #956.

## The defect

Opening a chat sends one `history` request and shows the loading indicator until the answer arrives. Nothing timed that answer — every timer in `use-ws-runtime.ts` covers *sending*. A frame lost for any reason parked the chat on the indicator indefinitely: no error, no retry, no way out but knowing to reload the page.

The server answers on **every** branch of `ClientRouter.handleHistory`, so silence past a generous deadline means the request or its answer was lost in transit — most plausibly a socket the OS tore down without a `close` event reaching the page, which leaves the client believing it is connected while everything it sends goes nowhere.

## What changed

- **One entry point.** Every path that asks for history (`onopen`, lifecycle resume, catch-up pull) now goes through `sendHistoryRequest()`, which arms the Tier-2b pre-history frame buffer **and** a 20s deadline together, so the two can't drift apart. The 20s is sized off `handleHistory`'s own worst case (`waitForConnection` 10s + 2s retry sleep + RPC round trips), so a slow server is never mistaken for a dead socket.
- **Self-heal.** On expiry the client drops its socket and reconnects, which cures the dead-socket case without user action. Bounded (2 attempts), so a server that genuinely never answers can't become an endless reconnect loop.
- **A real state with a way out.** `historyTimedOut` produces `unavailable/"historyTimeout"` — a red indicator plus a thread message with a **Try again** button that reconnects and re-requests. Whichever lands first wins: a history frame clears the state and the retry disappears unused.
- **Never fires on a healthy socket.** The deadline is dropped wherever nothing is waiting on a frame any more — the answer itself, a socket close, a user send (which disarms the buffer), a suspended tab, an agent/chat switch.
- **Scoped to the dead end.** The status only surfaces while `hasInitialContent` is false. A catch-up re-pull that times out mid-conversation still self-heals but leaves the transcript alone.

The retry action reaches `ThreadWelcome` through a store selector (`useChatSessionRetryHistory`) rather than a ninth nested context provider in `<Chat>` — same pattern as `useChatSessionHasInlineError`.

## Tests

- `use-ws-runtime.test.ts` — 9 cases: quiet inside the deadline, timeout on expiry, forced reconnect, re-armed deadline on the new socket, late frame clears the state, bounded self-heal, `retryHistory` with a fresh budget, and the two cases where it must **not** fire (mid-stream, backgrounded tab).
- `use-chat-status.test.ts` — the new reason, its precedence over `disconnected`, and that it is ignored once content is on screen.
- `thread-welcome.test.tsx` — the stalled state replaces the loading indicator, and the button calls the retry.
- `e2e/22-history-timeout.spec.ts` — the case the issue asks for, which nothing covered before because every test's server answers: a mock WebSocket swallows the history frame, the retry appears, and clicking it recovers the chat in place. Verified to **fail on the pre-fix code** (sits on the loading indicator for the full 35s window).

## Docs

`docs/.../explanation/chat-states.mdx` gains the new state and a section on what happens when a conversation doesn't load.

## Verification

- `pnpm -C packages/web test` — 9875 passed. Three unrelated failures on this host: `pinchy-files` pdf-cache/index (the better-sqlite3 ABI mismatch documented in #947 — host Node 25 vs module ABI, CI runs Node 22) and `vitest-exclude-node-modules` (shells out to `npx vitest list`, times out under load; fails identically on a clean tree).
- `tsc --noEmit -p tsconfig.typecheck.json` — clean.
- `pnpm format:check` — clean.
- `pnpm exec playwright test 22-history-timeout` — passes; fails without the fix.