### PR TITLE
fix(pinchy-odoo): stop write-verification errors from inviting blind retries (#720)

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/write-verification.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/write-verification.test.ts
@@ -245,7 +245,13 @@ describe("odoo_create verification", () => {
     expect(res.details?.verified).toBe(false);
     // Audit failure signal is present.
     expect(res.details?.error).toBeTruthy();
-    expect(res.content[0].text.toLowerCase()).toContain("could not be read back");
+    const msg = res.content[0].text.toLowerCase();
+    expect(msg).toContain("could not be read back");
+    // The message must not invite a blind identical retry (weak models loop
+    // 15–25× on "retry the create"); it must tell the agent to stop and report.
+    expect(msg).not.toContain("retry the create or check");
+    expect(msg).toContain("do not retry");
+    expect(msg).toContain("report");
   });
 
   it("fails when a written verbatim scalar reads back different", async () => {
@@ -263,6 +269,11 @@ describe("odoo_create verification", () => {
     expect(res.isError).toBe(true);
     expect(res.details?.verified).toBe(false);
     expect(res.content[0].text).toContain("ref");
+    // A mismatched create must not be retried (the record exists — retrying
+    // would duplicate); tell the agent to stop and report.
+    const msg = res.content[0].text.toLowerCase();
+    expect(msg).toContain("do not retry");
+    expect(msg).toContain("report");
   });
 
   it("does not verify non-covered models (no read-back, no verified flag)", async () => {
@@ -359,6 +370,10 @@ describe("odoo_write verification", () => {
     expect(res.isError).toBe(true);
     expect(res.details?.verified).toBe(false);
     expect(res.content[0].text).toContain("ref");
+    // A persist-mismatch on write must not trigger a blind identical retry.
+    const msg = res.content[0].text.toLowerCase();
+    expect(msg).toContain("do not retry");
+    expect(msg).toContain("report");
   });
 
   it("does not verify non-covered models", async () => {

--- a/packages/plugins/pinchy-odoo/__tests__/write-verification.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/write-verification.test.ts
@@ -199,6 +199,29 @@ describe("findVerbatimMismatches", () => {
   });
 });
 
+/**
+ * The contract every verification failure message must satisfy.
+ *
+ * Weak models take a retry invitation literally and repeat the identical call
+ * 15–25× (detectLoop `tool-result-not-recognized`), so no message may invite
+ * one — and the #720 reason the read-back exists at all, "do not report
+ * success", has to survive the rewording.
+ *
+ * Asserted positively on the exact clauses. A bare `toContain("report")` is
+ * vacuous here: two of these messages already open with "Odoo reports no
+ * error" / "Odoo reported the write", so they pass it with the instruction
+ * deleted.
+ */
+function expectStopAndReportContract(text: string, kind: "failure" | "discrepancy") {
+  const msg = text.toLowerCase();
+  expect(msg).toContain("do not report success");
+  expect(msg).toContain("do not retry");
+  expect(msg).toContain(`report this ${kind} to the user`);
+  // Once the prohibitions are removed, no retry invitation may remain —
+  // catches a reworded invitation, not just the literal old wording.
+  expect(msg.replaceAll("do not retry", "")).not.toMatch(/\bretry\b/);
+}
+
 // ---------------------------------------------------------------------------
 // odoo_create verification
 // ---------------------------------------------------------------------------
@@ -245,13 +268,10 @@ describe("odoo_create verification", () => {
     expect(res.details?.verified).toBe(false);
     // Audit failure signal is present.
     expect(res.details?.error).toBeTruthy();
-    const msg = res.content[0].text.toLowerCase();
-    expect(msg).toContain("could not be read back");
-    // The message must not invite a blind identical retry (weak models loop
-    // 15–25× on "retry the create"); it must tell the agent to stop and report.
-    expect(msg).not.toContain("retry the create or check");
-    expect(msg).toContain("do not retry");
-    expect(msg).toContain("report");
+    expect(res.content[0].text.toLowerCase()).toContain("could not be read back");
+    // The message must not invite a blind identical retry; it must tell the
+    // agent to stop and report the failure.
+    expectStopAndReportContract(res.content[0].text, "failure");
   });
 
   it("fails when a written verbatim scalar reads back different", async () => {
@@ -271,9 +291,7 @@ describe("odoo_create verification", () => {
     expect(res.content[0].text).toContain("ref");
     // A mismatched create must not be retried (the record exists — retrying
     // would duplicate); tell the agent to stop and report.
-    const msg = res.content[0].text.toLowerCase();
-    expect(msg).toContain("do not retry");
-    expect(msg).toContain("report");
+    expectStopAndReportContract(res.content[0].text, "discrepancy");
   });
 
   it("does not verify non-covered models (no read-back, no verified flag)", async () => {
@@ -371,9 +389,25 @@ describe("odoo_write verification", () => {
     expect(res.details?.verified).toBe(false);
     expect(res.content[0].text).toContain("ref");
     // A persist-mismatch on write must not trigger a blind identical retry.
-    const msg = res.content[0].text.toLowerCase();
-    expect(msg).toContain("do not retry");
-    expect(msg).toContain("report");
+    expectStopAndReportContract(res.content[0].text, "discrepancy");
+  });
+
+  it("fails when the written record cannot be read back at all", async () => {
+    mockWrite.mockResolvedValue(true);
+    mockSearchRead.mockResolvedValueOnce(empty()); // verification read: id MISSING
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_write", agentId);
+    const res = await tool.execute("w1", {
+      model: "account.move",
+      ids: [42],
+      values: { ref: "INV-2" },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.details?.verified).toBe(false);
+    expect(res.details?.error).toBeTruthy();
+    expect(res.content[0].text.toLowerCase()).toContain("could not be read back");
+    expectStopAndReportContract(res.content[0].text, "failure");
   });
 
   it("does not verify non-covered models", async () => {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2510,8 +2510,8 @@ const plugin = {
             `Odoo returned id ${id} for ${model} but the record could not be read back — ` +
             `the write did not persist. Odoo reports no error in this case, so this is not a ` +
             `transient failure: nothing was saved, and repeating the identical create will not ` +
-            `change that. Do not retry the same create — report this failure to the user and ` +
-            `stop; the Odoo connection needs checking.`,
+            `change that. Do not report success and do not retry the same create — report this ` +
+            `failure to the user and stop; the Odoo connection needs checking.`,
         };
       }
 
@@ -2521,9 +2521,9 @@ const plugin = {
           ok: false,
           error:
             `Odoo created ${model} id ${id} but the saved values do not match what was written ` +
-            `(${formatMismatches(mismatches)}). The record was not persisted as intended. Do not ` +
-            `retry the identical create — the record exists, so retrying would duplicate it. ` +
-            `Report this discrepancy to the user and stop.`,
+            `(${formatMismatches(mismatches)}). The record was not persisted as intended, so do ` +
+            `not report success. Do not retry the identical create — the record exists, so ` +
+            `retrying would duplicate it. Report this discrepancy to the user and stop.`,
         };
       }
 
@@ -2574,8 +2574,8 @@ const plugin = {
             ok: false,
             error:
               `Odoo reported the write to ${model} id ${id} succeeded but the record could not ` +
-              `be read back — the change did not persist. Do not retry the identical write; ` +
-              `report this failure to the user and stop.`,
+              `be read back — the change did not persist. Do not report success and do not retry ` +
+              `the identical write; report this failure to the user and stop.`,
           };
         }
         const mismatches = findVerbatimMismatches(compareFields, sentValues, record);
@@ -2584,8 +2584,9 @@ const plugin = {
             ok: false,
             error:
               `Odoo reported the write to ${model} id ${id} succeeded but the saved values do ` +
-              `not match what was written (${formatMismatches(mismatches)}). Do not retry the ` +
-              `identical write; report this discrepancy to the user and stop.`,
+              `not match what was written (${formatMismatches(mismatches)}). Do not report ` +
+              `success and do not retry the identical write; report this discrepancy to the user ` +
+              `and stop.`,
           };
         }
       }

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2509,8 +2509,9 @@ const plugin = {
           error:
             `Odoo returned id ${id} for ${model} but the record could not be read back — ` +
             `the write did not persist. Odoo reports no error in this case, so this is not a ` +
-            `transient failure: nothing was saved. Do not report success — retry the create or ` +
-            `check the Odoo connection.`,
+            `transient failure: nothing was saved, and repeating the identical create will not ` +
+            `change that. Do not retry the same create — report this failure to the user and ` +
+            `stop; the Odoo connection needs checking.`,
         };
       }
 
@@ -2520,8 +2521,9 @@ const plugin = {
           ok: false,
           error:
             `Odoo created ${model} id ${id} but the saved values do not match what was written ` +
-            `(${formatMismatches(mismatches)}). The record was not persisted as intended — do ` +
-            `not report success.`,
+            `(${formatMismatches(mismatches)}). The record was not persisted as intended. Do not ` +
+            `retry the identical create — the record exists, so retrying would duplicate it. ` +
+            `Report this discrepancy to the user and stop.`,
         };
       }
 
@@ -2572,7 +2574,8 @@ const plugin = {
             ok: false,
             error:
               `Odoo reported the write to ${model} id ${id} succeeded but the record could not ` +
-              `be read back — the change did not persist. Do not report success.`,
+              `be read back — the change did not persist. Do not retry the identical write; ` +
+              `report this failure to the user and stop.`,
           };
         }
         const mismatches = findVerbatimMismatches(compareFields, sentValues, record);
@@ -2581,7 +2584,8 @@ const plugin = {
             ok: false,
             error:
               `Odoo reported the write to ${model} id ${id} succeeded but the saved values do ` +
-              `not match what was written (${formatMismatches(mismatches)}). Do not report success.`,
+              `not match what was written (${formatMismatches(mismatches)}). Do not retry the ` +
+              `identical write; report this discrepancy to the user and stop.`,
           };
         }
       }


### PR DESCRIPTION
## Problem

The #720 read-back verification (`verifyCreate`/`verifyWrite`) turned a silent no-op into a hard error, but the message told the agent to **"retry the create"**:

> … Do not report success — retry the create or check the Odoo connection.

The Eval-v1 silent-failure re-run (2026-07-22) showed weak models (glm-5.2, kimi-k2.6, gemma4) take that literally and repeat the **identical** create 15–25× (detectLoop `tool-result-not-recognized`). glm-5.2 ballooned to ~25 min/run, and in production this burns tokens and wall-clock for a write that will never persist.

## Change

Reword all four `verifyCreate`/`verifyWrite` failure messages so none of them invites an identical retry:

- **create — not read back / mismatch** and **write — not read back / mismatch** now state that repeating the identical call cannot fix a non-persisting write (and for a mismatch would duplicate the record), and instruct the agent to **stop and report the failure to the user**.

Pure agent-facing error text — no behavior change to the verification logic itself, no eval-stack rebuild needed.

## Tests (TDD)

Added assertions to `write-verification.test.ts` pinning the new contract (no `retry the create` invitation; `do not retry` + `report` present). RED first (3 failing), then GREEN.

- `write-verification.test.ts`: 20/20
- full `pinchy-odoo` suite: 440/440
- `typecheck:plugins`: clean · Prettier: clean

## Related

Loop cost here is further motivation for #124 (approval queue).