### PR TITLE
fix(providers): bound the cloud catalog fetch, keep E2E off the internet

### DIFF
--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -32,6 +32,26 @@ export default defineConfig({
   webServer: {
     command:
       "DATABASE_URL=postgresql://pinchy:pinchy_dev@localhost:5433/pinchy_test BETTER_AUTH_SECRET=test-secret-for-e2e-at-least-32chars ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000001 AUDIT_HMAC_SECRET=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef WORKSPACE_BASE_PATH=/tmp/pinchy-test-workspaces OPENCLAW_CONFIG_PATH=/tmp/pinchy-e2e-config/openclaw.json OPENCLAW_DATA_PATH=/tmp/pinchy-e2e-config OPENCLAW_SECRETS_PATH=/tmp/pinchy-e2e-secrets/secrets.json PORT=7778 node -r ./server-preload.cjs --import tsx server.ts",
+    // `helpers.ts` seeds `default_provider=anthropic` with a fake key, so the
+    // first `/api/templates` render calls the REAL api.anthropic.com from the
+    // runner and waits out DNS + TLS + a 401 before falling back to the offline
+    // catalog. Measured at 5.2s on the merge-queue run that ejected PR #930,
+    // against a 5s `toBeVisible` — and 109ms on the next call, once the 1h
+    // provider cache was warm. That is a network round trip deciding whether a
+    // test passes, which is the definition of a flake.
+    //
+    // Point the catalog at a port nothing listens on: the connection is refused
+    // in microseconds and `fetchProviderModels` degrades to FALLBACK_MODELS —
+    // byte for byte what the 401 produced, so no assertion changes meaning. The
+    // suite asserts nothing about provider catalogs; it just must not depend on
+    // the internet to render a page. Suites with a real catalog to serve use
+    // `config/llm-providers-mock` instead (docker-compose.setup-wizard-test.yml).
+    env: {
+      PINCHY_PROVIDER_BASEURL_ANTHROPIC: "http://127.0.0.1:1",
+      PINCHY_PROVIDER_BASEURL_OPENAI: "http://127.0.0.1:1",
+      PINCHY_PROVIDER_BASEURL_GOOGLE: "http://127.0.0.1:1",
+      PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD: "http://127.0.0.1:1",
+    },
     port: 7778,
     reuseExistingServer: false,
     stdout: "pipe",

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -46,6 +46,14 @@ export default defineConfig({
     // suite asserts nothing about provider catalogs; it just must not depend on
     // the internet to render a page. Suites with a real catalog to serve use
     // `config/llm-providers-mock` instead (docker-compose.setup-wizard-test.yml).
+    //
+    // These vars feed `resolveProviderBaseUrl`, so they redirect every provider
+    // URL — the key-validation probe and the `baseUrl` emitted into
+    // openclaw.json too, not just the catalog fetch. Both are inert here: no
+    // spec in this suite submits an API key, and this stack runs no OpenClaw. A
+    // spec that later drives the wizard's key step would see a refused
+    // connection where it expected a 401 — serve it a real catalog from
+    // `config/llm-providers-mock` rather than dropping the override.
     env: {
       PINCHY_PROVIDER_BASEURL_ANTHROPIC: "http://127.0.0.1:1",
       PINCHY_PROVIDER_BASEURL_OPENAI: "http://127.0.0.1:1",

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -91,6 +91,7 @@ import {
   extractModelDate,
   isRejectedVariant,
   selectDefaultModel,
+  PROVIDER_CATALOG_FETCH_TIMEOUT_MS,
 } from "@/lib/provider-models";
 import { getSetting } from "@/lib/settings";
 import { listProvidersForModelFetch } from "@/lib/openai-compatible-providers";
@@ -195,6 +196,43 @@ describe("fetchProviderModels", () => {
       { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
       { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
     ]);
+  });
+
+  it("bounds a hanging provider fetch instead of pinning the request", async () => {
+    // `/api/templates` awaits this on every first render after a cache miss, so
+    // an unbounded fetch is a page that never loads — the exact failure mode a
+    // self-hosted deployment behind a filtering proxy hits, where the provider
+    // host accepts the connection and then never answers. Bounded, we degrade
+    // to the offline catalog, which is what "offline-first" has to mean here.
+    vi.mocked(getSetting).mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-test-key";
+      return null;
+    });
+
+    vi.useFakeTimers();
+    try {
+      vi.mocked(fetch).mockImplementation(
+        (_url: string | Request | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("The operation was aborted", "AbortError"))
+            );
+          })
+      );
+
+      const pending = fetchProviderModels();
+      await vi.advanceTimersByTimeAsync(PROVIDER_CATALOG_FETCH_TIMEOUT_MS + 100);
+      const result = await pending;
+
+      expect(result).toHaveLength(1);
+      expect(result[0].models).toEqual([
+        { id: "anthropic/claude-opus-4-7", name: "Claude Opus 4.7" },
+        { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+        { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("handles multiple configured providers", async () => {

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -232,6 +232,11 @@ describe("fetchProviderModels", () => {
       ]);
     } finally {
       vi.useRealTimers();
+      // `beforeEach` runs `clearAllMocks`, which clears calls but keeps
+      // implementations — so this never-settling one would outlive the test.
+      // Every test below happens to stub `fetch` itself; the first that forgets
+      // would hang for the abort timeout and fail somewhere unrelated to it.
+      vi.mocked(fetch).mockReset();
     }
   });
 

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -176,6 +176,12 @@ const PROVIDER_FETCH_CONFIG: Record<ProviderName, ProviderFetchConfig> = {
 // probe reports a key as valid or not, where a slow answer is worth waiting
 // for, while here every miss has a good offline answer sitting in
 // FALLBACK_MODELS.
+//
+// It bounds one provider call, not one request: `fetchProviderModels` walks the
+// configured cloud providers sequentially, so a deployment with all four keys
+// stored can still spend 4 × this before the page renders. That is a ceiling
+// instead of undici's minutes, which is the point — but do not read it as a 5s
+// page budget.
 export const PROVIDER_CATALOG_FETCH_TIMEOUT_MS = 5_000;
 
 async function fetchModelsForProvider(

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -167,21 +167,44 @@ const PROVIDER_FETCH_CONFIG: Record<ProviderName, ProviderFetchConfig> = {
   },
 };
 
+// The cloud catalog fetch runs in request context — `/api/templates` awaits it
+// before the agent-creation page can render — so it needs the same bound the
+// key-validation probe (`PROVIDER_PROBE_TIMEOUT_MS`) and Ollama discovery
+// (`OLLAMA_FETCH_TIMEOUT_MS`) already carry. It was the one provider call left
+// unbounded, and undici's own fallback is coarse enough (minutes) to read as a
+// page that simply never loads. Shorter than the 10s probe on purpose: the
+// probe reports a key as valid or not, where a slow answer is worth waiting
+// for, while here every miss has a good offline answer sitting in
+// FALLBACK_MODELS.
+export const PROVIDER_CATALOG_FETCH_TIMEOUT_MS = 5_000;
+
 async function fetchModelsForProvider(
   provider: ProviderName,
   apiKey: string
 ): Promise<ModelInfo[]> {
   const config = PROVIDER_FETCH_CONFIG[provider];
-  const response = await fetch(config.url(apiKey), {
-    headers: config.headers(apiKey),
-  });
+  // AbortController + setTimeout rather than `AbortSignal.timeout`: the latter
+  // schedules on a libuv timer that vitest's fake clock cannot advance, so the
+  // timeout would be untestable except in real time (see the equivalent in
+  // `infrastructure.ts#checkOpenClaw`).
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROVIDER_CATALOG_FETCH_TIMEOUT_MS);
 
-  if (!response.ok) {
-    return FALLBACK_MODELS[provider];
+  try {
+    const response = await fetch(config.url(apiKey), {
+      headers: config.headers(apiKey),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return FALLBACK_MODELS[provider];
+    }
+
+    const data = await response.json();
+    return config.transform(data);
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const data = await response.json();
-  return config.transform(data);
 }
 
 export const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {


### PR DESCRIPTION
## What ejected PR #930

The merge-queue run for #930 failed on one test:

```
✘ e2e/05-agents.spec.ts:14:7 › new agent form is reachable and renders template selection (12.0s)
  Error: expect(locator).toBeVisible() failed
  Locator: getByText(/start from scratch/i)   Timeout: 5000ms
```

#930 changes dev-stack ports and touches nothing this test reads. The server log says why:

```
GET /agents/new     200 in 2.7s (next.js: 2.6s,  application-code: 101ms)   ← route JIT
GET /api/templates  200 in 5.2s (next.js: 523ms, application-code: 4.7s)    ← the handler itself
```

and on the very next test, 47 seconds later: `GET /api/templates 200 in 109ms`.

`e2e/helpers.ts` seeds `default_provider=anthropic` with `sk-ant-fake-key`, and `/api/templates` awaits `fetchProviderModels()`, which calls **the real api.anthropic.com** from the runner and waits out DNS + TLS + a 401 before falling back to the offline catalog. `fetchProviderModels` then caches for an hour, which is the 5.2s → 109ms cliff. A ~5s network round trip raced a 5s `toBeVisible`; the test has been winning that race, not passing it.

## The production half

`fetchModelsForProvider` was the **one** provider call with no timeout. The key-validation probe (`PROVIDER_PROBE_TIMEOUT_MS`, 10s) and Ollama discovery (`OLLAMA_FETCH_TIMEOUT_MS`, 5s) are both bounded — and `providers.ts` already spells out why:

> Credential/URL probes run in request context. Without a timeout, a host that accepts the connection but never responds pins the request handler until undici's coarse internal timeout (minutes).

That reasoning applies verbatim to the catalog fetch, which sits in front of the agent-creation page. A self-hosted deployment behind a filtering proxy gets a page that never loads, while the good offline answer sits unused in `FALLBACK_MODELS`. This bounds it at 5s.

Implemented with `AbortController` + `setTimeout` rather than `AbortSignal.timeout`, matching `infrastructure.ts#checkOpenClaw`: the latter schedules on a libuv timer vitest's fake clock cannot advance, so the bound would be untestable outside real time.

## The E2E half

The four built-in catalogs now point at a port nothing listens on. The connection is refused in microseconds and the fetch degrades to `FALLBACK_MODELS` — byte for byte what the 401 produced, so **no assertion changes meaning**. This suite asserts nothing about provider catalogs; it just must not need the internet to render a page. Suites with a real catalog to serve keep using `config/llm-providers-mock` (`docker-compose.setup-wizard-test.yml`).

## Verification

Controlled A/B, locally, `01-setup.spec.ts` + `05-agents.spec.ts`, same machine, back to back:

| | first `/api/templates` | result |
|---|---|---|
| without the override | `5.1s` (app-code 4.9s) | **1 failed** — same assertion, same locator as CI |
| with the override | `273ms` (app-code 74ms) | 5 passed |

So the CI failure reproduces on demand and the fix removes it — not a hypothesis about a flake.

The unit test drives a fetch that only ever settles on abort and asserts the fallback catalog comes back. Mutation-verified: deleting the `signal:` line alone turns it red (5s vitest timeout).

Gates: `pnpm -C packages/web test` (10175 passed), `typecheck`, `lint`, `pnpm format:check`, `pnpm test:scripts` (462 passed). `next build` left to CI.

## Not in scope

`e2e/telegram`, `e2e/odoo` and `e2e/web` seed the same fake anthropic key against Docker stacks that also have internet, so they carry the same latent dependency. The timeout above bounds them at 5s, but they still make the call. Worth its own pass; I did not want to sprawl this PR across four compose overlays I have not measured.