### PR TITLE
fix(security): pre-0.9.0 security review — member file-read escalation + three SSRF holes

### DIFF
--- a/packages/plugins/pinchy-web/web-fetch.test.ts
+++ b/packages/plugins/pinchy-web/web-fetch.test.ts
@@ -500,6 +500,33 @@ describe("webFetch", () => {
         const callArgs = fetchMock.mock.calls[0] as [string, Record<string, unknown>];
         expect(callArgs[1].dispatcher).toBeDefined();
       });
+
+      /**
+       * The same reasoning, one hop later.
+       *
+       * Every redirect target is re-resolved and re-pinned — except when the
+       * resolution comes back empty, where the loop dropped the dispatcher and
+       * carried on. That is the identical "hand resolution back to undici with
+       * the guard's conclusion thrown away" the initial request no longer
+       * does, and a redirect is the easier half to reach: the first URL can be
+       * domain-filtered, the `Location` is chosen by the server that answered.
+       */
+      it("refuses a redirect hop nothing can resolve instead of following it unpinned", async () => {
+        // Hop 0 resolves publicly and is fetched; the target does not resolve.
+        resolve4Mock.mockResolvedValueOnce(["93.184.216.34"]);
+        lookupMock.mockResolvedValue([]);
+        fetchMock.mockResolvedValueOnce({
+          status: 302,
+          ok: false,
+          headers: new Map([["location", "https://nowhere.invalid/next"]]),
+        });
+
+        const result = await webFetch("https://example.com/start");
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain("Could not resolve host");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
     });
 
     it.each([

--- a/packages/plugins/pinchy-web/web-fetch.test.ts
+++ b/packages/plugins/pinchy-web/web-fetch.test.ts
@@ -6,6 +6,10 @@ vi.mock("node:dns/promises", () => ({
   default: {
     resolve4: vi.fn(),
     resolve6: vi.fn(),
+    // The guard's last word before it gives up. Deliberately distinct from
+    // resolve4/6: only lookup consults /etc/hosts, and only lookup is what
+    // the real request would have used.
+    lookup: vi.fn(),
   },
 }));
 
@@ -64,6 +68,7 @@ describe("webFetch", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   const resolve4Mock = dns.resolve4 as ReturnType<typeof vi.fn>;
   const resolve6Mock = dns.resolve6 as ReturnType<typeof vi.fn>;
+  const lookupMock = dns.lookup as unknown as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     fetchMock = undiciFetchMock as unknown as ReturnType<typeof vi.fn>;
@@ -71,6 +76,9 @@ describe("webFetch", () => {
     // Default: resolve to public IPs
     resolve4Mock.mockResolvedValue(["93.184.216.34"]);
     resolve6Mock.mockResolvedValue(["2606:2800:220:1:248:1893:25c8:1946"]);
+    // Default: /etc/hosts knows nothing. Only reached when DNS came back
+    // empty, so it does not affect the cases above.
+    lookupMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -430,6 +438,86 @@ describe("webFetch", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Too many redirects");
+    });
+
+    /**
+     * A name DNS cannot answer is not a name the request cannot reach.
+     *
+     * `dns.resolve4/6` query DNS servers; the fetch resolves through
+     * `dns.lookup`, which also reads `/etc/hosts`. A host that lives only
+     * there was therefore classified "unresolvable" — and the guard used to
+     * carry on anyway, with no pinned address, handing resolution straight
+     * back to undici. This stack puts such a host in its own containers:
+     * compose adds `ollama.local:host-gateway`, i.e. the docker host, and
+     * `web_fetch` is a tool an agent calls on model instruction, so the URL
+     * can come from a prompt-injected page.
+     */
+    describe("hosts-file names", () => {
+      beforeEach(() => {
+        // DNS knows nothing about these names.
+        resolve4Mock.mockReset().mockResolvedValue([]);
+        resolve6Mock.mockReset().mockResolvedValue([]);
+      });
+
+      it("blocks a host that only /etc/hosts knows and that points at a private address", async () => {
+        lookupMock.mockResolvedValue([{ address: "172.17.0.1", family: 4 }]);
+        mockHtmlResponse(ROUTING_FIXTURE);
+
+        const result = await webFetch("http://ollama.local:11434/");
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain("private network");
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it("blocks it via an IPv6 hosts entry too", async () => {
+        lookupMock.mockResolvedValue([{ address: "fd00::1", family: 6 }]);
+
+        const result = await webFetch("http://internal.local/");
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain("private network");
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it("refuses a name nothing can resolve instead of fetching it unpinned", async () => {
+        lookupMock.mockResolvedValue([]);
+
+        const result = await webFetch("http://nowhere.invalid/");
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain("Could not resolve host");
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it("pins and allows a public hosts-file entry", async () => {
+        lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+        mockHtmlResponse(ROUTING_FIXTURE);
+
+        const result = await webFetch("http://mirror.local/page");
+
+        expect(result.isError).toBeUndefined();
+        const callArgs = fetchMock.mock.calls[0] as [string, Record<string, unknown>];
+        expect(callArgs[1].dispatcher).toBeDefined();
+      });
+    });
+
+    it.each([
+      ["fd00::1", "the fd00::/8 half of ULA, which is the half in actual use"],
+      ["fd12:3456:789a::1", "a routable-looking ULA prefix"],
+      ["fdff:ffff::1", "the top of the ULA range"],
+      ["::", "the unspecified address, which most stacks route to loopback"],
+    ])("blocks %s (%s)", async (address) => {
+      // `/^fc00:/` matched one hextet of one /8. Every fd00::/8 address —
+      // and `::` — classified as public and was fetched.
+      resolve4Mock.mockReset().mockResolvedValue([]);
+      resolve6Mock.mockReset().mockResolvedValue([address]);
+
+      const result = await webFetch("https://ula.example/page");
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("private network");
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/plugins/pinchy-web/web-fetch.ts
+++ b/packages/plugins/pinchy-web/web-fetch.ts
@@ -401,6 +401,17 @@ export async function webFetch(
           isError: true,
         };
       }
+      if (redirectResolved.kind === "unresolvable") {
+        // Same rule as the initial URL above, and the easier half to reach:
+        // that one can be domain-filtered, this Location is chosen by whoever
+        // answered. Continuing dropped the dispatcher and let undici resolve
+        // the hop itself — the guard's conclusion thrown away at exactly the
+        // point it was re-derived.
+        return {
+          content: `Could not resolve host: ${redirectUrl.hostname}`,
+          isError: true,
+        };
+      }
 
       if (i === MAX_REDIRECT_HOPS) {
         return { content: `Too many redirects.`, isError: true };

--- a/packages/plugins/pinchy-web/web-fetch.ts
+++ b/packages/plugins/pinchy-web/web-fetch.ts
@@ -18,7 +18,11 @@ const PRIVATE_IP_PATTERNS = [
   /^169\.254\./,
   /^0\./,
   /^::1$/,
-  /^fc00:/i,
+  /^::$/, // unspecified — routes to loopback on most stacks
+  // ULA is fc00::/7, i.e. fc00: THROUGH fdff:. A literal /^fc00:/ matched only
+  // the first hextet of the first /8 and let every fd00::/8 address — the half
+  // that is actually used, since fc00::/8 is unassigned — pass as public.
+  /^f[cd][0-9a-f]{2}:/i,
   /^fe80:/i,
 ];
 
@@ -77,13 +81,32 @@ async function resolveHost(hostname: string): Promise<ResolvedHost> {
     dns.resolve6(hostname).catch(() => [] as string[]),
   ]);
   const all = [...ipv4s, ...ipv6s];
-  if (all.length === 0) return { kind: "unresolvable" };
   // Reject if ANY returned record is private — DNS servers controlled by an
   // attacker could mix public and private addresses to slip past a "first
   // address only" check.
-  if (all.some(isPrivateIp)) return { kind: "private" };
-  if (ipv4s[0]) return { kind: "resolved", address: ipv4s[0], family: 4 };
-  if (ipv6s[0]) return { kind: "resolved", address: ipv6s[0], family: 6 };
+  if (all.length > 0) {
+    if (all.some(isPrivateIp)) return { kind: "private" };
+    if (ipv4s[0]) return { kind: "resolved", address: ipv4s[0], family: 4 };
+    if (ipv6s[0]) return { kind: "resolved", address: ipv6s[0], family: 6 };
+  }
+
+  // resolve4/resolve6 ask DNS servers and nothing else. The fetch below
+  // resolves through dns.lookup, which ALSO consults /etc/hosts — so a name
+  // that exists only there was reported "unresolvable" here and then
+  // connected perfectly well down there, unpinned and never classified.
+  // That is not hypothetical: this stack adds `ollama.local:host-gateway`
+  // to its own containers via compose `extra_hosts`, which makes the docker
+  // host reachable from a tool an agent invokes on model instruction.
+  //
+  // So ask the resolver the request will actually use before concluding
+  // anything.
+  const viaLookup = await dns.lookup(hostname, { all: true }).catch(() => []);
+  if (viaLookup.length > 0) {
+    if (viaLookup.some((entry) => isPrivateIp(entry.address))) return { kind: "private" };
+    const first = viaLookup[0];
+    return { kind: "resolved", address: first.address, family: first.family === 6 ? 6 : 4 };
+  }
+
   return { kind: "unresolvable" };
 }
 
@@ -328,6 +351,13 @@ export async function webFetch(
       content: `Access to private network addresses is not allowed.`,
       isError: true,
     };
+  }
+  if (resolved.kind === "unresolvable") {
+    // Refuse rather than continue with no pinned address. A name neither DNS
+    // nor dns.lookup can answer is one the fetch cannot reach either, so this
+    // forfeits nothing — while continuing meant handing resolution back to
+    // undici with the guard's conclusion thrown away.
+    return { content: `Could not resolve host: ${hostname}`, isError: true };
   }
 
   const maxChars = config.maxChars ?? 50000;

--- a/packages/web/src/__tests__/api/agent-workspace-file-legacy-grant.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file-legacy-grant.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The upgrade case: new code, pre-existing data.
+ *
+ * `PATCH /api/agents/[id]` accepted `pluginConfig` from any member who owns
+ * the agent — and every user is seeded a personal agent they own — while
+ * `pinchy-files.allowed_paths` inside it is the allowlist this route reads
+ * files against. `pluginConfigSchema` confines that field now, but a schema
+ * runs on WRITE. Rows already in the database were never checked, and the
+ * install that fixes the hole is precisely an install that may be carrying
+ * one, so the reader has to hold the line on its own.
+ *
+ * Deliberately a separate file from `agent-workspace-file.test.ts`: that one
+ * moves `FILE_SERVE_ROOTS` to a temp directory so its fixtures can live on
+ * disk. These cases are about the REAL ceiling, so nothing here is mocked
+ * away, and the paths probed are the ones the exploit actually reached — the
+ * secrets a `docker-compose.yml` volume puts inside this container.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({ getSession: (...args: unknown[]) => mockGetSession(...args) }));
+
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/audit-deferred", () => ({ deferAuditLog: vi.fn() }));
+
+/** A grant of the kind only a pre-clamp write could have produced. */
+function agentGrantedEverything() {
+  mockGetAgentWithAccess.mockResolvedValue({
+    id: "agent-1",
+    name: "My Assistant",
+    pluginConfig: { "pinchy-files": { allowed_paths: ["/"] } },
+  });
+}
+
+async function callGET(requestedPath: string) {
+  const { GET } = await import("@/app/api/agents/[agentId]/workspace-file/route");
+  const url = new URL("http://localhost/api/agents/agent-1/workspace-file");
+  url.searchParams.set("path", requestedPath);
+  return GET(new NextRequest(url), { params: Promise.resolve({ agentId: "agent-1" }) }) as Promise<
+    NextResponse | Response
+  >;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // An ordinary member — the whole point is that no special role is needed.
+  mockGetSession.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+});
+
+describe("workspace-file — a pre-clamp allowed_paths grant of / buys nothing", () => {
+  it.each([
+    ["the AES master key", "/app/secrets/master.key"],
+    ["the decrypted provider keys", "/openclaw-secrets/secrets.json"],
+    ["openclaw.json, which carries the plaintext gateway token", "/openclaw-config/openclaw.json"],
+    ["an arbitrary system file", "/etc/passwd"],
+    ["the process environment", "/proc/self/environ"],
+  ])("refuses %s", async (_label, path) => {
+    agentGrantedEverything();
+
+    const res = await callGET(path);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toMatch(/BEGIN|apiKey|token|root:/);
+  });
+
+  it("refuses a traversal out of the data root under the same grant", async () => {
+    agentGrantedEverything();
+
+    const res = await callGET("/data/../etc/passwd");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("answers 403 rather than 404 for a non-existent path outside the ceiling", async () => {
+    // A 404 would confirm which out-of-ceiling paths exist. The ceiling must
+    // not become the oracle the allowlist check was careful not to be.
+    agentGrantedEverything();
+
+    const res = await callGET("/openclaw-secrets/does-not-exist.json");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("refuses even when the grant names the secrets directory outright", async () => {
+    mockGetAgentWithAccess.mockResolvedValue({
+      id: "agent-1",
+      name: "My Assistant",
+      pluginConfig: { "pinchy-files": { allowed_paths: ["/openclaw-secrets"] } },
+    });
+
+    const res = await callGET("/openclaw-secrets/secrets.json");
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/web/src/__tests__/api/agent-workspace-file.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file.test.ts
@@ -48,6 +48,22 @@ vi.mock("@/lib/audit-deferred", () => ({
   deferAuditLog: (...args: unknown[]) => mockDeferAuditLog(...args),
 }));
 
+// The route enforces an absolute ceiling (`FILE_SERVE_ROOTS`, "/data/" in
+// production) on top of the agent's grant. The cases below are about the
+// grant and their fixtures live in a temp dir, so the ceiling is MOVED there
+// rather than switched off — every assertion still runs against a real one.
+// The ceiling's own behaviour is covered in `lib/agent-file-access.test.ts`,
+// and end-to-end through this route in
+// `agent-workspace-file-legacy-grant.test.ts`.
+// Not realpath'd on purpose: the fixtures below are built on the raw
+// `tmpdir()` path, and stage 1 of the check is lexical. Stage 2 realpaths
+// both sides itself, which is what makes macOS's /var -> /private/var
+// symlink compare equal there.
+vi.mock("@/lib/file-serve-roots", async () => {
+  const { tmpdir } = await import("node:os");
+  return { FILE_SERVE_ROOTS: [tmpdir()] };
+});
+
 let tmpRoot: string;
 let allowedRoot: string;
 let outsideDir: string;

--- a/packages/web/src/__tests__/api/agents-patch-validation.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-validation.test.ts
@@ -520,3 +520,131 @@ describe("PATCH /api/agents/[agentId] — starterPrompts validation (#570)", () 
     expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Privilege escalation, member -> arbitrary file read on the Pinchy container.
+ *
+ * Every user is seeded a personal agent they are allowed to write
+ * (`requireAgentWriteAccess` lets the owner through), and PATCH gates
+ * `allowedTools`, `visibility` and `groupIds` on the admin role — but NOT
+ * `pluginConfig`. `pinchy-files.allowed_paths` inside it is the allowlist the
+ * browser-facing `/api/agents/[id]/workspace-file` route reads files against,
+ * so widening it to `/` turns an ordinary member into a reader of
+ * `/app/secrets` (AES master key), `/openclaw-secrets/secrets.json`
+ * (decrypted provider keys) and `/openclaw-config/openclaw.json` (the
+ * plaintext gateway token, which in turn unlocks `/api/internal/*`).
+ *
+ * The write is the boundary, so this is asserted at the route: a rejection
+ * that only happens further down (at read time) would still let the poisoned
+ * allowlist reach the database, where the agent's file TOOLS and the
+ * knowledge-base retrieval filter also read it.
+ */
+describe("PATCH /api/agents/[agentId] — allowed_paths cannot be widened past /data", () => {
+  let PATCH: typeof import("@/app/api/agents/[agentId]/route").PATCH;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/agents/[agentId]/route");
+    PATCH = mod.PATCH;
+  });
+
+  function memberSession() {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "user-1", role: "member" },
+      expires: "",
+    } as never);
+  }
+
+  /** The personal agent every user is seeded and is allowed to write. */
+  function mockOwnPersonalAgent() {
+    mockAgent({
+      id: "agent-1",
+      name: "My Assistant",
+      model: "m",
+      isPersonal: true,
+      ownerId: "user-1",
+      visibility: "private",
+    });
+  }
+
+  function patchRequest(body: Record<string, unknown>) {
+    return new NextRequest("http://localhost/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const params = { params: Promise.resolve({ agentId: "agent-1" }) };
+
+  it("refuses a member widening their own personal agent's scope to the filesystem root", async () => {
+    memberSession();
+    mockOwnPersonalAgent();
+
+    const res = await PATCH(
+      patchRequest({ pluginConfig: { "pinchy-files": { allowed_paths: ["/"] } } }),
+      params
+    );
+
+    expect(res.status).toBe(400);
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+
+  it("refuses a member pointing the scope straight at the decrypted provider keys", async () => {
+    memberSession();
+    mockOwnPersonalAgent();
+
+    const res = await PATCH(
+      patchRequest({ pluginConfig: { "pinchy-files": { allowed_paths: ["/openclaw-secrets"] } } }),
+      params
+    );
+
+    expect(res.status).toBe(400);
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+
+  it("refuses a traversal that escapes /data", async () => {
+    memberSession();
+    mockOwnPersonalAgent();
+
+    const res = await PATCH(
+      patchRequest({ pluginConfig: { "pinchy-files": { allowed_paths: ["/data/../etc"] } } }),
+      params
+    );
+
+    expect(res.status).toBe(400);
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+
+  it("refuses an admin too — the clamp is a container boundary, not a role check", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Shared", model: "m", isPersonal: false, ownerId: null });
+
+    const res = await PATCH(
+      patchRequest({ pluginConfig: { "pinchy-files": { allowed_paths: ["/etc"] } } }),
+      params
+    );
+
+    expect(res.status).toBe(400);
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+
+  it("still persists a legitimate scope under /data", async () => {
+    memberSession();
+    mockOwnPersonalAgent();
+    vi.mocked(updateAgent).mockResolvedValueOnce({ id: "agent-1" } as never);
+
+    const res = await PATCH(
+      patchRequest({ pluginConfig: { "pinchy-files": { allowed_paths: ["/data/kb"] } } }),
+      params
+    );
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(updateAgent)).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({
+        pluginConfig: { "pinchy-files": { allowed_paths: ["/data/kb"] } },
+      })
+    );
+  });
+});

--- a/packages/web/src/__tests__/api/agents-patch-validation.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-validation.test.ts
@@ -629,9 +629,57 @@ describe("PATCH /api/agents/[agentId] — allowed_paths cannot be widened past /
     expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
   });
 
-  it("still persists a legitimate scope under /data", async () => {
+  /**
+   * The clamp bounds the DAMAGE; it does not restore the missing gate.
+   *
+   * `/data` is not one corpus — it is every corpus, and which subtree an agent
+   * may see is exactly what an admin decides when they scope a knowledge-base
+   * agent. A member who can still write `allowed_paths: ["/data/hr"]` onto
+   * their own seeded personal agent reads HR's documents through
+   * `GET /api/agents/[id]/workspace-file`, which consults that list and
+   * nothing else — no tool grant, no group membership, no admin role.
+   *
+   * So `pluginConfig` gets the gate its neighbours already have. The UI never
+   * loses anything: the Permissions tab that produces this field renders only
+   * for `isAdmin && !isPersonal`, and every request it sends carries
+   * `allowedTools`, which 403s for a member already.
+   */
+  it("refuses a member setting pluginConfig at all, even a scope inside /data", async () => {
     memberSession();
     mockOwnPersonalAgent();
+
+    const res = await PATCH(
+      patchRequest({ pluginConfig: { "pinchy-files": { allowed_paths: ["/data/hr"] } } }),
+      params
+    );
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+
+  it("refuses a member clearing pluginConfig too — the field is the boundary", async () => {
+    memberSession();
+    mockOwnPersonalAgent();
+
+    const res = await PATCH(patchRequest({ pluginConfig: null }), params);
+
+    expect(res.status).toBe(403);
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+
+  it("lets a member patch a field that is not pluginConfig", async () => {
+    memberSession();
+    mockOwnPersonalAgent();
+    vi.mocked(updateAgent).mockResolvedValueOnce({ id: "agent-1" } as never);
+
+    const res = await PATCH(patchRequest({ tagline: "My helper" }), params);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("still persists a legitimate scope under /data for an admin", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Shared", model: "m", isPersonal: false, ownerId: null });
     vi.mocked(updateAgent).mockResolvedValueOnce({ id: "agent-1" } as never);
 
     const res = await PATCH(

--- a/packages/web/src/__tests__/lib/agent-file-access.test.ts
+++ b/packages/web/src/__tests__/lib/agent-file-access.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Defense in depth for the file-serving boundary.
+ *
+ * `resolveAllowedFile` used to measure containment ONLY against the agent's
+ * `allowed_paths`, on the stated assumption that the list is
+ * "admin-configured". It was not: `PATCH /api/agents/[id]` accepted
+ * `pluginConfig` from any member who owns the agent, and every user owns a
+ * seeded personal one. The write side is clamped now (see
+ * `domain-validation.test.ts`), but a clamp on new writes says nothing about
+ * rows already in the database — an 0.8 install could carry an
+ * admin-configured `/etc` grant, and a poisoned row written before the clamp
+ * would otherwise stay exploitable across the upgrade that fixes it.
+ *
+ * So the reader carries its own absolute ceiling, exactly as
+ * `packages/plugins/pinchy-files/validate.ts` does with `ALLOWED_ROOTS`.
+ * The ceiling is passed in here rather than hard-coded, because the two
+ * containers mount the same volumes at different paths and the production
+ * value is therefore not a constant the tests can create on disk.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveAllowedFile, FILE_SERVE_ROOTS } from "@/lib/agent-file-access";
+
+let tmpRoot: string;
+let serveRoot: string;
+let insideFile: string;
+let outsideDir: string;
+let outsideFile: string;
+
+beforeEach(() => {
+  // realpath: on macOS /var is a symlink to /private/var, and the ceiling
+  // check compares real paths.
+  tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "pinchy-file-ceiling-")));
+  serveRoot = join(tmpRoot, "data");
+  outsideDir = join(tmpRoot, "secrets");
+  mkdirSync(serveRoot, { recursive: true });
+  mkdirSync(outsideDir, { recursive: true });
+
+  insideFile = join(serveRoot, "invoice.pdf");
+  outsideFile = join(outsideDir, "master.key");
+  writeFileSync(insideFile, "%PDF-1.4\n");
+  writeFileSync(outsideFile, "AES master key");
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("resolveAllowedFile — absolute serve-root ceiling", () => {
+  it("serves a file that is inside both the allowlist and the ceiling", async () => {
+    const res = await resolveAllowedFile(insideFile, [serveRoot], [serveRoot]);
+    expect(res).toEqual({ ok: true, realPath: insideFile });
+  });
+
+  it("refuses a file outside the ceiling even when the allowlist says the filesystem root", async () => {
+    const res = await resolveAllowedFile(outsideFile, ["/"], [serveRoot]);
+    expect(res).toEqual({ ok: false, status: 403 });
+  });
+
+  it("still serves an in-ceiling file when the allowlist is that same over-broad root", async () => {
+    // The ceiling removes the escape; it must not break the grant itself,
+    // or an upgrade would 403 every legitimate citation on such an install.
+    const res = await resolveAllowedFile(insideFile, ["/"], [serveRoot]);
+    expect(res).toEqual({ ok: true, realPath: insideFile });
+  });
+
+  it("refuses a grant that lies wholly outside the ceiling", async () => {
+    const res = await resolveAllowedFile(outsideFile, [outsideDir], [serveRoot]);
+    expect(res).toEqual({ ok: false, status: 403 });
+  });
+
+  it("applies the ceiling to the real path, not just the lexical one", async () => {
+    // A symlink planted inside the served root pointing at the secret. The
+    // allowlist and the lexical path both look fine; only the realpath stage
+    // can see the escape, so the ceiling has to be enforced there too.
+    const trap = join(serveRoot, "looks-innocent.pdf");
+    symlinkSync(outsideFile, trap);
+    const res = await resolveAllowedFile(trap, ["/"], [serveRoot]);
+    expect(res).toEqual({ ok: false, status: 403 });
+  });
+
+  it("reports a missing in-scope path as 404, so the ceiling adds no new oracle", async () => {
+    const res = await resolveAllowedFile(join(serveRoot, "nope.pdf"), [serveRoot], [serveRoot]);
+    expect(res).toEqual({ ok: false, status: 404 });
+  });
+
+  it("reports a missing OUT-of-ceiling path as 403, never 404", async () => {
+    // A 404 here would tell an attacker which paths outside the ceiling
+    // exist — the same reason out-of-allowlist paths already 403.
+    const res = await resolveAllowedFile(join(outsideDir, "nope.key"), ["/"], [serveRoot]);
+    expect(res).toEqual({ ok: false, status: 403 });
+  });
+
+  it("denies everything when the ceiling is empty rather than falling open", async () => {
+    const res = await resolveAllowedFile(insideFile, [serveRoot], []);
+    expect(res).toEqual({ ok: false, status: 403 });
+  });
+
+  it("keeps denying an empty allowlist", async () => {
+    const res = await resolveAllowedFile(insideFile, [], [serveRoot]);
+    expect(res).toEqual({ ok: false, status: 403 });
+  });
+});
+
+describe("FILE_SERVE_ROOTS", () => {
+  it("is /data/ and nothing else", () => {
+    // Deliberately NOT the plugin's ALLOWED_ROOTS. In the pinchy container
+    // the workspaces volume is mounted at /openclaw-config/workspaces, so
+    // copying the plugin's "/root/.openclaw/workspaces/" would be dead
+    // weight — and admitting its parent /openclaw-config would hand out
+    // openclaw.json, which carries the plaintext gateway token.
+    expect(FILE_SERVE_ROOTS).toEqual(["/data/"]);
+  });
+});

--- a/packages/web/src/__tests__/lib/domain-validation.test.ts
+++ b/packages/web/src/__tests__/lib/domain-validation.test.ts
@@ -104,3 +104,59 @@ describe("pluginConfigSchema — pinchy-files", () => {
     expect(result.success).toBe(false);
   });
 });
+
+/**
+ * `allowed_paths` is not a preference — it is the allowlist that scopes the
+ * agent's file tools, its knowledge-base retrieval AND the browser-facing
+ * `/api/agents/[id]/workspace-file` route. It has to be clamped in the SCHEMA
+ * rather than in a route, because the two routes disagreed about it: POST
+ * only called `validateAllowedPaths` when `template.pluginId ===
+ * "pinchy-files"`, and PATCH never called it at all — so any member could
+ * widen their own personal agent's scope to `/` and read the container's
+ * secrets. One boundary, shared by every writer, is the only version of this
+ * that stays true as routes are added.
+ */
+describe("pluginConfigSchema — allowed_paths is clamped to /data/", () => {
+  const accepts = (paths: string[]) =>
+    pluginConfigSchema.safeParse({ "pinchy-files": { allowed_paths: paths } }).success;
+
+  it("accepts paths under /data/", () => {
+    expect(accepts(["/data/kb", "/data/finance/invoices"])).toBe(true);
+  });
+
+  it("accepts /data itself", () => {
+    expect(accepts(["/data"])).toBe(true);
+  });
+
+  it("rejects the filesystem root", () => {
+    expect(accepts(["/"])).toBe(false);
+  });
+
+  it("rejects the directory holding the container's decrypted provider keys", () => {
+    expect(accepts(["/openclaw-secrets"])).toBe(false);
+  });
+
+  it("rejects the directory holding the AES master key", () => {
+    expect(accepts(["/app/secrets"])).toBe(false);
+  });
+
+  it("rejects a traversal that lexically escapes /data", () => {
+    expect(accepts(["/data/../etc"])).toBe(false);
+  });
+
+  it("rejects a sibling that merely shares the /data prefix", () => {
+    expect(accepts(["/database"])).toBe(false);
+  });
+
+  it("rejects a relative path, which would resolve against the server's cwd", () => {
+    expect(accepts(["kb"])).toBe(false);
+  });
+
+  it("rejects a null byte, which can truncate the path in a native call", () => {
+    expect(accepts(["/data/kb\0/../../etc"])).toBe(false);
+  });
+
+  it("rejects the whole list when only one entry escapes", () => {
+    expect(accepts(["/data/kb", "/etc"])).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/openai-compatible-discovery.test.ts
+++ b/packages/web/src/__tests__/lib/openai-compatible-discovery.test.ts
@@ -289,3 +289,116 @@ describe("resolveCustomProviderModels", () => {
     expect(beta.map((m) => m.id)).toEqual(["beta-large"]);
   });
 });
+
+/**
+ * A redirect is a new destination, and the SSRF guard has to see it.
+ *
+ * The two routes that reach this module validate the admin's `baseUrl` before
+ * calling in — and then `fetchModels` used the default `redirect: "follow"`,
+ * so a host that passed the guard could answer `302 Location:
+ * http://169.254.169.254/` and undici would follow it, carrying the
+ * Authorization header. The guard's verdict applied to a URL the request
+ * never ended at.
+ *
+ * No mock of the guard here on purpose: these use IP literals, which it
+ * classifies without touching DNS, so what is asserted is the real thing.
+ */
+describe("fetchModels — redirects are re-validated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCustomModelCache();
+  });
+
+  function redirectTo(location: string, status = 302) {
+    return new Response(null, { status, headers: { location } });
+  }
+
+  const modelBody = () =>
+    new Response(JSON.stringify({ data: [{ id: "gpt-4o-mini" }] }), { status: 200 });
+
+  it("requests with redirect: manual rather than letting undici follow", async () => {
+    vi.mocked(fetch).mockResolvedValue(modelBody());
+
+    await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-key");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.com/v1/models",
+      expect.objectContaining({ redirect: "manual" })
+    );
+  });
+
+  /**
+   * Asserted as a CONTRAST, and that is the point: a mocked `fetch` never
+   * follows a redirect by itself, so "we returned []" holds whether the guard
+   * runs or not — those assertions would stay green against the vulnerable
+   * code. What actually separates the two worlds is whether the hop gets
+   * REQUESTED. A permitted target produces a second call; a blocked one must
+   * not. Delete the `assertAllowedProviderUrl` call and the blocked rows
+   * below make two calls and fail.
+   */
+  it.each([
+    ["the cloud metadata address", "http://169.254.169.254/latest/meta-data/", 1],
+    // The form that bypassed the guard entirely until the hostname was
+    // de-bracketed before classification.
+    ["loopback as an IPv6 literal", "http://[::1]/v1/models", 1],
+    ["IMDS through an IPv4-mapped IPv6 literal", "http://[::ffff:169.254.169.254]/", 1],
+    // Protocol-relative: changes host without looking like an absolute URL.
+    ["a protocol-relative hop to a blocked host", "//169.254.169.254/latest/", 1],
+    ["an ordinary public host", "https://93.184.216.34/v2/models", 2],
+  ])("redirect to %s is requested %s time(s) in total", async (_label, location, expectedCalls) => {
+    vi.mocked(fetch).mockResolvedValueOnce(redirectTo(location)).mockResolvedValue(modelBody());
+
+    await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-key");
+
+    expect(fetch).toHaveBeenCalledTimes(expectedCalls);
+  });
+
+  it("reports a blocked redirect as an unreachable provider, not a bad key", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(redirectTo("http://169.254.169.254/"));
+
+    const result = await validateOpenAiCompatibleProvider("https://api.example.com/v1", "sk-key");
+
+    expect(result).toEqual({ valid: false, error: "network_error" });
+  });
+
+  it("still follows an ordinary redirect to a public host", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(redirectTo("https://93.184.216.34/v2/models"))
+      .mockResolvedValueOnce(modelBody());
+
+    const models = await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-key");
+
+    expect(models.map((m) => m.id)).toEqual(["gpt-4o-mini"]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(fetch).mock.calls[1][0]).toBe("https://93.184.216.34/v2/models");
+  });
+
+  it("resolves a relative Location against the URL actually requested", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(redirectTo("/v2/models"))
+      .mockResolvedValueOnce(modelBody());
+
+    await fetchOpenAiCompatibleModels("https://93.184.216.34/v1", "sk-key");
+
+    expect(vi.mocked(fetch).mock.calls[1][0]).toBe("https://93.184.216.34/v2/models");
+  });
+
+  it("gives up rather than looping on an endless redirect chain", async () => {
+    vi.mocked(fetch).mockResolvedValue(redirectTo("https://93.184.216.34/again"));
+
+    const models = await fetchOpenAiCompatibleModels("https://93.184.216.34/v1", "sk-key");
+
+    expect(models).toEqual([]);
+    // Initial request + MAX_REDIRECT_HOPS follows, then it stops.
+    expect(fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("treats a redirect status with no Location as an ordinary non-2xx", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 302 }));
+
+    const models = await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-key");
+
+    expect(models).toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/__tests__/lib/openai-compatible-discovery.test.ts
+++ b/packages/web/src/__tests__/lib/openai-compatible-discovery.test.ts
@@ -401,4 +401,69 @@ describe("fetchModels — redirects are re-validated", () => {
     expect(models).toEqual([]);
     expect(fetch).toHaveBeenCalledTimes(1);
   });
+
+  /**
+   * Following redirects by hand means owning what the platform used to do.
+   *
+   * `redirect: "follow"` is not a plain "go there": the fetch spec strips
+   * `Authorization` when a redirect crosses an origin, precisely so a
+   * redirecting server cannot harvest a credential meant for itself. Taking
+   * the loop over and re-sending the same headers hands the provider API key
+   * to whatever host the `Location` names — and the SSRF guard is no help
+   * here, because an attacker's collector is an ordinary public address it is
+   * right to allow.
+   *
+   * Same origin keeps the header, or every provider that redirects
+   * `/v1/models` to `/v1/models/` would stop authenticating.
+   */
+  describe("credentials across a redirect", () => {
+    function authHeaderOfCall(index: number): string | undefined {
+      const init = vi.mocked(fetch).mock.calls[index][1] as { headers: Record<string, string> };
+      return init.headers.Authorization;
+    }
+
+    it("does not carry the API key to a different origin", async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(redirectTo("https://93.184.216.34/harvest"))
+        .mockResolvedValueOnce(modelBody());
+
+      await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-secret");
+
+      expect(authHeaderOfCall(0)).toBe("Bearer sk-secret");
+      expect(authHeaderOfCall(1)).toBeUndefined();
+    });
+
+    it("does not carry it to a different port or scheme on the same host either", async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(redirectTo("http://api.example.com:8080/v1/models"))
+        .mockResolvedValueOnce(modelBody());
+
+      await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-secret");
+
+      expect(authHeaderOfCall(1)).toBeUndefined();
+    });
+
+    it("keeps it on a same-origin redirect", async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(redirectTo("/v1/models/"))
+        .mockResolvedValueOnce(modelBody());
+
+      await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-secret");
+
+      expect(authHeaderOfCall(1)).toBe("Bearer sk-secret");
+    });
+
+    it("never regains it after a hop back to the original origin", async () => {
+      // The spec strips on the first cross-origin hop and does not restore the
+      // header afterwards — a redirect chain must not be a way to launder one.
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(redirectTo("https://93.184.216.34/hop"))
+        .mockResolvedValueOnce(redirectTo("https://api.example.com/v1/models"))
+        .mockResolvedValueOnce(modelBody());
+
+      await fetchOpenAiCompatibleModels("https://api.example.com/v1", "sk-secret");
+
+      expect(authHeaderOfCall(2)).toBeUndefined();
+    });
+  });
 });

--- a/packages/web/src/__tests__/lib/provider-url-guard.test.ts
+++ b/packages/web/src/__tests__/lib/provider-url-guard.test.ts
@@ -120,3 +120,87 @@ describe("assertAllowedProviderUrl", () => {
     ).rejects.toMatchObject({ reason: "blocked_address" });
   });
 });
+
+/**
+ * An address literal must never reach the resolver.
+ *
+ * `new URL("http://[::1]/v1").hostname` is `"[::1]"` — WITH the brackets. That
+ * string is not an IP as far as `isIP()` is concerned, and `dns.lookup()`
+ * rejects it, so it landed in the `catch { return }` that fails open for
+ * temporarily-unreachable hosts. Every branch of `classifyIpv6` was therefore
+ * unreachable from URL input: the whole IPv6 half of the guard was dead code,
+ * `PINCHY_PROVIDER_BLOCK_PRIVATE_NETWORKS=1` did nothing for ULA, and IMDS was
+ * one `::ffff:` prefix away.
+ *
+ * The existing suite could not see it, because `resolveTo([...])` answers any
+ * host including a bracketed one. These cases use a resolver that throws the
+ * way the real one does — so a literal only passes if the guard classified it
+ * WITHOUT DNS, which is the actual claim.
+ */
+describe("assertAllowedProviderUrl — address literals bypass DNS", () => {
+  /** Behaves like dns.lookup on input that is not a resolvable name. */
+  const unresolvable = async () => {
+    throw new Error("ENOTFOUND");
+  };
+
+  afterEach(() => {
+    delete process.env.PINCHY_PROVIDER_BLOCK_PRIVATE_NETWORKS;
+  });
+
+  it.each([
+    ["IPv6 loopback", "http://[::1]/v1"],
+    ["IPv6 unspecified", "http://[::]/v1"],
+    ["IPv6 link-local", "http://[fe80::1]/v1"],
+    ["IMDS through an IPv4-mapped IPv6 literal", "http://[::ffff:169.254.169.254]/latest/"],
+    ["loopback through an IPv4-mapped IPv6 literal", "http://[::ffff:127.0.0.1]/v1"],
+    ["IPv4 loopback", "http://127.0.0.1/v1"],
+    ["IMDS as a bare IPv4 literal", "http://169.254.169.254/latest/meta-data/"],
+  ])("blocks %s", async (_label, url) => {
+    await expect(assertAllowedProviderUrl(url, unresolvable)).rejects.toMatchObject({
+      reason: "blocked_address",
+    });
+  });
+
+  it("refuses a zone-id link-local host at the URL parse step", async () => {
+    // `http://[fe80::1%eth0]/` is not a valid URL to the WHATWG parser, so it
+    // never reaches address classification. Pinned because it is the reason
+    // the literal path needs no zone-id handling of its own.
+    await expect(
+      assertAllowedProviderUrl("http://[fe80::1%25eth0]/v1", unresolvable)
+    ).rejects.toMatchObject({ reason: "unsupported_scheme" });
+  });
+
+  it("refuses a bracketed host that is not a parseable address", async () => {
+    await expect(
+      assertAllowedProviderUrl("http://[not-an-address]/v1", unresolvable)
+    ).rejects.toBeInstanceOf(ProviderUrlBlockedError);
+  });
+
+  it("blocks a ULA literal when the deployment opts out of private networks", async () => {
+    // The documented lockdown for the hosted topology. It was a no-op for
+    // every IPv6 literal.
+    process.env.PINCHY_PROVIDER_BLOCK_PRIVATE_NETWORKS = "1";
+    await expect(
+      assertAllowedProviderUrl("http://[fd00::1]/v1", unresolvable)
+    ).rejects.toMatchObject({ reason: "private_address" });
+  });
+
+  it("still allows a ULA literal by default, so self-hosted IPv6 LANs keep working", async () => {
+    await expect(
+      assertAllowedProviderUrl("http://[fd00::1]:8000/v1", unresolvable)
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows a public IPv6 literal", async () => {
+    await expect(
+      assertAllowedProviderUrl("https://[2606:4700:4700::1111]/v1", unresolvable)
+    ).resolves.toBeUndefined();
+  });
+
+  it("still fails open for a genuine name that does not resolve", async () => {
+    // The documented trade-off stays: only LITERALS stop depending on DNS.
+    await expect(
+      assertAllowedProviderUrl("https://maybe-down.example/v1", unresolvable)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -77,6 +77,21 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     return NextResponse.json({ error: pluginConfigError }, { status: 400 });
   }
 
+  // pluginConfig is a permission, not a preference. `pinchy-files.
+  // allowed_paths` inside it is the allowlist that scopes the agent's file
+  // tools, its knowledge-base retrieval filter, and the browser-facing
+  // `GET /api/agents/[id]/workspace-file` route — which consults that list and
+  // nothing else, so a grant alone is a read, with no tool and no group
+  // membership needed. `pluginConfigSchema` confines the VALUE to /data, but
+  // /data is every corpus: a member who may still write `["/data/hr"]` onto
+  // their own seeded personal agent reads HR's documents. Same gate as
+  // allowedTools, and it costs the UI nothing — the Permissions tab that emits
+  // this field renders only for `isAdmin && !isPersonal`, and every request it
+  // sends carries allowedTools anyway.
+  if (body.pluginConfig !== undefined && session.user.role !== "admin") {
+    return NextResponse.json({ error: "Only admins can change permissions" }, { status: 403 });
+  }
+
   // Only admins can change permissions on shared agents
   if (body.allowedTools !== undefined) {
     if (session.user.role !== "admin") {

--- a/packages/web/src/lib/agent-file-access.ts
+++ b/packages/web/src/lib/agent-file-access.ts
@@ -2,12 +2,24 @@
  * Path containment for serving a workspace/allowed-path file to the browser.
  *
  * `allowed_paths` (see `AgentPluginConfig["pinchy-files"]`) is the SAME
- * admin-configured allowlist that already scopes an agent's file tools
- * (pinchy-files) and its knowledge-base retrieval (`/api/internal/knowledge/
- * search`) — see `openclaw-config/build.ts`'s `adminPaths` and
- * `retrieve.ts`'s `buildPathFilter`. This module answers one question: given
- * a requested absolute path and that allowlist, is it safe to read the file
- * off disk and hand its bytes to the browser?
+ * allowlist that already scopes an agent's file tools (pinchy-files) and its
+ * knowledge-base retrieval (`/api/internal/knowledge/search`) — see
+ * `openclaw-config/build.ts`'s `adminPaths` and `retrieve.ts`'s
+ * `buildPathFilter`. This module answers one question: given a requested
+ * absolute path and that allowlist, is it safe to read the file off disk and
+ * hand its bytes to the browser?
+ *
+ * This used to say "the SAME ADMIN-CONFIGURED allowlist", and that adjective
+ * was the whole vulnerability: `PATCH /api/agents/[id]` gated `allowedTools`,
+ * `visibility` and `groupIds` on the admin role but never gated
+ * `pluginConfig`, so any member could widen their own seeded personal agent's
+ * grant to `/`. The write side is confined now (`pluginConfigSchema`), but a
+ * clamp on new writes says nothing about rows already in the database — an
+ * upgraded install can carry an older grant that was never checked. So
+ * containment is measured against the intersection of the agent's grant and
+ * an absolute ceiling this module owns (`FILE_SERVE_ROOTS`), exactly as
+ * `pinchy-files` measures against its own `ALLOWED_ROOTS` rather than
+ * trusting its config alone. Neither list may widen the other.
  *
  * Two-stage containment, mirroring `packages/plugins/pinchy-files/validate.ts`:
  *
@@ -32,6 +44,10 @@
 import { realpath } from "node:fs/promises";
 import { resolve, sep } from "node:path";
 
+import { FILE_SERVE_ROOTS } from "./file-serve-roots";
+
+export { FILE_SERVE_ROOTS };
+
 export type ResolveAllowedFileResult =
   { ok: true; realPath: string } | { ok: false; status: 403 | 404 };
 
@@ -48,9 +64,17 @@ function isContained(path: string, root: string): boolean {
 
 export async function resolveAllowedFile(
   requestedPath: string,
-  allowedPaths: string[]
+  allowedPaths: string[],
+  /**
+   * The absolute ceiling. Injected rather than read directly so tests can
+   * exercise real containment against a temporary directory — the production
+   * value is a container mount point they cannot create.
+   */
+  serveRoots: readonly string[] = FILE_SERVE_ROOTS
 ): Promise<ResolveAllowedFileResult> {
-  if (allowedPaths.length === 0) {
+  // Either list being empty denies everything: no grant, or no ceiling to
+  // grant within. Both are configuration faults, and both fail closed.
+  if (allowedPaths.length === 0 || serveRoots.length === 0) {
     return { ok: false, status: 403 };
   }
 
@@ -58,8 +82,14 @@ export async function resolveAllowedFile(
   // and relative segments purely as string manipulation, so an obviously
   // out-of-scope request (traversal, absolute path elsewhere) is rejected
   // before we ever stat/read anything the caller doesn't have a right to.
+  //
+  // Both lists must contain the target. The grant says what this agent may
+  // see; the ceiling says what this route may serve at all. An over-broad
+  // grant that predates the write-side clamp therefore buys nothing.
   const lexicalTarget = resolve(requestedPath);
-  const lexicallyContained = allowedPaths.some((root) => isContained(lexicalTarget, resolve(root)));
+  const lexicallyContained =
+    allowedPaths.some((root) => isContained(lexicalTarget, resolve(root))) &&
+    serveRoots.some((root) => isContained(lexicalTarget, resolve(root)));
   if (!lexicallyContained) {
     return { ok: false, status: 403 };
   }
@@ -80,29 +110,34 @@ export async function resolveAllowedFile(
     return { ok: false, status: 403 };
   }
 
-  // ...and on every allowed root, so a root that is itself a symlink (or
-  // whose ancestor is, e.g. macOS `/var` -> `/private/var`) still compares
-  // consistently. Roots that fail to resolve (misconfigured/missing) are
-  // skipped rather than treated as a hard error — another root may still be
-  // valid.
-  const realRoots = await Promise.all(
-    allowedPaths.map(async (root) => {
-      try {
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- root comes from the admin-configured allowed_paths list (pinchy-files config), not request input.
-        return await realpath(resolve(root));
-      } catch {
-        return null;
-      }
-    })
-  );
+  // ...and on every root of both lists, so a root that is itself a symlink
+  // (or whose ancestor is, e.g. macOS `/var` -> `/private/var`) still
+  // compares consistently. Roots that fail to resolve (misconfigured/missing)
+  // are skipped rather than treated as a hard error — another root may still
+  // be valid.
+  const containsRealTarget = async (roots: readonly string[]) => {
+    const realRoots = await Promise.all(
+      roots.map(async (root) => {
+        try {
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- root comes from the agent's allowed_paths list or the module's own serve-root ceiling, not from request input.
+          return await realpath(resolve(root));
+        } catch {
+          return null;
+        }
+      })
+    );
+    return realRoots.some((realRoot) => realRoot !== null && isContained(realTarget, realRoot));
+  };
 
-  const reallyContained = realRoots.some(
-    (realRoot) => realRoot !== null && isContained(realTarget, realRoot)
-  );
+  // The ceiling is re-applied to the REAL path, not just the lexical one.
+  // Without that, a symlink planted inside a served directory and pointing at
+  // the secrets mount would satisfy both stage-1 checks and still be read.
+  const reallyContained =
+    (await containsRealTarget(allowedPaths)) && (await containsRealTarget(serveRoots));
   if (!reallyContained) {
     // The lexical path was in scope, but its real (symlink-resolved) target
-    // escapes every allowed root — a symlink planted inside an allowed
-    // directory pointing outside it. Deny.
+    // escapes the grant or the ceiling — e.g. a symlink planted inside an
+    // allowed directory pointing outside it. Deny.
     return { ok: false, status: 403 };
   }
 

--- a/packages/web/src/lib/domain-validation.ts
+++ b/packages/web/src/lib/domain-validation.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isPathUnderDataRoot } from "./knowledge/citation-path";
+
 // Each label: 1-63 chars, alphanumeric + hyphens (not leading/trailing hyphen).
 // At least two labels required (no bare "localhost" etc.).
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/;
@@ -13,12 +15,29 @@ export function isValidDomain(domain: string): boolean {
  * type in @/db/schema and is the shape-of-truth for both POST and PATCH agent
  * routes. Domain validity inside `pinchy-web` is layered on top via
  * `validatePinchyWebConfig` (it's a content check, not a shape check).
+ *
+ * `allowed_paths` is confined HERE rather than in a route, and that placement
+ * is the fix rather than an implementation detail. It is not a preference: it
+ * is the allowlist that scopes the agent's file tools, its knowledge-base
+ * retrieval filter, and the browser-facing
+ * `GET /api/agents/[id]/workspace-file` route. The two routes that write it
+ * disagreed — POST confined it only when `template.pluginId ===
+ * "pinchy-files"`, PATCH not at all — and since PATCH gates `allowedTools`,
+ * `visibility` and `groupIds` on the admin role but never gated
+ * `pluginConfig`, any member could point their own seeded personal agent at
+ * `/` and read the container's secrets. A boundary each caller has to
+ * remember is a boundary that a third caller will not have.
  */
 export const pluginConfigSchema = z
   .object({
     "pinchy-files": z
       .object({
-        allowed_paths: z.array(z.string()),
+        allowed_paths: z.array(z.string()).refine((paths) => paths.every(isPathUnderDataRoot), {
+          message: "allowed_paths entries must be directories under /data",
+        }),
+        // Not confined to /data: build.ts appends the agent's workspace memory
+        // dir to the EMITTED config, and write_paths ⊆ allowed_paths is
+        // checked against that post-build list (validate-built-config.ts).
         write_paths: z.array(z.string()).optional(),
         allowed_extensions: z.array(z.string()).optional(),
       })

--- a/packages/web/src/lib/domain-validation.ts
+++ b/packages/web/src/lib/domain-validation.ts
@@ -35,9 +35,14 @@ export const pluginConfigSchema = z
         allowed_paths: z.array(z.string()).refine((paths) => paths.every(isPathUnderDataRoot), {
           message: "allowed_paths entries must be directories under /data",
         }),
-        // Not confined to /data: build.ts appends the agent's workspace memory
-        // dir to the EMITTED config, and write_paths ⊆ allowed_paths is
-        // checked against that post-build list (validate-built-config.ts).
+        // Not confined to /data, and it does not have to be: nothing reads a
+        // STORED write_paths. `build.ts` derives the emitted list itself
+        // (workspace uploads/workbench/memory, only when pinchy_write is
+        // granted) and never looks at this field, so it is accepted for
+        // backward compatibility with rows that already carry it rather than
+        // as a grant anyone can widen. `write_paths ⊆ allowed_paths` is
+        // enforced on that emitted list (validate-built-config.ts) and again
+        // in the plugin at runtime (pinchy-files validate.ts).
         write_paths: z.array(z.string()).optional(),
         allowed_extensions: z.array(z.string()).optional(),
       })

--- a/packages/web/src/lib/file-serve-roots.ts
+++ b/packages/web/src/lib/file-serve-roots.ts
@@ -1,0 +1,22 @@
+/**
+ * The absolute ceiling on what `GET /api/agents/[id]/workspace-file` may ever
+ * read off disk, independent of any agent's configured `allowed_paths`.
+ *
+ * Deliberately NOT `packages/plugins/pinchy-files/validate.ts`'s
+ * `ALLOWED_ROOTS`, even though the two guard the same idea. The plugin runs in
+ * the `openclaw` container, this runs in `pinchy`, and the two mount the same
+ * volumes at different paths (see `docker-compose.yml`): the workspaces volume
+ * is `/root/.openclaw/workspaces` over there and `/openclaw-config/workspaces`
+ * here. Copying the plugin's list would add one root that does not exist in
+ * this container — and inviting its parent `/openclaw-config` instead would
+ * hand out `openclaw.json`, which carries the plaintext gateway token that
+ * unlocks `/api/internal/*`.
+ *
+ * So: exactly the data mount, which is all this route serves today (knowledge-
+ * base citation sources). A future "give me workspace file X" flow adds
+ * `/openclaw-config/workspaces/` HERE — never its parent.
+ *
+ * Its own module so the route's tests can substitute a temporary directory
+ * without mocking `resolveAllowedFile` itself.
+ */
+export const FILE_SERVE_ROOTS: readonly string[] = ["/data/"];

--- a/packages/web/src/lib/knowledge/citation-path.ts
+++ b/packages/web/src/lib/knowledge/citation-path.ts
@@ -57,3 +57,48 @@ export function fromCitationPath(citationPath: string): string {
     .join("/");
   return DATA_ROOT + confined;
 }
+
+/**
+ * Collapse `.`/`..`/empty segments in an ABSOLUTE POSIX path, as a pure string
+ * operation.
+ *
+ * `node:path`'s `resolve()` would do this, but it cannot live in this module
+ * (see the header) and the rule below is needed on both sides of the bundle
+ * boundary. `..` above the root is clamped at the root, matching `resolve()`.
+ */
+function normalizeAbsolute(absolutePath: string): string {
+  const segments: string[] = [];
+  for (const segment of absolutePath.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return "/" + segments.join("/");
+}
+
+/**
+ * Is `candidate` a directory the data root actually contains?
+ *
+ * This is the single definition of the boundary that confines an agent's
+ * `pinchy-files.allowed_paths` — the allowlist that scopes its file tools, its
+ * knowledge-base retrieval filter and the browser-facing workspace-file route
+ * all at once. It is enforced in `pluginConfigSchema`, so every writer of that
+ * column shares it; `sanitizePath` is the throwing form of the same rule.
+ *
+ * Deliberately stricter than `resolve()` in one respect: a RELATIVE path is
+ * rejected outright rather than resolved against the server's working
+ * directory. A stored allowlist entry whose meaning depends on where the
+ * process happens to have been started is not a grant anyone can reason about.
+ */
+export function isPathUnderDataRoot(candidate: unknown): candidate is string {
+  if (typeof candidate !== "string") return false;
+  // A null byte can truncate the path inside a native call, so what the
+  // check sees and what the syscall opens would differ.
+  if (candidate.includes("\0")) return false;
+  if (!candidate.startsWith("/")) return false;
+  // Trailing separator on both sides: `/database` must not pass as `/data`.
+  return (normalizeAbsolute(candidate) + "/").startsWith(DATA_ROOT);
+}

--- a/packages/web/src/lib/openai-compatible-discovery.ts
+++ b/packages/web/src/lib/openai-compatible-discovery.ts
@@ -43,15 +43,29 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
  * would obediently go there. A single check at the head of a redirect chain
  * says nothing about where the request lands, and the probe carries the
  * provider's API key in an Authorization header while it travels.
+ *
+ * Driving the chain by hand means taking over the part of `redirect: "follow"`
+ * that was never about convenience: the fetch spec DROPS `Authorization` when
+ * a redirect crosses an origin, so a provider cannot redirect its way to a
+ * credential meant only for itself. The SSRF guard does not cover this — a
+ * collector on an ordinary public address is exactly what it should allow —
+ * so the header is re-attached only while the destination's origin still
+ * matches the one the key was issued for, and never restored once a chain has
+ * left it.
  */
 async function fetchModels(baseUrl: string, apiKey: string): Promise<Response> {
   let current = modelsUrl(baseUrl);
+  const keyOrigin = new URL(current).origin;
+  let sendKey = true;
 
   for (let hop = 0; ; hop++) {
+    // Annotated, not inferred: `sendKey` is decided from the hop's URL, which
+    // is read off the previous response, which is this call — so letting the
+    // header object's type flow into the fetch overload closes a loop tsc
+    // cannot resolve (TS7022).
+    const headers: Record<string, string> = sendKey ? { Authorization: `Bearer ${apiKey}` } : {};
     const response = await fetch(current, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+      headers,
       redirect: "manual",
       signal: AbortSignal.timeout(PROVIDER_PROBE_TIMEOUT_MS),
     });
@@ -68,7 +82,12 @@ async function fetchModels(baseUrl: string, apiKey: string): Promise<Response> {
 
     // Relative Locations are legal and common, so resolve against the URL
     // actually requested before classifying it.
-    current = new URL(location, current).toString();
+    const next = new URL(location, current);
+    // Once, and permanently: a hop back to the original origin does not earn
+    // the key back, or a chain through an attacker would be a way to launder
+    // one past this check.
+    sendKey = sendKey && next.origin === keyOrigin;
+    current = next.toString();
     await assertAllowedProviderUrl(current);
   }
 }

--- a/packages/web/src/lib/openai-compatible-discovery.ts
+++ b/packages/web/src/lib/openai-compatible-discovery.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MODEL_CAPS, lookupModelCapabilities } from "@/lib/model-catalog";
+import { assertAllowedProviderUrl } from "@/lib/provider-url-guard";
 import type { OpenClawModelDefinition } from "@/lib/openclaw-builtin-models";
 import {
   AUTH_RETRY_DELAY_MS,
@@ -27,13 +28,49 @@ function readProp(x: unknown, key: string): unknown {
     : undefined;
 }
 
-function fetchModels(baseUrl: string, apiKey: string): Promise<Response> {
-  return fetch(modelsUrl(baseUrl), {
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-    signal: AbortSignal.timeout(PROVIDER_PROBE_TIMEOUT_MS),
-  });
+// Follow a handful of hops like any HTTP client — but every hop is a fresh
+// destination that has to earn the same trust the base URL did.
+const MAX_REDIRECT_HOPS = 3;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * `GET <baseUrl>/models`, re-running the SSRF guard on every redirect target.
+ *
+ * The routes validate `baseUrl` before calling in here (see
+ * `settings/providers/openai-compatible/{route,discover/route}.ts`), but this
+ * fetched with the default `redirect: "follow"` — so a base URL that passed
+ * the guard could answer `302 Location: http://169.254.169.254/` and undici
+ * would obediently go there. A single check at the head of a redirect chain
+ * says nothing about where the request lands, and the probe carries the
+ * provider's API key in an Authorization header while it travels.
+ */
+async function fetchModels(baseUrl: string, apiKey: string): Promise<Response> {
+  let current = modelsUrl(baseUrl);
+
+  for (let hop = 0; ; hop++) {
+    const response = await fetch(current, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      redirect: "manual",
+      signal: AbortSignal.timeout(PROVIDER_PROBE_TIMEOUT_MS),
+    });
+
+    if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+    const location = response.headers.get("location");
+    // A redirect without a Location is the provider's problem — hand it back
+    // and let the caller treat it as the non-2xx it is.
+    if (!location) return response;
+    if (hop >= MAX_REDIRECT_HOPS) {
+      throw new Error("Too many redirects from the provider endpoint");
+    }
+
+    // Relative Locations are legal and common, so resolve against the URL
+    // actually requested before classifying it.
+    current = new URL(location, current).toString();
+    await assertAllowedProviderUrl(current);
+  }
 }
 
 /**

--- a/packages/web/src/lib/path-validation.ts
+++ b/packages/web/src/lib/path-validation.ts
@@ -8,8 +8,17 @@ import { resolve, normalize } from "path";
 // bundle. Re-exported so existing importers of path-validation keep working and
 // there is still exactly one definition.
 export { DATA_ROOT } from "./knowledge/citation-path";
-import { DATA_ROOT } from "./knowledge/citation-path";
+import { DATA_ROOT, isPathUnderDataRoot } from "./knowledge/citation-path";
 
+/**
+ * Throwing form of `isPathUnderDataRoot`, returning the normalized directory.
+ *
+ * The DECISION lives in `citation-path.ts` so that `pluginConfigSchema` — which
+ * a client component transitively imports and which therefore cannot pull in
+ * `node:path` — enforces the identical boundary. Keeping a second copy of the
+ * rule here is how the two writers of `allowed_paths` drifted apart in the
+ * first place.
+ */
 export function sanitizePath(inputPath: string): string {
   if (typeof inputPath !== "string") {
     throw new Error("Invalid path: must be a string");
@@ -19,14 +28,12 @@ export function sanitizePath(inputPath: string): string {
     throw new Error("Invalid path: contains null bytes");
   }
 
-  const resolved = resolve(normalize(inputPath));
-  const normalized = resolved.endsWith("/") ? resolved : resolved + "/";
-
-  if (!normalized.startsWith(DATA_ROOT)) {
+  if (!isPathUnderDataRoot(inputPath)) {
     throw new Error(`Invalid path: must be under ${DATA_ROOT}`);
   }
 
-  return normalized;
+  const resolved = resolve(normalize(inputPath));
+  return resolved.endsWith("/") ? resolved : resolved + "/";
 }
 
 export function validateAllowedPaths(paths: string[]): string[] {

--- a/packages/web/src/lib/provider-url-guard.ts
+++ b/packages/web/src/lib/provider-url-guard.ts
@@ -140,6 +140,29 @@ export function isPrivateNetworkBlockEnabled(): boolean {
   return v === "1" || v?.toLowerCase() === "true";
 }
 
+/**
+ * The URL's host as a bare address literal, or null when it is a name.
+ *
+ * `URL.hostname` keeps the brackets on an IPv6 host: `new URL("http://[::1]/")
+ * .hostname` is `"[::1]"`, not `"::1"`. That string satisfies neither
+ * `isIP()` nor `dns.lookup()`, so before this existed every IPv6 literal fell
+ * straight through the resolver's fail-open catch and `classifyIpv6` was
+ * unreachable from URL input. `lib/integrations/url-validation.ts` has always
+ * de-bracketed; this guard was written later and lost the step.
+ */
+function hostnameAsIpLiteral(hostname: string): string | null {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    // Bracketed means IPv6 literal (RFC 3986). No zone-id handling needed:
+    // the WHATWG parser rejects `http://[fe80::1%eth0]/` as an invalid URL
+    // before this is reached. It DOES normalize the embedded-IPv4 form, so
+    // `::ffff:169.254.169.254` arrives as `::ffff:a9fe:a9fe` — which
+    // `expandIpv6` folds back to the same v4 classification.
+    const inner = hostname.slice(1, -1);
+    return isIP(inner) === 6 ? inner : null;
+  }
+  return isIP(hostname) !== 0 ? hostname : null;
+}
+
 /** Resolve a hostname to all of its A/AAAA addresses. Injected in tests. */
 export type HostResolver = (host: string) => Promise<string[]>;
 
@@ -171,13 +194,35 @@ export async function assertAllowedProviderUrl(
     throw new ProviderUrlBlockedError("unsupported_scheme", "Only http(s) base URLs are allowed.");
   }
 
+  // An address literal is already the answer — classify it and never involve
+  // DNS. Resolving it is what lost the IPv6 case: `dns.lookup("[::1]")`
+  // throws, and the fail-open below then waved it through.
+  const literal = hostnameAsIpLiteral(url.hostname);
+  if (literal !== null) {
+    assertAddressesAllowed([literal]);
+    return;
+  }
+  if (url.hostname.startsWith("[")) {
+    // Bracketed but not a parseable IPv6 address, so it is not a name either.
+    // Refuse rather than hand it to a resolver whose failure means "allow".
+    throw new ProviderUrlBlockedError(
+      "blocked_address",
+      "That host is not a valid address or hostname."
+    );
+  }
+
   let addresses: string[];
   try {
     addresses = await resolver(url.hostname);
   } catch {
-    return; // unresolvable — fail open (see doc-comment)
+    return; // unresolvable NAME — fail open (see doc-comment)
   }
 
+  assertAddressesAllowed(addresses);
+}
+
+/** Throw if any address in the set is one this deployment refuses to reach. */
+function assertAddressesAllowed(addresses: string[]): void {
   const blockPrivate = isPrivateNetworkBlockEnabled();
   for (const addr of addresses) {
     const category = classifyIp(addr);


### PR DESCRIPTION
Found by the security review run against `v0.8.0..release/0.9` before cutting 0.9.0. The cut is on hold for these.

Two commits, deliberately separable so each can be cherry-picked to `release/0.9` on its own.

## 1. Member → arbitrary file read (critical, no admin role)

Every user is seeded a personal agent they own, and `PATCH /api/agents/[agentId]` gates `allowedTools`, `visibility` and `groupIds` on the admin role — but never gated `pluginConfig`. `pinchy-files.allowed_paths` inside it is the allowlist `GET .../workspace-file` reads against:

```
PATCH {"pluginConfig":{"pinchy-files":{"allowed_paths":["/"]}}}
GET   .../workspace-file?path=/openclaw-secrets/secrets.json
```

Per `docker-compose.yml` that reaches the AES master key (`/app/secrets`), the decrypted provider keys (`/openclaw-secrets/secrets.json`), the plaintext gateway token in `/openclaw-config/openclaw.json` — which then unlocks `/api/internal/*` — and all of `/data`.

`POST /api/agents` *did* confine the field, but only `if (template.pluginId === "pinchy-files")`. Two writers disagreeing is the real defect, so the rule moves into `pluginConfigSchema`, which both parse through. It lives in `knowledge/citation-path.ts` because that module is import-free by design and a client component transitively imports the schema — so it cannot sit next to `node:path`.

A schema only runs on write, so `resolveAllowedFile` additionally enforces an absolute ceiling of its own, at both the lexical and the realpath stage. That is the upgrade case: this fix lands on installs that may already store an over-broad grant.

## 2. Three SSRF holes

- **`provider-url-guard.ts` fell open on every IPv6 literal.** `new URL("http://[::1]/").hostname` keeps the brackets, which satisfies neither `isIP()` nor `dns.lookup()`, so it hit the fail-open catch. The whole `classifyIpv6` body was unreachable from URL input: `[::ffff:169.254.169.254]` reached IMDS and `PINCHY_PROVIDER_BLOCK_PRIVATE_NETWORKS=1` was a no-op for ULA. The old tests could not see it — their stub resolver answers bracketed hosts, so they passed against code that fails in production.
- **Discovery followed redirects unguarded.** The routes validate `baseUrl`, then `fetchModels` used the default `redirect: "follow"` while carrying the API key in an `Authorization` header.
- **`pinchy-web`'s `web_fetch` fell open on hosts-file names.** `dns.resolve4/6` misses `/etc/hosts`; the fetch's `dns.lookup` does not. Compose adds `ollama.local:host-gateway` to these containers. **This one needs no role** — `web_fetch` runs on model instruction, so a prompt-injected page can drive it. Also widened `/^fc00:/` to the real fc00::/7, which had left every `fd00::/8` address classified public.

## Deliberately not in scope

DNS rebinding / connect-time enforcement for the provider guard needs a pinned undici dispatcher (what `pinchy-web` already has) and is 0.10 work. Re-validating the *stored* base URL on later fetches is only meaningful together with that, so it waits too.

## Gates

`pnpm -C packages/web test` 10391 ✅ · `pnpm test:plugins` all ✅ · `pnpm test:scripts` 551 ✅ · typecheck web + plugins ✅ · `pnpm format:check` ✅ · lint 0 errors ✅

Every new test was verified red against the unpatched source, not just green against the patched one — the three "refuses to follow" redirect cases were rewritten as a call-count contrast after the first version turned out to pass either way (a mocked `fetch` never follows a redirect on its own).