### PR TITLE
fix(ui): let Back walk back through settings tabs

### DIFF
--- a/packages/web/e2e/22-settings-tab-history.spec.ts
+++ b/packages/web/e2e/22-settings-tab-history.spec.ts
@@ -58,9 +58,17 @@ test.describe("Settings tab history", () => {
       "true"
     );
 
-    // …and only once the tabs are exhausted does Back leave Settings.
+    // Back to the tab-less entry, which renders the default tab. Landing here
+    // was the reported symptom — it just arrived one press too early, because
+    // the tabs in between never got entries of their own.
     await page.goBack();
     await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.getByRole("tab", { name: "Context" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+
+    // …and only once the tabs are exhausted does Back leave Settings.
     await page.goBack();
     await expect(page).toHaveURL(chatUrl);
   });

--- a/packages/web/e2e/22-settings-tab-history.spec.ts
+++ b/packages/web/e2e/22-settings-tab-history.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, type Page } from "@playwright/test";
+import { loginAsAdmin, seedProviderConfig } from "./helpers";
+
+/**
+ * Click a tab and wait for the URL to follow, retrying the click itself.
+ *
+ * A click that lands before hydration is silently dropped — the tab never
+ * switches and the URL never moves (the same race documented at length in
+ * `06-user-management.spec.ts`). Retrying the click rather than sleeping
+ * before it keeps the test honest about what it waits for. Re-clicking an
+ * already-active tab is a no-op in Radix (`onValueChange` fires on change
+ * only), so a retry cannot inflate the history this test measures.
+ */
+async function selectTab(page: Page, name: string, expectedUrl: RegExp) {
+  await expect(async () => {
+    await page.getByRole("tab", { name }).click();
+    await expect(page).toHaveURL(expectedUrl, { timeout: 1000 });
+  }).toPass({ timeout: 15000 });
+}
+
+/**
+ * Browser Back must walk back through the settings tabs the user visited (#951).
+ *
+ * The unit tests in `use-tab-param.test.ts` pin which router method the hook
+ * calls. That is the mechanism, not the outcome — and the mechanism is exactly
+ * what looked fine while the bug was live: `router.replace` is a perfectly
+ * ordinary call, it just leaves no history entry behind. What a user actually
+ * gets from a sequence of tab clicks is a question only a real browser history
+ * stack can answer, so this asks it there.
+ */
+test.describe("Settings tab history", () => {
+  test("Back walks back through the visited tabs", async ({ page }) => {
+    // Without a configured provider the first login lands on /setup/provider
+    // instead of the app shell, and `loginAsAdmin` waits for /chat/.
+    await seedProviderConfig();
+    await loginAsAdmin(page);
+
+    const chatUrl = page.url();
+
+    await page.goto("/settings");
+    await selectTab(page, "Profile", /\?tab=profile$/);
+    await selectTab(page, "Telegram", /\?tab=telegram$/);
+    await selectTab(page, "Support", /\?tab=support$/);
+
+    // The reported repro: three Back presses used to leave Settings entirely,
+    // because all four visits collapsed into a single history entry.
+    await page.goBack();
+    await expect(page).toHaveURL(/\?tab=telegram$/);
+    await expect(page.getByRole("tab", { name: "Telegram" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\?tab=profile$/);
+    await expect(page.getByRole("tab", { name: "Profile" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+
+    // …and only once the tabs are exhausted does Back leave Settings.
+    await page.goBack();
+    await expect(page).toHaveURL(/\/settings$/);
+    await page.goBack();
+    await expect(page).toHaveURL(chatUrl);
+  });
+});

--- a/packages/web/src/__tests__/components/settings-page-integrations-error-dot.test.tsx
+++ b/packages/web/src/__tests__/components/settings-page-integrations-error-dot.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/lib/auth-client", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: vi.fn().mockReturnValue({ replace: vi.fn() }),
+  useRouter: vi.fn().mockReturnValue({ replace: vi.fn(), push: vi.fn() }),
   useSearchParams: vi.fn().mockReturnValue(new URLSearchParams()),
   usePathname: vi.fn().mockReturnValue("/settings"),
 }));

--- a/packages/web/src/__tests__/components/settings-page-oauth-removed.test.tsx
+++ b/packages/web/src/__tests__/components/settings-page-oauth-removed.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/lib/auth-client", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: vi.fn().mockReturnValue({ replace: vi.fn() }),
+  useRouter: vi.fn().mockReturnValue({ replace: vi.fn(), push: vi.fn() }),
   useSearchParams: vi.fn().mockReturnValue(new URLSearchParams()),
   usePathname: vi.fn().mockReturnValue("/settings"),
 }));

--- a/packages/web/src/__tests__/hooks/use-tab-param.test.ts
+++ b/packages/web/src/__tests__/hooks/use-tab-param.test.ts
@@ -42,11 +42,11 @@ describe("useTabParam", () => {
       result.current[1]("license");
     });
 
-    expect(mockReplace).toHaveBeenCalledWith("/settings?tab=license", {
+    expect(mockPush).toHaveBeenCalledWith("/settings?tab=license", {
       scroll: false,
     });
 
-    // Simulate the URL update that router.replace triggers
+    // Simulate the URL update that router.push triggers
     mockSearchParams.set("tab", "license");
     const { result: updated } = renderHook(() => useTabParam("context", SETTINGS_TABS));
     expect(updated.current[0]).toBe("license");
@@ -61,7 +61,7 @@ describe("useTabParam", () => {
       result.current[1]("context");
     });
 
-    expect(mockReplace).toHaveBeenCalledWith("/settings", { scroll: false });
+    expect(mockPush).toHaveBeenCalledWith("/settings", { scroll: false });
 
     // Simulate the URL update
     mockSearchParams.delete("tab");
@@ -130,7 +130,7 @@ describe("useTabParam", () => {
       result.current[1]("context");
     });
 
-    expect(mockReplace).toHaveBeenCalledWith("/settings?tab=context", {
+    expect(mockPush).toHaveBeenCalledWith("/settings?tab=context", {
       scroll: false,
     });
   });
@@ -144,14 +144,12 @@ describe("useTabParam", () => {
       result.current[1]("context");
     });
 
-    expect(mockReplace).toHaveBeenCalledWith("/settings", { scroll: false });
+    expect(mockPush).toHaveBeenCalledWith("/settings", { scroll: false });
   });
 
-  it("pushes a history entry when entering a tab from the menu (pushOnEnter, not yet explicit)", () => {
+  it("pushes a history entry when entering a tab from the menu (not yet explicit)", () => {
     // No `?tab=` param → not explicit → this is a drill-in from the menu level.
-    const { result } = renderHook(() =>
-      useTabParam("context", SETTINGS_TABS, undefined, { pushOnEnter: true })
-    );
+    const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
 
     act(() => {
       result.current[1]("license");
@@ -161,30 +159,42 @@ describe("useTabParam", () => {
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
-  it("replaces (no history spam) when switching tabs while already explicit (pushOnEnter)", () => {
+  it("pushes when switching tabs while already explicit, so Back walks the tabs (#951)", () => {
     mockSearchParams.set("tab", "profile");
 
-    const { result } = renderHook(() =>
-      useTabParam("context", SETTINGS_TABS, undefined, { pushOnEnter: true })
-    );
-
-    act(() => {
-      result.current[1]("license");
-    });
-
-    expect(mockReplace).toHaveBeenCalledWith("/settings?tab=license", { scroll: false });
-    expect(mockPush).not.toHaveBeenCalled();
-  });
-
-  it("never pushes when pushOnEnter is not set", () => {
     const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
 
     act(() => {
       result.current[1]("license");
     });
 
-    expect(mockReplace).toHaveBeenCalledWith("/settings?tab=license", { scroll: false });
-    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/settings?tab=license", { scroll: false });
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("gives every tab in a multi-tab walk its own history entry (#951)", () => {
+    // The reported repro: Context → Profile → Telegram → Support produced a
+    // single history entry, so two Back presses left Settings entirely.
+    for (const [from, to] of [
+      [null, "profile"],
+      ["profile", "telegram"],
+      ["telegram", "support"],
+    ] as const) {
+      if (from) mockSearchParams.set("tab", from);
+      else mockSearchParams.delete("tab");
+
+      const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
+      act(() => {
+        result.current[1](to);
+      });
+    }
+
+    expect(mockPush.mock.calls.map(([url]) => url)).toEqual([
+      "/settings?tab=profile",
+      "/settings?tab=telegram",
+      "/settings?tab=support",
+    ]);
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -92,6 +92,11 @@ export function SettingsPageContent({
   // (level 1) vs. a selected tab's content with a back header (level 2).
   // Desktop always shows the split layout regardless of this flag.
   const goToMenu = useCallback(() => {
+    // `replace`, deliberately, even though every tab switch now pushes (#951):
+    // this control means "leave the tab I am in", so pushing would make the
+    // next Back walk straight back into it. Replacing drops the tab entry
+    // instead, which is what a back control should do.
+    //
     // Only drop `tab`; keep any unrelated query params (e.g. an OAuth `?error=`)
     // so the back control doesn't silently discard page state.
     const params = new URLSearchParams(searchParams.toString());

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -83,9 +83,6 @@ export function SettingsPageContent({
     : ["context", "profile", "telegram", "support"];
   const [activeTab, setActiveTab, isTabExplicit] = useTabParam("context", visibleTabs, initialTab, {
     keepParamForDefault: true,
-    // Drilling into a tab on mobile pushes a history entry so the browser
-    // Back button (and back gesture) returns to the menu, not off the page.
-    pushOnEnter: true,
   });
   // Mark the (admin-only) Integrations tab when a connection needs attention, so
   // the error trail continues from the sidebar badge down to the exact tab.

--- a/packages/web/src/hooks/use-tab-param.ts
+++ b/packages/web/src/hooks/use-tab-param.ts
@@ -47,23 +47,22 @@ export type AgentSettingsTab = (typeof AGENT_SETTINGS_TABS)[number];
  * menu) should pass `keepParamForDefault: true` so selecting the
  * default tab still writes `?tab=<default>` instead of clearing it.
  *
- * `pushOnEnter: true` makes the first selection out of the menu level
- * (i.e. while not yet `isExplicit`) a `router.push` instead of `replace`,
- * so the browser Back button returns to the menu in a mobile drill-down.
- * Switching between tabs afterwards still uses `replace` to avoid piling
- * up one history entry per tab click.
+ * `setTab` pushes a history entry. The tab lives in the URL, which makes
+ * each tab an addressable location, so Back walks back through the tabs
+ * the user visited — on desktop laterally, and on a mobile drill-down out
+ * to the menu level. Call it only for user-initiated switches; a
+ * programmatic normalisation of the URL belongs in a `router.replace`.
  */
 export function useTabParam<T extends string>(
   defaultTab: T,
   validTabs: readonly T[],
   initialTab?: string | null,
-  options?: { keepParamForDefault?: boolean; pushOnEnter?: boolean }
+  options?: { keepParamForDefault?: boolean }
 ): readonly [T, (tab: string) => void, boolean] {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
   const keepParamForDefault = options?.keepParamForDefault ?? false;
-  const pushOnEnter = options?.pushOnEnter ?? false;
 
   const rawTab = (searchParams.get("tab") ?? initialTab ?? null) as T | null;
   const isExplicit = Boolean(rawTab && validTabs.includes(rawTab));
@@ -82,24 +81,11 @@ export function useTabParam<T extends string>(
 
       const query = params.toString();
       const url = query ? `${pathname}?${query}` : pathname;
-      // Drilling in from the menu (not yet explicit) gets its own history
-      // entry so Back returns to the menu; every later switch replaces.
-      if (pushOnEnter && !isExplicit) {
-        router.push(url, { scroll: false });
-      } else {
-        router.replace(url, { scroll: false });
-      }
+      // Every tab is its own URL, so every switch is its own history entry
+      // and Back returns to the tab the user came from (#951).
+      router.push(url, { scroll: false });
     },
-    [
-      defaultTab,
-      isExplicit,
-      keepParamForDefault,
-      pushOnEnter,
-      pathname,
-      router,
-      searchParams,
-      validTabs,
-    ]
+    [defaultTab, keepParamForDefault, pathname, router, searchParams, validTabs]
   );
 
   return [tab, setTab, isExplicit] as const;


### PR DESCRIPTION
Closes #951.

## What was wrong

The tab lives in the `?tab=` URL param, which makes each tab an addressable location — but every switch after the first wrote it with `router.replace`. Four tab visits produced exactly one history entry, so on desktop Back skipped straight past every tab the user had visited and out of Settings.

## Option A from the issue

`pushOnEnter` was introduced for the **mobile** drill-down, where entering a tab is a real level change worth a history entry. On desktop there is no menu level — every click is a lateral move between locations.

Since `setTab` is only ever reached from `Tabs`' `onValueChange`, every call is user-initiated. That collapses the option entirely: **push always**, and `replace` stays available for the programmatic URL normalisation it is actually for. Mobile keeps its behaviour, because entering from the menu is itself a user-initiated switch.

The mobile "‹ Settings" control (`goToMenu`) keeps its `replace`, now with a comment saying why: it means "leave the tab I am in", so pushing would make the next Back walk straight back into it.

## The second location

`agent-settings-page-content.tsx` passed no options at all, so `pushOnEnter` was false and *every* agent-settings tab switch replaced — including the first. It inherits the fix without a change of its own, which is the point: the two pages had no reason a user could perceive to differ.

## Tests

- `use-tab-param.test.ts` — the `pushOnEnter` cases are rewritten for the new contract, plus a case walking the reported four-tab sequence and asserting three distinct pushes. Verified red against the old hook (7 failures).
- `e2e/22-settings-tab-history.spec.ts` — new. Walks the repro in a real browser: Context → Profile → Telegram → Support, then Back three times, asserting both the URL and which tab is actually selected at each step. Verified red against the old hook, failing with exactly the reported symptom (first Back lands on `/settings`, not Telegram).

The unit tests pin *which router method* the hook calls — that is the mechanism, not the outcome, and the mechanism is what read as correct while the bug was live. Only a real history stack answers what a sequence of clicks gives the user.

## Verification

Full `pnpm -C packages/web test`: **711/717 files, 9862 tests passing**. `pnpm format:check`, typecheck (with `.tsbuildinfo` cleared), `pnpm lint` (0 errors), and the E2E spec all green.

The 6 remaining failures are entirely in `packages/plugins/pinchy-files/` (`pdf-cache.test.ts` and the `pinchy_read` PDF block), untouched by this PR. They are the known local `better_sqlite3.node` ABI mismatch tracked in #947 — the module error is returned as a tool result, so it surfaces as a product assertion rather than a module error. Reproduced identically under Node 22 and Node 24, so it is the prebuilt binary, not a Node drift. Not rebuilt locally because the pnpm store is shared across worktrees; CI builds it fresh.