### PR TITLE
fix(deps): let pnpm audit see the brace-expansion acceptance osv-scanner already has

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,16 @@ The drift guard is `scripts/lib/precommit-tooling.test.mjs` (pure logic in `prec
 
 The `packages/web/src/**/*.{ts,tsx}` eslint rule _is_ wrapped, correctly: its binary lives in that package, and eslint genuinely cannot run from an uninstalled worktree anyway (its flat config resolves plugins from `packages/web/node_modules`). Unwrapping it would move the failure, not remove it. But a scoped rule runs only for the files it matches, so blocking on it up front would reject a docs commit over a binary it never invokes — hence the split: the preflight blocks only on what runs on **every** commit, and `--explain` runs **after** a lint-staged failure to name a missing per-package binary as `pnpm install` rather than leaving it to read as a lint error.
 
+## Two Scanners, One Acceptance
+
+A vulnerability can be accepted in two places, and they read different files. `osv-scanner.toml` feeds CI's `vuln-scan` job; `pnpm.auditConfig.ignoreGhsas` in the root `package.json` feeds `pnpm audit --audit-level=high --prod`, the gate `scripts/release.mjs` runs before a tag is cut. **`pnpm audit` does not read `osv-scanner.toml`.** GHSA-mh99-v99m-4gvg was triaged and accepted in #914 and told only to osv-scanner, so v0.9.0 could not be cut over an advisory the repo had already accepted — the acceptance sat on record in a place the release path never consults (#993).
+
+`scripts/lib/audit-ignore-parity.test.mjs` (pure logic in `audit-ignore-parity.mjs`, run by `pnpm test:scripts`) enforces the pairing. Every id in `ignoreGhsas` must have an `[[IgnoredVulns]]` entry with a `reason` and a **non-expired** `ignoreUntil`.
+
+- **The expiry rule is the load-bearing one.** `ignoreGhsas` is a bare array of ids — no reason, no expiry, and pnpm offers no `ignoreUntil`. So on the expiry date osv-scanner re-opens the question and `pnpm audit` structurally cannot; the two configs diverge by construction, with the _release_ path the silent one. The guard is how the pnpm-side silence inherits the deadline written next to the rationale.
+- **The check is one-directional on purpose** — `ignoreGhsas` ⊆ osv ids, never the reverse. Most entries here are things `pnpm audit --prod` at the root cannot see anyway (the astro advisories live in `docs/pnpm-lock.yaml`; the openclaw one is a devDependency). Mirroring those would silence a scanner about findings it never emits.
+- **The `reason` is the machine-readable record; the TOML comment above it is not.** osv-scanner prints `reason` and nothing else, so a route named only in the comment is not named at all — an acceptance that does not name a path it accepts is not an acceptance of that path.
+
 ## One Node Version, Stated In Four Kinds Of Place That Must Agree
 
 Node is pinned in `.nvmrc` (`22`) and `engines.node` (`>=22 <23`); CI's `node-version:` and every Dockerfile's `FROM …node:<major>` must name the same major. `scripts/lib/node-version-pin.test.mjs` (pure logic in `node-version-pin.mjs`, run by `pnpm test:scripts`) fails if any of them drifts.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -74,8 +74,16 @@ reason = "astro — docs static-site build tooling (docs/pnpm-lock.yaml), not sh
 # that cannot be cut, or a scanner that says nothing while the other says high.
 # Ignoring the id wholesale is bounded by the override above: the 5.x line cannot
 # regress below 5.0.8, and a future 6.x advisory would carry a different id.
+#
+# That lockstep is CHECKED, not merely requested: scripts/lib/audit-ignore-parity
+# .test.mjs (`pnpm test:scripts`) fails if an id in `ignoreGhsas` has no entry
+# here, or if the entry it has is missing a reason, missing an ignoreUntil, or
+# EXPIRED. The expiry rule is the load-bearing one — `ignoreGhsas` has no
+# ignoreUntil of its own and never will, so on 2026-10-25 osv-scanner re-opens
+# this question while `pnpm audit` goes on ignoring it silently. The guard is
+# how the pnpm-side silence inherits the deadline written down here.
 
 [[IgnoredVulns]]
 id = "GHSA-mh99-v99m-4gvg"
 ignoreUntil = 2026-10-25
-reason = "brace-expansion OOM — 5.x line IS fixed (override forces >=5.0.8); residual 1.1.16/2.1.2 come via archiver@5 (exceljs/pinchy-files) + @eslint/config-array, have no compatible upstream fix (5.0.8's changed CJS export breaks minimatch@3/@5), and are unreachable (archiver/eslint pass fixed internal globs, never attacker-controlled brace patterns). Re-triage when archiver depends on brace-expansion >=5.0.8."
+reason = "brace-expansion OOM — 5.x line IS fixed (override forces >=5.0.8); residual 1.1.16/2.1.2 come via three routes: archiver@5 (exceljs/pinchy-files), googleapis>googleapis-common>gaxios>rimraf (pinchy-email), and @eslint/config-array (dev toolchain). None has a compatible upstream fix (5.0.8's changed CJS export breaks minimatch@3/@5), and none is reachable: archiver walks fixed internal globs, rimraf deletes gaxios' own temp paths, eslint matches code-authored config globs — no attacker-controlled brace pattern reaches expand(). Re-triage when archiver depends on brace-expansion >=5.0.8."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -48,17 +48,32 @@ reason = "astro — docs static-site build tooling (docs/pnpm-lock.yaml), not sh
 # 5.0.8 (range <=5.0.7), and the 5.x line IS fixed here — the override forces
 # brace-expansion>=5.0.8 <6, so every modern minimatch@9/10 consumer is patched.
 # The residual flags are the 1.1.16 (minimatch@3 → glob@7) and 2.1.2
-# (minimatch@5 → readdir-glob) instances pulled transitively by archiver@5 (via
-# exceljs in pinchy-files) and by @eslint/config-array in the dev toolchain.
+# (minimatch@5 → readdir-glob) instances, reached by THREE routes — two of them
+# production dependencies:
+#   1. archiver@5 → archiver-utils → glob@7  (exceljs, in pinchy-files)
+#   2. googleapis → googleapis-common → gaxios → rimraf → glob@7  (pinchy-email)
+#      — missing from this rationale until v0.9.0's release audit reported it.
+#      The argument below always covered it, but an acceptance that does not
+#      name a path it accepts is not an acceptance of that path.
+#   3. @eslint/config-array, in the dev toolchain
 # Those lines have NO upstream fix: 5.0.8 changed the CommonJS export from a
 # default-exported function to a named export, which breaks `require(...)()` in
 # minimatch@3/@5 (and crashes eslint), so bumping them to the fix is not possible
 # without breaking archiver and the linter. Not reachable regardless: the OOM
 # requires an attacker-controlled brace PATTERN passed to expand(); archiver
-# walks the filesystem with fixed internal globs and eslint matches code-authored
-# config globs — neither passes untrusted pattern strings. ignoreUntil forces a
-# re-triage once archiver/minimatch ships a major depending on brace-expansion
-# >=5.0.8 (or exceljs drops archiver@5).
+# walks the filesystem with fixed internal globs, rimraf deletes gaxios' own
+# temp paths, and eslint matches code-authored config globs — none of the three
+# passes an untrusted pattern string. ignoreUntil forces a re-triage once
+# archiver/minimatch ships a major depending on brace-expansion >=5.0.8 (or
+# exceljs drops archiver@5).
+#
+# `pnpm audit` has to be told the same thing separately: it does not read this
+# file, and `pnpm release` gates on `pnpm audit --audit-level=high --prod`. So
+# the root package.json carries a matching `pnpm.auditConfig.ignoreGhsas` entry
+# for this GHSA. Keep the two in lockstep — dropping either one leaves a release
+# that cannot be cut, or a scanner that says nothing while the other says high.
+# Ignoring the id wholesale is bounded by the override above: the 5.x line cannot
+# regress below 5.0.8, and a future 6.x advisory would carry a different id.
 
 [[IgnoredVulns]]
 id = "GHSA-mh99-v99m-4gvg"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
     "prettier": "^3.9.5"
   },
   "pnpm": {
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-mh99-v99m-4gvg"
+      ]
+    },
     "packageExtensions": {
       "@hookform/resolvers@5.2.2": {
         "peerDependencies": {

--- a/scripts/lib/audit-ignore-parity.mjs
+++ b/scripts/lib/audit-ignore-parity.mjs
@@ -1,0 +1,223 @@
+/**
+ * Drift guard for the two places this repo accepts a vulnerability.
+ *
+ * There are two scanners and they read different files:
+ *
+ *   1. `osv-scanner --config=./osv-scanner.toml` — the CI `vuln-scan` job.
+ *      Acceptances live in `[[IgnoredVulns]]` blocks, each carrying a `reason`
+ *      and (usually) an `ignoreUntil` date that forces a re-triage.
+ *   2. `pnpm audit --audit-level=high --prod` — the gate `scripts/release.mjs`
+ *      runs before a tag is cut. It does NOT read `osv-scanner.toml`. Its
+ *      acceptances live in `pnpm.auditConfig.ignoreGhsas` in the root
+ *      package.json: a bare array of ids, with no reason field and no expiry.
+ *
+ * Until v0.9.0 only the first one had been told about GHSA-mh99-v99m-4gvg, so
+ * the release could not be cut over an advisory the repo had triaged and
+ * accepted months earlier (#914). The acceptance sat on record in a place the
+ * release path never consults. That is what pinchy#993 fixed, by hand, with a
+ * comment in osv-scanner.toml asking the next person to keep the two in
+ * lockstep.
+ *
+ * This file is that comment, enforced. The property guarded is not "an id is
+ * written down twice" — it is that **the pnpm-side silence never outlives the
+ * osv-side rationale**, in either of the two ways it can:
+ *
+ *   - An id in `ignoreGhsas` with no `[[IgnoredVulns]]` entry is an
+ *     unexplained, permanent silencer of the *release* gate on *production*
+ *     dependencies. `ignoreGhsas` has no `reason` field, so nothing about that
+ *     entry says what was accepted or why — and unlike a red CI job, nobody
+ *     ever sees it, because its whole effect is that nothing is printed.
+ *   - An id in `ignoreGhsas` whose osv entry has EXPIRED is worse than either
+ *     config alone. osv-scanner goes red on the expiry date and forces the
+ *     re-triage; `pnpm audit` cannot, because pnpm has no `ignoreUntil` and
+ *     never will notice. So on that date the two configs diverge by
+ *     construction: CI re-opens the question while the release path stays
+ *     silent about it forever. Expiry is the one property the two files cannot
+ *     express symmetrically, which is exactly why it needs a checker rather
+ *     than a convention.
+ *
+ * The check is deliberately ONE-DIRECTIONAL: every `ignoreGhsas` id needs an
+ * osv entry, never the reverse. Most `[[IgnoredVulns]]` entries here are things
+ * `pnpm audit --prod` at the repo root cannot see anyway — the astro advisories
+ * live in `docs/pnpm-lock.yaml` (a separate, non-workspace lockfile) and the
+ * openclaw one is a devDependency. Mirroring those into `ignoreGhsas` would
+ * silence a scanner about findings it never reports, which is a lie in the
+ * config rather than a safety property.
+ *
+ * Read-side sibling of the node-version-pin / format-gate / ci-path-filter
+ * guards (see AGENTS.md).
+ */
+
+/**
+ * Extract the `[[IgnoredVulns]]` entries from an osv-scanner.toml.
+ *
+ * Hand-rolled rather than pulled from a TOML library on purpose: the repo has
+ * no TOML dependency at the root, and this reads exactly one table-array whose
+ * shape is fixed by osv-scanner's own schema (`id`, `reason`, `ignoreUntil`).
+ *
+ * Known limits, so nobody reads a green check as more than it is: values are
+ * matched as single-line basic strings / bare date literals, which is how
+ * osv-scanner documents them and how every entry in this repo is written. A
+ * multi-line (`"""`) reason or a quoted date would parse as absent, and the
+ * guard would then complain about a field that is really there — loud and
+ * wrong, never silent and wrong.
+ *
+ * @param {string} toml
+ * @returns {Array<{ id: string, reason: string | null, ignoreUntil: string | null }>}
+ */
+export function parseOsvIgnoredVulns(toml) {
+  const entries = [];
+  // Split on the table-array header, keeping only what follows each one. A
+  // later `[SomethingElse]` header ends the entry.
+  const blocks = String(toml)
+    .split(/^\s*\[\[IgnoredVulns\]\]\s*$/m)
+    .slice(1);
+
+  for (const block of blocks) {
+    const body = block.split(/^\s*\[/m)[0];
+    const id = matchValue(body, "id");
+    if (!id) continue;
+    entries.push({
+      id,
+      reason: matchValue(body, "reason"),
+      ignoreUntil: matchDate(body, "ignoreUntil"),
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * @param {string} body
+ * @param {string} key
+ * @returns {string | null}
+ */
+function matchValue(body, key) {
+  const match = body.match(new RegExp(`^\\s*${key}\\s*=\\s*"([^"]*)"`, "m"));
+  return match ? match[1] : null;
+}
+
+/**
+ * @param {string} body
+ * @param {string} key
+ * @returns {string | null}
+ */
+function matchDate(body, key) {
+  const match = body.match(
+    new RegExp(`^\\s*${key}\\s*=\\s*(\\d{4}-\\d{2}-\\d{2})\\s*$`, "m"),
+  );
+  return match ? match[1] : null;
+}
+
+/**
+ * Read the pnpm-side acceptances out of a parsed root package.json.
+ *
+ * Returns `[]` when the key is absent — that is the honest reading (nothing is
+ * ignored), and it is the state this repo was in before pinchy#993.
+ *
+ * @param {unknown} pkg
+ * @returns {string[]}
+ */
+export function parseAuditIgnoreGhsas(pkg) {
+  const list = /** @type {any} */ (pkg)?.pnpm?.auditConfig?.ignoreGhsas ?? [];
+  if (!Array.isArray(list)) {
+    throw new TypeError(
+      `pnpm.auditConfig.ignoreGhsas must be an array of GHSA ids, got ${JSON.stringify(list)}`,
+    );
+  }
+  return list.map(String);
+}
+
+/**
+ * Check that every pnpm-side acceptance is backed by a live osv-side one.
+ *
+ * `today` is injected so the expiry rule is testable. The repo-level test
+ * passes the real date on purpose: the guard going red on the expiry date is
+ * the mechanism, not an accident — it is how `ignoreGhsas`, which has no
+ * expiry of its own, inherits the one written next to the rationale.
+ *
+ * @param {{
+ *   osvEntries: Array<{ id: string, reason: string | null, ignoreUntil: string | null }>,
+ *   ghsaIgnores: string[],
+ *   today: string,
+ * }} input
+ * @returns {string[]} one actionable message per problem, empty when clean
+ */
+export function validateAuditIgnoreParity({ osvEntries, ghsaIgnores, today }) {
+  const errors = [];
+  const byId = new Map(osvEntries.map((entry) => [entry.id, entry]));
+  const seen = new Set();
+
+  for (const id of ghsaIgnores) {
+    if (seen.has(id)) {
+      errors.push(
+        `pnpm.auditConfig.ignoreGhsas lists ${id} twice — remove the duplicate.`,
+      );
+      continue;
+    }
+    seen.add(id);
+
+    // pnpm matches this list against GitHub advisory ids only. A CVE, OSV or
+    // MAL id here matches nothing, so it reads as an acceptance while silencing
+    // exactly zero findings — and the release gate still fails, with the
+    // config appearing to say otherwise.
+    if (!/^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}$/.test(id)) {
+      errors.push(
+        `pnpm.auditConfig.ignoreGhsas entry "${id}" is not a GHSA id. ` +
+          `pnpm audit matches GitHub advisory ids only, so this entry silences nothing.`,
+      );
+      continue;
+    }
+
+    const entry = byId.get(id);
+    if (!entry) {
+      errors.push(
+        `${id} is ignored by pnpm audit (pnpm.auditConfig.ignoreGhsas) but has no ` +
+          `[[IgnoredVulns]] entry in osv-scanner.toml. ignoreGhsas carries no reason ` +
+          `and no expiry, so on its own it is an unexplained, permanent silencing of ` +
+          `the release gate. Add the entry with a reason and an ignoreUntil, or drop ` +
+          `the id from ignoreGhsas.`,
+      );
+      continue;
+    }
+
+    if (!entry.reason || !entry.reason.trim()) {
+      errors.push(
+        `${id} has an [[IgnoredVulns]] entry in osv-scanner.toml with no reason. ` +
+          `The reason is the only machine-readable record of what was accepted — ` +
+          `osv-scanner prints it, the TOML comments above it are not printed anywhere.`,
+      );
+    }
+
+    if (!entry.ignoreUntil) {
+      errors.push(
+        `${id} is ignored by pnpm audit but its osv-scanner.toml entry has no ignoreUntil. ` +
+          `pnpm has no expiry mechanism, so without one on the osv side the acceptance ` +
+          `is unbounded on the release path. Add ignoreUntil = YYYY-MM-DD.`,
+      );
+    } else if (entry.ignoreUntil <= today) {
+      errors.push(
+        `${id} expired on ${entry.ignoreUntil} (today is ${today}). osv-scanner now ` +
+          `reports it again, but pnpm audit still ignores it — pnpm has no expiry, so ` +
+          `the release gate stays silent unless someone acts. Re-triage: either renew ` +
+          `ignoreUntil with a fresh reason, or drop the id from BOTH osv-scanner.toml ` +
+          `and pnpm.auditConfig.ignoreGhsas.`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Today as `YYYY-MM-DD`, in UTC.
+ *
+ * String comparison against a TOML date literal is exact for this format, so
+ * the guard never needs to construct a Date from the config value.
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function todayIso(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}

--- a/scripts/lib/audit-ignore-parity.test.mjs
+++ b/scripts/lib/audit-ignore-parity.test.mjs
@@ -1,0 +1,217 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  parseOsvIgnoredVulns,
+  parseAuditIgnoreGhsas,
+  validateAuditIgnoreParity,
+  todayIso,
+} from "./audit-ignore-parity.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const GHSA = "GHSA-mh99-v99m-4gvg";
+
+/** @param {Partial<{id: string, reason: string | null, ignoreUntil: string | null}>} [over] */
+function osvEntry(over = {}) {
+  return {
+    id: GHSA,
+    reason: "unreachable — fixed internal globs only",
+    ignoreUntil: "2099-01-01",
+    ...over,
+  };
+}
+
+test("parseOsvIgnoredVulns reads id, reason and ignoreUntil out of every block", () => {
+  const toml = [
+    '# a comment mentioning id = "GHSA-not-an-entry"',
+    "",
+    "[[IgnoredVulns]]",
+    'id = "GHSA-aaaa-bbbb-cccc"',
+    'reason = "first"',
+    "",
+    "[[IgnoredVulns]]",
+    'id = "GHSA-dddd-eeee-ffff"',
+    "ignoreUntil = 2026-10-25",
+    'reason = "second"',
+  ].join("\n");
+
+  assert.deepEqual(parseOsvIgnoredVulns(toml), [
+    { id: "GHSA-aaaa-bbbb-cccc", reason: "first", ignoreUntil: null },
+    { id: "GHSA-dddd-eeee-ffff", reason: "second", ignoreUntil: "2026-10-25" },
+  ]);
+});
+
+test("parseOsvIgnoredVulns does not let a following table bleed into an entry", () => {
+  // Without a terminator the `id` of a later table would be read as this
+  // entry's second field — and TOML's last-wins would silently retarget the
+  // acceptance at a different advisory.
+  const toml = [
+    "[[IgnoredVulns]]",
+    'id = "GHSA-aaaa-bbbb-cccc"',
+    'reason = "kept"',
+    "",
+    "[SomethingElse]",
+    'reason = "not part of the entry above"',
+  ].join("\n");
+
+  assert.deepEqual(parseOsvIgnoredVulns(toml), [
+    { id: "GHSA-aaaa-bbbb-cccc", reason: "kept", ignoreUntil: null },
+  ]);
+});
+
+test("parseAuditIgnoreGhsas returns [] when the key is absent", () => {
+  // The pre-#993 state. `[]` is the honest reading: nothing is ignored.
+  assert.deepEqual(parseAuditIgnoreGhsas({}), []);
+  assert.deepEqual(parseAuditIgnoreGhsas({ pnpm: {} }), []);
+});
+
+test("parseAuditIgnoreGhsas throws rather than shrugging at a non-array", () => {
+  // A string here would iterate character by character and report nonsense.
+  assert.throws(
+    () =>
+      parseAuditIgnoreGhsas({ pnpm: { auditConfig: { ignoreGhsas: GHSA } } }),
+    /must be an array/,
+  );
+});
+
+test("a pnpm-side ignore backed by a live osv entry is clean", () => {
+  assert.deepEqual(
+    validateAuditIgnoreParity({
+      osvEntries: [osvEntry()],
+      ghsaIgnores: [GHSA],
+      today: "2026-07-30",
+    }),
+    [],
+  );
+});
+
+test("an ignoreGhsas id with no osv entry fails — nothing says what was accepted", () => {
+  const errors = validateAuditIgnoreParity({
+    osvEntries: [],
+    ghsaIgnores: [GHSA],
+    today: "2026-07-30",
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /no \[\[IgnoredVulns\]\] entry/);
+  assert.match(errors[0], new RegExp(GHSA));
+});
+
+test("an expired osv entry fails while pnpm audit would still stay silent", () => {
+  // The whole reason this guard exists: on the expiry date osv-scanner
+  // re-opens the question and pnpm audit cannot, because pnpm has no
+  // ignoreUntil. Without this rule the two configs diverge by construction.
+  const errors = validateAuditIgnoreParity({
+    osvEntries: [osvEntry({ ignoreUntil: "2026-10-25" })],
+    ghsaIgnores: [GHSA],
+    today: "2026-10-25",
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /expired on 2026-10-25/);
+});
+
+test("the day before expiry is still clean", () => {
+  assert.deepEqual(
+    validateAuditIgnoreParity({
+      osvEntries: [osvEntry({ ignoreUntil: "2026-10-25" })],
+      ghsaIgnores: [GHSA],
+      today: "2026-10-24",
+    }),
+    [],
+  );
+});
+
+test("an osv entry with no ignoreUntil fails for a pnpm-side ignore", () => {
+  const errors = validateAuditIgnoreParity({
+    osvEntries: [osvEntry({ ignoreUntil: null })],
+    ghsaIgnores: [GHSA],
+    today: "2026-07-30",
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /no ignoreUntil/);
+});
+
+test("an osv entry with an empty reason fails", () => {
+  const errors = validateAuditIgnoreParity({
+    osvEntries: [osvEntry({ reason: "   " })],
+    ghsaIgnores: [GHSA],
+    today: "2026-07-30",
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /no reason/);
+});
+
+test("a non-GHSA id in ignoreGhsas fails — pnpm matches GHSA ids only", () => {
+  const errors = validateAuditIgnoreParity({
+    osvEntries: [osvEntry({ id: "CVE-2026-1234" })],
+    ghsaIgnores: ["CVE-2026-1234"],
+    today: "2026-07-30",
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /not a GHSA id/);
+});
+
+test("a duplicate ignoreGhsas entry fails", () => {
+  const errors = validateAuditIgnoreParity({
+    osvEntries: [osvEntry()],
+    ghsaIgnores: [GHSA, GHSA],
+    today: "2026-07-30",
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /twice/);
+});
+
+test("osv-only acceptances are NOT required to appear in ignoreGhsas", () => {
+  // The astro advisories live in docs/pnpm-lock.yaml and the openclaw one is a
+  // devDependency; `pnpm audit --prod` at the root reports neither. Mirroring
+  // them would silence a scanner about findings it never emits.
+  assert.deepEqual(
+    validateAuditIgnoreParity({
+      osvEntries: [osvEntry(), osvEntry({ id: "GHSA-4g3v-8h47-v7g6" })],
+      ghsaIgnores: [GHSA],
+      today: "2026-07-30",
+    }),
+    [],
+  );
+});
+
+test("the repo's own osv-scanner.toml and package.json agree, today", () => {
+  const toml = readFileSync(join(REPO_ROOT, "osv-scanner.toml"), "utf8");
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8"));
+
+  const errors = validateAuditIgnoreParity({
+    osvEntries: parseOsvIgnoredVulns(toml),
+    ghsaIgnores: parseAuditIgnoreGhsas(pkg),
+    today: todayIso(),
+  });
+
+  assert.deepEqual(errors, [], errors.join("\n"));
+});
+
+test("the repo's ignoreGhsas is not empty — the release gate needs the entry", () => {
+  // Guards the pinchy#993 regression directly: dropping the entry makes
+  // `pnpm audit --audit-level=high --prod` fail and no release can be cut,
+  // which is a state nothing else in CI reports (osv-scanner stays green).
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8"));
+  assert.ok(
+    parseAuditIgnoreGhsas(pkg).includes(GHSA),
+    `${GHSA} must stay in pnpm.auditConfig.ignoreGhsas until the residual ` +
+      `minimatch@3/@5 lines have a compatible upstream fix — without it the ` +
+      `release audit gate fails on an advisory osv-scanner.toml accepts.`,
+  );
+});
+
+test("the brace-expansion reason names every route it accepts", () => {
+  // The reason string is what osv-scanner prints; the rationale comment above
+  // it is printed nowhere. pinchy#993's own argument — "an acceptance that
+  // does not name a path it accepts is not an acceptance of that path" —
+  // applies to the machine-readable record first.
+  const toml = readFileSync(join(REPO_ROOT, "osv-scanner.toml"), "utf8");
+  const entry = parseOsvIgnoredVulns(toml).find((e) => e.id === GHSA);
+  assert.ok(entry, `${GHSA} entry missing from osv-scanner.toml`);
+  for (const route of ["archiver", "gaxios", "config-array"]) {
+    assert.match(entry.reason ?? "", new RegExp(route));
+  }
+});


### PR DESCRIPTION
Blocks the v0.9.0 cut. `pnpm release` gates on `pnpm audit --audit-level=high --prod`, and that gate fails on **GHSA-mh99-v99m-4gvg** — an advisory this repo triaged and accepted in `osv-scanner.toml` back in #914.

The two scanners disagreed for exactly one reason: `pnpm audit` does not read `osv-scanner.toml`. So `main` cannot cut a release either (it reports *two* paths; `release/0.9` reports one), and the acceptance sat on record in a place the release path never consults.

## What this changes

`pnpm.auditConfig.ignoreGhsas` in the root `package.json`, plus the rationale in `osv-scanner.toml` extended to say the two configs must move together.

Ignoring the id wholesale is **bounded by the existing override**: `brace-expansion@>=5.0.0 <5.0.8` → `>=5.0.8 <6`, so the 5.x line cannot regress beneath the patch, and a 6.x advisory would carry a different id. The unignorable part is the 1.1.16 / 2.1.2 residual, which npm has no fix for — 5.0.8 changed the CJS export from a default-exported function to a named one, which breaks `require(...)()` in minimatch@3/@5 and crashes eslint (see #914).

## The part that was an actual gap

The rationale named archiver@5 (exceljs/pinchy-files) and @eslint/config-array. The path `pnpm audit --prod` reported is a **third** one, also production:

```
pinchy-email → googleapis → googleapis-common → gaxios → rimraf → glob@7 → minimatch@3
```

The unreachability argument covers it — rimraf deletes gaxios' own temp paths, never an attacker-supplied brace pattern — but an acceptance that doesn't name a path isn't an acceptance of that path. All three routes are now listed.

## Verified

- `pnpm audit --audit-level=high --prod` → exit 0, no advisory table printed (pnpm's summary line still says "2 high (1 ignored)"; it counts matched paths pre-filter — zero GHSA ids appear in the output and the exit code is 0)
- `osv-scanner` → exit 0, unchanged
- `pnpm -C packages/web lint` → 0 errors (the CJS break the override exists to prevent)
- `pnpm test:scripts` → 551 pass
- No lockfile drift — `auditConfig` does not affect resolution

Needs backporting to `release/0.9` before the cut.