### PR TITLE
fix(ui): let the keyboard push the composer up instead of covering it

### DIFF
--- a/packages/web/src/__tests__/app/root-layout-viewport.test.ts
+++ b/packages/web/src/__tests__/app/root-layout-viewport.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The root layout pulls in next/font (an SWC-time transform that has no
+// runtime in vitest) and the global stylesheet. Neither matters for the
+// viewport export under test.
+vi.mock("next/font/google", () => ({
+  Geist: () => ({ variable: "--font-geist-sans" }),
+  Geist_Mono: () => ({ variable: "--font-geist-mono" }),
+}));
+
+describe("root layout viewport", () => {
+  it("lets the virtual keyboard resize the layout viewport (#955)", async () => {
+    const { viewport } = await import("@/app/layout");
+
+    // Without this, the browser default `resizes-visual` applies: the on-screen
+    // keyboard shrinks only the VISUAL viewport, so a `h-dvh` chat column keeps
+    // its full height and the composer stays underneath the keyboard — reaching
+    // it means scrolling the whole page, which drags the chat header off screen.
+    // `resizes-content` shrinks the LAYOUT viewport instead, so the existing
+    // flex column reflows on its own: header pinned, composer above the keyboard.
+    expect(viewport.interactiveWidget).toBe("resizes-content");
+  });
+
+  it("keeps the existing viewport settings", async () => {
+    const { viewport } = await import("@/app/layout");
+
+    expect(viewport.width).toBe("device-width");
+    expect(viewport.initialScale).toBe(1);
+    expect(viewport.viewportFit).toBe("cover");
+  });
+});

--- a/packages/web/src/__tests__/components/mobile-chat-header.test.tsx
+++ b/packages/web/src/__tests__/components/mobile-chat-header.test.tsx
@@ -26,6 +26,15 @@ describe("MobileChatHeader", () => {
     expect(header).toHaveClass("border-b");
   });
 
+  it("does not shrink when the chat column runs out of space (#955)", () => {
+    // The header sits in `flex flex-col h-full min-h-0` next to a growing
+    // message list. Without shrink-0 it gets compressed — visibly so once the
+    // on-screen keyboard shortens the layout viewport. Its desktop sibling in
+    // chat.tsx has carried shrink-0 all along.
+    render(<MobileChatHeader {...defaultProps} />);
+    expect(screen.getByRole("banner")).toHaveClass("shrink-0");
+  });
+
   it("is hidden on md screens and above", () => {
     render(<MobileChatHeader {...defaultProps} />);
     const header = screen.getByRole("banner");

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -42,6 +42,13 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover" as const,
+  // Without this, the browser default `resizes-visual` applies: the on-screen
+  // keyboard shrinks only the visual viewport and leaves the layout viewport at
+  // full height. A `h-dvh` chat column then keeps its height, the composer stays
+  // where it was — underneath the keyboard — and reaching it means scrolling the
+  // whole page, which drags the chat header off screen (#955). `resizes-content`
+  // shrinks the layout viewport, so the flex column reflows on its own.
+  interactiveWidget: "resizes-content",
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#ffffff" },
     { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -834,9 +834,13 @@ describe("Composer no longer gates attachments client-side", () => {
 describe("Composer autofocus is pointer-gated (#955)", () => {
   const realMatchMedia = window.matchMedia;
 
+  // Matches the EXACT query, not a substring: `(any-pointer: fine)` contains
+  // `pointer: fine`, and that one is a different gate — it matches a phone with
+  // a stylus, i.e. precisely the device this is supposed to spare. A loose
+  // stub would let that swap through green.
   function stubPointer(fine: boolean) {
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      matches: query.includes("pointer: fine") ? fine : false,
+      matches: query === "(pointer: fine)" ? fine : false,
       media: query,
       onchange: null,
       addListener: vi.fn(),

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
@@ -824,6 +824,55 @@ describe("Composer no longer gates attachments client-side", () => {
     );
 
     expect(screen.queryByRole("region", { name: /can't be sent/i })).not.toBeInTheDocument();
+  });
+});
+
+// Autofocus is a desktop convenience and a mobile annoyance: on a touch device
+// it forces the on-screen keyboard open the moment a chat is opened, before the
+// user has decided to type — which is what made the composer disappear behind
+// the keyboard in #955, share attachment and all. Gate it on a pointing device.
+describe("Composer autofocus is pointer-gated (#955)", () => {
+  const realMatchMedia = window.matchMedia;
+
+  function stubPointer(fine: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("pointer: fine") ? fine : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+  }
+
+  afterEach(() => {
+    window.matchMedia = realMatchMedia;
+  });
+
+  async function renderComposer() {
+    const { ChatStatusContext } = await import("@/components/chat");
+    const { Composer } = await import("@/components/assistant-ui/thread");
+    return render(
+      <ChatStatusContext.Provider value={{ kind: "ready" }}>
+        <Composer />
+      </ChatStatusContext.Provider>
+    );
+  }
+
+  it("focuses the input on a device with a fine pointer", async () => {
+    stubPointer(true);
+    await renderComposer();
+
+    expect(screen.getByRole("textbox")).toHaveFocus();
+  });
+
+  it("leaves the input unfocused on a touch device, so the keyboard stays closed", async () => {
+    stubPointer(false);
+    await renderComposer();
+
+    expect(screen.getByRole("textbox")).not.toHaveFocus();
   });
 });
 

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -462,6 +462,20 @@ export function PendingUploadChips() {
   );
 }
 
+/**
+ * True when the device's primary input is a pointing device (mouse, trackpad).
+ *
+ * Read once, lazily, rather than tracked: React only honours `autoFocus` when
+ * the DOM node first mounts, so a value arriving later from an effect would
+ * never focus anything.
+ */
+function useFinePointer(): boolean {
+  const [finePointer] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(pointer: fine)").matches
+  );
+  return finePointer;
+}
+
 export const Composer: FC = () => {
   // Capability gating used to live here: a text-only model would block an image
   // send and pop the recovery dialog. That's gone — the WebSocket chat router
@@ -474,6 +488,11 @@ export const Composer: FC = () => {
   // key handler sits on the Root form element so it can intercept Enter/↑/↓
   // before the form submits when the menu is open.
   const slashMenu = useSlashCommandMenu();
+  // Autofocus is a desktop convenience and a mobile annoyance: on a touch
+  // device it forces the on-screen keyboard open on every chat entry, before
+  // the user has decided to type — hiding the composer, and with it whatever a
+  // share just pre-filled into it (#955).
+  const autoFocus = useFinePointer();
   return (
     <ComposerPrimitive.Root
       className="aui-composer-root relative flex w-full flex-col"
@@ -490,7 +509,7 @@ export const Composer: FC = () => {
           placeholder="Send a message, or type / for commands"
           className="aui-composer-input mb-0.5 md:mb-1 max-h-32 min-h-10 md:min-h-14 w-full resize-none bg-transparent px-4 pt-2 pb-1 md:pb-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-0"
           rows={1}
-          autoFocus
+          autoFocus={autoFocus}
           aria-label="Message input"
           {...slashMenu.inputAriaProps}
         />

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -468,6 +468,13 @@ export function PendingUploadChips() {
  * Read once, lazily, rather than tracked: React only honours `autoFocus` when
  * the DOM node first mounts, so a value arriving later from an effect would
  * never focus anything.
+ *
+ * `pointer`, not `any-pointer`: the latter matches a phone with a stylus (an
+ * S-Pen counts as a fine pointer), which is the device this exists to spare.
+ * Measured in Playwright's Chromium: a default context reports `fine`, a
+ * `hasTouch` or device-emulated one reports `coarse` — so the e2e suite keeps
+ * the autofocus it has always had, and a future mobile-emulating project would
+ * legitimately not.
  */
 function useFinePointer(): boolean {
   const [finePointer] = useState(

--- a/packages/web/src/components/mobile-chat-header.tsx
+++ b/packages/web/src/components/mobile-chat-header.tsx
@@ -20,7 +20,7 @@ export function MobileChatHeader({
   canEdit = false,
 }: MobileChatHeaderProps) {
   return (
-    <header className="md:hidden flex items-center justify-between p-3 border-b">
+    <header className="md:hidden shrink-0 flex items-center justify-between p-3 border-b">
       <Link href="/agents" aria-label="Back" className="p-1">
         <ArrowLeft className="size-5" />
       </Link>


### PR DESCRIPTION
Closes #955

Opening an agent chat on mobile put the composer — and any text a share had just pre-filled into it — behind the on-screen keyboard, and reaching it scrolled the agent header away. Three causes, all addressed.

## What changed

**`interactiveWidget: "resizes-content"`** (`packages/web/src/app/layout.tsx`) — the browser default `resizes-visual` shrinks only the *visual* viewport, so a `h-dvh` chat column keeps its full height and the composer stays where it was. `resizes-content` shrinks the *layout* viewport instead, and the existing flex column reflows on its own: header pinned, composer above the keyboard.

**`shrink-0` on `MobileChatHeader`** — the desktop sibling in `chat.tsx` has carried it all along; without it the header can be compressed once space gets tight.

**`autoFocus` gated on `(pointer: fine)`** (`thread.tsx`) — a desktop convenience, a mobile annoyance: it forced the keyboard open on every chat entry, before the user had decided to type, which is what made the other two visible immediately rather than only once someone typed. A small `useFinePointer()` reads the media query once and lazily, because React only honours `autoFocus` when the node first mounts. `pointer`, not `any-pointer`: the latter matches a phone with a stylus — the exact device this spares.

## Tests

- `root-layout-viewport.test.ts` — drift guard on the viewport export.
- `mobile-chat-header.test.tsx` — asserts `shrink-0`.
- `thread.test.tsx` — the composer takes focus on a fine pointer and stays unfocused on a touch device. The stub matches the **exact** media query; swapping the implementation to `any-pointer: fine` fails it (verified by mutation).

All were red first.

## Known effect outside the chat view — please check on device

`interactiveWidget` is a document-level setting, so it applies to every route, not just `/chat/*`. On the tab-bar routes (`/agents`, `/settings`, `/usage`, `/audit`) `BottomTabBar` is `fixed bottom-0`, which resolves against the **layout** viewport. Under `resizes-visual` it sat hidden below the keyboard; under `resizes-content` it will sit visibly above the keyboard, costing ~56px of form space while typing.

That is a deliberate non-fix: it is a plausible consequence I have reasoned about but not observed, and hiding the bar behind a `visualViewport` listener is new machinery that cannot be verified without a real keyboard either. Worth one look during the device test — if it is in the way, it deserves its own change.

## Verification

`(pointer: fine)` in Playwright's Chromium was **measured**, not assumed: a default context (what every config here uses) reports `fine`, a `hasTouch` or device-emulated one reports `coarse`. So the e2e suite keeps the autofocus it has always had.

What no automated test here can cover is the keyboard itself — Playwright emulates none, and devtools device emulation does not either. The real-device check on Android/Chrome (and ideally iOS/Safari, which differs on `resizes-content`) is still the one the issue asks for.

Local gates: web unit suite (9891 passed), `typecheck`, `lint` (0 errors), `format:check`, `test:scripts`, `test:plugins`, `typecheck:plugins` — all green. `test:db` not run: this diff touches no server module, schema, or export that an `*.integration.test.ts` mocks.