### PR TITLE
feat(kb): anchor a citation with a locator, and cite a path users recognise (#933)

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -123,18 +123,22 @@ Go back to the agent's chat and start asking questions. The agent calls `knowled
 
 ### Cite-then-answer
 
-Every grounded answer cites its sources inline, like `[1]` and `[2]`, and ends with a **Sources** list mapping each number to its document path and page:
+Every grounded answer cites its sources inline, like `[1]` and `[2]`, and ends with a **Sources** list mapping each number to its document path and the spot inside it:
 
 ```
 **Sources:**
 
-- [1] /data/handbook/policies/Employee Handbook.pdf — p. 12
-- [2] /data/handbook/policies/Employee Handbook.pdf — p. 14
+- [1] handbook/policies/Employee Handbook.pdf — p. 12
+- [2] handbook/policies/Employee Handbook.pdf — p. 14
 ```
 
-That makes every claim in the answer traceable back to a specific document and page, even though the underlying search results aren't shown in the chat.
+That makes every claim in the answer traceable back to a specific document and a specific spot in it, even though the underlying search results aren't shown in the chat.
 
-Sources are named by their full path, not just the filename. In a real document tree a bare filename is often impossible to act on — you can't tell which of several folders it lives in, and two folders may hold files with the same name. The path is what lets you open the document and check the claim for yourself.
+Sources are named by their path, not just the filename. In a real document tree a bare filename is often impossible to act on — you can't tell which of several folders it lives in, and two folders may hold files with the same name. The path is what lets you open the document and check the claim for yourself.
+
+The path you see is the one you'd recognise: it starts at the folder you mounted, not at the container path underneath. If you mounted a share as `quality`, a citation reads `quality/QM/Handbook.pdf` — the same tree you see in Explorer, minus the plumbing.
+
+Not every document has pages, which is why a citation says "the spot" rather than "the page". A PDF is cited by page and a slide deck by slide number, because both are properties of the file itself. A Word document is cited by its heading path instead: where a Word page break falls depends on fonts and printer settings, so a page number would describe our rendering of the document rather than yours, and a citation should never state something you can't verify in the file you open.
 
 ### Open a source and check it
 

--- a/packages/plugins/pinchy-knowledge/index.test.ts
+++ b/packages/plugins/pinchy-knowledge/index.test.ts
@@ -134,7 +134,8 @@ describe("pinchy-knowledge plugin", () => {
               chunkId: "c1",
               text: "Snippet one.",
               sourcePath: "/data/kb/a.pdf",
-              page: 3,
+              citationPath: "kb/a.pdf",
+              locator: { kind: "page", page: 3 },
               docName: "a.pdf",
             },
           ],
@@ -169,10 +170,10 @@ describe("pinchy-knowledge plugin", () => {
         text:
           "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
           "The reader sees only your answer, never these passages, so end it with a Sources list " +
-          "giving each number you cited the document path and page exactly as written above — " +
+          "giving each number you cited the document path and position exactly as written above — " +
           "every number you cite, and no number you did not. " +
           "If they do not answer the question, say so instead of answering from memory.\n\n" +
-          '[1] /data/kb/a.pdf (p. 3): "Snippet one."',
+          '[1] kb/a.pdf (p. 3): "Snippet one."',
       },
     ]);
     // details keeps the human-readable docName: an audit reviewer wants to
@@ -317,26 +318,33 @@ describe("formatWithCitations", () => {
       chunkId: "c1",
       text: "Snippet one.",
       sourcePath: "/data/kb/a.pdf",
-      page: 3,
+      citationPath: "kb/a.pdf",
+      locator: { kind: "page", page: 3 },
       docName: "a.pdf",
     },
     {
       chunkId: "c2",
       text: "Snippet two.",
       sourcePath: "/data/kb/b.pdf",
-      page: null,
+      citationPath: "kb/b.pdf",
+      locator: null,
       docName: "b.pdf",
     },
   ];
 
-  it("formats results as numbered, citable sources with sourcePath and page", () => {
+  // The contract prefix, spelled once so the locator/citation assertions below
+  // stay readable. It is still pinned literally where it matters most — the
+  // dispatch test above asserts the whole payload without this indirection.
+  const CONTRACT =
+    "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
+    "The reader sees only your answer, never these passages, so end it with a Sources list " +
+    "giving each number you cited the document path and position exactly as written above — " +
+    "every number you cite, and no number you did not. " +
+    "If they do not answer the question, say so instead of answering from memory.\n\n";
+
+  it("formats results as numbered, citable sources with citationPath and locator", () => {
     expect(formatWithCitations(results)).toBe(
-      "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
-        "The reader sees only your answer, never these passages, so end it with a Sources list " +
-        "giving each number you cited the document path and page exactly as written above — " +
-        "every number you cite, and no number you did not. " +
-        "If they do not answer the question, say so instead of answering from memory.\n\n" +
-        '[1] /data/kb/a.pdf (p. 3): "Snippet one."\n\n[2] /data/kb/b.pdf: "Snippet two."'
+      CONTRACT + '[1] kb/a.pdf (p. 3): "Snippet one."\n\n[2] kb/b.pdf: "Snippet two."'
     );
   });
 
@@ -383,7 +391,10 @@ describe("formatWithCitations", () => {
     // change exists to close, so the contract has to close it here too.
     const out = formatWithCitations(results);
     expect(out).toMatch(/sources list/i);
-    expect(out).toMatch(/path and page/i);
+    // "position", not "page": only PDFs have pages, and asking for one would
+    // make the model state something false of a Word file (#933).
+    expect(out).toMatch(/path and position/i);
+    expect(out).not.toMatch(/path and page/i);
   });
 
   it("tells the model to admit a miss rather than answer from memory", () => {
@@ -393,26 +404,48 @@ describe("formatWithCitations", () => {
     expect(formatWithCitations(results)).toMatch(/say so instead of answering from memory/i);
   });
 
-  it("identifies a source by its full path, not its bare filename", () => {
+  it("cites the path the reader recognises, never the container path", () => {
+    // The absolute path is what the CONTAINER sees. Showing it in a citation
+    // misleads: the customer knows the tree below the mount from Explorer and
+    // has never seen "/data/noack". The model can only cite what it is shown,
+    // so the leak has to be closed here, in the string. (#933)
+    const noack: KnowledgeSearchResult[] = [
+      {
+        chunkId: "c1",
+        text: "Incubate 24 h.",
+        sourcePath: "/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf",
+        citationPath: "OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf",
+        locator: { kind: "page", page: 2 },
+        docName: "PI_EColi.pdf",
+      },
+    ];
+    const out = formatWithCitations(noack);
+    expect(out).toBe(
+      CONTRACT + '[1] OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf (p. 2): "Incubate 24 h."'
+    );
+    expect(out).not.toContain("/data/");
+  });
+
+  it("identifies a source by its path, not its bare filename", () => {
     // A real corpus nests documents many levels deep and reuses filenames
     // across folders (the 3M/Noack corpus has ~194 docs under
-    // /data/noack/OLD/QF_2012/PrintingFiles_QF/...). The model can only cite
-    // what it is shown, so a bare basename leaves the reader unable to FIND
-    // the document and verify the claim — which is the entire point of
-    // cite-then-answer. Found in the 2026-07-16 live Block-A test: the answer
-    // was fully grounded, but the citation "PI_EColi-Coliform_Count_Plate.pdf"
-    // was unfindable in a 194-document tree.
+    // /data/noack/OLD/QF_2012/PrintingFiles_QF/...). A bare basename leaves the
+    // reader unable to FIND the document and verify the claim — which is the
+    // entire point of cite-then-answer. Found in the 2026-07-16 live Block-A
+    // test: the answer was fully grounded, but the citation
+    // "PI_EColi-Coliform_Count_Plate.pdf" was unfindable in a 194-document tree.
     const nested: KnowledgeSearchResult[] = [
       {
         chunkId: "c1",
         text: "Incubate 24 h.",
         sourcePath: "/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf",
-        page: 2,
+        citationPath: "OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf",
+        locator: { kind: "page", page: 2 },
         docName: "PI_EColi.pdf",
       },
     ];
     const out = formatWithCitations(nested);
-    expect(out).toContain("/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf");
+    expect(out).toContain("OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf");
   });
 
   it("distinguishes same-named documents in different folders", () => {
@@ -423,20 +456,60 @@ describe("formatWithCitations", () => {
         chunkId: "c1",
         text: "A.",
         sourcePath: "/data/kb/2011/spec.pdf",
-        page: 1,
+        citationPath: "2011/spec.pdf",
+        locator: { kind: "page", page: 1 },
         docName: "spec.pdf",
       },
       {
         chunkId: "c2",
         text: "B.",
         sourcePath: "/data/kb/2012/spec.pdf",
-        page: 1,
+        citationPath: "2012/spec.pdf",
+        locator: { kind: "page", page: 1 },
         docName: "spec.pdf",
       },
     ];
     const out = formatWithCitations(collision);
-    expect(out).toContain("/data/kb/2011/spec.pdf");
-    expect(out).toContain("/data/kb/2012/spec.pdf");
+    expect(out).toContain("2011/spec.pdf");
+    expect(out).toContain("2012/spec.pdf");
+  });
+
+  it("renders a Word anchor as its heading path, a slide as its number, a sheet as its rows", () => {
+    // Only the page producer exists today; these three are what Wave 2 emits.
+    // Pinned now so a later producer cannot quietly invent a second spelling
+    // for the same anchor — the whole reason the locator is a closed union.
+    const mixed: KnowledgeSearchResult[] = [
+      {
+        chunkId: "c1",
+        text: "Goods are checked on arrival.",
+        sourcePath: "/data/noack/QM/handbook.docx",
+        citationPath: "QM/handbook.docx",
+        locator: { kind: "heading", headings: ["Quality", "Incoming goods"] },
+        docName: "handbook.docx",
+      },
+      {
+        chunkId: "c2",
+        text: "Q3 revenue was flat.",
+        sourcePath: "/data/noack/Sales/review.pptx",
+        citationPath: "Sales/review.pptx",
+        locator: { kind: "slide", slide: 4 },
+        docName: "review.pptx",
+      },
+      {
+        chunkId: "c3",
+        text: "Acme GmbH, DE, approved.",
+        sourcePath: "/data/noack/Platform/suppliers.xlsx",
+        citationPath: "Platform/suppliers.xlsx",
+        locator: { kind: "sheet", sheet: "Suppliers", startRow: 5, endRow: 12 },
+        docName: "suppliers.xlsx",
+      },
+    ];
+    expect(formatWithCitations(mixed)).toBe(
+      CONTRACT +
+        '[1] QM/handbook.docx (§ Quality > Incoming goods): "Goods are checked on arrival."\n\n' +
+        '[2] Sales/review.pptx (slide 4): "Q3 revenue was flat."\n\n' +
+        '[3] Platform/suppliers.xlsx (Suppliers, rows 5-12): "Acme GmbH, DE, approved."'
+    );
   });
 
   it("returns a deterministic empty-state message for no results", () => {
@@ -449,10 +522,34 @@ describe("formatWithCitations", () => {
 
 describe("returnedDocumentIds", () => {
   it("dedupes chunks from the same document into a single ref", () => {
+    // Keyed on the ABSOLUTE sourcePath, not the citation path: this ref is a
+    // document identity for the audit trail, and the trail has to name the
+    // path the filesystem answers to.
     const results: KnowledgeSearchResult[] = [
-      { chunkId: "c1", text: "a", sourcePath: "/data/kb/a.pdf", page: 1, docName: "a.pdf" },
-      { chunkId: "c2", text: "b", sourcePath: "/data/kb/a.pdf", page: 2, docName: "a.pdf" },
-      { chunkId: "c3", text: "c", sourcePath: "/data/kb/b.pdf", page: 1, docName: "b.pdf" },
+      {
+        chunkId: "c1",
+        text: "a",
+        sourcePath: "/data/kb/a.pdf",
+        citationPath: "kb/a.pdf",
+        locator: { kind: "page", page: 1 },
+        docName: "a.pdf",
+      },
+      {
+        chunkId: "c2",
+        text: "b",
+        sourcePath: "/data/kb/a.pdf",
+        citationPath: "kb/a.pdf",
+        locator: { kind: "page", page: 2 },
+        docName: "a.pdf",
+      },
+      {
+        chunkId: "c3",
+        text: "c",
+        sourcePath: "/data/kb/b.pdf",
+        citationPath: "kb/b.pdf",
+        locator: { kind: "page", page: 1 },
+        docName: "b.pdf",
+      },
     ];
     expect(returnedDocumentIds(results)).toEqual([
       { id: "/data/kb/a.pdf", name: "a.pdf" },

--- a/packages/plugins/pinchy-knowledge/index.ts
+++ b/packages/plugins/pinchy-knowledge/index.ts
@@ -9,6 +9,8 @@
  * of Pinchy's governance logic already lives.
  */
 
+import { formatLocator, type ChunkLocator } from "./locator";
+
 interface PluginToolContext {
   agentId?: string;
 }
@@ -57,13 +59,19 @@ interface AgentTool {
 // Mirrors the response shape of POST /api/internal/knowledge/search
 // (packages/web/src/app/api/internal/knowledge/search/route.ts). Note there
 // is deliberately no `documentId` here — the route's public response only
-// exposes chunkId/text/sourcePath/page/docName, so the plugin uses
-// `sourcePath` as the per-document identity below.
+// exposes chunkId/text/sourcePath/citationPath/locator/docName, so the plugin
+// uses `sourcePath` as the per-document identity below.
+//
+// Two paths, two jobs: `sourcePath` is absolute and IDENTIFIES the document
+// (audit refs, anything that has to open the file); `citationPath` is what the
+// reader is shown, relative to the data root, and is the only one that belongs
+// in the citation string.
 export interface KnowledgeSearchResult {
   chunkId: string;
   text: string;
   sourcePath: string;
-  page: number | null;
+  citationPath: string;
+  locator: ChunkLocator | null;
   docName: string;
 }
 
@@ -119,7 +127,11 @@ export function returnedDocumentIds(results: KnowledgeSearchResult[]): DocumentR
 const CITATION_CONTRACT =
   "Cite the passages you use inline as [1], [2] next to the claim each one supports. " +
   "The reader sees only your answer, never these passages, so end it with a Sources list " +
-  "giving each number you cited the document path and page exactly as written above — " +
+  // "position", not "page": the anchor is a ChunkLocator now, and only PDFs
+  // have pages. Asking for a page would make the model state something false of
+  // a Word file, whose pagination is a rendering result rather than a property
+  // of the document the reader opens (#933).
+  "giving each number you cited the document path and position exactly as written above — " +
   "every number you cite, and no number you did not. " +
   "If they do not answer the question, say so instead of answering from memory.";
 
@@ -138,14 +150,21 @@ const NO_RESULTS =
  * that says what to do with them. Deterministic and unit-tested: the same
  * input always yields the same output string.
  *
- * Sources are identified by full `sourcePath`, not `docName`. A citation only
- * earns trust if the reader can FIND the document and check it: a bare
- * basename is unfindable in a deep corpus and, worse, collapses same-named
- * files from different folders into one indistinguishable citation. The model
- * can only cite what it is shown, so the path has to be in this string — the
- * tool result never reaches the browser. `docName` stays in the response shape
- * for `returnedDocumentIds`, which wants a human-readable name for the audit
- * row, not a locator.
+ * Sources are identified by their PATH, not `docName`. A citation only earns
+ * trust if the reader can FIND the document and check it: a bare basename is
+ * unfindable in a deep corpus and, worse, collapses same-named files from
+ * different folders into one indistinguishable citation. The model can only
+ * cite what it is shown, so the path has to be in this string — the tool result
+ * never reaches the browser. `docName` stays in the response shape for
+ * `returnedDocumentIds`, which wants a human-readable name for the audit row,
+ * not a locator.
+ *
+ * The path shown is `citationPath` — relative to the data root — because the
+ * absolute `/data/<mount>/…` form is what the CONTAINER sees and nobody at the
+ * customer recognises it (#933). And the anchor is a `ChunkLocator`, not a
+ * page: only PDFs have pages, and a Word file's page number is a rendering
+ * result, so citing one would state something false of the document the reader
+ * opens.
  */
 export function formatWithCitations(results: KnowledgeSearchResult[]): string {
   if (results.length === 0) {
@@ -153,8 +172,8 @@ export function formatWithCitations(results: KnowledgeSearchResult[]): string {
   }
   const sources = results
     .map((result, index) => {
-      const pageSuffix = result.page != null ? ` (p. ${result.page})` : "";
-      return `[${index + 1}] ${result.sourcePath}${pageSuffix}: "${result.text}"`;
+      const anchor = result.locator ? ` (${formatLocator(result.locator)})` : "";
+      return `[${index + 1}] ${result.citationPath}${anchor}: "${result.text}"`;
     })
     .join("\n\n");
   return `${CITATION_CONTRACT}\n\n${sources}`;

--- a/packages/plugins/pinchy-knowledge/locator.ts
+++ b/packages/plugins/pinchy-knowledge/locator.ts
@@ -1,0 +1,68 @@
+/**
+ * Where inside a document a chunk sits — the anchor a citation points at.
+ *
+ * `kb_chunks` used to carry a bare `page`, which only PDFs have. Each format
+ * needs a different anchor, and the reason is not cosmetic:
+ *
+ *   PDF          page          intrinsic
+ *   PowerPoint   slide number  intrinsic, and slide N is PDF page N
+ *   Spreadsheet  sheet + rows  intrinsic
+ *   Word         heading path  pagination is a RENDERING result (fonts,
+ *                              printer metrics, Word vs LibreOffice), so a
+ *                              page number is not a property of the document
+ *                              the reader opens
+ *
+ * Forcing every format onto "page" would make a citation state something that
+ * is false of the file the user opens. Hence a CLOSED, typed union rather than
+ * a free-form string: Wave 2 adds one producer per format against it, and a
+ * stringly-typed anchor is exactly what would let two of them drift apart.
+ *
+ * ── Duplicated on purpose ────────────────────────────────────────────────
+ * This file exists twice, byte-for-byte:
+ *   packages/web/src/lib/knowledge/locator.ts
+ *   packages/plugins/pinchy-knowledge/locator.ts
+ * The plugin is a separate package that cannot import from the web app (the
+ * same bundle-isolation reason `normalizeTableHtml` is duplicated), yet it is
+ * the layer that RENDERS the citation. `chunk-locator-drift.test.ts` pins the
+ * two copies to be identical modulo comments and whitespace, so a fifth kind
+ * added on one side cannot silently go unrendered on the other.
+ */
+
+export type ChunkLocator =
+  /** A PDF page, 1-based. */
+  | { kind: "page"; page: number }
+  /** A presentation slide, 1-based. */
+  | { kind: "slide"; slide: number }
+  /**
+   * A Word heading path from the document's outline, outermost first
+   * (`["Quality", "Incoming goods"]`). Producers must supply at least one
+   * heading — a document with no outline at all has no stable anchor and its
+   * chunks carry a null locator instead.
+   */
+  | { kind: "heading"; headings: string[] }
+  /** A spreadsheet sheet and the 1-based, inclusive row range the chunk spans. */
+  | { kind: "sheet"; sheet: string; startRow: number; endRow: number };
+
+/**
+ * Renders a locator as the parenthesised hint that follows a document path in
+ * a citation ("p. 12", "slide 4", "§ Quality > Incoming goods").
+ *
+ * The switch deliberately has no `default`: with an explicit `string` return
+ * type, a fifth locator kind stops compiling here until it is given a
+ * rendering, which is what keeps the union closed in practice rather than
+ * merely in the type.
+ */
+export function formatLocator(locator: ChunkLocator): string {
+  switch (locator.kind) {
+    case "page":
+      return `p. ${locator.page}`;
+    case "slide":
+      return `slide ${locator.slide}`;
+    case "heading":
+      return `§ ${locator.headings.join(" > ")}`;
+    case "sheet":
+      return locator.startRow === locator.endRow
+        ? `${locator.sheet}, row ${locator.startRow}`
+        : `${locator.sheet}, rows ${locator.startRow}-${locator.endRow}`;
+  }
+}

--- a/packages/plugins/pinchy-knowledge/locator.ts
+++ b/packages/plugins/pinchy-knowledge/locator.ts
@@ -40,7 +40,11 @@ export type ChunkLocator =
    * chunks carry a null locator instead.
    */
   | { kind: "heading"; headings: string[] }
-  /** A spreadsheet sheet and the 1-based, inclusive row range the chunk spans. */
+  /**
+   * A spreadsheet sheet and the 1-based, inclusive row range the chunk spans.
+   * Field-for-field what `xlsx-extract.ts`'s `XlsxChunk` already produces, so
+   * wiring that extractor into the ingest is a spread rather than a mapping.
+   */
   | { kind: "sheet"; sheet: string; startRow: number; endRow: number };
 
 /**

--- a/packages/web/drizzle/0061_kb_chunk_locator.sql
+++ b/packages/web/drizzle/0061_kb_chunk_locator.sql
@@ -1,0 +1,24 @@
+-- #933: kb_chunks anchors a chunk with a LOCATOR, not a page.
+--
+-- Only PDFs have pages. A PowerPoint chunk is anchored by slide, a spreadsheet
+-- chunk by sheet + row range, and a Word chunk by its heading path — because
+-- Word pagination is a rendering result (fonts, printer metrics, Word vs
+-- LibreOffice), so a page number is not a property of the document the reader
+-- opens. Citing one would state something false about the file the user opens.
+--
+-- The backfill is total and lossless in the direction that matters: every
+-- existing row was written by the PDF ingest, so `page` IS its honest anchor
+-- and becomes the equivalent page locator. A row whose page was never recorded
+-- keeps no anchor rather than gaining a fabricated one.
+--
+-- Split across two migrations on purpose. The ADD + backfill is committed
+-- before 0062 drops `page`, so a run that dies between them leaves every anchor
+-- already carried over instead of destroyed. The shape of that conversion is
+-- pinned against rows written by the OLD code in
+-- migration-kb-chunk-locator.integration.test.ts (AGENTS.md § "Test Migrations
+-- Against Pre-Existing Data") — a fresh-DB run proves nothing here, since every
+-- row that needs converting predates the column.
+ALTER TABLE "kb_chunks" ADD COLUMN "locator" jsonb;--> statement-breakpoint
+UPDATE "kb_chunks"
+SET "locator" = jsonb_build_object('kind', 'page', 'page', "page")
+WHERE "page" IS NOT NULL;

--- a/packages/web/drizzle/0062_kb_chunk_locator_drop_page.sql
+++ b/packages/web/drizzle/0062_kb_chunk_locator_drop_page.sql
@@ -1,0 +1,5 @@
+-- #933, second half: with every anchor carried into `locator` by 0061, the old
+-- column goes. Dropping it is the point rather than tidiness — a column that
+-- still exists is a column ingest can still be made to write, and two anchors
+-- for one chunk is exactly the drift the closed locator union exists to stop.
+ALTER TABLE "kb_chunks" DROP COLUMN "page";

--- a/packages/web/drizzle/meta/0061_snapshot.json
+++ b/packages/web/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,3629 @@
+{
+  "id": "0d767c10-1696-4990-839b-ddfcdc2646e2",
+  "prevId": "14df3ce3-76e3-41b2-9d1b-7aea5b25cb4b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_delivered_files": {
+      "name": "agent_delivered_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_delivered_files_lookup": {
+          "name": "idx_agent_delivered_files_lookup",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_delivered_files_session": {
+          "name": "idx_agent_delivered_files_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_delivered_files_user_id_user_id_fk": {
+          "name": "agent_delivered_files_user_id_user_id_fk",
+          "tableFrom": "agent_delivered_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_delivered_files_agent_id_agents_id_fk": {
+          "name": "agent_delivered_files_agent_id_agents_id_fk",
+          "tableFrom": "agent_delivered_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_groups_group_id_idx": {
+          "name": "agent_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_visibility_check": {
+          "name": "agents_visibility_check",
+          "value": "\"agents\".\"visibility\" IN ('restricted', 'all')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_timestamp": {
+          "name": "idx_audit_resource_timestamp",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_integrity_violation": {
+          "name": "idx_audit_integrity_violation",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"event_type\" = 'audit.integrity_check' AND \"audit_log\".\"outcome\" = 'failure'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_verify_state": {
+      "name": "audit_verify_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified_id": {
+          "name": "last_verified_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_verified_hmac": {
+          "name": "last_verified_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_connection_cursors": {
+      "name": "email_connection_cursors",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_connection_cursors_connection_id_integration_connections_id_fk": {
+          "name": "email_connection_cursors_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_connection_cursors",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflow_connections": {
+      "name": "email_workflow_connections",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since_ts": {
+          "name": "since_ts",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_workflow_connections_workflow_id_email_workflows_id_fk": {
+          "name": "email_workflow_connections_workflow_id_email_workflows_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflow_connections_connection_id_integration_connections_id_fk": {
+          "name": "email_workflow_connections_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_workflow_connections_workflow_id_connection_id_pk": {
+          "name": "email_workflow_connections_workflow_id_connection_id_pk",
+          "columns": ["workflow_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflows": {
+      "name": "email_workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_every": {
+          "name": "poll_every",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'5m'"
+        },
+        "sweep_window_days": {
+          "name": "sweep_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "openclaw_job_id": {
+          "name": "openclaw_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_workflows_agent_idx": {
+          "name": "email_workflows_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_workflows_enabled_idx": {
+          "name": "email_workflows_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_workflows\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_workflows_agent_id_agents_id_fk": {
+          "name": "email_workflows_agent_id_agents_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflows_created_by_user_id_fk": {
+          "name": "email_workflows_created_by_user_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_workflows_status_check": {
+          "name": "email_workflows_status_check",
+          "value": "\"email_workflows\".\"status\" IN ('pending', 'active', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_type_check": {
+          "name": "integration_connections_type_check",
+          "value": "\"integration_connections\".\"type\" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')"
+        },
+        "integration_connections_status_check": {
+          "name": "integration_connections_status_check",
+          "value": "\"integration_connections\".\"status\" IN ('active', 'pending', 'auth_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_claimed_by_user_id_idx": {
+          "name": "invites_claimed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_email_expires_at_idx": {
+          "name": "invites_email_expires_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_role_check": {
+          "name": "invites_role_check",
+          "value": "\"invites\".\"role\" IN ('admin', 'member')"
+        },
+        "invites_type_check": {
+          "name": "invites_type_check",
+          "value": "\"invites\".\"type\" IN ('invite', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kb_chunks": {
+      "name": "kb_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kb_chunks_doc": {
+          "name": "idx_kb_chunks_doc",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_chunks_org_path": {
+          "name": "idx_kb_chunks_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_chunks_document_id_kb_documents_id_fk": {
+          "name": "kb_chunks_document_id_kb_documents_id_fk",
+          "tableFrom": "kb_chunks",
+          "tableTo": "kb_documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_documents": {
+      "name": "kb_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_kb_doc_org_path": {
+          "name": "uq_kb_doc_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_doc_org_hash": {
+          "name": "idx_kb_doc_org_hash",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_index_jobs": {
+      "name": "kb_index_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paths": {
+          "name": "paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_kb_index_jobs_active": {
+          "name": "uq_kb_index_jobs_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kb_index_jobs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_status_created": {
+          "name": "idx_kb_index_jobs_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_agent_created": {
+          "name": "idx_kb_index_jobs_agent_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_index_jobs_agent_id_agents_id_fk": {
+          "name": "kb_index_jobs_agent_id_agents_id_fk",
+          "tableFrom": "kb_index_jobs",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kb_index_jobs_status_check": {
+          "name": "kb_index_jobs_status_check",
+          "value": "\"kb_index_jobs\".\"status\" IN ('pending', 'running', 'succeeded', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipients": {
+      "name": "notification_recipients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_recipients_user_unread_idx": {
+          "name": "notification_recipients_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipients_user_id_user_id_fk": {
+          "name": "notification_recipients_user_id_user_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_recipients_notification_id_notifications_id_fk": {
+          "name": "notification_recipients_notification_id_notifications_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notification_recipients_user_id_notification_id_pk": {
+          "name": "notification_recipients_user_id_notification_id_pk",
+          "columns": ["user_id", "notification_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_agent_created_idx": {
+          "name": "notifications_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_agent_id_agents_id_fk": {
+          "name": "notifications_agent_id_agents_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_status_check": {
+          "name": "notifications_status_check",
+          "value": "\"notifications\".\"status\" IN ('success', 'failure')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.openai_compatible_providers": {
+      "name": "openai_compatible_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models": {
+          "name": "models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "openai_compatible_providers_slug_unique": {
+          "name": "openai_compatible_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.processed_emails": {
+      "name": "processed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id_header": {
+          "name": "message_id_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "processed_emails_claim_uniq": {
+          "name": "processed_emails_claim_uniq",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "processed_emails_status_idx": {
+          "name": "processed_emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "processed_emails_workflow_id_email_workflows_id_fk": {
+          "name": "processed_emails_workflow_id_email_workflows_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "processed_emails_status_check": {
+          "name": "processed_emails_status_check",
+          "value": "\"processed_emails\".\"status\" IN ('processing', 'done', 'no_action', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user_timestamp": {
+          "name": "idx_usage_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent_timestamp": {
+          "name": "idx_usage_agent_timestamp",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_groups_group_id_idx": {
+          "name": "user_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_pseudonym": {
+          "name": "audit_pseudonym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_audit_pseudonym_unique": {
+          "name": "user_audit_pseudonym_unique",
+          "nullsNotDistinct": false,
+          "columns": ["audit_pseudonym"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"user\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"starter_prompts\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/0062_snapshot.json
+++ b/packages/web/drizzle/meta/0062_snapshot.json
@@ -1,0 +1,3623 @@
+{
+  "id": "644c27ce-79ec-4cad-8833-b92e36232b00",
+  "prevId": "0d767c10-1696-4990-839b-ddfcdc2646e2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_delivered_files": {
+      "name": "agent_delivered_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_delivered_files_lookup": {
+          "name": "idx_agent_delivered_files_lookup",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_delivered_files_session": {
+          "name": "idx_agent_delivered_files_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_delivered_files_user_id_user_id_fk": {
+          "name": "agent_delivered_files_user_id_user_id_fk",
+          "tableFrom": "agent_delivered_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_delivered_files_agent_id_agents_id_fk": {
+          "name": "agent_delivered_files_agent_id_agents_id_fk",
+          "tableFrom": "agent_delivered_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_groups_group_id_idx": {
+          "name": "agent_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_visibility_check": {
+          "name": "agents_visibility_check",
+          "value": "\"agents\".\"visibility\" IN ('restricted', 'all')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_timestamp": {
+          "name": "idx_audit_resource_timestamp",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_integrity_violation": {
+          "name": "idx_audit_integrity_violation",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"event_type\" = 'audit.integrity_check' AND \"audit_log\".\"outcome\" = 'failure'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_verify_state": {
+      "name": "audit_verify_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified_id": {
+          "name": "last_verified_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_verified_hmac": {
+          "name": "last_verified_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_connection_cursors": {
+      "name": "email_connection_cursors",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_connection_cursors_connection_id_integration_connections_id_fk": {
+          "name": "email_connection_cursors_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_connection_cursors",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflow_connections": {
+      "name": "email_workflow_connections",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since_ts": {
+          "name": "since_ts",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_workflow_connections_workflow_id_email_workflows_id_fk": {
+          "name": "email_workflow_connections_workflow_id_email_workflows_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflow_connections_connection_id_integration_connections_id_fk": {
+          "name": "email_workflow_connections_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_workflow_connections_workflow_id_connection_id_pk": {
+          "name": "email_workflow_connections_workflow_id_connection_id_pk",
+          "columns": ["workflow_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflows": {
+      "name": "email_workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_every": {
+          "name": "poll_every",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'5m'"
+        },
+        "sweep_window_days": {
+          "name": "sweep_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "openclaw_job_id": {
+          "name": "openclaw_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_workflows_agent_idx": {
+          "name": "email_workflows_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_workflows_enabled_idx": {
+          "name": "email_workflows_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_workflows\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_workflows_agent_id_agents_id_fk": {
+          "name": "email_workflows_agent_id_agents_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflows_created_by_user_id_fk": {
+          "name": "email_workflows_created_by_user_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_workflows_status_check": {
+          "name": "email_workflows_status_check",
+          "value": "\"email_workflows\".\"status\" IN ('pending', 'active', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_type_check": {
+          "name": "integration_connections_type_check",
+          "value": "\"integration_connections\".\"type\" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')"
+        },
+        "integration_connections_status_check": {
+          "name": "integration_connections_status_check",
+          "value": "\"integration_connections\".\"status\" IN ('active', 'pending', 'auth_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_claimed_by_user_id_idx": {
+          "name": "invites_claimed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_email_expires_at_idx": {
+          "name": "invites_email_expires_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_role_check": {
+          "name": "invites_role_check",
+          "value": "\"invites\".\"role\" IN ('admin', 'member')"
+        },
+        "invites_type_check": {
+          "name": "invites_type_check",
+          "value": "\"invites\".\"type\" IN ('invite', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kb_chunks": {
+      "name": "kb_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kb_chunks_doc": {
+          "name": "idx_kb_chunks_doc",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_chunks_org_path": {
+          "name": "idx_kb_chunks_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_chunks_document_id_kb_documents_id_fk": {
+          "name": "kb_chunks_document_id_kb_documents_id_fk",
+          "tableFrom": "kb_chunks",
+          "tableTo": "kb_documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_documents": {
+      "name": "kb_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_kb_doc_org_path": {
+          "name": "uq_kb_doc_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_doc_org_hash": {
+          "name": "idx_kb_doc_org_hash",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_index_jobs": {
+      "name": "kb_index_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paths": {
+          "name": "paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_kb_index_jobs_active": {
+          "name": "uq_kb_index_jobs_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kb_index_jobs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_status_created": {
+          "name": "idx_kb_index_jobs_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_agent_created": {
+          "name": "idx_kb_index_jobs_agent_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_index_jobs_agent_id_agents_id_fk": {
+          "name": "kb_index_jobs_agent_id_agents_id_fk",
+          "tableFrom": "kb_index_jobs",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kb_index_jobs_status_check": {
+          "name": "kb_index_jobs_status_check",
+          "value": "\"kb_index_jobs\".\"status\" IN ('pending', 'running', 'succeeded', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipients": {
+      "name": "notification_recipients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_recipients_user_unread_idx": {
+          "name": "notification_recipients_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipients_user_id_user_id_fk": {
+          "name": "notification_recipients_user_id_user_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_recipients_notification_id_notifications_id_fk": {
+          "name": "notification_recipients_notification_id_notifications_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notification_recipients_user_id_notification_id_pk": {
+          "name": "notification_recipients_user_id_notification_id_pk",
+          "columns": ["user_id", "notification_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_agent_created_idx": {
+          "name": "notifications_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_agent_id_agents_id_fk": {
+          "name": "notifications_agent_id_agents_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_status_check": {
+          "name": "notifications_status_check",
+          "value": "\"notifications\".\"status\" IN ('success', 'failure')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.openai_compatible_providers": {
+      "name": "openai_compatible_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models": {
+          "name": "models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "openai_compatible_providers_slug_unique": {
+          "name": "openai_compatible_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.processed_emails": {
+      "name": "processed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id_header": {
+          "name": "message_id_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "processed_emails_claim_uniq": {
+          "name": "processed_emails_claim_uniq",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "processed_emails_status_idx": {
+          "name": "processed_emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "processed_emails_workflow_id_email_workflows_id_fk": {
+          "name": "processed_emails_workflow_id_email_workflows_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "processed_emails_status_check": {
+          "name": "processed_emails_status_check",
+          "value": "\"processed_emails\".\"status\" IN ('processing', 'done', 'no_action', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user_timestamp": {
+          "name": "idx_usage_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent_timestamp": {
+          "name": "idx_usage_agent_timestamp",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_groups_group_id_idx": {
+          "name": "user_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_pseudonym": {
+          "name": "audit_pseudonym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_audit_pseudonym_unique": {
+          "name": "user_audit_pseudonym_unique",
+          "nullsNotDistinct": false,
+          "columns": ["audit_pseudonym"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"user\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"starter_prompts\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -428,6 +428,20 @@
       "when": 1785323913327,
       "tag": "0060_gigantic_texas_twister",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1785348706074,
+      "tag": "0061_kb_chunk_locator",
+      "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1785348713884,
+      "tag": "0062_kb_chunk_locator_drop_page",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/src/__tests__/api/knowledge-search.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-search.test.ts
@@ -80,7 +80,7 @@ const retrievedChunks = [
     documentId: "doc-1",
     text: "Employees get 25 days of vacation per year.",
     sourcePath: "/data/hr/handbook.pdf",
-    page: 4,
+    locator: { kind: "page" as const, page: 4 },
     score: 0.9,
   },
   {
@@ -88,7 +88,7 @@ const retrievedChunks = [
     documentId: "doc-1",
     text: "Unused vacation carries over up to 5 days.",
     sourcePath: "/data/hr/handbook.pdf",
-    page: 5,
+    locator: { kind: "page" as const, page: 5 },
     score: 0.7,
   },
 ];
@@ -144,18 +144,63 @@ describe("POST /api/internal/knowledge/search", () => {
           chunkId: "chunk-1",
           text: "Employees get 25 days of vacation per year.",
           sourcePath: "/data/hr/handbook.pdf",
-          page: 4,
+          citationPath: "hr/handbook.pdf",
+          locator: { kind: "page", page: 4 },
           docName: "handbook.pdf",
         },
         {
           chunkId: "chunk-2",
           text: "Unused vacation carries over up to 5 days.",
           sourcePath: "/data/hr/handbook.pdf",
-          page: 5,
+          citationPath: "hr/handbook.pdf",
+          locator: { kind: "page", page: 5 },
           docName: "handbook.pdf",
         },
       ],
     });
+  });
+
+  it("derives citationPath from the data root so the container path never reaches the model", async () => {
+    // The response keeps `sourcePath` absolute — the audit trail and anything
+    // that opens the file need the path the filesystem answers to — but the
+    // model is shown `citationPath`, and that one must not carry /data/<mount>.
+    mockRetrieve.mockResolvedValueOnce([
+      {
+        chunkId: "chunk-9",
+        documentId: "doc-9",
+        text: "Incubate 24 h.",
+        sourcePath: "/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf",
+        locator: { kind: "page" as const, page: 2 },
+        score: 0.5,
+      },
+    ]);
+    const res = await POST(makeRequest(validBody));
+    const body = await res.json();
+
+    expect(body.results[0].sourcePath).toBe(
+      "/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf"
+    );
+    expect(body.results[0].citationPath).toBe("OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf");
+  });
+
+  it("passes a null locator through instead of inventing a page for it", async () => {
+    // A chunk from a document with no stable anchor (a Word file with no
+    // outline) has none. The citation then names the document and nothing
+    // more, which is honest; a fabricated "p. 1" would not be.
+    mockRetrieve.mockResolvedValueOnce([
+      {
+        chunkId: "chunk-8",
+        documentId: "doc-8",
+        text: "No anchor here.",
+        sourcePath: "/data/hr/notes.pdf",
+        locator: null,
+        score: 0.4,
+      },
+    ]);
+    const res = await POST(makeRequest(validBody));
+    const body = await res.json();
+
+    expect(body.results[0].locator).toBeNull();
   });
 
   it("resolves agentId -> allowedPaths from the agent's pinchy-files admin config and denies by default with []", async () => {

--- a/packages/web/src/__tests__/api/knowledge-search.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-search.test.ts
@@ -180,7 +180,7 @@ describe("POST /api/internal/knowledge/search", () => {
     expect(body.results[0].sourcePath).toBe(
       "/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf"
     );
-    expect(body.results[0].citationPath).toBe("OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf");
+    expect(body.results[0].citationPath).toBe("noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf");
   });
 
   it("passes a null locator through instead of inventing a page for it", async () => {

--- a/packages/web/src/__tests__/components/markdown-citation-render.test.tsx
+++ b/packages/web/src/__tests__/components/markdown-citation-render.test.tsx
@@ -38,16 +38,22 @@ import { AgentIdContext } from "@/components/chat";
 
 /**
  * The template's Sources shape, verbatim: a markdown list, a bracketed index,
- * an em dash, a page. Every element here is one markdown could parse into
+ * an em dash, a position. Every element here is one markdown could parse into
  * something other than a plain text node.
+ *
+ * The paths are data-root-relative, because that is what `knowledge_search`
+ * shows the model and a model can only cite what it is shown (#933). Which also
+ * makes this the one test that would catch the whole feature going dark on that
+ * change: with no leading `/` to key off, a linkifier still looking for an
+ * absolute path matches nothing and every answer renders as flat text.
  */
 const ANSWER = [
   "Die Nachweisgrenze liegt bei 0,05 mg/kg.",
   "",
   "**Quellen:**",
   "",
-  "- [1] /data/noack/PPR/document.pdf — p. 510",
-  "- [2] /data/noack/PF LAB/afnor_update_&_support.pdf — p. 44",
+  "- [1] noack/PPR/document.pdf — p. 510",
+  "- [2] noack/PF LAB/afnor_update_&_support.pdf — p. 44",
 ].join("\n");
 
 function renderAnswer(agentId: string | null, text = ANSWER) {
@@ -74,8 +80,8 @@ describe("a cited source rendered through the real markdown pipeline", () => {
     // rescans the whole tree on every retry, which is slow enough under load to
     // exhaust the timeout before the assertion ever runs. The tag check below
     // keeps the guarantee that matters.
-    const first = await screen.findByText("/data/noack/PPR/document.pdf");
-    const second = await screen.findByText("/data/noack/PF LAB/afnor_update_&_support.pdf");
+    const first = await screen.findByText("noack/PPR/document.pdf");
+    const second = await screen.findByText("noack/PF LAB/afnor_update_&_support.pdf");
 
     // A citation opens the lightbox rather than navigating away from the answer
     // it belongs to, so the trigger is a button and not an anchor.
@@ -97,9 +103,9 @@ describe("a cited source rendered through the real markdown pipeline", () => {
     // Inside backticks a path is being displayed, not referenced. remark gives
     // it its own node type, and the plugin has to respect that in the real tree
     // and not only in a hand-built one.
-    renderAnswer("agent-1", "Der Pfad `/data/noack/PPR/document.pdf` liegt im Korpus.");
+    renderAnswer("agent-1", "Der Pfad `noack/PPR/document.pdf` liegt im Korpus.");
 
-    expect(await screen.findByText("/data/noack/PPR/document.pdf")).toBeInTheDocument();
+    expect(await screen.findByText("noack/PPR/document.pdf")).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/components/markdown-remark-plugins.test.ts
+++ b/packages/web/src/__tests__/components/markdown-remark-plugins.test.ts
@@ -72,7 +72,7 @@ function firstLink(tree: MdastNode): MdastNode | null {
 describe("buildRemarkPlugins", () => {
   it("registers the source-link plugin so unified can attach it and it rewrites a citation", () => {
     const transformers = applyPlugins(buildRemarkPlugins("agent-1"));
-    const tree = paragraph("- [1] /data/noack/PPR/document.pdf — p. 510");
+    const tree = paragraph("- [1] noack/PPR/document.pdf — p. 510");
 
     // Every transformer runs, exactly as it would during a real render. If the
     // list carried a transformer instead of an attacher, `applyPlugins` above
@@ -90,7 +90,7 @@ describe("buildRemarkPlugins", () => {
     // An href without an agent id cannot resolve to anything the route would
     // authorize, so no link is better than a broken one.
     const transformers = applyPlugins(buildRemarkPlugins(null));
-    const tree = paragraph("- [1] /data/noack/PPR/document.pdf — p. 510");
+    const tree = paragraph("- [1] noack/PPR/document.pdf — p. 510");
 
     for (const transform of transformers) transform(tree);
 

--- a/packages/web/src/__tests__/components/pdf-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/pdf-dialog.test.tsx
@@ -37,7 +37,7 @@ describe("PdfDialog", () => {
   it("names the document by its filename, not the route or the full path", () => {
     // Chrome's own title bar reads "workspace-file" here — the route segment.
     // A reader checking a citation needs to know WHICH document opened.
-    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+    openDialog(SOURCE_URL, "noack/PPR/document.pdf");
 
     expect(screen.getByText("document.pdf")).toBeInTheDocument();
   });
@@ -45,9 +45,9 @@ describe("PdfDialog", () => {
   it("keeps the full path reachable without spending width on it", () => {
     // A corpus has same-named files in different folders, so the path has to
     // survive somewhere — but it must not push the controls off a narrow screen.
-    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+    openDialog(SOURCE_URL, "noack/PPR/document.pdf");
 
-    expect(screen.getByTitle("/data/noack/PPR/document.pdf")).toBeInTheDocument();
+    expect(screen.getByTitle("noack/PPR/document.pdf")).toBeInTheDocument();
   });
 
   it("shows which page the citation pointed at", () => {
@@ -55,7 +55,7 @@ describe("PdfDialog", () => {
     // decided what a citation's page is; a second regex here would be a second
     // answer to the same question, and the two had already drifted (`\d{1,5}`
     // against a whole fragment vs `\d+` anywhere in the string).
-    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf", 510);
+    openDialog(SOURCE_URL, "noack/PPR/document.pdf", 510);
 
     expect(screen.getByText(/page 510/i)).toBeInTheDocument();
   });
@@ -70,7 +70,7 @@ describe("PdfDialog", () => {
   it("offers a full tab, which is the only working path on iOS Safari", () => {
     // iOS Safari renders an embedded PDF blank regardless of headers or markup.
     // Without this link the dialog is a dead end on every iPhone.
-    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+    openDialog(SOURCE_URL, "noack/PPR/document.pdf");
 
     const link = screen.getByRole("link", { name: /open in new tab/i });
     expect(link).toHaveAttribute("href", SOURCE_URL);
@@ -80,14 +80,14 @@ describe("PdfDialog", () => {
   });
 
   it("still closes", () => {
-    openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+    openDialog(SOURCE_URL, "noack/PPR/document.pdf");
 
     expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
   });
 
   it("renders the viewer at the exact url it was given, fragment included", () => {
     // The `#page=N` fragment is the whole reason a citation lands where it does.
-    const { container } = openDialog(SOURCE_URL, "/data/noack/PPR/document.pdf");
+    const { container } = openDialog(SOURCE_URL, "noack/PPR/document.pdf");
 
     const embed = container.ownerDocument.querySelector("embed");
     expect(embed).toHaveAttribute("src", SOURCE_URL);

--- a/packages/web/src/__tests__/db/kb-schema.integration.test.ts
+++ b/packages/web/src/__tests__/db/kb-schema.integration.test.ts
@@ -31,7 +31,7 @@ it("inserts a document + chunk and queries the chunk by orgId", async () => {
     orgId: ORG_ID,
     sourcePath: "/data/handbook.pdf",
     chunkText: "Onboarding starts on day one.",
-    page: 1,
+    locator: { kind: "page", page: 1 },
     embedding: Array(768).fill(0.1),
   });
 
@@ -40,6 +40,10 @@ it("inserts a document + chunk and queries the chunk by orgId", async () => {
   expect(rows[0].chunkText).toBe("Onboarding starts on day one.");
   expect(rows[0].sourcePath).toBe("/data/handbook.pdf");
   expect(rows[0].embedding).toHaveLength(768);
+  // Round-trips through jsonb as the typed union, not as an opaque blob: the
+  // citation renderer switches on `kind`, so a column that came back as a
+  // string would fail there rather than here.
+  expect(rows[0].locator).toEqual({ kind: "page", page: 1 });
 });
 
 it("keys a document by (org_id, source_path), with content_hash as a non-unique change-detection column", async () => {

--- a/packages/web/src/__tests__/db/migration-kb-chunk-locator.integration.test.ts
+++ b/packages/web/src/__tests__/db/migration-kb-chunk-locator.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Migration-against-populated-data test for 0060_kb_chunk_locator (#933), in
+ * Migration-against-populated-data test for 0061_kb_chunk_locator (#933), in
  * the spirit AGENTS.md § "Test Migrations Against Pre-Existing Data" asks for:
  * every kb_chunks row that exists BEFORE this migration was written by code
  * that stored a bare `page` integer, so a fresh-DB run proves nothing. The
@@ -7,8 +7,8 @@
  * new code — and getting it wrong silently blanks the anchor on every citation
  * in an existing corpus while the whole suite stays green.
  *
- * Phase 1 migrates a throwaway DB to the pre-locator state (journal idx < 60,
- * i.e. before 0060's ADD + backfill and 0061's DROP),
+ * Phase 1 migrates a throwaway DB to the pre-locator state (journal idx < 61,
+ * i.e. before 0061's ADD + backfill and 0062's DROP),
  * phase 2 seeds chunks the way the OLD ingest wrote them (`page` integer, NULL
  * included), phase 3 migrates to HEAD and asserts every page became the
  * equivalent page locator — and that a NULL page did NOT become a fabricated
@@ -33,9 +33,9 @@ import { formatLocator, type ChunkLocator } from "@/lib/knowledge/locator";
 
 // vitest runs with cwd = packages/web; the real migrations live in ./drizzle.
 const REAL_MIGRATIONS = join(process.cwd(), "drizzle");
-// The ADD + backfill (0060) and the DROP (0061) are separate migrations, so
+// The ADD + backfill (0061) and the DROP (0062) are separate migrations, so
 // "before the change" means before the first of them.
-const LOCATOR_IDX = 60;
+const LOCATOR_IDX = 61;
 
 // Per-process DB name so concurrent runs can't collide on the throwaway DB.
 const DB_NAME = `pinchy_kb_chunk_locator_test_${process.pid}`;
@@ -73,7 +73,7 @@ function withDbName(url: string, name: string): string {
   return u.toString();
 }
 
-describe("0060 kb chunk locator (populated pre-#933 data)", () => {
+describe("0061 kb chunk locator (populated pre-#933 data)", () => {
   const baseUrl =
     process.env.DATABASE_URL ??
     process.env.VITEST_INTEGRATION_DB_URL ??
@@ -139,7 +139,7 @@ describe("0060 kb chunk locator (populated pre-#933 data)", () => {
         `;
       }
 
-      // Phase 3 — upgrade to HEAD (applies 0060).
+      // Phase 3 — upgrade to HEAD (applies 0061 + 0062).
       await migrate(drizzle(client), { migrationsFolder: REAL_MIGRATIONS });
 
       const rows = await client<{ chunk_text: string; locator: ChunkLocator | null }[]>`

--- a/packages/web/src/__tests__/db/migration-kb-chunk-locator.integration.test.ts
+++ b/packages/web/src/__tests__/db/migration-kb-chunk-locator.integration.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Migration-against-populated-data test for 0060_kb_chunk_locator (#933), in
+ * the spirit AGENTS.md § "Test Migrations Against Pre-Existing Data" asks for:
+ * every kb_chunks row that exists BEFORE this migration was written by code
+ * that stored a bare `page` integer, so a fresh-DB run proves nothing. The
+ * column swap only matters for the state a real upgrade produces — old rows,
+ * new code — and getting it wrong silently blanks the anchor on every citation
+ * in an existing corpus while the whole suite stays green.
+ *
+ * Phase 1 migrates a throwaway DB to the pre-locator state (journal idx < 60,
+ * i.e. before 0060's ADD + backfill and 0061's DROP),
+ * phase 2 seeds chunks the way the OLD ingest wrote them (`page` integer, NULL
+ * included), phase 3 migrates to HEAD and asserts every page became the
+ * equivalent page locator — and that a NULL page did NOT become a fabricated
+ * one.
+ *
+ * Phase 4 then reads those migrated rows through the NEW retrieval projection,
+ * because "the column converted" and "retrieval still answers with an anchor"
+ * are different claims and only the second one is what a reader gets.
+ *
+ * Runs under `pnpm -C packages/web test:db` (vitest-integration CI job).
+ * Uses its own throwaway database, like migration-kb-archive-backfill.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { cp, mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { formatLocator, type ChunkLocator } from "@/lib/knowledge/locator";
+
+// vitest runs with cwd = packages/web; the real migrations live in ./drizzle.
+const REAL_MIGRATIONS = join(process.cwd(), "drizzle");
+// The ADD + backfill (0060) and the DROP (0061) are separate migrations, so
+// "before the change" means before the first of them.
+const LOCATOR_IDX = 60;
+
+// Per-process DB name so concurrent runs can't collide on the throwaway DB.
+const DB_NAME = `pinchy_kb_chunk_locator_test_${process.pid}`;
+
+/** Chunks as the pre-#933 ingest persisted them: a bare `page`, nullable. */
+const FIXTURE_CHUNKS: Array<{ chunkText: string; page: number | null }> = [
+  { chunkText: "First page of the handbook.", page: 1 },
+  { chunkText: "Deep in a long binder.", page: 275 },
+  { chunkText: "A chunk whose page was never recorded.", page: null },
+];
+
+type JournalEntry = {
+  idx: number;
+  tag: string;
+  when: number;
+  version: string;
+  breakpoints: boolean;
+};
+
+async function rewriteJournal(
+  dir: string,
+  transform: (entries: JournalEntry[]) => JournalEntry[]
+): Promise<void> {
+  const journalPath = join(dir, "meta", "_journal.json");
+  const journal = JSON.parse(await readFile(journalPath, "utf-8")) as {
+    entries: JournalEntry[];
+  };
+  journal.entries = transform(journal.entries);
+  await writeFile(journalPath, JSON.stringify(journal, null, 2));
+}
+
+function withDbName(url: string, name: string): string {
+  const u = new URL(url);
+  u.pathname = `/${name}`;
+  return u.toString();
+}
+
+describe("0060 kb chunk locator (populated pre-#933 data)", () => {
+  const baseUrl =
+    process.env.DATABASE_URL ??
+    process.env.VITEST_INTEGRATION_DB_URL ??
+    "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy_test_vitest";
+  const adminUrl = withDbName(baseUrl, "postgres");
+  const testUrl = withDbName(baseUrl, DB_NAME);
+
+  let preLocatorDir: string;
+
+  beforeAll(async () => {
+    const admin = postgres(adminUrl, { max: 1 });
+    try {
+      await admin.unsafe(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`);
+      await admin.unsafe(`CREATE DATABASE ${DB_NAME}`);
+    } finally {
+      await admin.end();
+    }
+
+    // Real .sql files, journal truncated to just before the locator swap.
+    preLocatorDir = await mkdtemp(join(tmpdir(), "pinchy-kb-locator-pre-"));
+    await cp(REAL_MIGRATIONS, preLocatorDir, { recursive: true });
+    await rewriteJournal(preLocatorDir, (entries) => entries.filter((e) => e.idx < LOCATOR_IDX));
+  });
+
+  afterAll(async () => {
+    if (preLocatorDir) await rm(preLocatorDir, { recursive: true, force: true });
+    const admin = postgres(adminUrl, { max: 1 });
+    try {
+      await admin.unsafe(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`);
+    } finally {
+      await admin.end();
+    }
+  });
+
+  it("converts a pre-existing page into a page locator, and a null page into no locator", async () => {
+    const client = postgres(testUrl, { max: 1 });
+    try {
+      // Phase 1 — the pre-locator schema state.
+      await migrate(drizzle(client), { migrationsFolder: preLocatorDir });
+
+      // Proves the seeded state is genuinely pre-migration: the old column is
+      // there and the new one is not. Without this the test could silently
+      // become a fresh-DB test again if the journal filter ever stops biting.
+      const preColumns = await client<{ column_name: string }[]>`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'kb_chunks' AND column_name IN ('page', 'locator')
+      `;
+      expect(preColumns.map((c) => c.column_name).sort()).toEqual(["page"]);
+
+      // Phase 2 — seed rows the way pre-#933 ingest wrote them.
+      const documentId = crypto.randomUUID();
+      await client`
+        INSERT INTO kb_documents (id, org_id, content_hash, source_path)
+        VALUES (${documentId}, 'org-locator-test', 'hash-locator', '/data/noack/QM/handbook.pdf')
+      `;
+      for (const { chunkText, page } of FIXTURE_CHUNKS) {
+        await client`
+          INSERT INTO kb_chunks (id, document_id, org_id, source_path, chunk_text, page)
+          VALUES (
+            ${crypto.randomUUID()}, ${documentId}, 'org-locator-test',
+            '/data/noack/QM/handbook.pdf', ${chunkText}, ${page}
+          )
+        `;
+      }
+
+      // Phase 3 — upgrade to HEAD (applies 0060).
+      await migrate(drizzle(client), { migrationsFolder: REAL_MIGRATIONS });
+
+      const rows = await client<{ chunk_text: string; locator: ChunkLocator | null }[]>`
+        SELECT chunk_text, locator FROM kb_chunks WHERE org_id = 'org-locator-test'
+      `;
+      const byText = new Map(rows.map((r) => [r.chunk_text, r.locator]));
+
+      for (const { chunkText, page } of FIXTURE_CHUNKS) {
+        expect(byText.get(chunkText), chunkText).toEqual(
+          page === null ? null : { kind: "page", page }
+        );
+      }
+
+      // Phase 4 — the rows a pre-#933 corpus consists of still render an
+      // anchor. The conversion is only worth anything if this holds.
+      const migrated = byText.get("Deep in a long binder.");
+      expect(migrated).not.toBeNull();
+      expect(formatLocator(migrated as ChunkLocator)).toBe("p. 275");
+    } finally {
+      await client.end();
+    }
+  });
+
+  it("drops the page column, so nothing can keep writing the old anchor", async () => {
+    const client = postgres(testUrl, { max: 1 });
+    try {
+      const columns = await client<{ column_name: string }[]>`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'kb_chunks' AND column_name IN ('page', 'locator')
+      `;
+      expect(columns.map((c) => c.column_name).sort()).toEqual(["locator"]);
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/chunk-locator-drift.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/chunk-locator-drift.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Drift guard: the chunk locator — the union AND its renderer — is duplicated
+ * across
+ *   packages/web/src/lib/knowledge/locator.ts   (writes it: ingest, retrieve, schema)
+ *   packages/plugins/pinchy-knowledge/locator.ts (renders it: formatWithCitations)
+ *
+ * The duplication is intentional and unavoidable: a plugin is a separate
+ * package that cannot import from the web app (the same bundle-isolation reason
+ * `normalizeTableHtml` is duplicated), yet the plugin is the layer that turns a
+ * locator into the citation string a reader sees.
+ *
+ * What drift would cost: Wave 2 adds a producer per format (Word headings,
+ * slides, sheet ranges). A kind added on the web side only would reach the
+ * plugin as an unhandled variant and render as nothing — a citation that names
+ * a document but no longer says WHERE in it, which is half of what makes a
+ * citation checkable. The whole point of keeping the locator a closed union
+ * (#933) is that the two sides cannot diverge, so the closure has to be
+ * enforced across the package boundary too, not just inside each copy.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const WEB_FILE = resolve(import.meta.dirname, "../../../lib/knowledge/locator.ts");
+const PLUGIN_FILE = resolve(
+  import.meta.dirname,
+  "../../../../../plugins/pinchy-knowledge/locator.ts"
+);
+
+/** Strips comments and collapses whitespace: prose may differ, code may not. */
+function canonicalize(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+describe("ChunkLocator drift guard", () => {
+  it("web and plugin copies are identical modulo comments and whitespace", () => {
+    const web = canonicalize(readFileSync(WEB_FILE, "utf-8"));
+    const plugin = canonicalize(readFileSync(PLUGIN_FILE, "utf-8"));
+
+    expect(plugin).toBe(web);
+  });
+
+  it("both copies declare every locator kind, so neither can quietly lose one", () => {
+    // Belt and braces on top of the equality check: if a future edit ever
+    // relaxes the comparison, this still fails when a kind goes missing.
+    for (const [label, file] of [
+      ["web", WEB_FILE],
+      ["plugin", PLUGIN_FILE],
+    ] as const) {
+      const source = readFileSync(file, "utf-8");
+      for (const kind of ["page", "slide", "heading", "sheet"]) {
+        expect(source, `${label} copy is missing the "${kind}" locator kind`).toContain(
+          `kind: "${kind}"`
+        );
+      }
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/citation-path.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/citation-path.test.ts
@@ -1,0 +1,76 @@
+/**
+ * A citation is only useful if the reader recognises the path in it. We index
+ * from a container mount and store `/data/…`, which nobody at the customer has
+ * ever seen — they know the tree below it from Explorer. #933.
+ *
+ * The pair is a BIJECTION on purpose, and that is the load-bearing property
+ * here rather than a nicety: the citation shown to the model is also the string
+ * `source-links.ts` linkifies, and the link has to resolve back to the exact
+ * file the retrieval returned. A lossy prettifier would hand the reader a
+ * citation they recognise attached to a link that opens nothing.
+ */
+import { describe, it, expect } from "vitest";
+
+import { toCitationPath, fromCitationPath, DATA_ROOT } from "@/lib/knowledge/citation-path";
+
+const CORPUS = [
+  "/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf",
+  "/data/handbook-2011/policy.md",
+  "/data/kb/2011/spec.pdf",
+  "/data/kb/2012/spec.pdf",
+  "/data/report.pdf",
+];
+
+describe("toCitationPath", () => {
+  it("drops the data root so the citation reads as the customer's own tree", () => {
+    expect(toCitationPath("/data/noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf")).toBe(
+      "noack/OLD/QF_2012/PrintingFiles_QF/PI_EColi.pdf"
+    );
+  });
+
+  it("keeps same-named documents in different folders distinguishable", () => {
+    expect(toCitationPath("/data/kb/2011/spec.pdf")).toBe("kb/2011/spec.pdf");
+    expect(toCitationPath("/data/kb/2012/spec.pdf")).toBe("kb/2012/spec.pdf");
+  });
+
+  it("keeps the mount name, because two mounts can hold the same tree", () => {
+    // Stripping the mount as well would read marginally closer to Explorer and
+    // cost two things that matter more: `hr/policy.pdf` and `eng/policy.pdf`
+    // would collapse into one indistinguishable citation, and the mapping would
+    // stop being invertible — see fromCitationPath.
+    expect(toCitationPath("/data/hr/policy.pdf")).toBe("hr/policy.pdf");
+    expect(toCitationPath("/data/eng/policy.pdf")).toBe("eng/policy.pdf");
+  });
+
+  it("leaves a path outside the data root untouched rather than mangling it", () => {
+    // Ingest cannot reach outside /data (path-validation.ts), so this is a
+    // can't-happen. Returning the input unchanged means an unexpected shape
+    // costs readability, never correctness.
+    expect(toCitationPath("/srv/elsewhere/report.pdf")).toBe("/srv/elsewhere/report.pdf");
+  });
+
+  it("never leaks the absolute container path for any corpus-shaped input", () => {
+    for (const absolute of CORPUS) {
+      expect(toCitationPath(absolute).startsWith(DATA_ROOT), absolute).toBe(false);
+    }
+  });
+});
+
+describe("fromCitationPath", () => {
+  it("round-trips every corpus-shaped path back to the byte-identical original", () => {
+    // The property the citation link depends on. If this ever stops holding,
+    // a reader gets a citation they recognise and a link that opens nothing.
+    for (const absolute of CORPUS) {
+      expect(fromCitationPath(toCitationPath(absolute)), absolute).toBe(absolute);
+    }
+  });
+
+  it("confines a citation path to the data root even when it tries to climb out", () => {
+    // The path in a link comes from MODEL output, so it is untrusted. This
+    // function only ever produces a /data/-prefixed string; the workspace-file
+    // route still resolves and re-checks it against the agent's granted paths,
+    // so this is the outer of two gates, not the only one.
+    expect(fromCitationPath("../etc/passwd").startsWith(DATA_ROOT)).toBe(true);
+    expect(fromCitationPath("/etc/passwd").startsWith(DATA_ROOT)).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/citation-path.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/citation-path.test.ts
@@ -10,6 +10,8 @@
  * citation they recognise attached to a link that opens nothing.
  */
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import { toCitationPath, fromCitationPath, DATA_ROOT } from "@/lib/knowledge/citation-path";
 
@@ -53,6 +55,22 @@ describe("toCitationPath", () => {
     for (const absolute of CORPUS) {
       expect(toCitationPath(absolute).startsWith(DATA_ROOT), absolute).toBe(false);
     }
+  });
+});
+
+describe("client-bundle safety", () => {
+  it("imports nothing, so the markdown renderer cannot drag node:path into the browser", () => {
+    // `source-links.ts` is reached from a client component and imports this
+    // module. DATA_ROOT therefore lives HERE and `path-validation.ts` (which
+    // imports `node:path`) imports it back, not the other way round. The real
+    // authority on this is `next build` in CI — a source check cannot see a
+    // transitive pull-in through a barrel file — but this states the constraint
+    // where the constraint lives, and fails in seconds rather than minutes.
+    const source = readFileSync(
+      resolve(import.meta.dirname, "../../../lib/knowledge/citation-path.ts"),
+      "utf-8"
+    );
+    expect(source).not.toMatch(/^\s*import\b/m);
   });
 });
 

--- a/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
@@ -109,7 +109,18 @@ it("indexes a PDF into kb_documents + kb_chunks with real embeddings, then skips
     expect(chunk.embedding).toHaveLength(768);
     expect(chunk.sourcePath).toBe(pdfPath);
     expect(chunk.orgId).toBe(ORG_ID);
+    // The anchor a citation will point at. PDF pages are intrinsic, so `page`
+    // is the honest locator kind here — and it is the ONLY producer that
+    // exists, so anything else in this column means a chunk was written by
+    // something that has not been reviewed against the union (#933).
+    expect(chunk.locator).toEqual({ kind: "page", page: expect.any(Number) });
   }
+  // Both extracted pages are represented, so a citation can distinguish them.
+  // A set, not a list: how many chunks a page yields is the chunker's business.
+  const anchoredPages = new Set(
+    chunks.map((c) => (c.locator?.kind === "page" ? c.locator.page : null))
+  );
+  expect([...anchoredPages].sort()).toEqual([1, 2]);
   // notes.txt must never have reached extraction/embedding.
   expect(embed).toHaveBeenCalledTimes(1);
 

--- a/packages/web/src/__tests__/lib/knowledge/kb-retrieval-eval.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/kb-retrieval-eval.integration.test.ts
@@ -144,7 +144,7 @@ async function seedCorpus(
           orgId: ORG_ID,
           sourcePath: doc.sourcePath,
           chunkText: chunk.text,
-          page: chunk.page,
+          locator: { kind: "page", page: chunk.page },
           embedding,
         })
         .returning();

--- a/packages/web/src/__tests__/lib/knowledge/linkable-extensions-drift.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/linkable-extensions-drift.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Drift guard: which extensions a citation can be turned into a link for is
+ * decided TWICE inside source-links.ts, and the two must agree.
+ *
+ * `EXTENSION` is the landmark the windowed scan hunts for — the reason the
+ * transform is linear rather than catastrophically backtracking — and
+ * `SOURCE_PATH_ENDING_HERE` is the anchored pattern that validates the path
+ * ending there. They exist as a pair only because the scan cannot be driven by
+ * the anchored pattern itself, not because they are allowed to differ.
+ *
+ * Both directions are a real defect and neither shows up as a test failure
+ * elsewhere:
+ *
+ *   - an extension in `EXTENSION` but not in the path pattern is dead work —
+ *     every occurrence is found and then rejected, and it reads as "we support
+ *     .docx" while linking nothing;
+ *   - an extension in the path pattern but not in `EXTENSION` is worse: the
+ *     scan never looks there, so the type is silently unlinkable and the only
+ *     symptom is a citation that stopped being clickable.
+ *
+ * Wave 2 widens this alternation (#936/#937 make Office and spreadsheets
+ * servable), which is exactly when a pair like this drifts. Source inspection
+ * rather than behaviour, because the failure is a MISSING case: no fixture set
+ * can cover an extension nobody has thought of yet.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { DEFAULT_ALLOWED_EXTENSIONS } from "@/lib/knowledge/exclude-globs";
+
+const SOURCE_LINKS = resolve(import.meta.dirname, "../../../lib/knowledge/source-links.ts");
+
+/** Every `.ext` literal inside a regex assigned to `name`. */
+function extensionsIn(source: string, name: string): string[] {
+  const declaration = new RegExp(`const ${name}\\s*=\\s*(/[^\\n]+/[gimsuy]*)`).exec(source);
+  if (!declaration) {
+    throw new Error(`No regex literal assigned to ${name} in source-links.ts — update this guard`);
+  }
+  return [...declaration[1].matchAll(/\\\.([a-z0-9]+)/gi)].map((m) => m[1].toLowerCase()).sort();
+}
+
+describe("linkable-extension drift guard", () => {
+  const source = readFileSync(SOURCE_LINKS, "utf-8");
+
+  it("the scan landmark and the path pattern allow exactly the same extensions", () => {
+    expect(extensionsIn(source, "EXTENSION")).toEqual(
+      extensionsIn(source, "SOURCE_PATH_ENDING_HERE")
+    );
+  });
+
+  it("links no type the ingest cannot index in the first place", () => {
+    // The looser direction is fine and stays unasserted: the ingest may accept
+    // a type before the viewer can render it (Wave 2 lands in that order). The
+    // reverse is a broken promise — a link the route can only 404, offered for
+    // a document that was never in the corpus.
+    const indexable = DEFAULT_ALLOWED_EXTENSIONS.map((ext) => ext.replace(/^\./, "").toLowerCase());
+    for (const linkable of extensionsIn(source, "EXTENSION")) {
+      expect(indexable, `.${linkable} is linkable but not indexable`).toContain(linkable);
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/locator.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/locator.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The chunk locator is the anchor a citation points at. It is a CLOSED union
+ * rather than a free-form string because Wave 2 adds one producer per format
+ * (Office, spreadsheets) against it, and a stringly-typed anchor is exactly
+ * what would let two of them drift apart — see #933.
+ *
+ * Only the `page` producer exists today (PDF ingest), so the other three kinds
+ * are pinned here by their rendering alone. That is deliberate: the renderer is
+ * the contract Wave 2 has to hit, and pinning it now means a later producer
+ * cannot quietly invent a second spelling for the same anchor.
+ */
+import { describe, it, expect } from "vitest";
+
+import { formatLocator, type ChunkLocator } from "@/lib/knowledge/locator";
+
+describe("formatLocator", () => {
+  it("renders a PDF page as the `p. N` form citations already use", () => {
+    expect(formatLocator({ kind: "page", page: 12 })).toBe("p. 12");
+  });
+
+  it("renders a slide by its number, because slide N is intrinsic to the deck", () => {
+    expect(formatLocator({ kind: "slide", slide: 4 })).toBe("slide 4");
+  });
+
+  it("renders a Word anchor as its heading path, never as a page", () => {
+    // Word pagination is a RENDERING result (fonts, printer metrics, Word vs
+    // LibreOffice), so a page number is not a property of the document the
+    // reader opens. The heading path is.
+    expect(formatLocator({ kind: "heading", headings: ["Quality", "Incoming goods"] })).toBe(
+      "§ Quality > Incoming goods"
+    );
+  });
+
+  it("renders a single-level heading path without a separator", () => {
+    expect(formatLocator({ kind: "heading", headings: ["Scope"] })).toBe("§ Scope");
+  });
+
+  it("renders a spreadsheet anchor as its sheet and row range", () => {
+    expect(formatLocator({ kind: "sheet", sheet: "Suppliers", startRow: 5, endRow: 12 })).toBe(
+      "Suppliers, rows 5-12"
+    );
+  });
+
+  it("renders a one-row spreadsheet anchor in the singular", () => {
+    expect(formatLocator({ kind: "sheet", sheet: "Suppliers", startRow: 7, endRow: 7 })).toBe(
+      "Suppliers, row 7"
+    );
+  });
+
+  it("is exhaustive over the union — a new kind must not fall through to a bare string", () => {
+    // Compile-time exhaustiveness is what actually enforces this (the switch
+    // has no default), so this case only guards the runtime fallback a future
+    // edit might add: every declared kind must render to something non-empty.
+    const all: ChunkLocator[] = [
+      { kind: "page", page: 1 },
+      { kind: "slide", slide: 1 },
+      { kind: "heading", headings: ["A"] },
+      { kind: "sheet", sheet: "S", startRow: 1, endRow: 2 },
+    ];
+    for (const locator of all) {
+      expect(formatLocator(locator).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/retrieve.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/retrieve.integration.test.ts
@@ -24,6 +24,7 @@ import { db } from "@/db";
 import { kbChunks, kbDocuments } from "@/db/schema";
 import { EMBEDDING_DIMENSIONS } from "@/lib/knowledge/constants";
 import { retrieve, type RetrieveDeps } from "@/lib/knowledge/retrieve";
+import type { ChunkLocator } from "@/lib/knowledge/locator";
 
 const ORG_ID = "org-kb-retrieve-test";
 // Match the live column width so inserts don't fail the vector(N) check; a
@@ -58,6 +59,8 @@ interface SeedChunk {
   embedding: number[];
   page?: number;
   status?: "active" | "archived";
+  /** Set to null to seed a chunk with no anchor at all, the way a format without a stable one would. */
+  locator?: ChunkLocator | null;
 }
 
 async function seedChunk(seed: SeedChunk): Promise<{ documentId: string; chunkId: string }> {
@@ -78,7 +81,7 @@ async function seedChunk(seed: SeedChunk): Promise<{ documentId: string; chunkId
       orgId: ORG_ID,
       sourcePath: seed.sourcePath,
       chunkText: seed.text,
-      page: seed.page ?? 1,
+      locator: seed.locator === undefined ? { kind: "page", page: seed.page ?? 1 } : seed.locator,
       embedding: seed.embedding,
     })
     .returning();
@@ -106,7 +109,7 @@ it("ranks the chunk matching both the embedding and the query terms on top", asy
     chunkId: best.chunkId,
     documentId: best.documentId,
     sourcePath: "/data/handbook.pdf",
-    page: 1,
+    locator: { kind: "page", page: 1 },
   });
   expect(typeof results[0].score).toBe("number");
   expect(results[0].score).toBeGreaterThan(0);
@@ -273,7 +276,7 @@ it("only retrieves chunks for the given org (ignores another org's data even und
       orgId: "org-kb-retrieve-other",
       sourcePath: "/data/shared-name.pdf",
       chunkText: "The vacation policy allows unlimited PTO.",
-      page: 1,
+      locator: { kind: "page", page: 1 },
       embedding: oneHot(0),
     })
     .returning();
@@ -344,7 +347,7 @@ async function seedDoc(
         orgId: ORG_ID,
         sourcePath,
         chunkText: chunk.text,
-        page: i + 1,
+        locator: { kind: "page", page: i + 1 },
         embedding: chunk.embedding,
       })
       .returning();

--- a/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
@@ -3,14 +3,19 @@
  * Sources list is written by the model — nothing renders it. Three real shapes
  * were observed against the same corpus within one day:
  *
- *   - kimi-k2.6, obeying the template:  `- [2] /data/x/doc.pdf — p. 44`
- *   - kimi-k2.6, embellishing:          `[1] /data/x/doc.pdf – AOAC study, Tabelle 18 …`
+ *   - kimi-k2.6, obeying the template:  `- [2] noack/x/doc.pdf — p. 44`
+ *   - kimi-k2.6, embellishing:          `[1] noack/x/doc.pdf – AOAC study, Tabelle 18 …`
  *   - deepseek-v4-pro, its own idea:    `*Quelle: PPR document.pdf, S. 275*`
  *
  * So the transform keys off the ONE thing every shape carries — a path with a
  * known document extension — and never off the surrounding format. Whatever it
  * does not recognise it leaves untouched: the fallback is today's plain text,
  * so a model inventing a fourth shape costs a link, never a broken answer.
+ *
+ * The paths are DATA-ROOT-RELATIVE, because that is what `knowledge_search`
+ * shows the model and the model can only cite what it is shown (#933). The href
+ * carries the absolute path the route needs — `citation-path.ts` is the single
+ * place that converts between the two, in both directions.
  */
 import { describe, it, expect } from "vitest";
 
@@ -46,30 +51,44 @@ const run = (tree: Node) => {
 };
 
 describe("buildSourceHref", () => {
-  it("points at the agent's workspace-file route with the path encoded", () => {
-    // Spaces and & are both real in this corpus ("PF LAB/… afnor_update_&_support.pdf")
-    // and both break a bare query string, so encoding is not cosmetic.
-    const href = buildSourceHref(AGENT, "/data/noack/PF LAB/a & b.pdf", null);
+  it("points at the agent's workspace-file route with the ABSOLUTE path encoded", () => {
+    // The citation is relative; the route opens a file, so the href has to
+    // carry the path the filesystem answers to. Spaces and & are both real in
+    // this corpus ("PF LAB/… afnor_update_&_support.pdf") and both break a bare
+    // query string, so encoding is not cosmetic either.
+    const href = buildSourceHref(AGENT, "noack/PF LAB/a & b.pdf", null);
     expect(href).toBe(
       "/api/agents/agent-1/workspace-file?path=%2Fdata%2Fnoack%2FPF%20LAB%2Fa%20%26%20b.pdf"
     );
   });
 
   it("appends the PDF viewer's page fragment when a page is known", () => {
-    const href = buildSourceHref(AGENT, "/data/x/doc.pdf", 44);
+    const href = buildSourceHref(AGENT, "x/doc.pdf", 44);
     expect(href.endsWith("#page=44")).toBe(true);
+  });
+
+  it("cannot be talked out of the data root by a fabricated citation", () => {
+    // The path comes from model output. This is the outer of two gates — the
+    // route still resolves the result against the agent's allowed_paths — but a
+    // fabricated citation must not even be SHAPED into an escape.
+    expect(buildSourceHref(AGENT, "../../etc/passwd.pdf", null)).toBe(
+      "/api/agents/agent-1/workspace-file?path=%2Fdata%2Fetc%2Fpasswd.pdf"
+    );
   });
 });
 
 describe("parseSourceHref", () => {
   it("round-trips a path built by buildSourceHref, so the viewer gets a real title", () => {
-    const path = "/data/noack/PF LAB/a & b.pdf";
+    // Round-trips to the CITATION path, not the absolute one: this value is the
+    // viewer's title, and a title reading "/data/noack/…" would put the
+    // container path back in front of the reader that #933 took out of it.
+    const path = "noack/PF LAB/a & b.pdf";
     expect(parseSourceHref(buildSourceHref(AGENT, path, 44))).toEqual({ path, page: 44 });
   });
 
   it("reports no page when the href carries none", () => {
-    expect(parseSourceHref(buildSourceHref(AGENT, "/data/x/doc.pdf", null))).toEqual({
-      path: "/data/x/doc.pdf",
+    expect(parseSourceHref(buildSourceHref(AGENT, "x/doc.pdf", null))).toEqual({
+      path: "x/doc.pdf",
       page: null,
     });
   });
@@ -101,31 +120,31 @@ describe("parseSourceHref", () => {
 
 describe("remarkSourceLinks", () => {
   it("links a template-formatted source and keeps its page", () => {
-    const tree = run(paragraph("- [2] /data/noack/PPR/document.pdf — p. 44"));
+    const tree = run(paragraph("- [2] noack/PPR/document.pdf — p. 44"));
     expect(links(tree)).toEqual([
       {
         url: "/api/agents/agent-1/workspace-file?path=%2Fdata%2Fnoack%2FPPR%2Fdocument.pdf#page=44",
-        text: "/data/noack/PPR/document.pdf",
+        text: "noack/PPR/document.pdf",
       },
     ]);
   });
 
   it("links a source buried in prose, where the format collapsed", () => {
     const tree = run(
-      paragraph("Quellen: [1] /data/noack/PF RAC/study.pdf – AOAC Performance Tested Method Study")
+      paragraph("Quellen: [1] noack/PF RAC/study.pdf – AOAC Performance Tested Method Study")
     );
     const found = links(tree);
     expect(found).toHaveLength(1);
-    expect(found[0].text).toBe("/data/noack/PF RAC/study.pdf");
+    expect(found[0].text).toBe("noack/PF RAC/study.pdf");
   });
 
   it("reads a German page abbreviation", () => {
-    const tree = run(paragraph("Quelle: /data/noack/PPR/document.pdf, S. 275"));
+    const tree = run(paragraph("Quelle: noack/PPR/document.pdf, S. 275"));
     expect(links(tree)[0].url.endsWith("#page=275")).toBe(true);
   });
 
   it("keeps the surrounding words as text around the link", () => {
-    const tree = run(paragraph("siehe /data/x/doc.pdf für Details"));
+    const tree = run(paragraph("siehe x/doc.pdf für Details"));
     const para = tree.children![0];
     expect(para.children!.map((c) => c.type)).toEqual(["text", "link", "text"]);
     expect(para.children![0].value).toBe("siehe ");
@@ -133,8 +152,8 @@ describe("remarkSourceLinks", () => {
   });
 
   it("links every source when one line names several", () => {
-    const tree = run(paragraph("[1] /data/a/one.pdf — p. 1 [2] /data/b/two.pdf — p. 2"));
-    expect(links(tree).map((l) => l.text)).toEqual(["/data/a/one.pdf", "/data/b/two.pdf"]);
+    const tree = run(paragraph("[1] a/one.pdf — p. 1 [2] b/two.pdf — p. 2"));
+    expect(links(tree).map((l) => l.text)).toEqual(["a/one.pdf", "b/two.pdf"]);
   });
 
   it("leaves text without a document path completely alone", () => {
@@ -151,16 +170,16 @@ describe("remarkSourceLinks", () => {
     const tree: Node = {
       type: "root",
       children: [
-        { type: "inlineCode", value: "/data/x/doc.pdf" },
-        { type: "link", url: "/elsewhere", children: [{ type: "text", value: "/data/x/doc.pdf" }] },
+        { type: "inlineCode", value: "x/doc.pdf" },
+        { type: "link", url: "/elsewhere", children: [{ type: "text", value: "x/doc.pdf" }] },
       ],
     };
     run(tree);
-    expect(links(tree)).toEqual([{ url: "/elsewhere", text: "/data/x/doc.pdf" }]);
+    expect(links(tree)).toEqual([{ url: "/elsewhere", text: "x/doc.pdf" }]);
   });
 
   it("ignores a path whose extension we cannot serve", () => {
-    const tree = paragraph("/etc/passwd and /data/x/notes.exe");
+    const tree = paragraph("/etc/passwd and x/notes.exe");
     const before = JSON.stringify(tree);
     run(tree);
     expect(JSON.stringify(tree)).toBe(before);
@@ -169,11 +188,30 @@ describe("remarkSourceLinks", () => {
   it("links a url-shaped path the same way, because the route decides access", () => {
     // remark-gfm turns a real `https://…` url into a link node before this
     // plugin runs, so it never sees one. What DOES reach here is a bare
-    // `example.com/docs/manual.pdf`, which gfm does not autolink. Linking its
-    // path part is harmless — the route resolves it against allowed_paths and
-    // 403s — but it should be a decision on record, not an accident.
+    // `example.com/docs/manual.pdf`, which gfm does not autolink. Linking it is
+    // harmless — the route resolves it against allowed_paths and 403s — but it
+    // should be a decision on record, not an accident.
     const tree = run(paragraph("siehe example.com/docs/manual.pdf"));
-    expect(links(tree).map((l) => l.text)).toEqual(["/docs/manual.pdf"]);
+    expect(links(tree).map((l) => l.text)).toEqual(["example.com/docs/manual.pdf"]);
+  });
+
+  it("does not link a bare filename, which names no findable document", () => {
+    // A citation shortened to a basename is the failure a path exists to
+    // prevent — unfindable in a deep tree, ambiguous across folders. Linking it
+    // would dress that failure up as a working reference.
+    const tree = paragraph("siehe report.pdf für Details");
+    const before = JSON.stringify(tree);
+    run(tree);
+    expect(JSON.stringify(tree)).toBe(before);
+  });
+
+  it("treats an absolute path a model invented as just another citation path", () => {
+    // Nothing shows the model an absolute path any more, so one appearing in an
+    // answer is fabricated or copied from elsewhere. It resolves under the data
+    // root like everything else and 403s there — a decision on record, not a
+    // second code path.
+    const tree = run(paragraph("siehe /data/x/doc.pdf hier"));
+    expect(links(tree).map((l) => l.text)).toEqual(["data/x/doc.pdf"]);
   });
 
   it("keeps the path intact when earlier text case-folds to a different length", () => {
@@ -182,8 +220,8 @@ describe("remarkSourceLinks", () => {
     // characters, so every offset after it shifts by one and the extracted path
     // silently loses its first character. A German lab corpus with a Turkish
     // name in a sentence is enough to hit it.
-    const tree = run(paragraph("İ siehe /data/x/doc.PDF hier"));
-    expect(links(tree).map((l) => l.text)).toEqual(["/data/x/doc.PDF"]);
+    const tree = run(paragraph("İ siehe x/doc.PDF hier"));
+    expect(links(tree).map((l) => l.text)).toEqual(["x/doc.PDF"]);
   });
 
   it("reads a doubled extension as the shorter path", () => {
@@ -191,8 +229,8 @@ describe("remarkSourceLinks", () => {
     // pinned only so the windowed scan below cannot change it unnoticed: the
     // scan stops at the FIRST `.pdf` that a path can legally end on, where the
     // earlier unbounded regex kept expanding across it.
-    const tree = run(paragraph("/data/x/report.pdf.pdf"));
-    expect(links(tree).map((l) => l.text)).toEqual(["/data/x/report.pdf"]);
+    const tree = run(paragraph("x/report.pdf.pdf"));
+    expect(links(tree).map((l) => l.text)).toEqual(["x/report.pdf"]);
   });
 
   describe("pathological input", () => {

--- a/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
@@ -254,6 +254,15 @@ describe("remarkSourceLinks", () => {
       ["path-shaped text with no extension at all", "/" + "a/".repeat(6000) + "b".repeat(6000)],
       ["an extension the lookahead rejects", "/" + "a/".repeat(6000) + "b".repeat(6000) + ".pdfX"],
       ["many near-misses in one node", ("/" + "a/".repeat(20) + "b.pdfX ").repeat(300)],
+      // The three above never reach the anchored pattern — the boundary check
+      // rejects them first — so none of them measures the pattern itself. This
+      // one does: every `.pdf` passes the boundary check, and the window behind
+      // it holds no `/` at all, so the pattern has to fail from every start
+      // position in the window. That search only stays bounded because
+      // MAX_PATH_LENGTH bounds the window; the case matters more since the path
+      // became relative, because a leading `/` no longer pins where a match may
+      // begin.
+      ["an extension with no path in front of it", ("a".repeat(300) + ".pdf ").repeat(200)],
     ])("finishes %s in linear time", (_label, text) => {
       const tree = paragraph(text);
       const before = JSON.stringify(tree);

--- a/packages/web/src/__tests__/lib/knowledge/unsearchable.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/unsearchable.integration.test.ts
@@ -43,7 +43,7 @@ async function seedReadable(sourcePath: string): Promise<void> {
     orgId: ORG_ID,
     sourcePath,
     chunkText: "Some extracted text.",
-    page: 1,
+    locator: { kind: "page", page: 1 },
   });
 }
 
@@ -78,14 +78,14 @@ it("never lists a document that has chunks, not even once per chunk", async () =
       orgId: ORG_ID,
       sourcePath: "/data/certs/Handbook.pdf",
       chunkText: "Page one.",
-      page: 1,
+      locator: { kind: "page", page: 1 },
     },
     {
       documentId: doc.id,
       orgId: ORG_ID,
       sourcePath: "/data/certs/Handbook.pdf",
       chunkText: "Page two.",
-      page: 2,
+      locator: { kind: "page", page: 2 },
     },
   ]);
 
@@ -180,7 +180,7 @@ it("decides per document, not per path", async () => {
     orgId: ORG_ID,
     sourcePath: "/data/certs/Shared name.pdf",
     chunkText: "Text belonging to the other document.",
-    page: 1,
+    locator: { kind: "page", page: 1 },
   });
   await seedUnsearchable("/data/certs/Shared name.pdf");
 

--- a/packages/web/src/app/api/internal/knowledge/search/route.ts
+++ b/packages/web/src/app/api/internal/knowledge/search/route.ts
@@ -12,6 +12,7 @@ import { retrieve, type RetrievedChunk } from "@/lib/knowledge/retrieve";
 import { embedTexts } from "@/lib/knowledge/embeddings";
 import { kbEmbedderAvailable, kbEmbeddingConfig } from "@/lib/knowledge/kb-embedder";
 import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
+import { toCitationPath } from "@/lib/knowledge/citation-path";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { safeProviderError, type AuditLogEntry, type EntityRef } from "@/lib/audit";
 
@@ -176,11 +177,18 @@ export async function POST(request: NextRequest) {
   );
 
   return NextResponse.json({
+    // Two paths, two jobs. `sourcePath` stays ABSOLUTE: it identifies the
+    // document for the audit trail and for anything that has to open the file.
+    // `citationPath` is what the model is shown and therefore what lands in a
+    // citation, and it is relative to the data root — the `/data/<mount>/`
+    // prefix is what the container sees, and nobody at the customer recognises
+    // it (#933).
     results: chunks.map((chunk) => ({
       chunkId: chunk.chunkId,
       text: chunk.text,
       sourcePath: chunk.sourcePath,
-      page: chunk.page,
+      citationPath: toCitationPath(chunk.sourcePath),
+      locator: chunk.locator,
       docName: basename(chunk.sourcePath),
     })),
   });

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -42,6 +42,7 @@ import {
 } from "./enums";
 import type { EmailWorkflowFilter, ProcessedEmailOutcome } from "@/lib/email-workflows/types";
 import type { IngestResult } from "@/lib/knowledge/ingest";
+import type { ChunkLocator } from "@/lib/knowledge/locator";
 import type { OpenClawModelDefinition } from "@/lib/openclaw-builtin-models";
 import { vector } from "./vector";
 
@@ -1003,7 +1004,13 @@ export const kbChunks = pgTable(
     orgId: text("org_id").notNull(),
     sourcePath: text("source_path").notNull(),
     chunkText: text("chunk_text").notNull(),
-    page: integer("page"),
+    // Where in the document this chunk sits — a closed union (page / slide /
+    // heading path / sheet+rows), not a page number, because only PDFs have
+    // pages and Word pagination is a rendering result rather than a property
+    // of the file (see lib/knowledge/locator.ts, #933). Null when the format
+    // offers no stable anchor at all; a citation then names the document and
+    // says nothing more, which beats inventing a page.
+    locator: jsonb("locator").$type<ChunkLocator>(),
     lang: text("lang"),
     embedding: vector("embedding"),
   },

--- a/packages/web/src/lib/agent-templates/data/knowledge-base.ts
+++ b/packages/web/src/lib/agent-templates/data/knowledge-base.ts
@@ -25,14 +25,14 @@ export const KNOWLEDGE_BASE_TEMPLATES: Record<string, AgentTemplate> = {
 - If the sources don't contain the answer, say so honestly ("I couldn't find this in the knowledge base") — never guess
 - A knowledge_search ERROR is different from zero results: if the tool returns an error (not just an empty result set), the knowledge base is temporarily unavailable — tell the user to try again in a moment, and NEVER claim the knowledge base is empty or that no documents exist
 - If only partial context is found, answer what's supported and clearly flag what's missing, or ask a clarifying question — never pad an unsupported answer
-- Make citations self-contained: the reader only sees your answer text, not the search results, so end every grounded answer with a "Sources" list mapping each cited number to its document path and page. Reproduce the document path exactly as \`knowledge_search\` gave it to you — a bare filename cannot be found in a large document tree, and two folders may hold files with the same name
+- Make citations self-contained: the reader only sees your answer text, not the search results, so end every grounded answer with a "Sources" list mapping each cited number to its document path and the position \`knowledge_search\` gave for it — a page for a PDF, a slide number, a heading path, a sheet and row range. Reproduce both exactly as the tool wrote them: a bare filename cannot be found in a large document tree, two folders may hold files with the same name, and a page number invented for a document that has no pages points at nothing
 - The Sources list and your inline citations must match exactly — no more and no fewer. Every source number you cite inline MUST have an entry, or the reader hits a dead end and cannot check that claim at all. A source \`knowledge_search\` returned but that you did not cite must NOT have one: it makes a single-source claim look independently corroborated. Check the list against your finished answer before you send it. If you abstained and cited nothing, omit the list entirely
 - Write the Sources list as a markdown bullet list, one bullet per source, with a blank line before it. Your answer is rendered as markdown, so plain consecutive lines collapse into a single run-on paragraph. Format:
 \`\`\`
 
 **Sources:**
 
-- [1] <document path> — p. <page>
+- [1] <document path> — <position>
 \`\`\`
 - Structure longer answers with headings and bullet points`,
     modelHint: { tier: "balanced", capabilities: ["tools", "vision"] },

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -179,6 +179,26 @@ describe("gradePathCitation", () => {
     expect(gradePathCitation(input)).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
   });
 
+  it("passes when the answer cites the data-root-relative path the tool actually showed it", () => {
+    // The two sides arrive in different forms and always have: `retrieved`
+    // comes from the audit row, which records the ABSOLUTE sourcePath because
+    // that is a document's identity, while the answer reproduces what
+    // `knowledge_search` printed — data-root-relative since #933. Comparing
+    // them raw would fail every correctly-cited answer, which is the worst
+    // possible grader bug: it makes the metric that guards citation integrity
+    // read zero precisely when citation integrity is fine.
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:**
+
+- [1] handbook-2012/policy.md — p. 12`,
+      retrieved: [src(1, "/data/handbook-2012/policy.md")],
+    };
+
+    expect(gradePathCitation(input)).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
+  });
+
   it("does not choke on a hyphen inside the path itself when parsing the trailing page suffix", () => {
     // "/data/handbook-2012/policy.md" has a hyphen in the folder name; the
     // page-suffix parser must land on the LAST "— p. N" and not mistake the

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -35,6 +35,8 @@
  * concern belongs here, on what the model actually CITES, not on what
  * retrieval returns.
  */
+import { toCitationPath } from "@/lib/knowledge/citation-path";
+
 import type { KbFailureTag, KbGraderResult } from "./types";
 
 /** A source `knowledge_search` returned for the query this answer responds to. */
@@ -298,7 +300,15 @@ export function gradeCitationResolution(input: AttributionInput): KbGraderResult
  */
 export function gradePathCitation(input: AttributionInput): KbGraderResult {
   const { entries } = parseAnswer(input.answer);
-  const retrievedPaths = new Set(input.retrieved.map((source) => source.sourcePath));
+  // Compared in CITATION form on both sides. `retrieved` is built from the
+  // audit row, which records the absolute sourcePath because that is a
+  // document's identity; the answer reproduces what `knowledge_search` printed,
+  // which is data-root-relative (#933). `toCitationPath` is a no-op on a path
+  // that is already relative, so an answer echoing either form still resolves
+  // to the same document instead of reading as a fabrication.
+  const retrievedPaths = new Set(
+    input.retrieved.map((source) => toCitationPath(source.sourcePath))
+  );
 
   const notes: string[] = [];
   for (const entry of entries) {
@@ -308,7 +318,7 @@ export function gradePathCitation(input: AttributionInput): KbGraderResult {
       );
       continue;
     }
-    if (!retrievedPaths.has(entry.path)) {
+    if (!retrievedPaths.has(toCitationPath(entry.path))) {
       notes.push(
         `Sources entry [${entry.n}] cites path "${entry.path}", which does not match any path in the returned sources.`
       );

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -139,6 +139,16 @@ const BULLET_LINE = /^[ \t]*[-*][ \t]+\[(\d+)\]\s*(.+)$/gm;
  * range from folding into `entry.path` and spuriously failing the exact
  * path-match in `gradePathCitation`. `page` stores the FIRST page number
  * (`parseInt` of the range) — it is not asserted downstream yet.
+ *
+ * Only pages, deliberately, and only correct while only pages exist. Since
+ * #933 the anchor is a `ChunkLocator` and the contract asks for a POSITION:
+ * `slide 4`, `§ Quality > Incoming goods`, `Suppliers, rows 5-12`. None of
+ * those match here, so the whole line would fall into `entry.path` and grade a
+ * correct citation as a fabricated one. Nothing writes a non-page locator yet
+ * (xlsx-extract is not wired into the ingest, the Office path produces pages),
+ * so this cannot fire today — but the producer that changes that must
+ * generalise this parser in the same change. #982 has the trap and the reason
+ * a naive "split on any dash" fix would move committed eval numbers.
  */
 const PAGE_SUFFIX = /^(.*?)\s*[—-]\s*pp?\.?\s*(\d+(?:\s*[-–]\s*\d+)?)\s*$/i;
 

--- a/packages/web/src/lib/knowledge/citation-path.ts
+++ b/packages/web/src/lib/knowledge/citation-path.ts
@@ -1,0 +1,59 @@
+/**
+ * The two directions between the path ingest stored and the path a citation
+ * shows.
+ *
+ * A citation earns trust only if the reader can (a) find the document and (b)
+ * check the spot. We store what the CONTAINER sees — `/data/noack/OLD/QF_2012/
+ * PrintingFiles_QF/x.pdf` — and nobody at the customer has ever seen that
+ * prefix; what they know from Explorer is the tree below the mount. So a
+ * citation shows the path relative to the data root. (#933)
+ *
+ * The pair is a bijection, and that is a requirement rather than tidiness. The
+ * citation string is not only read by a human: `source-links.ts` linkifies it,
+ * and the link has to resolve back to the exact file retrieval returned. Which
+ * is also why the MOUNT segment stays. Dropping it too would read marginally
+ * closer to Explorer and cost two things worth more — `hr/policy.pdf` and
+ * `eng/policy.pdf` would collapse into one indistinguishable citation, the
+ * failure a full path exists to prevent, and there would be no way back to an
+ * absolute path at all, so every citation link would break.
+ *
+ * `sourcePath` stays absolute everywhere it IDENTIFIES a document — the
+ * retrieval audit row, the plugin's `returnedDocumentIds`, the workspace-file
+ * route — because those need the path the filesystem answers to.
+ *
+ * No imports on purpose: this module is reached from a client component (the
+ * markdown renderer, via source-links.ts), so it must not drag `node:path` into
+ * the browser bundle. `path-validation.ts` imports DATA_ROOT from HERE for the
+ * same reason, rather than the other way round.
+ */
+
+/** The one mount every corpus and every agent-visible file lives under. */
+export const DATA_ROOT = "/data/";
+
+/**
+ * Absolute stored path → the path a citation shows.
+ *
+ * A path outside the data root cannot come from ingest (path-validation.ts
+ * confines it) and is returned unchanged rather than guessed at.
+ */
+export function toCitationPath(absolutePath: string): string {
+  return absolutePath.startsWith(DATA_ROOT) ? absolutePath.slice(DATA_ROOT.length) : absolutePath;
+}
+
+/**
+ * The path a citation shows → the absolute path to open.
+ *
+ * The input is MODEL output, so it is untrusted: leading slashes and `..`
+ * segments are stripped before prefixing, which makes the result unconditionally
+ * a path under the data root. That is the outer of two gates — the
+ * workspace-file route still resolves the result and re-checks it against the
+ * agent's granted `allowed_paths` — but it means a fabricated citation cannot
+ * even be SHAPED into an escape before it gets there.
+ */
+export function fromCitationPath(citationPath: string): string {
+  const confined = citationPath
+    .split("/")
+    .filter((segment) => segment !== "" && segment !== "." && segment !== "..")
+    .join("/");
+  return DATA_ROOT + confined;
+}

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -47,6 +47,7 @@ import {
 import { isArchivedPath, statusForPath } from "./archive-paths";
 import { chunkPages } from "./chunk";
 import { detectLang } from "./lid";
+import type { ChunkLocator } from "./locator";
 import type { IngestPage, IngestResult } from "./types";
 
 // IngestPage/IngestResult live in ./types (a runtime-free module) because
@@ -203,7 +204,10 @@ async function writeChunks(
       orgId,
       sourcePath,
       chunkText: chunk.text,
-      page: chunk.page,
+      // The only locator producer that exists today. PDF pages are intrinsic,
+      // so `page` is the honest anchor here; Wave 2 adds the heading/slide/
+      // sheet producers against the same closed union (locator.ts, #933).
+      locator: { kind: "page", page: chunk.page } satisfies ChunkLocator,
       lang: detectLang(chunk.text),
       embedding: vectors[i],
     }))

--- a/packages/web/src/lib/knowledge/locator.ts
+++ b/packages/web/src/lib/knowledge/locator.ts
@@ -1,0 +1,68 @@
+/**
+ * Where inside a document a chunk sits — the anchor a citation points at.
+ *
+ * `kb_chunks` used to carry a bare `page`, which only PDFs have. Each format
+ * needs a different anchor, and the reason is not cosmetic:
+ *
+ *   PDF          page          intrinsic
+ *   PowerPoint   slide number  intrinsic, and slide N is PDF page N
+ *   Spreadsheet  sheet + rows  intrinsic
+ *   Word         heading path  pagination is a RENDERING result (fonts,
+ *                              printer metrics, Word vs LibreOffice), so a
+ *                              page number is not a property of the document
+ *                              the reader opens
+ *
+ * Forcing every format onto "page" would make a citation state something that
+ * is false of the file the user opens. Hence a CLOSED, typed union rather than
+ * a free-form string: Wave 2 adds one producer per format against it, and a
+ * stringly-typed anchor is exactly what would let two of them drift apart.
+ *
+ * ── Duplicated on purpose ────────────────────────────────────────────────
+ * This file exists twice, byte-for-byte:
+ *   packages/web/src/lib/knowledge/locator.ts
+ *   packages/plugins/pinchy-knowledge/locator.ts
+ * The plugin is a separate package that cannot import from the web app (the
+ * same bundle-isolation reason `normalizeTableHtml` is duplicated), yet it is
+ * the layer that RENDERS the citation. `chunk-locator-drift.test.ts` pins the
+ * two copies to be identical modulo comments and whitespace, so a fifth kind
+ * added on one side cannot silently go unrendered on the other.
+ */
+
+export type ChunkLocator =
+  /** A PDF page, 1-based. */
+  | { kind: "page"; page: number }
+  /** A presentation slide, 1-based. */
+  | { kind: "slide"; slide: number }
+  /**
+   * A Word heading path from the document's outline, outermost first
+   * (`["Quality", "Incoming goods"]`). Producers must supply at least one
+   * heading — a document with no outline at all has no stable anchor and its
+   * chunks carry a null locator instead.
+   */
+  | { kind: "heading"; headings: string[] }
+  /** A spreadsheet sheet and the 1-based, inclusive row range the chunk spans. */
+  | { kind: "sheet"; sheet: string; startRow: number; endRow: number };
+
+/**
+ * Renders a locator as the parenthesised hint that follows a document path in
+ * a citation ("p. 12", "slide 4", "§ Quality > Incoming goods").
+ *
+ * The switch deliberately has no `default`: with an explicit `string` return
+ * type, a fifth locator kind stops compiling here until it is given a
+ * rendering, which is what keeps the union closed in practice rather than
+ * merely in the type.
+ */
+export function formatLocator(locator: ChunkLocator): string {
+  switch (locator.kind) {
+    case "page":
+      return `p. ${locator.page}`;
+    case "slide":
+      return `slide ${locator.slide}`;
+    case "heading":
+      return `§ ${locator.headings.join(" > ")}`;
+    case "sheet":
+      return locator.startRow === locator.endRow
+        ? `${locator.sheet}, row ${locator.startRow}`
+        : `${locator.sheet}, rows ${locator.startRow}-${locator.endRow}`;
+  }
+}

--- a/packages/web/src/lib/knowledge/locator.ts
+++ b/packages/web/src/lib/knowledge/locator.ts
@@ -40,7 +40,11 @@ export type ChunkLocator =
    * chunks carry a null locator instead.
    */
   | { kind: "heading"; headings: string[] }
-  /** A spreadsheet sheet and the 1-based, inclusive row range the chunk spans. */
+  /**
+   * A spreadsheet sheet and the 1-based, inclusive row range the chunk spans.
+   * Field-for-field what `xlsx-extract.ts`'s `XlsxChunk` already produces, so
+   * wiring that extractor into the ingest is a spread rather than a mapping.
+   */
   | { kind: "sheet"; sheet: string; startRow: number; endRow: number };
 
 /**

--- a/packages/web/src/lib/knowledge/retrieve.ts
+++ b/packages/web/src/lib/knowledge/retrieve.ts
@@ -19,12 +19,15 @@ import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { buildPathFilter } from "./path-filter";
 
+import type { ChunkLocator } from "./locator";
+
 export interface RetrievedChunk {
   chunkId: string;
   documentId: string;
   text: string;
   sourcePath: string;
-  page: number | null;
+  /** Where in the document this chunk sits (page / slide / heading path / sheet+rows). Null when the format offers no stable anchor. */
+  locator: ChunkLocator | null;
   /** Fused RRF score (higher is more relevant). Not a probability or a distance. */
   score: number;
 }
@@ -82,7 +85,7 @@ interface RetrieveRow extends Record<string, unknown> {
   document_id: string;
   chunk_text: string;
   source_path: string;
-  page: number | null;
+  locator: ChunkLocator | null;
   score: string | number;
 }
 
@@ -180,7 +183,7 @@ export async function retrieve(
              c.document_id AS document_id,
              c.chunk_text AS chunk_text,
              c.source_path AS source_path,
-             c.page AS page,
+             c.locator AS locator,
              r.score AS score
       FROM ranked r
       JOIN kb_chunks c ON c.id = r.chunk_id
@@ -194,7 +197,7 @@ export async function retrieve(
       documentId: row.document_id,
       text: row.chunk_text,
       sourcePath: row.source_path,
-      page: row.page,
+      locator: row.locator,
       score: Number(row.score),
     }));
   });

--- a/packages/web/src/lib/knowledge/source-links.ts
+++ b/packages/web/src/lib/knowledge/source-links.ts
@@ -40,8 +40,12 @@ import { fromCitationPath, toCitationPath } from "./citation-path";
  * At least one `/` is required. A bare `report.pdf` is exactly the citation
  * shape a full path exists to prevent — unfindable in a deep tree, ambiguous
  * across folders — and linking it would dress that failure up as a working
- * reference. Anchoring on the extension is what keeps arbitrary path-shaped
- * strings (`/etc/passwd`) out.
+ * reference. The known cost: a grant that points at a single FILE at the data
+ * root (`/data/report.pdf`, a shape `discoverFiles` supports) cites as a bare
+ * name legitimately, and that citation stays plain text. Prose mentioning a
+ * filename is far commoner than that grant, so the trade goes this way.
+ * Anchoring on the extension is what keeps arbitrary path-shaped strings
+ * (`/etc/passwd`) out.
  *
  * Paths in a real corpus routinely contain spaces ("PF LAB/…"), so segments
  * allow them — except the FIRST one, which must be a whitespace-delimited

--- a/packages/web/src/lib/knowledge/source-links.ts
+++ b/packages/web/src/lib/knowledge/source-links.ts
@@ -20,22 +20,38 @@
  * the view. A fabricated path in an answer therefore yields a link that 403s —
  * it cannot widen what the user may read.
  */
+import { fromCitationPath, toCitationPath } from "./citation-path";
 
 /**
- * An absolute path ending in an extension we can serve, anchored at the END of
- * the slice it is run against — see `findSourcePaths` for why it is never let
- * loose on a whole text node. The extension is baked into the pattern rather
+ * A DATA-ROOT-RELATIVE path ending in an extension we can serve, anchored at the
+ * END of the slice it is run against — see `findSourcePaths` for why it is never
+ * let loose on a whole text node. The extension is baked into the pattern rather
  * than checked separately: a second predicate deciding the same thing is a pair
  * that drifts, and a mutation test proved the separate check was already
  * unreachable. Widening what is linkable therefore means editing this
  * alternation — today only `.pdf`, which is also the only type the ingest
  * accepts and the only one the route renders inline.
  *
- * Anchoring on the extension is what keeps arbitrary path-shaped strings
- * (`/etc/passwd`) out. Paths in a real corpus routinely contain spaces
- * ("PF LAB/…"), so segments allow them.
+ * Relative, with NO leading slash, because that is the shape `knowledge_search`
+ * shows the model and a model can only cite what it is shown (#933). The
+ * absolute form is rebuilt in `buildSourceHref` via `fromCitationPath`, the one
+ * place that knows the data root.
+ *
+ * At least one `/` is required. A bare `report.pdf` is exactly the citation
+ * shape a full path exists to prevent — unfindable in a deep tree, ambiguous
+ * across folders — and linking it would dress that failure up as a working
+ * reference. Anchoring on the extension is what keeps arbitrary path-shaped
+ * strings (`/etc/passwd`) out.
+ *
+ * Paths in a real corpus routinely contain spaces ("PF LAB/…"), so segments
+ * allow them — except the FIRST one, which must be a whitespace-delimited
+ * token. That asymmetry replaces the leading `/` the absolute form used to be
+ * pinned by: without something marking where a path may begin, the leftmost
+ * match happily swallows the prose in front of it and links "[1] a/one.pdf"
+ * rather than "a/one.pdf". A mount name with a space in it is the price, and
+ * "the citation starts at a word" is a rule a reader can predict.
  */
-const SOURCE_PATH_ENDING_HERE = /\/(?:[^\s/]|[^\s/][^/]*?[^\s/])?(?:\/[^/\n]+?)*?\.pdf$/i;
+const SOURCE_PATH_ENDING_HERE = /[^\s/]+(?:\/[^/\n]+?)+?\.pdf$/i;
 
 /** What may follow a path so that "…/doc.pdf." links the file and not the full stop. */
 const PATH_BOUNDARY = /[\s,.;:)\]]/;
@@ -110,13 +126,23 @@ interface MdastNode {
 }
 
 /**
- * Builds the href for one cited document. The path is carried as a query
- * parameter (not a path segment) because it is absolute and may contain any
- * character a filesystem allows; `#page=N` is the fragment Chrome's and
- * Firefox's built-in PDF viewers both honour, and it is inert for anything else.
+ * Builds the href for one cited document from the citation path the answer
+ * shows. The route opens a file, so the href carries the ABSOLUTE path — the
+ * conversion is `fromCitationPath`, which also confines the result to the data
+ * root, since `citationPath` reaches here from model output.
+ *
+ * The path is carried as a query parameter (not a path segment) because it is
+ * absolute and may contain any character a filesystem allows; `#page=N` is the
+ * fragment Chrome's and Firefox's built-in PDF viewers both honour, and it is
+ * inert for anything else.
  */
-export function buildSourceHref(agentId: string, path: string, page: number | null): string {
-  const base = `/api/agents/${encodeURIComponent(agentId)}/workspace-file?path=${encodeURIComponent(path)}`;
+export function buildSourceHref(
+  agentId: string,
+  citationPath: string,
+  page: number | null
+): string {
+  const absolutePath = fromCitationPath(citationPath);
+  const base = `/api/agents/${encodeURIComponent(agentId)}/workspace-file?path=${encodeURIComponent(absolutePath)}`;
   return page === null ? base : `${base}#page=${page}`;
 }
 
@@ -137,12 +163,15 @@ export function buildSourceHref(agentId: string, path: string, page: number | nu
 export const WORKSPACE_FILE_HREF = /^\/api\/agents\/[^/]+\/workspace-file\?path=([^#]*)(?:#(.*))?$/;
 
 /**
- * Recovers the document path from an href built by `buildSourceHref`, for use
- * as the viewer's title. Returns null for anything else, which is how the
- * renderer tells a citation from an ordinary link. Kept beside the builder so
- * the two cannot drift — a dialog whose accessible name silently came back
- * empty would be a real defect for a screen-reader user, and string surgery on
- * a url is exactly the kind of code that decays quietly.
+ * Recovers the CITATION path from an href built by `buildSourceHref`, for use
+ * as the viewer's title. Citation and not absolute: this value is what the
+ * reader sees above the document, and `/data/noack/…` there would put the
+ * container path straight back in front of them (#933). Returns null for
+ * anything else, which is how the renderer tells a citation from an ordinary
+ * link. Kept beside the builder so the two cannot drift — a dialog whose
+ * accessible name silently came back empty would be a real defect for a
+ * screen-reader user, and string surgery on a url is exactly the kind of code
+ * that decays quietly.
  */
 export function parseSourceHref(href: string): { path: string; page: number | null } | null {
   const match = WORKSPACE_FILE_HREF.exec(href);
@@ -153,7 +182,10 @@ export function parseSourceHref(href: string): { path: string; page: number | nu
 
   const pageMatch = /^page=(\d{1,5})$/.exec(fragment ?? "");
   try {
-    return { path: decodeURIComponent(encodedPath), page: pageMatch ? Number(pageMatch[1]) : null };
+    return {
+      path: toCitationPath(decodeURIComponent(encodedPath)),
+      page: pageMatch ? Number(pageMatch[1]) : null,
+    };
   } catch {
     // A malformed percent-escape must not take down the render of a whole message.
     return null;

--- a/packages/web/src/lib/path-validation.ts
+++ b/packages/web/src/lib/path-validation.ts
@@ -1,6 +1,14 @@
 import { resolve, normalize } from "path";
 
-const DATA_ROOT = "/data/";
+// DATA_ROOT is defined in knowledge/citation-path.ts, not here, and imported
+// back — a one-way dependency chosen for a bundling reason, not a layering
+// one. citation-path.ts is reached from a client component (the markdown
+// renderer, via source-links.ts); this module imports `node:path`, so a
+// dependency in the other direction would pull a Node builtin into the browser
+// bundle. Re-exported so existing importers of path-validation keep working and
+// there is still exactly one definition.
+export { DATA_ROOT } from "./knowledge/citation-path";
+import { DATA_ROOT } from "./knowledge/citation-path";
 
 export function sanitizePath(inputPath: string): string {
   if (typeof inputPath !== "string") {


### PR DESCRIPTION
## What does this PR do?

Generalises the knowledge-base chunk anchor and makes a citation name a path the reader recognises.

Closes #933

`kb_chunks` carried `page`. Only PDFs have pages. A slide deck is anchored by slide number and a spreadsheet by sheet + row range — both intrinsic — and a Word document by its **heading path**, because Word pagination is a *rendering* result (fonts, printer metrics, Word vs LibreOffice) rather than a property of the file the reader opens. Forcing every format onto "page" would make a citation state something false about the document the user is looking at.

So the anchor becomes a closed, typed union (`ChunkLocator`): page / slide / heading path / sheet+rows. Closed rather than a free-form string because Wave 2 adds one producer per format against it, and a stringly-typed anchor is exactly what lets two of them drift apart. Only the PDF producer exists here, so retrieval, citation text and link are unchanged end to end for an existing corpus.

The second half is the path. We showed the *container's* view — `/data/noack/OLD/QF_2012/…` — which nobody at the customer recognises; what they know from Explorer is the tree below the mount.

### One deliberate deviation from the issue

The issue asks to strip `/data/<mount>/`, so a citation reads `OLD/QF_2012/….pdf`. This PR strips only `/data/`: `noack/OLD/QF_2012/….pdf`.

`source-links.ts` landed between the issue being written and this work, and it turns the cited path **back** into the file to open. Mount-stripping is not invertible, so every citation link would break; and with two mounts, `hr/policy.pdf` and `eng/policy.pdf` would collapse into one indistinguishable citation — the exact failure a full path exists to prevent. `citation-path.ts` is therefore a bijection (`toCitationPath` / `fromCitationPath`), with a round-trip test over corpus-shaped paths. Happy to go the other way if you'd rather have the shorter string and accept a lookup for the link.

### Also in scope, because it would otherwise have broken silently

- **`gradePathCitation`** compared the cited path (now relative) against the audit row's `sourcePath` (absolute, because that is a document's identity). Left alone it would have failed **every correct citation** — the worst kind of grader bug: the metric guarding citation integrity reads zero precisely when integrity is fine. Both sides are now normalised to citation form.
- **The citation contract** in the tool result and the KB template now ask for "path and position", not "path and page".
- **`source-links.ts`** recognises a data-root-relative path. A bare filename is deliberately *not* linkable — linking it would dress up an unfindable citation as a working reference.

### Notes for Wave 2

`xlsx-extract.ts` (#937) already exists on main but is not wired into the ingest — the locator column was the missing piece. The `sheet` variant matches `XlsxChunk` field-for-field, so wiring it in is a spread rather than a mapping.

## Type of change

- [x] ✨ New feature
- [x] ♻️ Refactor
- [x] 📝 Documentation
- [x] 🧪 Tests

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [ ] All existing tests pass — see below

## Testing

Green locally: `typecheck` (web incl. tests) and `typecheck:plugins` (9/9), `format:check`, `lint` (0 errors), `test:scripts` (407), `test:plugins`, a focused unit run across every touched area (651 tests), and the KB + DB integration files against a real Postgres (19 files, 112 tests).

**Not** verified locally: the *full* unit and integration suites. This machine sat at load average 100–435 from parallel worktree stacks; the failures were all `CONNECT_TIMEOUT` and "Failed to start forks worker", never an assertion. I'm not claiming a green full local run — CI owns that here.

Worth a reviewer's attention:

- **`drizzle/0060` + `0061`** are split on purpose: add + backfill is committed before the drop, so a run dying between them leaves every anchor carried over instead of destroyed. `migration-kb-chunk-locator.integration.test.ts` seeds rows the way the **old** code wrote them and reads them with the new (AGENTS.md § *Test Migrations Against Pre-Existing Data*) — a fresh-DB run proves nothing when every row that needs converting predates the column.
- **The locator union + renderer is duplicated** into `packages/plugins/pinchy-knowledge/`, which cannot import from the web app but is the layer that renders the citation. `chunk-locator-drift.test.ts` pins the two copies together; verified by mutation.
- **`source-links.ts` now holds two `.pdf` literals** (the scan landmark and the path pattern). `linkable-extensions-drift.test.ts` keeps them identical and refuses an extension the ingest cannot index — this is the pair Wave 2 widens.
- **`DATA_ROOT` moved** from `path-validation.ts` into `citation-path.ts`, and is re-exported back. Bundling, not layering: `citation-path.ts` is reached from a client component via the markdown renderer, and `path-validation.ts` imports `node:path`.
