### PR TITLE
feat(settings): name the migration target when removing a provider

### DIFF
--- a/docs/src/content/docs/guides/llm-providers.mdx
+++ b/docs/src/content/docs/guides/llm-providers.mdx
@@ -66,7 +66,9 @@ The **very first** provider you configure — built-in or custom — automatical
 2. Click the provider's tile in the grid
 3. Click **Remove key** / **Remove URL** (built-in) or **Remove provider** (custom), and confirm
 
-If any agent currently uses a model from the removed provider, the chat will fail to start until you assign that agent a model from a still-configured provider. Pinchy will not silently re-assign agents.
+Agents pinned to a model from the removed provider are moved to a still-configured one, so no agent is left on a model that no longer exists. The confirmation dialog states the outcome before you commit: how many agents are affected, and which provider and model they'll be moved to. If the removed provider was the default, that same provider becomes the new default.
+
+The move is a starting point, not a verdict: pick a different model for any agent afterwards — see [Change an agent's model](#change-an-agents-model).
 
 ## OpenAI-compatible providers
 

--- a/docs/src/content/docs/guides/llm-providers.mdx
+++ b/docs/src/content/docs/guides/llm-providers.mdx
@@ -66,7 +66,7 @@ The **very first** provider you configure — built-in or custom — automatical
 2. Click the provider's tile in the grid
 3. Click **Remove key** / **Remove URL** (built-in) or **Remove provider** (custom), and confirm
 
-Agents pinned to a model from the removed provider are moved to a still-configured one, so no agent is left on a model that no longer exists. The confirmation dialog states the outcome before you commit: how many agents are affected, and which provider and model they'll be moved to. If the removed provider was the default, that same provider becomes the new default.
+Agents pinned to a model from the removed provider are moved to a still-configured one, so no agent is left on a model that no longer exists. The confirmation dialog states the outcome before you commit: how many agents are affected, and which provider and model they'll be moved to. If you removed your default provider, the provider those agents moved to becomes the new default.
 
 The move is a starting point, not a verdict: pick a different model for any agent afterwards — see [Change an agent's model](#change-an-agents-model).
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -482,9 +482,30 @@ Add or update a provider.
 
 Pinchy validates the credentials by calling the provider's `/models` endpoint before persisting. API keys are encrypted at rest with AES-256-GCM.
 
-### `DELETE /api/settings/providers?provider=<id>`
+### `DELETE /api/settings/providers`
 
-Remove a provider. Any agent still using a model from this provider will fail to start chats until reassigned.
+Remove a provider. Takes a JSON body: `{ "provider": "<id>" }`. Refused with `400` for the last configured provider.
+
+Every agent pinned to one of the provider's models is moved to the first remaining provider's default model, and that provider becomes the new default if the removed one was it.
+
+**Response:** `{ "success": true, "migratedAgents": 3 }`
+
+### `GET /api/settings/providers/deletion-preview?provider=<nameOrSlug>`
+
+What a removal would do, without doing it — the confirmation dialog uses this to name the migration target instead of guessing it. `provider` is a built-in provider name or a custom provider's slug.
+
+**Response:**
+
+```json
+{
+  "targetProvider": "anthropic",
+  "targetProviderLabel": "Anthropic",
+  "targetModel": "anthropic/claude-sonnet-4-6",
+  "affectedAgents": [{ "id": "…", "name": "Hermes" }]
+}
+```
+
+The target fields are `null` when no other provider is configured (that removal is refused anyway).
 
 ### `GET /api/providers/models`
 

--- a/packages/web/src/__tests__/api/openai-compatible-providers.test.ts
+++ b/packages/web/src/__tests__/api/openai-compatible-providers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST, GET, DELETE } from "@/app/api/settings/providers/openai-compatible/route";
 import { POST as DISCOVER } from "@/app/api/settings/providers/openai-compatible/discover/route";
+import { GET as PREVIEW } from "@/app/api/settings/providers/deletion-preview/route";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
@@ -1049,6 +1050,48 @@ describe("DELETE /api/settings/providers/openai-compatible", () => {
       slug: "acme-llm",
     });
     expect(JSON.stringify(entry.detail)).not.toContain(SECRET_KEY);
+  });
+
+  // #949 — the removal dialog names the target BEFORE the delete, from a
+  // preflight route. Its whole reason to exist is that it must not drift from
+  // what the delete then does, so assert the agreement on the custom path too:
+  // the preview runs while the row still exists (and must exclude it by slug),
+  // the delete runs after it's gone.
+  it("agrees with the deletion preview on the target model for the same state", async () => {
+    vi.mocked(listConfiguredBuiltIns).mockResolvedValue([
+      {
+        name: "anthropic",
+        config: { name: "Anthropic", defaultModel: "anthropic/claude-haiku-4-5-20251001" },
+      },
+    ] as any);
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "agent-1", name: "Booker", model: "acme-llm/acme-large" },
+    ] as any);
+
+    // Pre-delete state: the row the admin is about to remove is still listed.
+    vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([listItem()]);
+    const previewRes = await PREVIEW(
+      makeNextRequest("http://localhost/api/settings/providers/deletion-preview?provider=acme-llm"),
+      routeCtx
+    );
+    expect(previewRes.status).toBe(200);
+    const previewed = await previewRes.json();
+    expect(previewed.targetProviderLabel).toBe("Anthropic");
+    expect(previewed.affectedAgents).toEqual([{ id: "agent-1", name: "Booker" }]);
+
+    // Post-delete state, exactly as deleteProviderById leaves it.
+    vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([]);
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+    const res = await DELETE(deleteRequest({ id: PROVIDER_ID }), routeCtx);
+
+    expect(res.status).toBe(200);
+    expect(setSpy).toHaveBeenCalledWith({ model: previewed.targetModel });
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      migratedAgents: previewed.affectedAgents.length,
+    });
   });
 
   it("still succeeds with runtimeApplied:false when regenerate throws (best-effort)", async () => {

--- a/packages/web/src/__tests__/api/settings-providers-deletion-preview.test.ts
+++ b/packages/web/src/__tests__/api/settings-providers-deletion-preview.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "@/app/api/settings/providers/deletion-preview/route";
+import { DELETE } from "@/app/api/settings/providers/route";
+
+// #949 — the removal dialog names the migration target instead of "another
+// configured provider". The target is picked by `buildRemainingCandidates()`
+// (built-ins first, first candidate wins), so the preview MUST go through that
+// same helper rather than re-deriving the ordering. The load-bearing test here
+// is the last one: preview and DELETE must agree on the target for one and the
+// same state — that agreement is the entire reason this route exists.
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/auth", () => {
+  const mockGetSession = vi.fn().mockResolvedValue({
+    user: { id: "1", email: "admin@test.com", role: "admin" },
+  });
+  return {
+    getSession: mockGetSession,
+    auth: { api: { getSession: mockGetSession } },
+  };
+});
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+  deleteSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/openai-compatible-providers", () => ({
+  listOpenAiCompatibleProviders: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/provider-models", () => ({
+  resetCache: vi.fn(),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      agents: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    },
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    }),
+  },
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...(actual as object), eq: vi.fn() };
+});
+
+import { auth } from "@/lib/auth";
+import { getSetting } from "@/lib/settings";
+import { listOpenAiCompatibleProviders } from "@/lib/openai-compatible-providers";
+import type { OpenAiCompatibleProviderListItem } from "@/lib/openai-compatible-providers";
+import { db } from "@/db";
+import { PROVIDERS } from "@/lib/providers";
+import { mockSession } from "@/test-helpers/auth";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
+import type { DeletionPreviewResponse } from "@/lib/schemas/provider-deletion";
+
+function customProvider(slug: string, displayName: string): OpenAiCompatibleProviderListItem {
+  return {
+    id: `id-${slug}`,
+    slug,
+    displayName,
+    baseUrl: `https://${slug}.test/v1`,
+    models: [
+      {
+        id: `${slug}-large`,
+        name: `${slug} large`,
+        contextWindow: 8192,
+        maxTokens: 4096,
+        reasoning: false,
+        vision: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    ],
+    keyHint: "abcd",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+/** Only these settings keys resolve — every other lookup is unconfigured. */
+function configure(keys: Record<string, string>) {
+  vi.mocked(getSetting).mockImplementation(async (key: string) => keys[key] ?? null);
+}
+
+function previewRequest(query: string) {
+  return makeNextRequest(`http://localhost/api/settings/providers/deletion-preview${query}`);
+}
+
+async function preview(query: string): Promise<DeletionPreviewResponse> {
+  const res = await GET(previewRequest(query), routeContext());
+  expect(res.status).toBe(200);
+  return (await res.json()) as DeletionPreviewResponse;
+}
+
+describe("GET /api/settings/providers/deletion-preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSetting).mockResolvedValue(null);
+    vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([]);
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([]);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
+
+    const res = await GET(previewRequest("?provider=anthropic"), routeContext());
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-admin user", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "2", email: "user@test.com", role: "member" } })
+    );
+
+    const res = await GET(previewRequest("?provider=anthropic"), routeContext());
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns a structured 400 when the provider param is missing", async () => {
+    const res = await GET(previewRequest(""), routeContext());
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.provider).toBeDefined();
+  });
+
+  it("returns 404 for a name that is neither a built-in nor a custom slug", async () => {
+    const res = await GET(previewRequest("?provider=nope"), routeContext());
+
+    expect(res.status).toBe(404);
+  });
+
+  it("names the target provider, its label, its model, and every affected agent", async () => {
+    configure({ anthropic_api_key: "sk-ant", openai_api_key: "sk-openai" });
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "agent-1", name: "Hermes", model: "anthropic/claude-sonnet-4-6" },
+      { id: "agent-2", name: "Booker", model: "openai/gpt-5.5" },
+      { id: "agent-3", name: "Reader", model: "anthropic/claude-haiku-4-5" },
+    ] as never);
+
+    const data = await preview("?provider=anthropic");
+
+    expect(data.targetProvider).toBe("openai");
+    expect(data.targetProviderLabel).toBe("OpenAI");
+    expect(data.targetModel).toBe(PROVIDERS.openai.defaultModel);
+    expect(data.affectedAgents).toEqual([
+      { id: "agent-1", name: "Hermes" },
+      { id: "agent-3", name: "Reader" },
+    ]);
+  });
+
+  it("reflects the built-ins-first ordering: a configured built-in beats a custom provider", async () => {
+    configure({ google_api_key: "AIza", ollama_cloud_api_key: "sk-ollama" });
+    vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([
+      customProvider("acme", "Acme LLM"),
+    ]);
+
+    const data = await preview("?provider=ollama-cloud");
+
+    expect(data.targetProvider).toBe("google");
+    expect(data.targetModel).toBe(PROVIDERS.google.defaultModel);
+  });
+
+  it("previews a custom provider by slug, excluding it from its own candidate set", async () => {
+    configure({ anthropic_api_key: "sk-ant" });
+    vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([
+      customProvider("acme", "Acme LLM"),
+    ]);
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "agent-1", name: "Hermes", model: "acme/acme-large" },
+    ] as never);
+
+    const data = await preview("?provider=acme");
+
+    expect(data.targetProvider).toBe("anthropic");
+    expect(data.targetProviderLabel).toBe("Anthropic");
+    expect(data.affectedAgents).toEqual([{ id: "agent-1", name: "Hermes" }]);
+  });
+
+  it("names a custom provider as the target with its display name and namespaced model", async () => {
+    configure({ anthropic_api_key: "sk-ant" });
+    vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([
+      customProvider("acme", "Acme LLM"),
+    ]);
+
+    const data = await preview("?provider=anthropic");
+
+    expect(data.targetProvider).toBe("acme");
+    expect(data.targetProviderLabel).toBe("Acme LLM");
+    expect(data.targetModel).toBe("acme/acme-large");
+  });
+
+  it("matches agents on the ollama/ prefix when removing ollama-local", async () => {
+    configure({ ollama_local_url: "http://localhost:11434", anthropic_api_key: "sk-ant" });
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "agent-1", name: "Local", model: "ollama/llama3.2" },
+      { id: "agent-2", name: "Cloud", model: "ollama-cloud/kimi-k2.6" },
+    ] as never);
+
+    const data = await preview("?provider=ollama-local");
+
+    expect(data.affectedAgents).toEqual([{ id: "agent-1", name: "Local" }]);
+  });
+
+  it("returns an empty affected list — not a zero count — when nothing is pinned to the provider", async () => {
+    configure({ anthropic_api_key: "sk-ant", openai_api_key: "sk-openai" });
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "agent-1", name: "Booker", model: "openai/gpt-5.5" },
+    ] as never);
+
+    const data = await preview("?provider=anthropic");
+
+    expect(data.affectedAgents).toEqual([]);
+    expect(data.targetProvider).toBe("openai");
+  });
+
+  it("reports no target when the provider is the only configured one", async () => {
+    configure({ anthropic_api_key: "sk-ant" });
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "agent-1", name: "Hermes", model: "anthropic/claude-sonnet-4-6" },
+    ] as never);
+
+    const data = await preview("?provider=anthropic");
+
+    expect(data.targetProvider).toBeNull();
+    expect(data.targetProviderLabel).toBeNull();
+    expect(data.targetModel).toBeNull();
+    // Nothing migrates without a target, so nothing may be promised either.
+    expect(data.affectedAgents).toEqual([]);
+  });
+
+  it("agrees with the DELETE route on the target model for the same state", async () => {
+    configure({
+      anthropic_api_key: "sk-ant",
+      google_api_key: "AIza",
+      openai_api_key: "sk-openai",
+      default_provider: "anthropic",
+    });
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "agent-1", name: "Hermes", model: "anthropic/claude-sonnet-4-6" },
+    ] as never);
+
+    const data = await preview("?provider=anthropic");
+
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    vi.mocked(db.update).mockReturnValue({ set: setSpy } as never);
+
+    const deleteRes = await DELETE(
+      makeNextRequest("http://localhost/api/settings/providers", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "anthropic" }),
+      }),
+      routeContext()
+    );
+
+    expect(deleteRes.status).toBe(200);
+    // The dialog promised `data.targetModel`; the DELETE must write exactly it.
+    expect(setSpy).toHaveBeenCalledWith({ model: data.targetModel });
+    expect(await deleteRes.json()).toMatchObject({
+      success: true,
+      migratedAgents: data.affectedAgents.length,
+    });
+  });
+});

--- a/packages/web/src/__tests__/components/provider-key-form.test.tsx
+++ b/packages/web/src/__tests__/components/provider-key-form.test.tsx
@@ -1,6 +1,6 @@
 // packages/web/src/__tests__/components/provider-key-form.test.tsx
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { toast } from "sonner";
@@ -46,12 +46,10 @@ function previewResponse(overrides: Partial<DeletionPreviewResponse> = {}): Resp
  */
 function deleteFlowResponse(
   url: string,
-  method: string,
   deleteBody: unknown,
   previewOverrides: Partial<DeletionPreviewResponse> = {}
 ): Response {
   if (url.includes("deletion-preview")) return previewResponse(previewOverrides);
-  void method;
   return {
     ok: true,
     status: 200,
@@ -527,8 +525,8 @@ describe("ProviderKeyForm", () => {
     });
 
     it("should call DELETE endpoint and onSuccess after confirming removal", async () => {
-      vi.mocked(global.fetch).mockImplementation(async (input, init) =>
-        deleteFlowResponse(String(input), init?.method ?? "GET", { success: true })
+      vi.mocked(global.fetch).mockImplementation(async (input) =>
+        deleteFlowResponse(String(input), { success: true })
       );
 
       render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
@@ -674,12 +672,70 @@ describe("ProviderKeyForm", () => {
         expect(dialog).not.toHaveTextContent(/will be moved to/i);
       });
 
+      // The preflight exists so the dialog never names a target the DELETE
+      // won't use. A slow response is the second way to break that promise:
+      // it belongs to a provider the admin has since moved on from, and
+      // committing it would state one provider's consequence in another
+      // provider's dialog — the same confidently-wrong failure, arriving over
+      // the network instead of through a duplicated ordering policy.
+      it("ignores a preflight that lands after another provider's dialog opened", async () => {
+        const twoConfigured = {
+          anthropic: { configured: true, hint: "xY9z" },
+          openai: { configured: true, hint: "ab12" },
+        };
+        let landStalePreview!: (res: Response) => void;
+        const stalePreview = new Promise<Response>((resolve) => {
+          landStalePreview = resolve;
+        });
+        vi.mocked(global.fetch).mockImplementation(async (input) => {
+          const url = String(input);
+          if (url.includes("deletion-preview?provider=anthropic")) return stalePreview;
+          if (url.includes("deletion-preview?provider=openai")) {
+            return previewResponse({
+              targetProvider: "google",
+              targetProviderLabel: "Google",
+              targetModel: "google/gemini-3-pro",
+              affectedAgents: [{ id: "a1", name: "Hermes" }],
+            });
+          }
+          return { ok: true, json: async () => ({}) } as Response;
+        });
+
+        render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={twoConfigured} />);
+
+        // Open Anthropic's dialog — its preflight stays in flight — then leave.
+        fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+        await screen.findByRole("alertdialog");
+        fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+        // Now OpenAI's, whose preflight answers immediately.
+        fireEvent.click(screen.getByRole("button", { name: /^openai$/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+        const dialog = await screen.findByRole("alertdialog");
+        await waitFor(() => {
+          expect(dialog).toHaveTextContent(/1 agent using its models will be moved to Google/);
+        });
+
+        // Anthropic's answer arrives late, naming a different target.
+        await act(async () => {
+          landStalePreview(
+            previewResponse({
+              targetProvider: "anthropic",
+              targetProviderLabel: "Anthropic",
+              targetModel: "anthropic/claude-sonnet-4-6",
+              affectedAgents: [{ id: "a9", name: "Ghost" }],
+            })
+          );
+        });
+
+        expect(dialog).toHaveTextContent(/moved to Google \(gemini-3-pro\)/);
+        expect(dialog).not.toHaveTextContent(/Anthropic/);
+      });
+
       it("confirms in the success toast what the removal actually did", async () => {
-        vi.mocked(global.fetch).mockImplementation(async (input, init) =>
-          deleteFlowResponse(String(input), init?.method ?? "GET", {
-            success: true,
-            migratedAgents: 3,
-          })
+        vi.mocked(global.fetch).mockImplementation(async (input) =>
+          deleteFlowResponse(String(input), { success: true, migratedAgents: 3 })
         );
 
         render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
@@ -697,10 +753,9 @@ describe("ProviderKeyForm", () => {
       });
 
       it("keeps the toast to the removal alone when no agent moved", async () => {
-        vi.mocked(global.fetch).mockImplementation(async (input, init) =>
+        vi.mocked(global.fetch).mockImplementation(async (input) =>
           deleteFlowResponse(
             String(input),
-            init?.method ?? "GET",
             { success: true, migratedAgents: 0 },
             { affectedAgents: [] }
           )

--- a/packages/web/src/__tests__/components/provider-key-form.test.tsx
+++ b/packages/web/src/__tests__/components/provider-key-form.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { toast } from "sonner";
+import type { DeletionPreviewResponse } from "@/lib/schemas/provider-deletion";
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
@@ -17,6 +18,47 @@ vi.mock("@/lib/github-issue", () => ({
 vi.mock("next/navigation", () => ({
   usePathname: () => "/setup/provider",
 }));
+
+/** A `GET /api/settings/providers/deletion-preview` body (#949). */
+function previewResponse(overrides: Partial<DeletionPreviewResponse> = {}): Response {
+  const body: DeletionPreviewResponse = {
+    targetProvider: "openai",
+    targetProviderLabel: "OpenAI",
+    targetModel: "openai/gpt-5.5",
+    affectedAgents: [
+      { id: "a1", name: "Hermes" },
+      { id: "a2", name: "Booker" },
+      { id: "a3", name: "Reader" },
+    ],
+    ...overrides,
+  };
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+/**
+ * Routes the two requests a removal now makes: the preflight when the dialog
+ * opens, then the DELETE itself.
+ */
+function deleteFlowResponse(
+  url: string,
+  method: string,
+  deleteBody: unknown,
+  previewOverrides: Partial<DeletionPreviewResponse> = {}
+): Response {
+  if (url.includes("deletion-preview")) return previewResponse(previewOverrides);
+  void method;
+  return {
+    ok: true,
+    status: 200,
+    json: async () => deleteBody,
+    text: async () => JSON.stringify(deleteBody),
+  } as Response;
+}
 
 describe("ProviderKeyForm", () => {
   const onSuccess = vi.fn();
@@ -476,14 +518,18 @@ describe("ProviderKeyForm", () => {
       fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
       fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
 
-      expect(global.fetch).not.toHaveBeenCalled();
+      // Opening the dialog fetches the read-only removal preview (#949); the
+      // only thing Cancel must guarantee is that nothing was deleted.
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        "/api/settings/providers",
+        expect.objectContaining({ method: "DELETE" })
+      );
     });
 
     it("should call DELETE endpoint and onSuccess after confirming removal", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockImplementation(async (input, init) =>
+        deleteFlowResponse(String(input), init?.method ?? "GET", { success: true })
+      );
 
       render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
 
@@ -502,12 +548,18 @@ describe("ProviderKeyForm", () => {
     });
 
     it("should show error toast when trying to remove the last configured provider", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({
-          error: "Cannot remove the last configured provider. Add another provider first.",
-        }),
-      } as Response);
+      vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+        if (String(input).includes("deletion-preview")) {
+          return previewResponse();
+        }
+        void init;
+        return {
+          ok: false,
+          json: async () => ({
+            error: "Cannot remove the last configured provider. Add another provider first.",
+          }),
+        } as Response;
+      });
 
       render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
 
@@ -519,6 +571,151 @@ describe("ProviderKeyForm", () => {
         expect(toast.error).toHaveBeenCalledWith(
           "Cannot remove the last configured provider. Add another provider first."
         );
+      });
+    });
+
+    // #949 — the dialog used to say "agents will be switched to another
+    // configured provider" while the exact target was already determined. It
+    // now states the outcome, sourced from the server-side preflight so the
+    // built-ins-first ordering is never re-derived (and mis-derived) here.
+    describe("removal preview (#949)", () => {
+      it("names the affected agent count, the target provider and its model", async () => {
+        vi.mocked(global.fetch).mockImplementation(async (input) =>
+          String(input).includes("deletion-preview")
+            ? previewResponse({
+                affectedAgents: [
+                  { id: "a1", name: "Hermes" },
+                  { id: "a2", name: "Booker" },
+                  { id: "a3", name: "Reader" },
+                ],
+              })
+            : ({ ok: true, json: async () => ({}) } as Response)
+        );
+
+        render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          "/api/settings/providers/deletion-preview?provider=anthropic",
+          expect.anything()
+        );
+        const dialog = await screen.findByRole("alertdialog");
+        await waitFor(() => {
+          expect(dialog).toHaveTextContent(
+            /3 agents using its models will be moved to OpenAI \(gpt-5\.5\)/
+          );
+        });
+        expect(dialog).toHaveTextContent(/change each agent's model afterwards/i);
+      });
+
+      it("uses the singular for a single affected agent", async () => {
+        vi.mocked(global.fetch).mockImplementation(async (input) =>
+          String(input).includes("deletion-preview")
+            ? previewResponse({ affectedAgents: [{ id: "a1", name: "Hermes" }] })
+            : ({ ok: true, json: async () => ({}) } as Response)
+        );
+
+        render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+
+        const dialog = await screen.findByRole("alertdialog");
+        await waitFor(() => {
+          expect(dialog).toHaveTextContent(/1 agent using its models will be moved to OpenAI/);
+        });
+      });
+
+      it("says nothing about agents when none are affected — never '0 agents'", async () => {
+        vi.mocked(global.fetch).mockImplementation(async (input) =>
+          String(input).includes("deletion-preview")
+            ? previewResponse({ affectedAgents: [] })
+            : ({ ok: true, json: async () => ({}) } as Response)
+        );
+
+        render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+
+        const dialog = await screen.findByRole("alertdialog");
+        await waitFor(() => {
+          // The preview resolved: the fallback sentence is gone…
+          expect(dialog).not.toHaveTextContent(/another configured provider/i);
+        });
+        // …and no count is printed at all.
+        expect(dialog).not.toHaveTextContent(/0 agent/);
+        expect(dialog).not.toHaveTextContent(/will be moved/i);
+        expect(dialog).toHaveTextContent(/Removes your Anthropic API key\./);
+      });
+
+      it("falls back to the generic sentence when the preview fails", async () => {
+        vi.mocked(global.fetch).mockImplementation(async (input) =>
+          String(input).includes("deletion-preview")
+            ? ({
+                ok: false,
+                status: 500,
+                json: async () => ({ error: "boom" }),
+                text: async () => '{"error":"boom"}',
+              } as Response)
+            : ({ ok: true, json: async () => ({}) } as Response)
+        );
+
+        render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+
+        const dialog = await screen.findByRole("alertdialog");
+        expect(dialog).toHaveTextContent(/switched to another configured provider/i);
+        // No invented target when the preflight didn't answer.
+        expect(dialog).not.toHaveTextContent(/will be moved to/i);
+      });
+
+      it("confirms in the success toast what the removal actually did", async () => {
+        vi.mocked(global.fetch).mockImplementation(async (input, init) =>
+          deleteFlowResponse(String(input), init?.method ?? "GET", {
+            success: true,
+            migratedAgents: 3,
+          })
+        );
+
+        render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+        await screen.findByRole("alertdialog");
+        fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+        await waitFor(() => {
+          expect(toast.success).toHaveBeenCalledWith(
+            "Anthropic removed. 3 agents moved to OpenAI."
+          );
+        });
+      });
+
+      it("keeps the toast to the removal alone when no agent moved", async () => {
+        vi.mocked(global.fetch).mockImplementation(async (input, init) =>
+          deleteFlowResponse(
+            String(input),
+            init?.method ?? "GET",
+            { success: true, migratedAgents: 0 },
+            { affectedAgents: [] }
+          )
+        );
+
+        render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+        fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+        await screen.findByRole("alertdialog");
+        fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+        await waitFor(() => {
+          expect(toast.success).toHaveBeenCalledWith("Anthropic removed.");
+        });
       });
     });
   });
@@ -1078,11 +1275,14 @@ describe("ProviderKeyForm", () => {
       vi.mocked(global.fetch).mockImplementation(async (input, init) => {
         const url = String(input);
         const method = init?.method ?? "GET";
+        if (url.includes("deletion-preview")) {
+          return previewResponse();
+        }
         if (url.endsWith("/api/settings/providers/openai-compatible") && method === "GET") {
           return jsonResponse([acmeRow]);
         }
         if (url.endsWith("/api/settings/providers/openai-compatible") && method === "DELETE") {
-          return jsonResponse({ ok: true });
+          return jsonResponse({ ok: true, migratedAgents: 0 });
         }
         return jsonResponse({});
       });
@@ -1105,6 +1305,57 @@ describe("ProviderKeyForm", () => {
           })
         );
         expect(onSuccess).toHaveBeenCalled();
+      });
+    });
+
+    // #949 — the custom path carries the same disclosure as the built-in one:
+    // the dialog names the target the shared migration helper will pick, and
+    // the toast reports what happened.
+    it("names the migration target for a custom provider and confirms it in the toast", async () => {
+      vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url.includes("deletion-preview")) {
+          return previewResponse({
+            targetProvider: "anthropic",
+            targetProviderLabel: "Anthropic",
+            targetModel: "anthropic/claude-sonnet-4-6",
+            affectedAgents: [{ id: "a1", name: "Hermes" }],
+          });
+        }
+        if (url.endsWith("/api/settings/providers/openai-compatible") && method === "GET") {
+          return jsonResponse([acmeRow]);
+        }
+        if (url.endsWith("/api/settings/providers/openai-compatible") && method === "DELETE") {
+          return jsonResponse({ ok: true, migratedAgents: 1 });
+        }
+        return jsonResponse({});
+      });
+
+      render(<ProviderKeyForm onSuccess={onSuccess} manageCustomProviders />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /acme llm/i })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole("button", { name: /acme llm/i }));
+      fireEvent.click(screen.getByRole("button", { name: /remove provider/i }));
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/settings/providers/deletion-preview?provider=acme-llm",
+        expect.anything()
+      );
+      const dialog = await screen.findByRole("alertdialog");
+      await waitFor(() => {
+        expect(dialog).toHaveTextContent(
+          /1 agent using its models will be moved to Anthropic \(claude-sonnet-4-6\)/
+        );
+      });
+      expect(dialog).toHaveTextContent(/Removes Acme LLM\./);
+
+      fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("Acme LLM removed. 1 agent moved to Anthropic.");
       });
     });
   });

--- a/packages/web/src/__tests__/lib/provider-deletion.test.ts
+++ b/packages/web/src/__tests__/lib/provider-deletion.test.ts
@@ -63,8 +63,8 @@ describe("migrateAgentsOffDeletedProvider", () => {
     const result = await migrateAgentsOffDeletedProvider({
       deletedPrefix: "acme/",
       remainingCandidates: [
-        { name: "openai", defaultModel: "openai/gpt-5.4-mini" },
-        { name: "other", defaultModel: "other/x" },
+        { name: "openai", label: "OpenAI", defaultModel: "openai/gpt-5.4-mini" },
+        { name: "other", label: "Other", defaultModel: "other/x" },
       ],
       wasDefault: false,
     });
@@ -82,7 +82,9 @@ describe("migrateAgentsOffDeletedProvider", () => {
   it("reassigns default_provider to the first candidate when wasDefault", async () => {
     const result = await migrateAgentsOffDeletedProvider({
       deletedPrefix: "acme/",
-      remainingCandidates: [{ name: "openai", defaultModel: "openai/gpt-5.4-mini" }],
+      remainingCandidates: [
+        { name: "openai", label: "OpenAI", defaultModel: "openai/gpt-5.4-mini" },
+      ],
       wasDefault: true,
     });
 
@@ -117,47 +119,55 @@ describe("buildRemainingCandidates", () => {
 
   it("lists built-ins first, then custom instances namespaced <slug>/<models[0].id>", async () => {
     vi.mocked(listConfiguredBuiltIns).mockResolvedValue([
-      { name: "anthropic", config: { defaultModel: "anthropic/claude-haiku" } },
-      { name: "openai", config: { defaultModel: "openai/gpt-5.4-mini" } },
+      { name: "anthropic", config: { name: "Anthropic", defaultModel: "anthropic/claude-haiku" } },
+      { name: "openai", config: { name: "OpenAI", defaultModel: "openai/gpt-5.4-mini" } },
     ] as any);
     vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([
-      { slug: "acme", models: [{ id: "acme-large" }, { id: "acme-small" }] },
+      {
+        slug: "acme",
+        displayName: "Acme LLM",
+        models: [{ id: "acme-large" }, { id: "acme-small" }],
+      },
     ] as any);
 
     const candidates = await buildRemainingCandidates();
 
+    // `label` is what the removal dialog prints (#949) — carried here so the
+    // display name comes from the same place the target itself does.
     expect(candidates).toEqual([
-      { name: "anthropic", defaultModel: "anthropic/claude-haiku" },
-      { name: "openai", defaultModel: "openai/gpt-5.4-mini" },
+      { name: "anthropic", label: "Anthropic", defaultModel: "anthropic/claude-haiku" },
+      { name: "openai", label: "OpenAI", defaultModel: "openai/gpt-5.4-mini" },
       // Custom instance uses the FIRST persisted model, namespaced by slug.
-      { name: "acme", defaultModel: "acme/acme-large" },
+      { name: "acme", label: "Acme LLM", defaultModel: "acme/acme-large" },
     ]);
   });
 
   it("excludes the named built-in when excludeBuiltInName is set", async () => {
     vi.mocked(listConfiguredBuiltIns).mockResolvedValue([
-      { name: "anthropic", config: { defaultModel: "anthropic/claude-haiku" } },
-      { name: "openai", config: { defaultModel: "openai/gpt-5.4-mini" } },
+      { name: "anthropic", config: { name: "Anthropic", defaultModel: "anthropic/claude-haiku" } },
+      { name: "openai", config: { name: "OpenAI", defaultModel: "openai/gpt-5.4-mini" } },
     ] as any);
 
     const candidates = await buildRemainingCandidates({ excludeBuiltInName: "anthropic" });
 
-    expect(candidates).toEqual([{ name: "openai", defaultModel: "openai/gpt-5.4-mini" }]);
+    expect(candidates).toEqual([
+      { name: "openai", label: "OpenAI", defaultModel: "openai/gpt-5.4-mini" },
+    ]);
   });
 
   it("excludes no built-in when excludeBuiltInName is absent (custom-delete path)", async () => {
     vi.mocked(listConfiguredBuiltIns).mockResolvedValue([
-      { name: "anthropic", config: { defaultModel: "anthropic/claude-haiku" } },
+      { name: "anthropic", config: { name: "Anthropic", defaultModel: "anthropic/claude-haiku" } },
     ] as any);
     vi.mocked(listOpenAiCompatibleProviders).mockResolvedValue([
-      { slug: "acme", models: [{ id: "acme-large" }] },
+      { slug: "acme", displayName: "Acme LLM", models: [{ id: "acme-large" }] },
     ] as any);
 
     const candidates = await buildRemainingCandidates();
 
     expect(candidates).toEqual([
-      { name: "anthropic", defaultModel: "anthropic/claude-haiku" },
-      { name: "acme", defaultModel: "acme/acme-large" },
+      { name: "anthropic", label: "Anthropic", defaultModel: "anthropic/claude-haiku" },
+      { name: "acme", label: "Acme LLM", defaultModel: "acme/acme-large" },
     ]);
   });
 });

--- a/packages/web/src/app/api/settings/providers/deletion-preview/route.ts
+++ b/packages/web/src/app/api/settings/providers/deletion-preview/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { withAdmin } from "@/lib/api-auth";
+import { formatValidationError } from "@/lib/api-validation";
+import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { listOpenAiCompatibleProviders } from "@/lib/openai-compatible-providers";
+import { builtInModelPrefix, previewProviderDeletion } from "@/lib/provider-deletion";
+import {
+  deletionPreviewQuerySchema,
+  type DeletionPreviewResponse,
+} from "@/lib/schemas/provider-deletion";
+
+// Preflight for the provider-removal dialog (#949): which provider and model
+// every affected agent WOULD be moved onto, and which agents those are.
+//
+// It exists so the client never re-derives the migration target. The ordering
+// policy lives in `buildRemainingCandidates()`; a copy in provider-key-form.tsx
+// would drift, and the dialog would then confidently name the wrong provider —
+// strictly worse than the vague sentence it replaces. Both DELETE routes and
+// this preview call that one helper (see previewProviderDeletion).
+//
+// Admin-only, mirroring the DELETE routes it previews: it discloses configured
+// providers and agent names.
+export const GET = withAdmin(async (request) => {
+  // audit-exempt: read-only preview, no state change.
+  const parsed = deletionPreviewQuerySchema.safeParse({
+    provider: request.nextUrl.searchParams.get("provider") ?? undefined,
+  });
+  if (!parsed.success) return formatValidationError(parsed.error);
+  const { provider } = parsed.data;
+
+  // A built-in is identified by name, a custom instance by slug. Resolving the
+  // prefix here is what makes the preview count the same agents the DELETE
+  // migrates — `ollama-local` notably namespaces its models as `ollama/`.
+  const builtIn = PROVIDERS[provider as ProviderName];
+  let deletedPrefix: string;
+  if (builtIn) {
+    deletedPrefix = builtInModelPrefix(provider);
+  } else {
+    const custom = (await listOpenAiCompatibleProviders()).find((row) => row.slug === provider);
+    if (!custom) {
+      return NextResponse.json({ error: "Provider not found." }, { status: 404 });
+    }
+    deletedPrefix = `${custom.slug}/`;
+  }
+
+  const { target, affectedAgents } = await previewProviderDeletion({
+    providerName: provider,
+    deletedPrefix,
+  });
+
+  const body: DeletionPreviewResponse = {
+    targetProvider: target?.name ?? null,
+    targetProviderLabel: target?.label ?? null,
+    targetModel: target?.defaultModel ?? null,
+    affectedAgents,
+  };
+  return NextResponse.json(body);
+});

--- a/packages/web/src/app/api/settings/providers/route.ts
+++ b/packages/web/src/app/api/settings/providers/route.ts
@@ -9,6 +9,7 @@ import { countConfiguredProviders } from "@/lib/provider-count";
 import { appendAuditLog } from "@/lib/audit";
 import {
   buildRemainingCandidates,
+  builtInModelPrefix,
   migrateAgentsOffDeletedProvider,
   capMigratedAgents,
 } from "@/lib/provider-deletion";
@@ -70,9 +71,10 @@ export const DELETE = withAdmin(async (request, _ctx, session) => {
   const previousDefault = await getSetting("default_provider");
   const wasDefault = previousDefault === provider;
 
-  // Provider name to model prefix mapping.
-  // ollama-local uses "ollama/" as model prefix, not "ollama-local/".
-  const providerPrefix = provider === "ollama-local" ? "ollama/" : `${provider}/`;
+  // Provider name to model prefix mapping (ollama-local namespaces its models
+  // as "ollama/"). Shared with the deletion preview so the dialog counts
+  // exactly the agents this migration moves — see provider-deletion.ts.
+  const providerPrefix = builtInModelPrefix(provider);
 
   // Shared with the custom OpenAI-compatible DELETE route: migrate orphaned
   // agents onto the first remaining candidate and reassign the default when the
@@ -111,5 +113,8 @@ export const DELETE = withAdmin(async (request, _ctx, session) => {
     })
   );
 
-  return NextResponse.json({ success: true });
+  // `migratedAgents` mirrors the custom DELETE's response shape (#949): the
+  // success toast confirms what actually happened ("3 agents moved to …") for
+  // anyone who dismissed the confirmation dialog without reading it.
+  return NextResponse.json({ success: true, migratedAgents: migratedAgents.length });
 });

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -35,6 +35,7 @@ import type { ProviderName } from "@/lib/providers";
 import { apiGet, apiPatch, apiDelete, ApiError } from "@/lib/api-client";
 import type { DeleteOpenAiCompatibleInput } from "@/lib/schemas/openai-compatible-provider";
 import type { SetDefaultProviderInput } from "@/lib/schemas/provider-default";
+import type { DeletionPreviewResponse } from "@/lib/schemas/provider-deletion";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -246,6 +247,63 @@ function CornerIndicator({ state }: { state: TileState }) {
   return null;
 }
 
+/** `anthropic/claude-sonnet-4-6` → `claude-sonnet-4-6`, for display only. */
+function bareModelId(model: string): string {
+  const slash = model.indexOf("/");
+  return slash === -1 ? model : model.slice(slash + 1);
+}
+
+/**
+ * What removing a provider does to the agents pinned to it (#949).
+ *
+ * The preflight (`/api/settings/providers/deletion-preview`) determines the
+ * target, so this only renders it — the ordering policy stays server-side.
+ * Three states, deliberately:
+ *
+ * - preview not (yet) available — still loading, or the request failed: fall
+ *   back to the old, vague-but-true sentence rather than guessing a target.
+ * - no affected agents: say nothing at all. "0 agents will be moved" is noise
+ *   in a confirmation dialog.
+ * - affected agents: name the count, the target provider and its model. The
+ *   move is reversible per agent, which is why the dialog states the outcome
+ *   instead of offering a picker.
+ */
+function RemovalConsequence({ preview }: { preview: DeletionPreviewResponse | null }) {
+  if (!preview) {
+    return <> Any agents using its models will be switched to another configured provider.</>;
+  }
+  const count = preview.affectedAgents.length;
+  if (count === 0 || !preview.targetModel) return null;
+  return (
+    <>
+      {" "}
+      {count} {count === 1 ? "agent" : "agents"} using its models will be moved to{" "}
+      {preview.targetProviderLabel} ({bareModelId(preview.targetModel)}). You can change each
+      agent&apos;s model afterwards.
+    </>
+  );
+}
+
+/**
+ * Success toast copy that closes the loop for anyone who clicked through the
+ * dialog without reading it. The count comes from the DELETE response (what
+ * actually happened), the target label from the preview (what was promised) —
+ * the preflight and the DELETE agree by construction, see provider-deletion.ts.
+ */
+function removalSummary(
+  providerLabel: string,
+  migratedAgents: number,
+  targetLabel: string | null
+): string {
+  const removed = `${providerLabel} removed.`;
+  // `!migratedAgents` also covers a response that omitted the count — better a
+  // plain confirmation than "undefined agents moved".
+  if (!migratedAgents || !targetLabel) return removed;
+  return `${removed} ${migratedAgents} ${
+    migratedAgents === 1 ? "agent" : "agents"
+  } moved to ${targetLabel}.`;
+}
+
 interface ProviderKeyFormProps {
   onSuccess: (provider?: ProviderName) => void;
   submitLabel?: string;
@@ -308,6 +366,10 @@ export function ProviderKeyForm({
   );
   const [settingDefault, setSettingDefault] = useState(false);
   const [deletingCustom, setDeletingCustom] = useState(false);
+  // #949 — what the pending removal would do, fetched when a removal dialog
+  // opens. Null while loading and after a failed preflight, which renders the
+  // generic consequence sentence instead of an invented target.
+  const [deletionPreview, setDeletionPreview] = useState<DeletionPreviewResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);
   const [removing, setRemoving] = useState(false);
@@ -354,6 +416,26 @@ export function ProviderKeyForm({
     };
   }, [fetchCustomProviders]);
 
+  // #949 — load (or clear) the removal preflight as a confirmation dialog opens
+  // or closes. Read-only, and deliberately non-blocking: on failure the dialog
+  // keeps the generic sentence rather than blocking a removal on a preview.
+  const handleRemovalDialogOpenChange = useCallback((open: boolean, nameOrSlug: string) => {
+    setDeletionPreview(null);
+    if (!open) return;
+    void (async () => {
+      try {
+        const data = await apiGet<DeletionPreviewResponse>(
+          `/api/settings/providers/deletion-preview?provider=${encodeURIComponent(nameOrSlug)}`
+        );
+        // Only a well-formed preview may replace the generic sentence — a
+        // partial body must not make the dialog state a wrong consequence.
+        if (Array.isArray(data?.affectedAgents)) setDeletionPreview(data);
+      } catch {
+        // Keep the generic consequence sentence.
+      }
+    })();
+  }, []);
+
   // Settings-only: flip `default_provider` to a built-in name or a custom
   // slug. Shared by both the built-in panel's and the custom panel's
   // "Set as default" button.
@@ -380,11 +462,17 @@ export function ProviderKeyForm({
     setDeletingCustom(true);
     try {
       const body: DeleteOpenAiCompatibleInput = { id: target.id };
-      await apiDelete<{ ok: true }, DeleteOpenAiCompatibleInput>(
-        "/api/settings/providers/openai-compatible",
-        body
+      const result = await apiDelete<
+        { ok: true; migratedAgents: number },
+        DeleteOpenAiCompatibleInput
+      >("/api/settings/providers/openai-compatible", body);
+      toast.success(
+        removalSummary(
+          target.displayName,
+          result.migratedAgents,
+          deletionPreview?.targetProviderLabel ?? null
+        )
       );
-      toast.success("Provider removed.");
       setSelectedCustomProvider(null);
       void fetchCustomProviders();
       onSuccess();
@@ -693,7 +781,11 @@ export function ProviderKeyForm({
                 {settingDefault ? "Setting as default..." : "Set as default"}
               </Button>
             )}
-            <AlertDialog>
+            <AlertDialog
+              onOpenChange={(open) =>
+                handleRemovalDialogOpenChange(open, selectedCustomProvider.slug)
+              }
+            >
               <AlertDialogTrigger asChild>
                 <Button
                   type="button"
@@ -708,8 +800,8 @@ export function ProviderKeyForm({
                 <AlertDialogHeader>
                   <AlertDialogTitle>Remove provider?</AlertDialogTitle>
                   <AlertDialogDescription>
-                    This removes {selectedCustomProvider.displayName}. Any agents using its models
-                    will be switched to another configured provider.
+                    Removes {selectedCustomProvider.displayName}.
+                    <RemovalConsequence preview={deletionPreview} />
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
@@ -851,7 +943,7 @@ export function ProviderKeyForm({
             )}
 
             {configuredProviders && isConfigured && (
-              <AlertDialog>
+              <AlertDialog onOpenChange={(open) => handleRemovalDialogOpenChange(open, provider)}>
                 <AlertDialogTrigger asChild>
                   <Button
                     type="button"
@@ -868,9 +960,8 @@ export function ProviderKeyForm({
                       {isUrlProvider ? "Remove URL?" : "Remove API key?"}
                     </AlertDialogTitle>
                     <AlertDialogDescription>
-                      This will remove your {provider ? PROVIDERS[provider].name : ""}{" "}
-                      {isUrlProvider ? "URL" : "API key"}. If this is the active provider, agents
-                      will be switched to another configured provider.
+                      Removes your {PROVIDERS[provider].name} {isUrlProvider ? "URL" : "API key"}.
+                      <RemovalConsequence preview={deletionPreview} />
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>
@@ -885,10 +976,17 @@ export function ProviderKeyForm({
                             headers: { "Content-Type": "application/json" },
                             body: JSON.stringify({ provider }),
                           });
+                          const data = await res.json().catch(() => ({}));
                           if (!res.ok) {
-                            const data = await res.json();
                             throw new Error(data.error || "Failed to remove key");
                           }
+                          toast.success(
+                            removalSummary(
+                              PROVIDERS[provider].name,
+                              data.migratedAgents,
+                              deletionPreview?.targetProviderLabel ?? null
+                            )
+                          );
                           triggerRestart();
                           onSuccess(provider!);
                         } catch (err) {

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -419,7 +419,16 @@ export function ProviderKeyForm({
   // #949 — load (or clear) the removal preflight as a confirmation dialog opens
   // or closes. Read-only, and deliberately non-blocking: on failure the dialog
   // keeps the generic sentence rather than blocking a removal on a preview.
+  //
+  // Every open/close bumps the request id, and only the newest request may
+  // commit. A response that outlived its dialog belongs to a provider the admin
+  // has since left, and showing it would state one provider's consequence in
+  // another provider's dialog — the same confidently-wrong outcome this whole
+  // preflight exists to prevent, arriving over the network rather than through
+  // a second copy of the ordering policy.
+  const previewRequestId = useRef(0);
   const handleRemovalDialogOpenChange = useCallback((open: boolean, nameOrSlug: string) => {
+    const requestId = ++previewRequestId.current;
     setDeletionPreview(null);
     if (!open) return;
     void (async () => {
@@ -427,6 +436,7 @@ export function ProviderKeyForm({
         const data = await apiGet<DeletionPreviewResponse>(
           `/api/settings/providers/deletion-preview?provider=${encodeURIComponent(nameOrSlug)}`
         );
+        if (previewRequestId.current !== requestId) return;
         // Only a well-formed preview may replace the generic sentence — a
         // partial body must not make the dialog state a wrong consequence.
         if (Array.isArray(data?.affectedAgents)) setDeletionPreview(data);

--- a/packages/web/src/lib/provider-deletion.ts
+++ b/packages/web/src/lib/provider-deletion.ts
@@ -27,6 +27,8 @@ import { eq } from "drizzle-orm";
 export interface RemainingCandidate {
   /** Built-in ProviderName or custom slug — also the value written to default_provider. */
   name: string;
+  /** Human-readable name, for user-facing copy (#949). Never used for matching. */
+  label: string;
   /** The namespaced model an agent is repointed to (e.g. `anthropic/…` or `<slug>/…`). */
   defaultModel: string;
 }
@@ -54,16 +56,34 @@ export async function buildRemainingCandidates(opts?: {
   const candidates: RemainingCandidate[] = [];
   for (const builtIn of await listConfiguredBuiltIns()) {
     if (excludeBuiltInName !== undefined && builtIn.name === excludeBuiltInName) continue;
-    candidates.push({ name: builtIn.name, defaultModel: builtIn.config.defaultModel });
+    candidates.push({
+      name: builtIn.name,
+      label: builtIn.config.name,
+      defaultModel: builtIn.config.defaultModel,
+    });
   }
   for (const custom of await listOpenAiCompatibleProviders()) {
     // models non-empty by create schema (.min(1))
     candidates.push({
       name: custom.slug,
+      label: custom.displayName,
       defaultModel: `${custom.slug}/${custom.models[0].id}`,
     });
   }
   return candidates;
+}
+
+/**
+ * The model prefix a built-in provider's models carry.
+ *
+ * `ollama-local` is the one provider whose settings name and model namespace
+ * differ: its models are emitted as `ollama/…`. Both the DELETE route (which
+ * migrates agents off the prefix) and the deletion preview (#949, which counts
+ * them) need this mapping, and a second copy would make the dialog promise a
+ * different set of agents than the delete moves.
+ */
+export function builtInModelPrefix(provider: string): string {
+  return provider === "ollama-local" ? "ollama/" : `${provider}/`;
 }
 
 export interface MigratedAgent {
@@ -125,6 +145,48 @@ export async function migrateAgentsOffDeletedProvider(opts: {
   }
 
   return { migratedAgents, newDefault };
+}
+
+/**
+ * Read-only twin of `migrateAgentsOffDeletedProvider` (#949): what removing
+ * `providerName` WOULD do, so the confirmation dialog can name the target
+ * instead of saying "another configured provider".
+ *
+ * It answers with the same two facts the migration acts on — the first
+ * remaining candidate, and the agents matching the deleted prefix — by calling
+ * the very same `buildRemainingCandidates()`. That shared call is the point:
+ * any client-side re-derivation of the built-ins-first ordering would drift and
+ * make the dialog promise a target the DELETE doesn't use.
+ *
+ * Unlike the two DELETE routes, this runs while the provider still exists, so
+ * it excludes it from its own candidate set by NAME afterwards — which covers
+ * both flavours, since `RemainingCandidate.name` is the built-in name for
+ * built-ins and the slug for custom instances.
+ *
+ * With no remaining candidate the migration moves nothing, so neither does the
+ * preview: `affectedAgents` stays empty rather than promising a move that would
+ * not happen (the last-provider guard rejects that delete anyway).
+ */
+export async function previewProviderDeletion(opts: {
+  providerName: string;
+  deletedPrefix: string;
+}): Promise<{
+  target: RemainingCandidate | null;
+  affectedAgents: { id: string; name: string }[];
+}> {
+  const { providerName, deletedPrefix } = opts;
+
+  const candidates = await buildRemainingCandidates();
+  const target = candidates.find((candidate) => candidate.name !== providerName) ?? null;
+  if (!target) return { target: null, affectedAgents: [] };
+
+  const allAgents = await db.query.agents.findMany();
+  return {
+    target,
+    affectedAgents: allAgents
+      .filter((agent) => agent.model?.startsWith(deletedPrefix))
+      .map((agent) => ({ id: agent.id, name: agent.name })),
+  };
 }
 
 /**

--- a/packages/web/src/lib/provider-deletion.ts
+++ b/packages/web/src/lib/provider-deletion.ts
@@ -161,7 +161,11 @@ export async function migrateAgentsOffDeletedProvider(opts: {
  * Unlike the two DELETE routes, this runs while the provider still exists, so
  * it excludes it from its own candidate set by NAME afterwards — which covers
  * both flavours, since `RemainingCandidate.name` is the built-in name for
- * built-ins and the slug for custom instances.
+ * built-ins and the slug for custom instances. That one exclusion can stand in
+ * for the DELETEs' two only because the namespaces are disjoint:
+ * `RESERVED_PROVIDER_SLUGS` (openai-compatible-slug.ts) keeps a custom slug
+ * from ever equalling a built-in name, so no candidate is dropped by accident.
+ * Its "reserves every built-in provider name" test guards that.
  *
  * With no remaining candidate the migration moves nothing, so neither does the
  * preview: `affectedAgents` stays empty rather than promising a move that would

--- a/packages/web/src/lib/schemas/provider-deletion.ts
+++ b/packages/web/src/lib/schemas/provider-deletion.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// Shared contract for the provider-removal preflight (#949).
+//
+// The removal dialog must name the migration target ("3 agents will be moved to
+// Anthropic (claude-…)") instead of the vague "another configured provider".
+// The ordering policy that PICKS that target lives in
+// `buildRemainingCandidates()` (provider-deletion.ts) and must NOT be
+// re-derived in the client: a second copy would drift, and the dialog would
+// then promise one target while the DELETE performs another — confidently
+// wrong, which is worse than vague. Hence a read-only preflight route, and this
+// module as the single place its query + response shape are declared.
+
+/** `GET /api/settings/providers/deletion-preview?provider=<nameOrSlug>`. */
+export const deletionPreviewQuerySchema = z.object({
+  /** A built-in `ProviderName` or a custom OpenAI-compatible provider's slug. */
+  provider: z.string().min(1),
+});
+
+export type DeletionPreviewQuery = z.infer<typeof deletionPreviewQuerySchema>;
+
+/** An agent currently pinned to a model of the provider being removed. */
+export interface AffectedAgent {
+  id: string;
+  name: string;
+}
+
+export interface DeletionPreviewResponse {
+  /** Built-in name or custom slug every affected agent is migrated onto. */
+  targetProvider: string | null;
+  /** Human-readable name of that provider, for the dialog copy. */
+  targetProviderLabel: string | null;
+  /** The namespaced model written to every affected agent (`anthropic/…`). */
+  targetModel: string | null;
+  affectedAgents: AffectedAgent[];
+}


### PR DESCRIPTION
Closes #949.

## What

The provider removal dialog said:

> This removes {displayName}. Any agents using its models will be switched to another configured provider.

Every part of that outcome was already determined before the dialog opened. It now states it:

> Removes Mistral. **3 agents** using its models will be moved to **Anthropic (claude-sonnet-4-6)**. You can change each agent's model afterwards.

With zero affected agents the middle sentence is dropped rather than printing "0 agents". Both paths — built-in and custom OpenAI-compatible — carry the same disclosure.

## The part worth reviewing

**The target is not recomputed in the client.** The ordering policy lives in `buildRemainingCandidates()` (built-ins first, first candidate wins). A second copy in `provider-key-form.tsx` would drift, and the dialog would then promise one target while the migration performs another — confidently wrong, which is strictly worse than the vague sentence it replaces.

So there is a read-only preflight, `GET /api/settings/providers/deletion-preview?provider=<nameOrSlug>`, built on the very same helper both DELETE routes call. Two tests pin that agreement, one per delete path: **the model the preview names must be the model the DELETE writes for the same state.**

`builtInModelPrefix()` moved into `provider-deletion.ts` for the same reason — `ollama-local` namespaces its models as `ollama/`, and a second copy would make the dialog count a different set of agents than the migration moves.

## Deliberately not a provider picker

A confirmation dialog is the worst place for a configuration decision — users there are in "finish this" mode. The consequence is reversible (`agents.model` is a plain field the agent settings change at any time), and it would double the API surface of a destructive route for a case agent settings already cover. Comparable products only force a choice when the outcome is irreversible; for reassignment they name the target and move on.

## Also

- The built-in DELETE returns `migratedAgents`, mirroring the custom one, so the success toast confirms what happened ("Anthropic removed. 3 agents moved to OpenAI.") for anyone who clicked through the dialog.
- `RemainingCandidate` carries `label`, so the display name comes from the same place the target does.
- `docs/guides/llm-providers.mdx` claimed *"Pinchy will not silently re-assign agents"* — the opposite of what the code has done since #894. Fixed, and the API reference now documents the DELETE body (it documented a query param that never existed) plus the new route.

## Tests

- Preview and DELETE agree on the target — one test per delete path (the drift this design exists to prevent).
- Built-ins-first ordering reflected in the preview; custom provider excluded from its own candidate set; `ollama-local` matched on the `ollama/` prefix.
- Zero affected agents renders without the "0 agents" phrasing; a failed preflight falls back to the generic sentence instead of inventing a target.
- Toast copy, singular/plural, both paths.

Verified by mutation: dropping the self-exclusion in `previewProviderDeletion` turns 5 route tests red; ignoring the preview in the dialog turns 3 component tests red.

Local gates: `pnpm test` 714 files / 9907 tests green, `test:db` 368 green, `test:scripts` 390 green, typecheck (incl. tests), eslint, `format:check`.