### PR TITLE
test: give the vitest-collection guard a budget that fits a vitest spawn

### DIFF
--- a/packages/web/src/__tests__/lib/vitest-exclude-node-modules.test.ts
+++ b/packages/web/src/__tests__/lib/vitest-exclude-node-modules.test.ts
@@ -21,6 +21,16 @@ import { resolve } from "node:path";
 const WEB_ROOT = resolve(__dirname, "../../..");
 
 describe("vitest.config.ts exclude", () => {
+  // The test budget must exceed the child's own `timeout` below, not vitest's
+  // default 5s: this test boots a SECOND, complete vitest process (config
+  // load, vite transform, collection glob over the whole workspace), which
+  // costs ~3.7s on an idle machine. That is a 1.35x margin against the
+  // default, and parallel worktree sessions eat it routinely (measured 5162ms
+  // on 2026-07-28). The budget is pure subprocess infrastructure — the
+  // assertion is about WHICH files vitest collects, never how fast. Keeping
+  // it above the execFileSync timeout also means a genuinely hung child is
+  // killed by the child timeout, which reports the child's own output,
+  // instead of by a bare "Test timed out" that says nothing.
   it("does not collect vendored test files from nested plugin node_modules", () => {
     const output = execFileSync("npx", ["vitest", "list", "--filesOnly"], {
       cwd: WEB_ROOT,
@@ -39,5 +49,5 @@ describe("vitest.config.ts exclude", () => {
         "found'). Fix the `exclude` glob in vitest.config.ts.",
       ].join("\n")
     ).toEqual([]);
-  });
+  }, 90_000);
 });

--- a/packages/web/src/__tests__/lib/vitest-exclude-node-modules.test.ts
+++ b/packages/web/src/__tests__/lib/vitest-exclude-node-modules.test.ts
@@ -21,16 +21,23 @@ import { resolve } from "node:path";
 const WEB_ROOT = resolve(__dirname, "../../..");
 
 describe("vitest.config.ts exclude", () => {
-  // The test budget must exceed the child's own `timeout` below, not vitest's
-  // default 5s: this test boots a SECOND, complete vitest process (config
-  // load, vite transform, collection glob over the whole workspace), which
-  // costs ~3.7s on an idle machine. That is a 1.35x margin against the
-  // default, and parallel worktree sessions eat it routinely (measured 5162ms
-  // on 2026-07-28). The budget is pure subprocess infrastructure — the
-  // assertion is about WHICH files vitest collects, never how fast. Keeping
-  // it above the execFileSync timeout also means a genuinely hung child is
-  // killed by the child timeout, which reports the child's own output,
-  // instead of by a bare "Test timed out" that says nothing.
+  // 90s, and deliberately ABOVE the child's own 60s `timeout` below. This test
+  // boots a SECOND, complete vitest process (config load, vite transform,
+  // collection glob over the whole workspace). Measured here: ~0.65s with a
+  // warm vite cache, but 2.7-5.4s cold or under parallel-worktree load (5162ms
+  // on 2026-07-28) — and CI is always cold, so the cold number is the real
+  // one. Against vitest's 5s default that is no margin at all, for a budget
+  // that is pure subprocess infrastructure: the assertion is about WHICH files
+  // vitest collects, never how fast it collects them.
+  //
+  // The default never aborted anything either. `execFileSync` blocks the
+  // worker synchronously, so vitest's timer cannot preempt it — measured: a 7s
+  // child ran its full 7011ms and was only THEN reported as "Test timed out in
+  // 5000ms". Work already done, marked red by accounting. The only real kill
+  // switch is the child `timeout`, and it stays the one that fires only while
+  // it is the smaller of the two. It throws `spawnSync npx ETIMEDOUT`
+  // (SIGTERM), which at least names the hang; note that the child's own output
+  // lands on err.stdout/err.stderr and is not printed.
   it("does not collect vendored test files from nested plugin node_modules", () => {
     const output = execFileSync("npx", ["vitest", "list", "--filesOnly"], {
       cwd: WEB_ROOT,


### PR DESCRIPTION
## What

`packages/web/src/__tests__/lib/vitest-exclude-node-modules.test.ts` gets an explicit `90_000` test budget, kept above the child's own 60s `execFileSync` timeout. No behaviour of the assertion changes.

## Why

The test boots a **second, complete vitest process** (`npx vitest list --filesOnly`: config load, vite transform, collection glob over the whole workspace) and asserts on *which* files vitest collects.

Measured cost of that child, in this worktree:

| Condition | Runtime |
| --- | --- |
| warm vite cache | ~0.65 s |
| cold cache / parallel-worktree load | 2.7–5.4 s (5162 ms observed on 2026-07-28) |

**CI always installs fresh, so the cold number is the one the budget has to fit** — and against vitest's 5000 ms default that is no margin at all. The timeout here is pure subprocess infrastructure; the assertion is about which files get collected, never how fast. So this is a corrected assumption about spawn cost, not a suppressed failure.

## The mechanism, measured rather than assumed

Worth knowing for reviewers, because it is counter-intuitive and the first version of this PR got it wrong:

- **vitest's test timeout cannot abort this test.** `execFileSync` blocks the worker synchronously, so the timer never gets to run. Probe: a 7 s child ran its **full 7011 ms** and was only *then* reported as `Test timed out in 5000ms`. The default budget was not cutting anything short — it was marking an already-finished test red by accounting.
- **The child's `timeout` is therefore the only real kill switch**, which is precisely why the test budget must sit above it (90 s > 60 s). If the child ever hangs, `execFileSync` throws `spawnSync npx ETIMEDOUT` (SIGTERM), which names the hang; a bare test timeout names nothing.
- Caveat, also measured: that error does **not** print the child's output — it lands on `err.stdout` / `err.stderr` and is dropped. The layering buys a better error message, not the child's diagnostics.

## Audit: is anything else in the same class?

Every test in the repo that spawns a subprocess, measured (single run, machine under load — the shell-script numbers are stable, the vitest one is not):

| Test | Spawns | Measured | Margin vs 5 s |
| --- | --- | --- | --- |
| `vitest-exclude-node-modules` | a whole vitest | 0.65 s warm / 2.7–5.4 s cold | **1.0–1.9x cold** ← this PR |
| `stage-llama-cpp-provider` | `bash` + tiny script | 52–669 ms | 7.5x |
| `sync-plugins` | `sh` + tiny script | 100–107 ms | 47x |
| `install-plugin-deps` | `bash` + tiny script | 23–80 ms | 63x |

Only the first spawns a full toolchain. The three shell-script tests share the *pattern* but sit two orders of magnitude from the ceiling, so they are left unchanged.

Outside this budget entirely, checked for completeness:

- `scripts/lib/*.test.mjs`, `docs/scripts/*`, `config/*` run under `node --test`, which has **no** default timeout.
- `db-migrate-runner.integration.test.ts` runs under `vitest.integration.config.ts` (`testTimeout: 30_000`).
- `eval/fingerprint.ts` spawns `git`, but only in its I/O shell; the tests exercise the pure function.

## Verification

- Test green on repeated runs (655 ms – 5385 ms depending on cache state); the 5385 ms run would have been **red** under the old budget with nothing actually broken.
- `prettier --check` on the changed file: clean.
- `pnpm -C packages/web typecheck` (includes test files): clean.

## Note for reviewers

A **global** `testTimeout` is the broader fix for this class — a per-test budget cannot help the component tests that take 10.5 s under load. That is proposed in #947 and deliberately not done here: it is a decision about the whole suite, not a side effect of this fix. `packages/web/vitest.config.ts` currently sets no `testTimeout` at all.