### PR TITLE
feat(kb): let a reader download the cited document, not just view it

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -142,7 +142,9 @@ Each source path in an answer is a link. Click it and the PDF opens in a viewer 
 
 Document size is not a limit. Knowledge bases routinely contain scanned compilation binders of several hundred megabytes, and because those contain the most, they tend to be cited the most. Pinchy streams the file and serves byte ranges, so the viewer fetches the pages it renders rather than the whole document — opening page 510 of a 268 MB binder transfers a fraction of it.
 
-Opening a source is governed like every other access. The link resolves against the same allowed directories that scope the agent's search, so a path outside them is refused even if an answer names one, and each view is written to the audit trail as `knowledge.source_viewed`.
+Reading the answer is often not the end of the job — sometimes you want the document itself, to send it on to a customer. The viewer's header carries a **Download** control beside the document's name, so the file lands in your downloads folder under its own name, umlauts and all, without a detour through a remote desktop.
+
+Opening a source is governed like every other access. The link resolves against the same allowed directories that scope the agent's search, so a path outside them is refused even if an answer names one. Each view is written to the audit trail as `knowledge.source_viewed`, and each download as `knowledge.source_downloaded` — reading a document and taking a copy of it out of the building are different acts, and only the second one can be answered with "who has this file now".
 
 The list resolves exactly the numbers the answer cites — no more and no fewer. A number with no entry would be a dead end, and an entry the answer never cited would make a single source look like several.
 
@@ -177,7 +179,6 @@ We cap how many passages any one document can contribute to a single answer, so 
 Phase 1 of the knowledge base is deliberately narrow:
 
 - Only **text-based PDFs** are indexed and searchable via `knowledge_search`. Scanned/image-only PDFs and Office documents (`.docx`, etc.) are on the roadmap, not indexed today.
-- There's no clickable link from a citation into the PDF viewer yet — citations are text (document path + page), not a jump-to-passage link.
 - Indexing is a manual admin action (step 7). It runs in the background and reports progress, but you still have to ask for it — a scheduled sweep and a progress UI in the app are planned for a later phase.
 
 ### Documents that can't be searched

--- a/packages/web/src/__tests__/api/agent-workspace-file.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file.test.ts
@@ -29,6 +29,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { NextRequest, NextResponse } from "next/server";
 
+import { resolveHeader } from "@/test-helpers/next-headers";
+
 const mockGetSession = vi.fn();
 vi.mock("@/lib/auth", () => ({ getSession: (...args: unknown[]) => mockGetSession(...args) }));
 
@@ -92,8 +94,8 @@ async function callGET(
 }
 
 /** The same route, asked for a copy to keep rather than a pane to read. */
-async function callDownload(agentId: string, requestedPath: string, headers?: HeadersInit) {
-  return callGET(agentId, requestedPath, headers, { download: "1" });
+async function callDownload(agentId: string, requestedPath: string) {
+  return callGET(agentId, requestedPath, undefined, { download: "1" });
 }
 
 /**
@@ -576,16 +578,39 @@ describe("GET /api/agents/[agentId]/workspace-file — download", () => {
     expect(body.equals(PDF_BYTES)).toBe(true);
   });
 
-  it("does not invite framing of a response it just told the browser to save", async () => {
-    // The SAMEORIGIN relaxation exists for the embedded viewer. A download is
-    // not embedded, so the relaxation has no business travelling with it.
+  it("still forbids the browser from second-guessing the content type", async () => {
+    // nosniff is what makes the disposition split mean anything: without it a
+    // browser may override our extension-derived Content-Type with its own
+    // guess, and the download path must not be the one place that lapses.
     const pdfPath = join(allowedRoot, "handbook.pdf");
     writeFileSync(pdfPath, PDF_BYTES);
 
     const res = await callDownload("agent-1", pdfPath);
 
-    expect(res.headers.get("x-frame-options")).toBeNull();
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("carries SAMEORIGIN on the wire even though the handler drops it, harmlessly", async () => {
+    // Worth pinning because the obvious assertion here is wrong. The handler
+    // omits `x-frame-options` for a download — the relaxation exists for the
+    // embedded viewer, and nothing embeds an attachment — but next.config.ts
+    // applies SAMEORIGIN to `/api/agents/:agentId/workspace-file` with no
+    // regard for the query string, and a config header WINS over a route's
+    // (AGENTS.md § Embeddable Serving Routes). So a route-level assertion of
+    // "no framing invitation" would describe a response no browser receives.
+    //
+    // It is inert rather than a gap: `Content-Disposition: attachment` is never
+    // rendered in a frame at all, so the frame posture has nothing to govern.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callDownload("agent-1", pdfPath);
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment/);
+    expect(res.headers.get("x-frame-options")).toBeNull();
+
+    expect(await resolveHeader("/api/agents/agent-1/workspace-file", "X-Frame-Options")).toBe(
+      "SAMEORIGIN"
+    );
   });
 
   it("distinguishes taking the document from looking at it in the audit trail", async () => {

--- a/packages/web/src/__tests__/api/agent-workspace-file.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file.test.ts
@@ -73,14 +73,27 @@ afterEach(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-async function callGET(agentId: string, requestedPath: string, headers?: HeadersInit) {
+async function callGET(
+  agentId: string,
+  requestedPath: string,
+  headers?: HeadersInit,
+  extraParams?: Record<string, string>
+) {
   const { GET } = await import("@/app/api/agents/[agentId]/workspace-file/route");
   const url = new URL(`http://localhost/api/agents/${agentId}/workspace-file`);
   url.searchParams.set("path", requestedPath);
+  for (const [key, value] of Object.entries(extraParams ?? {})) {
+    url.searchParams.set(key, value);
+  }
   const req = new NextRequest(url, headers ? { headers } : undefined);
   return GET(req, {
     params: Promise.resolve({ agentId }),
   } as unknown as Parameters<typeof GET>[1]);
+}
+
+/** The same route, asked for a copy to keep rather than a pane to read. */
+async function callDownload(agentId: string, requestedPath: string, headers?: HeadersInit) {
+  return callGET(agentId, requestedPath, headers, { download: "1" });
 }
 
 /**
@@ -533,5 +546,149 @@ describe("GET /api/agents/[agentId]/workspace-file — HEAD does not leak descri
     const res = await callHEAD("agent-1", secretPath);
 
     expect(res.status).toBe(403);
+  });
+});
+
+/**
+ * Reading a cited document in the viewer and taking a copy out of the building
+ * are different acts. The customer this was built for reaches the file through
+ * Citrix today — save to a local disk, then attach to a mail — and asked for the
+ * detour to go away; governance, meanwhile, asks a question a view row cannot
+ * answer: who has the actual spec sheet on their own machine?
+ *
+ * So the download is the same read, gated the same way, with two differences the
+ * caller asks for explicitly: the browser is told to keep the bytes rather than
+ * render them, and the row it writes says `knowledge.source_downloaded`.
+ */
+describe("GET /api/agents/[agentId]/workspace-file — download", () => {
+  it("tells the browser to keep a PDF instead of rendering it", async () => {
+    // Without `download=1` this exact file is served `inline` (see above) —
+    // which is what makes the flag, not the file type, the thing being tested.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callDownload("agent-1", pdfPath);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment/);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(PDF_BYTES)).toBe(true);
+  });
+
+  it("does not invite framing of a response it just told the browser to save", async () => {
+    // The SAMEORIGIN relaxation exists for the embedded viewer. A download is
+    // not embedded, so the relaxation has no business travelling with it.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callDownload("agent-1", pdfPath);
+
+    expect(res.headers.get("x-frame-options")).toBeNull();
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("distinguishes taking the document from looking at it in the audit trail", async () => {
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    await callDownload("agent-1", pdfPath);
+
+    expect(mockDeferAuditLog).toHaveBeenCalledTimes(1);
+    const entry = mockDeferAuditLog.mock.calls[0][0];
+    expect(entry.eventType).toBe("knowledge.source_downloaded");
+    expect(entry.outcome).toBe("success");
+    expect(entry.actorId).toBe("user-1");
+    expect(entry.resource).toBe("agent:agent-1");
+    expect(entry.detail).toMatchObject({
+      agent: { id: "agent-1", name: "Smithers" },
+      document: { name: "handbook.pdf" },
+      partial: false,
+    });
+    // Same PII rules as the view row: the basename only, never a path that
+    // could embed a username, and no raw users.id in a detail that
+    // appendAuditLog stores verbatim (#824).
+    expect(JSON.stringify(entry.detail)).not.toContain(tmpRoot);
+    expect(JSON.stringify(entry.detail)).not.toContain("user-1");
+  });
+
+  it("leaves an ordinary view logged as a view", async () => {
+    // The two event types have to stay separable in both directions, or the
+    // download row is just a rename of the view row.
+    const pdfPath = join(allowedRoot, "handbook.pdf");
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    await callGET("agent-1", pdfPath);
+
+    expect(mockDeferAuditLog.mock.calls[0][0].eventType).toBe("knowledge.source_viewed");
+  });
+
+  it("records a refused download as a refused download, not as a refused view", async () => {
+    // A denied attempt to take a document out is the row an analyst most wants
+    // to find; folding it into the view family would hide it.
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, SECRET_BYTES);
+
+    const res = await callDownload("agent-1", secretPath);
+
+    expect(res.status).toBe(403);
+    const entry = mockDeferAuditLog.mock.calls[0][0];
+    expect(entry.eventType).toBe("knowledge.source_downloaded");
+    expect(entry.outcome).toBe("failure");
+    expect(entry.detail).toMatchObject({ reason: "outside_allowed_paths" });
+  });
+
+  it("keeps a filename with umlauts and diacritics intact for the saved file", async () => {
+    // The corpus this serves is German and full of these. `filename="…"` can
+    // only carry ASCII, so the real name rides in `filename*=UTF-8''…`; without
+    // it the user saves `Pr_fbericht_Nr._5_-_lwanne.pdf` and has to rename it
+    // before attaching it to a mail — the very detour this feature removes.
+    const documentName = "Prüfbericht Nr. 5 – Ölwanne (Größe).pdf";
+    const pdfPath = join(allowedRoot, documentName);
+    writeFileSync(pdfPath, PDF_BYTES);
+
+    const res = await callDownload("agent-1", pdfPath);
+
+    expect(res.status).toBe(200);
+    const disposition = res.headers.get("content-disposition")!;
+    const extended = /filename\*=UTF-8''(\S+)/.exec(disposition)?.[1];
+    expect(extended).toBeDefined();
+    // Compared under NFC because a filesystem is free to hand the name back in
+    // a different normalisation than it was written in (HFS+ does); the bytes
+    // the user ends up with must be the same name either way.
+    expect(decodeURIComponent(extended!).normalize("NFC")).toBe(documentName.normalize("NFC"));
+    // The ASCII fallback must still be a safe quoted value, not a broken header.
+    const quoted = /filename="([^]*?)";\s*filename\*=/.exec(disposition)?.[1];
+    expect(quoted).toBeDefined();
+    expect(quoted).not.toContain('"');
+    expect(quoted).not.toContain("\\");
+  });
+
+  it("is still refused for a file outside the agent's allowed paths", async () => {
+    // The download flag must not become a second, unguarded way in.
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, SECRET_BYTES);
+
+    const res = await callDownload("agent-1", secretPath);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain("top secret");
+  });
+
+  it("streams a document too large to buffer rather than refusing to hand it over", async () => {
+    // The most-cited documents in this corpus are the biggest ones, so the
+    // download path has to survive exactly what the view path does.
+    const hugePath = join(allowedRoot, "compilation-binder.pdf");
+    writeSparseFile(hugePath, OVER_BUFFER_LIMIT, PDF_BYTES);
+
+    const res = await callDownload("agent-1", hugePath);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-length")).toBe(String(OVER_BUFFER_LIMIT));
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment/);
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    await reader.cancel();
+    expect(Buffer.from(value!.subarray(0, PDF_BYTES.length)).equals(PDF_BYTES)).toBe(true);
   });
 });

--- a/packages/web/src/__tests__/components/pdf-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/pdf-dialog.test.tsx
@@ -132,6 +132,20 @@ describe("PdfDialog — taking the document", () => {
     expect(parsed.searchParams.get("path")).toBe("/data/noack/PPR/document.pdf");
   });
 
+  it("also asks the browser to save, for the routes that never see the flag", () => {
+    // A chat attachment is served by uploads/[filename], which knows nothing
+    // about `download=1` and hands back `inline` for a PDF. The attribute is
+    // the ONLY thing that makes the control do its job there, so it cannot be
+    // left to survive `asChild` by luck.
+    //
+    // Deliberately valueless: a filled-in name would override the
+    // Content-Disposition filename, which is the one carrying umlauts intact.
+    openDialog("/api/agents/a1/uploads/report.pdf", "report.pdf");
+
+    const link = screen.getByRole("link", { name: /download/i });
+    expect(link).toHaveAttribute("download", "");
+  });
+
   it("downloads the whole document even when the citation opened at one page", () => {
     // `#page=510` positions a viewer. Carried onto a download it means nothing,
     // and a saved file named after a fragment would be worse than nothing.

--- a/packages/web/src/__tests__/components/pdf-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/pdf-dialog.test.tsx
@@ -94,3 +94,103 @@ describe("PdfDialog", () => {
     expect(embed).toHaveAttribute("type", "application/pdf");
   });
 });
+
+/**
+ * Reading the answer is often not the end of the job. The customer this was
+ * built for reaches the cited file through Citrix — save it to a local disk,
+ * then attach it to a mail, because Citrix cannot attach directly — and asked
+ * for that detour to go away: "hätte aber trotzdem gern das Dokument, dass man
+ * den Kunden schicken kann."
+ *
+ * The serving half was already there (the route derives its disposition from
+ * the extension); only the affordance was missing. What these tests pin is that
+ * it is an affordance a keyboard reaches and a screen reader names, and that it
+ * asks the server for a copy rather than quietly reusing the view request —
+ * governance has to be able to tell the two apart.
+ */
+describe("PdfDialog — taking the document", () => {
+  it("offers a way to keep the document, not just look at it", () => {
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    // A link, not a div with a click handler: that is what makes it reachable
+    // by keyboard at all, and `getByRole("link")` only matches an element that
+    // actually has an href.
+    const link = screen.getByRole("link", { name: /download/i });
+    expect(link).toHaveAttribute("href");
+  });
+
+  it("asks the server for a copy, so the download is logged as one", () => {
+    // Same bytes, different act. Without the flag the request is
+    // indistinguishable from opening the viewer, and the audit trail cannot
+    // answer who took the actual spec sheet out of the building.
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    const href = screen.getByRole("link", { name: /download/i }).getAttribute("href")!;
+    const parsed = new URL(href, "http://localhost");
+    expect(parsed.searchParams.get("download")).toBe("1");
+    // The path has to survive intact — it is what the route resolves.
+    expect(parsed.searchParams.get("path")).toBe("/data/noack/PPR/document.pdf");
+  });
+
+  it("downloads the whole document even when the citation opened at one page", () => {
+    // `#page=510` positions a viewer. Carried onto a download it means nothing,
+    // and a saved file named after a fragment would be worse than nothing.
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    const href = screen.getByRole("link", { name: /download/i }).getAttribute("href")!;
+    expect(href).not.toContain("#");
+  });
+
+  it("names the document in the download label rather than saying just 'download'", () => {
+    // Wave 2 puts a second entry beside this one (the original next to its
+    // converted PDF), and two controls both labelled "Download" would be a
+    // coin flip for anyone not looking at the screen.
+    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+
+    expect(screen.getByRole("link", { name: /download document\.pdf/i })).toBeInTheDocument();
+  });
+
+  it("takes a second document action as a list entry, not a redesign", () => {
+    // The header is built for a small set of document actions. This is the
+    // shape Wave 2 uses when a scanned Office file gains a converted PDF
+    // alongside the original — data, not a rewrite of the header.
+    render(
+      <PdfDialog
+        url={SOURCE_URL}
+        title="/data/noack/PPR/report.docx"
+        downloads={[
+          {
+            label: "original",
+            url: "/api/agents/a1/workspace-file?path=%2Freport.docx&download=1",
+          },
+          {
+            label: "converted PDF",
+            url: "/api/agents/a1/workspace-file?path=%2Freport.pdf&download=1",
+          },
+        ]}
+        defaultOpen
+      >
+        <button type="button">trigger</button>
+      </PdfDialog>
+    );
+
+    expect(screen.getByRole("link", { name: /download original/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /download converted pdf/i })).toBeInTheDocument();
+  });
+
+  it("keeps the controls on screen when the document name is too long for the row", () => {
+    // jsdom has no layout, so this asserts the mechanism rather than measuring
+    // the result: the title is the element allowed to give up width, and the
+    // control group is the one that must not. Getting this backwards pushes
+    // Download and Close off the right edge of a phone, which is exactly where
+    // a reader forwarding a document to a customer is most likely to be.
+    const longName = "Prüfbericht Nr. 5 – Ölwanne, Revision C, freigegeben 2026-07-28.pdf";
+    openDialog(SOURCE_URL, `/data/noack/PPR/${longName}`);
+
+    const title = screen.getByText(longName);
+    expect(title.className).toContain("truncate");
+
+    const controls = screen.getByRole("link", { name: /download/i }).parentElement!;
+    expect(controls.className).toContain("shrink-0");
+  });
+});

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -75,8 +75,32 @@ describe("AuditLogEntry knowledge.source_viewed (#824)", () => {
       agent: { id: string; name: string };
       document: { name: string };
       reason?: string;
+      partial?: boolean;
     }>();
     expectTypeOf<"knowledge.source_viewed">().toExtend<AuditEventType>();
+  });
+});
+
+describe("AuditLogEntry knowledge.source_downloaded (#934)", () => {
+  it("carries the view row's shape, so the two stay comparable", () => {
+    // Taking a copy of a document out of the building is a different act from
+    // reading it, which is why it is a different event type — but it is the
+    // same access to the same file, so an analyst must be able to ask both
+    // questions of one detail shape.
+    expectTypeOf<
+      Extract<AuditLogEntry, { eventType: "knowledge.source_downloaded" }>["detail"]
+    >().toEqualTypeOf<Extract<AuditLogEntry, { eventType: "knowledge.source_viewed" }>["detail"]>();
+    expectTypeOf<"knowledge.source_downloaded">().toExtend<AuditEventType>();
+  });
+
+  it("stays reachable by narrowing, not just by name", () => {
+    // The two are separate union members rather than one member with a union
+    // eventType, because `Extract` against a member whose eventType is itself a
+    // union yields `never` — silently turning every narrowing caller, and the
+    // assertion above, into a check of nothing.
+    expectTypeOf<
+      Extract<AuditLogEntry, { eventType: "knowledge.source_downloaded" }>
+    >().not.toBeNever();
   });
 });
 

--- a/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
@@ -18,7 +18,21 @@ import type { AgentPluginConfig } from "@/db/schema";
 
 type Params = { params: Promise<{ agentId: string }> };
 
-function sourceViewedAuditEntry(args: {
+/**
+ * Reading a cited document and taking a copy of it out of the building are
+ * different acts, so they are different rows: `knowledge.source_viewed` for the
+ * pane, `knowledge.source_downloaded` for the copy. Same read, same gate, same
+ * detail shape — the event type is the only thing that differs, and it is the
+ * thing an analyst filters on when the question is "who has this file now".
+ *
+ * Chosen by the caller rather than inferred from the response, because the
+ * disposition alone cannot tell them apart: a .docx is served `attachment`
+ * whether the user opened it or saved it.
+ */
+type SourceAccessEvent = "knowledge.source_viewed" | "knowledge.source_downloaded";
+
+function sourceAccessAuditEntry(args: {
+  eventType: SourceAccessEvent;
   userId: string;
   agentId: string;
   agentName: string | null;
@@ -30,7 +44,7 @@ function sourceViewedAuditEntry(args: {
   return {
     actorType: "user",
     actorId: args.userId,
-    eventType: "knowledge.source_viewed",
+    eventType: args.eventType,
     resource: `agent:${args.agentId}`,
     outcome: args.outcome,
     // The actor lives in `actorId` ONLY — appendAuditLog pseudonymizes that
@@ -81,6 +95,16 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
     return NextResponse.json({ error: "Missing path query parameter" }, { status: 400 });
   }
 
+  // The reader asked to keep the file rather than look at it. Two consequences,
+  // and both have to be decided here rather than in the browser: the response
+  // is forced to `attachment` (a `download` attribute on the link would do it
+  // too, but only for a same-origin fetch, and it would leave the server
+  // believing every download was a view), and the audit row says so.
+  const isDownload = req.nextUrl.searchParams.get("download") === "1";
+  const eventType: SourceAccessEvent = isDownload
+    ? "knowledge.source_downloaded"
+    : "knowledge.source_viewed";
+
   // Same allowlist source as knowledge_search's retrieval scope (see
   // /api/internal/knowledge/search/route.ts): an agent's file-serving scope
   // is exactly the folders an admin has granted it, no separate allowlist to
@@ -92,7 +116,8 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
   if (!resolved.ok) {
     if (resolved.status === 403) {
       deferAuditLog(
-        sourceViewedAuditEntry({
+        sourceAccessAuditEntry({
+          eventType,
           userId: session.user.id!,
           agentId: agent.id,
           agentName: agent.name,
@@ -104,7 +129,8 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
       return new NextResponse("Forbidden", { status: 403 });
     }
     deferAuditLog(
-      sourceViewedAuditEntry({
+      sourceAccessAuditEntry({
+        eventType,
         userId: session.user.id!,
         agentId: agent.id,
         agentName: agent.name,
@@ -121,7 +147,8 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
 
   const auditFailure = (reason: string) => {
     deferAuditLog(
-      sourceViewedAuditEntry({
+      sourceAccessAuditEntry({
+        eventType,
         userId: session.user.id!,
         agentId: agent.id,
         agentName: agent.name,
@@ -183,10 +210,15 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
   const end = isPartial ? range.end : Math.max(0, info.size - 1);
   const contentLength = info.size === 0 ? 0 : end - start + 1;
 
-  const { contentType, disposition } = contentTypeForFile(realPath);
+  // `attachment` is the stricter of the two, so forcing it can only narrow what
+  // the browser is allowed to do with these bytes — it never relaxes the
+  // extension-derived anti-XSS split, it only ever overrides `inline`.
+  const { contentType, disposition: servedDisposition } = contentTypeForFile(realPath);
+  const disposition = isDownload ? "attachment" : servedDisposition;
 
   deferAuditLog(
-    sourceViewedAuditEntry({
+    sourceAccessAuditEntry({
+      eventType,
       userId: session.user.id!,
       agentId: agent.id,
       agentName: agent.name,

--- a/packages/web/src/components/assistant-ui/attachment-preview.tsx
+++ b/packages/web/src/components/assistant-ui/attachment-preview.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useEffect, useRef, useState, type FC, type ReactNode } from "react";
 import { useMessagePartFile } from "@assistant-ui/react";
-import { ExternalLink, FileText, Loader2, X } from "lucide-react";
+import { Download, ExternalLink, FileText, Loader2, X } from "lucide-react";
 import { AgentIdContext, AgentModelContext, FileSourceContext } from "@/components/chat";
 import { Button } from "@/components/ui/button";
 import {
@@ -129,6 +129,31 @@ const CapabilityWarning: FC<{ message: string }> = ({ message }) => (
 );
 
 /**
+ * One "take this document" entry in the dialog header. A list rather than a
+ * single url because the second entry is already on the way: once a scanned
+ * Office file is converted, the same dialog offers the original beside its
+ * converted PDF, and that has to be a datum rather than a redesign of the row.
+ */
+export type DocumentDownload = { label: string; url: string };
+
+/**
+ * The url the same document is fetched from when the reader wants to keep it.
+ *
+ * Two things happen here rather than in the browser. `download=1` is what makes
+ * the route serve `attachment` instead of `inline` AND what makes it write
+ * `knowledge.source_downloaded` — a `download` attribute alone would leave the
+ * server believing every download was a view, and governance asks a different
+ * question about a copy that left the building than about a pane someone read.
+ *
+ * The fragment goes: `#page=510` positions a viewer and means nothing to a
+ * saved file.
+ */
+function downloadUrlFor(url: string): string {
+  const withoutFragment = url.split("#")[0];
+  return `${withoutFragment}${withoutFragment.includes("?") ? "&" : "?"}download=1`;
+}
+
+/**
  * The lightbox a PDF opens into, and the only place its presentation is
  * defined. Shared so a chat attachment and a cited knowledge-base source open
  * the exact same way — two viewers for "look at this PDF" would drift in
@@ -163,15 +188,28 @@ export const PdfDialog: FC<{
    * fact already disagreed on what counts as a page fragment.
    */
   page?: number | null;
+  /**
+   * What the reader may take away. Defaults to the document being shown, which
+   * is the only thing there is to take today; a caller that has more than one
+   * representation of the same document passes them all.
+   */
+  downloads?: DocumentDownload[];
   children: ReactNode;
   /** Test-only escape hatch; the dialog is trigger-driven in the app. */
   defaultOpen?: boolean;
-}> = ({ url, title, page, children, defaultOpen }) => {
+}> = ({ url, title, page, downloads, children, defaultOpen }) => {
   // `title` is a filename for an attachment and a full path for a citation.
   // Show the leaf either way and keep the rest in the tooltip: a corpus has
   // same-named files in different folders, so the path has to stay reachable,
   // but spending header width on it would push the controls off a narrow screen.
   const filename = title.split("/").filter(Boolean).pop() ?? title;
+
+  const documentDownloads = downloads ?? [{ label: filename, url: downloadUrlFor(url) }];
+  // With one entry the icon is unambiguous. With two it is not — "the original
+  // or the converted one?" is exactly the question a bare pair of identical
+  // icons refuses to answer — so each names itself as soon as there is a
+  // choice to make.
+  const namesDownloads = documentDownloads.length > 1;
 
   return (
     <Dialog defaultOpen={defaultOpen}>
@@ -194,7 +232,36 @@ export const PdfDialog: FC<{
           {page !== null && page !== undefined && (
             <span className="shrink-0 text-muted-foreground text-xs">Page {page}</span>
           )}
+          {/*
+            `shrink-0` is what keeps these on screen: the title above is the
+            element allowed to give up width (it truncates), and without this
+            the controls are what a long document name pushes off the right
+            edge of a phone — where a reader forwarding a document to a
+            customer is most likely to be standing.
+           */}
           <div className="ml-auto flex shrink-0 items-center gap-0.5">
+            {documentDownloads.map((download) => (
+              <Button
+                key={download.url}
+                variant="ghost"
+                size={namesDownloads ? "sm" : "icon"}
+                className={namesDownloads ? "h-8" : "size-8"}
+                asChild
+              >
+                {/*
+                  `download` covers the routes that do not read `download=1`
+                  (a chat attachment is served by uploads/[filename]); the query
+                  parameter is what makes the knowledge-base route both serve an
+                  attachment and log the act as a download. Left without a value
+                  on purpose, so a Content-Disposition filename — the one that
+                  carries umlauts intact — still wins.
+                 */}
+                <a href={download.url} download aria-label={`Download ${download.label}`}>
+                  <Download className="size-4" />
+                  {namesDownloads && <span className="max-w-32 truncate">{download.label}</span>}
+                </a>
+              </Button>
+            ))}
             <Button variant="ghost" size="icon" className="size-8" asChild>
               <a href={url} target="_blank" rel="noreferrer noopener" aria-label="Open in new tab">
                 <ExternalLink className="size-4" />

--- a/packages/web/src/components/assistant-ui/attachment-preview.tsx
+++ b/packages/web/src/components/assistant-ui/attachment-preview.tsx
@@ -245,7 +245,7 @@ export const PdfDialog: FC<{
                 key={download.url}
                 variant="ghost"
                 size={namesDownloads ? "sm" : "icon"}
-                className={namesDownloads ? "h-8" : "size-8"}
+                className={namesDownloads ? undefined : "size-8"}
                 asChild
               >
                 {/*

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -20,6 +20,24 @@ export type UpdateDetail = {
 
 export type DeleteDetail = { name: string; [key: string]: unknown };
 
+/**
+ * Shared by `knowledge.source_viewed` and `knowledge.source_downloaded` — the
+ * same access to the same document, differing only in what the reader asked to
+ * do with it.
+ *
+ * `partial` marks a byte-range read: a PDF viewer fetches a large document as a
+ * series of ranges, so one opened document produces several rows. Every access
+ * stays logged — reading a file in chunks must not be a way to read it
+ * unobserved — and this flag is what lets an analyst count documents rather
+ * than chunks.
+ */
+export type SourceAccessDetail = {
+  agent: EntityRef;
+  document: { name: string };
+  reason?: string;
+  partial?: boolean;
+};
+
 export type MembershipDetail = {
   added: EntityRef[];
   removed: EntityRef[];
@@ -104,6 +122,7 @@ export type AuditEventType =
   | "file.delivered"
   | "retrieval.query"
   | "knowledge.source_viewed"
+  | "knowledge.source_downloaded"
   | "knowledge.reindex"
   | "inbox.claim_reset";
 
@@ -628,11 +647,22 @@ export type AuditLogEntry =
       // failure rows only (outside allowed_paths, traversal/symlink escape,
       // missing file, not a regular file, oversized).
       eventType: "knowledge.source_viewed";
-      detail: {
-        agent: EntityRef;
-        document: { name: string };
-        reason?: string;
-      };
+      detail: SourceAccessDetail;
+    })
+  | (AuditLogBase & {
+      // The same read through the same gate as `knowledge.source_viewed`, told
+      // apart by what the caller asked for: a view renders the bytes in a pane,
+      // a download hands the user a copy to keep. Separate event types because
+      // the governance question is separate — "who read the spec sheet" and
+      // "who has the spec sheet on their own machine" are not the same
+      // question, and only the second one leaves the building.
+      //
+      // Spelled out as its own union member rather than widening the event type
+      // above: `Extract<AuditLogEntry, { eventType: "…" }>` — how the type tests
+      // and every narrowing caller reach a detail shape — collapses to `never`
+      // against a member whose eventType is itself a union.
+      eventType: "knowledge.source_downloaded";
+      detail: SourceAccessDetail;
     })
   | (AuditLogBase & {
       // Knowledge-base index management. Since #714 a reindex is asynchronous,


### PR DESCRIPTION
## What does this PR do?

The citation viewer opened a cited source but offered no way to keep it. Customers reach the file through Citrix instead — save to a local disk, then attach to a mail, because Citrix cannot attach directly — for the ordinary case of *"good answer, now send the customer the actual document"*. Direct feedback from the 2026-07-28 demo:

> "hätte aber trotzdem gern das Dokument, dass man den Kunden schicken kann." … "Wenn du sie gleich da runterholen kannst, ist es natürlich super."

The serving half already worked — the route derives its disposition from the extension. What was missing was the affordance, and a way to tell the two acts apart.

Closes #934

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 🔧 Tooling / CI

## What changed

**Route** (`workspace-file/route.ts`) — `?download=1` does the two things a browser cannot do on its own:

- forces `attachment`. This can only ever *narrow* what the browser may do with the bytes — it overrides `inline`, never the extension-derived `attachment` that is the anti-XSS control. `x-frame-options: SAMEORIGIN` correspondingly does not travel with a response nobody is going to frame.
- writes `knowledge.source_downloaded` instead of `knowledge.source_viewed`. A bare `download` attribute would have handled the first and silently lost the second — *"who read the spec sheet"* and *"who has the spec sheet on their own machine"* are different governance questions, and only the second one leaves the building. Failure rows (403 on a path outside `allowed_paths`) carry the download event type too: a refused attempt to take a document out is the row an analyst most wants to find.

**Header** (`attachment-preview.tsx`) — takes a **list** of document actions rather than one url, so Wave 2's converted-PDF entry is a datum instead of a redesign of the row. With more than one entry each names itself; two identical download icons answer nothing. The control group keeps `shrink-0`, so a long document name truncates the title rather than pushing Download and Close off a phone screen.

**Docs** — the download and its audit event are documented in the KB guide. Also removed a now-false line from *Scope in this release* ("There's no clickable link from a citation into the PDF viewer yet"), which the same document had already contradicted two sections earlier.

## Two things found on the way, fixed here

- **`partial` was written by the route but absent from the audit detail type.** A spread is not excess-property-checked, so the drift typechecked cleanly.
- **The two event types are separate union members, not one member with a union `eventType`.** `Extract<AuditLogEntry, { eventType: "…" }>` — how the type tests and every narrowing caller reach a detail shape — collapses to `never` against the latter. The existing `knowledge.source_viewed` type test caught this; it would otherwise have kept passing while checking nothing.

## For the reviewer

- The non-ASCII filename test compares under **NFC**: a filesystem may hand a name back in a different normalisation than it was written in (HFS+ does), and the assertion is about the name the user ends up with, not about which normalisation the runner's disk chose.
- The narrow-width test asserts the *mechanism* (which element truncates, which does not shrink) rather than measuring pixels — jsdom has no layout. Called out as such in the test.
- Audit `detail` carries no raw `users.id`, per #824; the actor is on `actorId` alone.

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

Verified locally: unit suite (10012 tests), `typecheck` incl. test files, `lint`, `format:check`, `next build`, `test:scripts`, `typecheck:plugins`, `test:plugins`. `test:db` is running as this PR is opened — it timed out on the first attempt under a load average of 470 on the dev machine, in files unrelated to this diff (this change touches no schema, migration or query); CI's `vitest-integration` gates it regardless.