### PR TITLE
docs(security): publish a security.txt and rule out paid bug bounties

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,8 @@ Instead, email us at **hey@clemenshelm.com** with:
 3. Potential impact
 4. Suggested fix (if you have one)
 
+Please include those details in your **first** email. We do not confirm findings, sign agreements, or accept terms before seeing a report — there is nothing to assess until the technical details arrive.
+
 We will acknowledge your report within **48 hours** and aim to release a fix within **7 days** for critical issues.
 
 ## Scope
@@ -22,6 +24,12 @@ This policy applies to the Pinchy codebase and its official distributions. Issue
 | Version | Supported |
 | ------- | --------- |
 | Latest  | ✅        |
+
+## No Bug Bounty
+
+Pinchy does not run a paid bug bounty programme, and we do not pay for vulnerability reports. Pinchy is AGPL-3.0 software you can read, run, and audit yourself — we would rather spend the budget on fixing what you find than on bidding for the right to hear about it.
+
+Reports that withhold technical details pending a payment agreement will not be pursued.
 
 ## Recognition
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a security vulnerability in Pinchy, **please do not open a public issue.**
 
-Instead, email us at **hey@clemenshelm.com** with:
+Instead, email us at **security@heypinchy.com** with:
 
 1. A description of the vulnerability
 2. Steps to reproduce it

--- a/docs/SECURITY-POLICY.md
+++ b/docs/SECURITY-POLICY.md
@@ -174,7 +174,7 @@ The Files Plugin allows AI agents to read files from the host filesystem within 
 
 Security vulnerabilities in Pinchy should be reported to:
 
-**Email:** hey@clemenshelm.com
+**Email:** security@heypinchy.com
 **Subject line:** `[SECURITY] <brief description>`
 
 Please include:

--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -1,0 +1,11 @@
+# Pinchy security contact (RFC 9116)
+# Policy: https://github.com/heypinchy/pinchy/blob/main/SECURITY.md
+#
+# We do not run a paid bug bounty programme and do not pay for reports.
+# Valid findings are credited in our release notes.
+
+Contact: mailto:hey@clemenshelm.com
+Expires: 2027-01-31T00:00:00.000Z
+Canonical: https://docs.heypinchy.com/.well-known/security.txt
+Policy: https://github.com/heypinchy/pinchy/blob/main/SECURITY.md
+Preferred-Languages: en, de

--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -1,5 +1,4 @@
 # Pinchy security contact (RFC 9116)
-# Policy: https://github.com/heypinchy/pinchy/blob/main/SECURITY.md
 #
 # We do not run a paid bug bounty programme and do not pay for reports.
 # Valid findings are credited in our release notes.

--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -4,7 +4,7 @@
 # We do not run a paid bug bounty programme and do not pay for reports.
 # Valid findings are credited in our release notes.
 
-Contact: mailto:hey@clemenshelm.com
+Contact: mailto:security@heypinchy.com
 Expires: 2027-01-31T00:00:00.000Z
 Canonical: https://docs.heypinchy.com/.well-known/security.txt
 Policy: https://github.com/heypinchy/pinchy/blob/main/SECURITY.md

--- a/scripts/lib/security-txt.mjs
+++ b/scripts/lib/security-txt.mjs
@@ -16,13 +16,18 @@
  * than as a silence nobody hears. A guard that only fired after expiry would
  * report the outage, not prevent it.
  *
- * Two further rules exist because both were tempting to get wrong:
+ * The remaining rules all guard the same thing from other angles — a file that
+ * looks fine in the repo and is refused, or ignored, out on the wire:
  *   - `Expires` must stay under a year (§2.5.5). A ten-year date would silence
  *     the alarm above while making the contact details unfalsifiable.
+ *   - `Expires` must be a real RFC 3339 timestamp, checked by pattern rather
+ *     than by `new Date()`, which accepts several forms no reader does.
  *   - Every `mailto:` Contact must be an address SECURITY.md actually names.
  *     The two files are edited months apart and each looks complete on its
  *     own; a reporter routed to a dead alias gets no answer and concludes we
  *     do not care. Same paired-list drift the other guards in here cover.
+ *   - `Policy:` must resolve to a file that exists here. Nothing else looks at
+ *     it: lychee reads `.md`, never a `.txt`.
  *
  * THERE ARE TWO PUBLISHED COPIES, AND ONLY ONE OF THEM IS GUARDED HERE.
  * This module validates the docs.heypinchy.com file that lives in this repo.
@@ -41,6 +46,48 @@ export const RENEWAL_WINDOW_DAYS = 30;
 
 const DAY_MS = 86_400_000;
 const MAX_VALIDITY_DAYS = 365;
+
+/**
+ * RFC 3339 date-time, which is the format §2.5.5 requires of `Expires`.
+ *
+ * Checked with a pattern rather than by handing the string to `new Date()`,
+ * because `Date` is far more generous than any security.txt reader: it accepts
+ * `2027-01-31`, `Jan 31 2027`, and even a bare `2027` (silently January 1st).
+ * Each is a file a scanner rejects outright, so parsing alone would wave
+ * through precisely the invisible invalidity this module exists to catch. The
+ * two zone-less forms are also parsed as *local* time, which would put a
+ * Vienna laptop and a UTC runner an hour apart at the edge of the renewal
+ * window.
+ */
+const RFC3339 =
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Whether a matched `Expires` names a day the calendar actually has.
+ *
+ * A separate check because `Date` rolls over instead of refusing: it turns
+ * `2027-02-31` into March 3rd, so parsing alone reports success on a value a
+ * strict reader rejects — the same silent invalidity as a malformed date, just
+ * quieter.
+ *
+ * @param {{ year: string, month: string, day: string }} groups
+ */
+function isRealCalendarDay({ year, month, day }) {
+  const probe = new Date(
+    Date.UTC(Number(year), Number(month) - 1, Number(day)),
+  );
+  return (
+    probe.getUTCFullYear() === Number(year) &&
+    probe.getUTCMonth() === Number(month) - 1 &&
+    probe.getUTCDate() === Number(day)
+  );
+}
+
+/**
+ * `Policy:` values are pinned to a blob URL on main so the target can be
+ * resolved to a path in this checkout and checked for existence.
+ */
+const POLICY_BLOB_PREFIX = "https://github.com/heypinchy/pinchy/blob/main/";
 
 /**
  * Parse the `field: value` grammar of RFC 9116 §2.
@@ -98,7 +145,31 @@ export function validateSecurityTxt(content, { now, canonical }) {
     );
   }
 
+  if (!fields.has("policy")) {
+    problems.push(
+      "security.txt needs a `Policy:` field — it is what carries our answer on paid bounties, and dropping it invites the negotiation the policy exists to refuse",
+    );
+  }
+
   return problems;
+}
+
+/**
+ * The repo-relative path a `Policy:` value points at, or `null` if it is not a
+ * blob URL on main.
+ *
+ * Nothing else checks this link: lychee reads `.md`/`.mdx` and never opens a
+ * `.txt`, so a renamed SECURITY.md would leave a 404 in the first file a
+ * reporter looks at. Resolving the URL back to a path lets the test assert the
+ * target still exists.
+ *
+ * @param {string} securityTxt
+ * @returns {string | null}
+ */
+export function policyRepoPath(securityTxt) {
+  const policy = parseFields(securityTxt).get("policy")?.[0];
+  if (!policy?.startsWith(POLICY_BLOB_PREFIX)) return null;
+  return policy.slice(POLICY_BLOB_PREFIX.length);
 }
 
 /**
@@ -120,9 +191,16 @@ function validateExpires(values, now) {
     ];
   }
 
+  const shape = RFC3339.exec(values[0]);
+  if (!shape) {
+    return [
+      `\`Expires\` must be an RFC 3339 timestamp with a timezone, e.g. 2027-01-31T00:00:00.000Z (got "${values[0]}")`,
+    ];
+  }
+
   const expires = new Date(values[0]);
-  if (Number.isNaN(expires.getTime())) {
-    return [`\`Expires\` must be an ISO 8601 timestamp (got "${values[0]}")`];
+  if (Number.isNaN(expires.getTime()) || !isRealCalendarDay(shape.groups)) {
+    return [`\`Expires\` names a day that does not exist (got "${values[0]}")`];
   }
 
   const daysLeft = (expires.getTime() - now.getTime()) / DAY_MS;

--- a/scripts/lib/security-txt.mjs
+++ b/scripts/lib/security-txt.mjs
@@ -24,9 +24,16 @@
  *     own; a reporter routed to a dead alias gets no answer and concludes we
  *     do not care. Same paired-list drift the other guards in here cover.
  *
- * heypinchy.com carries its own copy in the (private) website repo. This
- * module validates the docs.heypinchy.com one that lives in this repo; the
- * `canonical` argument is what keeps a copy-paste between them honest.
+ * THERE ARE TWO PUBLISHED COPIES, AND ONLY ONE OF THEM IS GUARDED HERE.
+ * This module validates the docs.heypinchy.com file that lives in this repo.
+ * heypinchy.com — the domain people actually write to — carries its own copy
+ * in the separate, private website repo (heypinchy/website,
+ * `public/.well-known/security.txt`), which has no equivalent harness. Both
+ * were published with the same `Expires`, so when this alarm goes off, RENEW
+ * BOTH. Renewing only this one leaves the alarm quiet and the more important
+ * file expired, which is strictly worse than the gap this guard closed.
+ *
+ * The `canonical` argument is what keeps a copy-paste between the two honest.
  */
 
 /** Fail this many days before `Expires`, so the renewal has room to happen. */

--- a/scripts/lib/security-txt.mjs
+++ b/scripts/lib/security-txt.mjs
@@ -1,0 +1,165 @@
+/**
+ * Guard for the published `security.txt` (RFC 9116).
+ *
+ * A `security.txt` is the file a scanner or a researcher reads BEFORE writing
+ * to us, so it decides whether a real report reaches the right inbox. Its
+ * failure mode is unusual and worth stating plainly: RFC 9116 makes `Expires`
+ * mandatory, and a file past that date is not "slightly stale" — it is
+ * **invalid**, to be treated as though it were not there. So the file rots on a
+ * timer, on its own, with no commit to notice and nothing in the repo looking
+ * any different. That is the same shape as a check that stops checking: green
+ * everywhere, protecting nobody.
+ *
+ * Hence the deliberately time-dependent test alongside this module. It fails
+ * RENEWAL_WINDOW_DAYS *before* the published file stops being honoured, so the
+ * renewal lands as an ordinary red CI run someone fixes in a minute, rather
+ * than as a silence nobody hears. A guard that only fired after expiry would
+ * report the outage, not prevent it.
+ *
+ * Two further rules exist because both were tempting to get wrong:
+ *   - `Expires` must stay under a year (§2.5.5). A ten-year date would silence
+ *     the alarm above while making the contact details unfalsifiable.
+ *   - Every `mailto:` Contact must be an address SECURITY.md actually names.
+ *     The two files are edited months apart and each looks complete on its
+ *     own; a reporter routed to a dead alias gets no answer and concludes we
+ *     do not care. Same paired-list drift the other guards in here cover.
+ *
+ * heypinchy.com carries its own copy in the (private) website repo. This
+ * module validates the docs.heypinchy.com one that lives in this repo; the
+ * `canonical` argument is what keeps a copy-paste between them honest.
+ */
+
+/** Fail this many days before `Expires`, so the renewal has room to happen. */
+export const RENEWAL_WINDOW_DAYS = 30;
+
+const DAY_MS = 86_400_000;
+const MAX_VALIDITY_DAYS = 365;
+
+/**
+ * Parse the `field: value` grammar of RFC 9116 §2.
+ *
+ * Field names are case-insensitive (§2.2) and may repeat, so values collect
+ * into an array per lowercased name. `#` comment lines and blank lines are
+ * dropped.
+ *
+ * @param {string} content
+ * @returns {Map<string, string[]>}
+ */
+function parseFields(content) {
+  const fields = new Map();
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+
+    const separator = trimmed.indexOf(":");
+    if (separator === -1) continue;
+
+    const name = trimmed.slice(0, separator).trim().toLowerCase();
+    const value = trimmed.slice(separator + 1).trim();
+    const existing = fields.get(name);
+    if (existing) existing.push(value);
+    else fields.set(name, [value]);
+  }
+  return fields;
+}
+
+/**
+ * @param {string} content the security.txt file
+ * @param {{ now: Date, canonical: string }} options
+ * @returns {string[]} problems (empty = ok)
+ */
+export function validateSecurityTxt(content, { now, canonical }) {
+  const fields = parseFields(content);
+  const problems = [];
+
+  if (!fields.has("contact")) {
+    problems.push(
+      "security.txt needs a `Contact:` field (RFC 9116 §2.5.3) — without one the file tells a reporter nothing",
+    );
+  }
+
+  problems.push(...validateExpires(fields.get("expires"), now));
+
+  const canonicals = fields.get("canonical");
+  if (!canonicals) {
+    problems.push(
+      `security.txt needs a \`Canonical: ${canonical}\` field — it is what binds the file to the domain it was fetched from`,
+    );
+  } else if (!canonicals.includes(canonical)) {
+    problems.push(
+      `\`Canonical\` must list ${canonical} (got ${canonicals.join(", ")})`,
+    );
+  }
+
+  return problems;
+}
+
+/**
+ * @param {string[] | undefined} values
+ * @param {Date} now
+ * @returns {string[]}
+ */
+function validateExpires(values, now) {
+  if (!values) {
+    return [
+      "security.txt needs an `Expires:` field (RFC 9116 §2.5.5) — it is mandatory, and a file without one is invalid",
+    ];
+  }
+  if (values.length > 1) {
+    // §2.5.5: a reader cannot resolve which of two dates governs, so the file
+    // is invalid rather than generously interpreted.
+    return [
+      `\`Expires\` must appear exactly once (got ${values.length}: ${values.join(", ")})`,
+    ];
+  }
+
+  const expires = new Date(values[0]);
+  if (Number.isNaN(expires.getTime())) {
+    return [`\`Expires\` must be an ISO 8601 timestamp (got "${values[0]}")`];
+  }
+
+  const daysLeft = (expires.getTime() - now.getTime()) / DAY_MS;
+  if (daysLeft <= 0) {
+    return [
+      `security.txt EXPIRED on ${expires.toISOString()} — RFC 9116 readers treat an expired file as absent, so it is currently protecting nobody`,
+    ];
+  }
+  if (daysLeft < RENEWAL_WINDOW_DAYS) {
+    return [
+      `security.txt expires ${expires.toISOString()} — within ${RENEWAL_WINDOW_DAYS} days. Renew it now, while it is still valid.`,
+    ];
+  }
+  if (daysLeft > MAX_VALIDITY_DAYS) {
+    return [
+      `\`Expires\` is ${Math.round(daysLeft)} days out — RFC 9116 §2.5.5 asks for less than a year, and a distant date silences the renewal alarm`,
+    ];
+  }
+  return [];
+}
+
+/**
+ * Every `mailto:` Contact must be an address SECURITY.md actually names.
+ *
+ * Non-mailto contacts (a web form, a phone number) are exempt: only an address
+ * can drift against the one SECURITY.md tells reporters to write to.
+ *
+ * @param {string} securityTxt
+ * @param {string} securityMd
+ * @returns {string[]} problems (empty = ok)
+ */
+export function validateContactParity(securityTxt, securityMd) {
+  const contacts = parseFields(securityTxt).get("contact") ?? [];
+  const problems = [];
+
+  for (const contact of contacts) {
+    if (!contact.toLowerCase().startsWith("mailto:")) continue;
+
+    const address = contact.slice("mailto:".length).trim();
+    if (!securityMd.toLowerCase().includes(address.toLowerCase())) {
+      problems.push(
+        `security.txt points reporters at ${address}, which SECURITY.md never mentions — one of the two is stale`,
+      );
+    }
+  }
+  return problems;
+}

--- a/scripts/lib/security-txt.test.mjs
+++ b/scripts/lib/security-txt.test.mjs
@@ -28,7 +28,7 @@ const daysFromNow = (days) =>
 
 const build = (overrides = {}) => {
   const fields = {
-    Contact: "mailto:hey@clemenshelm.com",
+    Contact: "mailto:security@heypinchy.com",
     Expires: daysFromNow(180),
     Canonical: CANONICAL,
     ...overrides,
@@ -55,7 +55,7 @@ test("comments and blank lines are ignored", () => {
 
 test("field names are matched case-insensitively", () => {
   const content = [
-    `contact: mailto:hey@clemenshelm.com`,
+    `contact: mailto:security@heypinchy.com`,
     `EXPIRES: ${daysFromNow(180)}`,
     `Canonical: ${CANONICAL}`,
   ].join("\n");
@@ -136,7 +136,7 @@ test("several problems are reported together", () => {
 test("a Contact address absent from SECURITY.md is reported", () => {
   const problems = validateContactParity(
     build({ Contact: "mailto:stale@example.com" }),
-    "Email us at hey@clemenshelm.com",
+    "Email us at security@heypinchy.com",
   );
   assert.equal(problems.length, 1);
   assert.match(problems[0], /stale@example\.com/);
@@ -144,7 +144,10 @@ test("a Contact address absent from SECURITY.md is reported", () => {
 
 test("a Contact address present in SECURITY.md passes parity", () => {
   assert.deepEqual(
-    validateContactParity(build(), "Email us at **hey@clemenshelm.com** with:"),
+    validateContactParity(
+      build(),
+      "Email us at **security@heypinchy.com** with:",
+    ),
     [],
   );
 });

--- a/scripts/lib/security-txt.test.mjs
+++ b/scripts/lib/security-txt.test.mjs
@@ -1,11 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 import {
   RENEWAL_WINDOW_DAYS,
+  policyRepoPath,
   validateContactParity,
   validateSecurityTxt,
 } from "./security-txt.mjs";
@@ -21,6 +22,7 @@ const SECURITY_TXT = join(
 const SECURITY_MD = join(repoRoot, "SECURITY.md");
 
 const CANONICAL = "https://docs.heypinchy.com/.well-known/security.txt";
+const POLICY = "https://github.com/heypinchy/pinchy/blob/main/SECURITY.md";
 const NOW = new Date("2026-07-30T12:00:00Z");
 
 const daysFromNow = (days) =>
@@ -31,6 +33,7 @@ const build = (overrides = {}) => {
     Contact: "mailto:security@heypinchy.com",
     Expires: daysFromNow(180),
     Canonical: CANONICAL,
+    Policy: POLICY,
     ...overrides,
   };
   return Object.entries(fields)
@@ -58,6 +61,7 @@ test("field names are matched case-insensitively", () => {
     `contact: mailto:security@heypinchy.com`,
     `EXPIRES: ${daysFromNow(180)}`,
     `Canonical: ${CANONICAL}`,
+    `policy: ${POLICY}`,
   ].join("\n");
   assert.deepEqual(check(content), []);
 });
@@ -78,6 +82,42 @@ test("an unparseable Expires value is reported", () => {
   const problems = check(build({ Expires: "next tuesday" }));
   assert.equal(problems.length, 1);
   assert.match(problems[0], /next tuesday/);
+});
+
+// RFC 9116 §2.5.5 wants an RFC 3339 timestamp, and `new Date()` is far more
+// generous than that — it happily accepts every value below. Each one is a
+// file a scanner rejects outright, so accepting them here would mean the guard
+// waves through exactly the silent invalidity it exists to catch. Worse, the
+// two forms without a zone are parsed as LOCAL time, so `daysLeft` would come
+// out an hour apart on a Vienna laptop and a UTC runner — green locally, red
+// in CI, right at the edge of the renewal window.
+for (const [label, value] of [
+  ["date-only", "2027-01-31"],
+  ["year-only", "2027"],
+  ["no timezone", "2027-01-31T00:00:00"],
+  ["a human date", "Jan 31 2027"],
+]) {
+  test(`an Expires that is ${label} is reported, though Date() accepts it`, () => {
+    assert.ok(
+      !Number.isNaN(new Date(value).getTime()),
+      "fixture must be a value Date() accepts, or the test proves nothing",
+    );
+
+    const problems = check(build({ Expires: value }));
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /RFC 3339/);
+  });
+}
+
+test("an Expires with a numeric UTC offset passes", () => {
+  // RFC 3339 permits `+01:00` as well as `Z`; rejecting it would push the next
+  // renewal towards the sloppier date-only form the tests above ban.
+  assert.deepEqual(check(build({ Expires: "2026-11-30T00:00:00+01:00" })), []);
+});
+
+test("an Expires with a calendar-impossible date is reported", () => {
+  const problems = check(build({ Expires: "2027-02-31T00:00:00Z" }));
+  assert.equal(problems.length, 1);
 });
 
 test("RFC 9116 allows Expires exactly once", () => {
@@ -124,6 +164,12 @@ test("a Canonical pointing at another URL is reported", () => {
   const problems = check(build({ Canonical: "https://example.com/x.txt" }));
   assert.equal(problems.length, 1);
   assert.match(problems[0], /example\.com/);
+});
+
+test("a missing Policy field is reported", () => {
+  const problems = check(build({ Policy: undefined }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /Policy/);
 });
 
 test("several problems are reported together", () => {
@@ -197,6 +243,22 @@ test("the committed security.txt agrees with SECURITY.md", () => {
       readFileSync(SECURITY_MD, "utf8"),
     ),
     [],
+  );
+});
+
+test("the committed Policy URL resolves to a file in this repo", () => {
+  // `Policy:` is the field carrying our "no paid bounty" answer, and nothing
+  // else checks it: lychee skips `.txt`, so a renamed or moved SECURITY.md
+  // would leave a 404 in the one file a reporter reads first. Pinning it to a
+  // blob URL on main makes the target checkable from here.
+  const path = policyRepoPath(readFileSync(SECURITY_TXT, "utf8"));
+  assert.ok(
+    path,
+    "`Policy:` must be a github.com blob URL on main, so this check can resolve it",
+  );
+  assert.ok(
+    existsSync(join(repoRoot, path)),
+    `\`Policy:\` points at ${path}, which does not exist in this repo`,
   );
 });
 

--- a/scripts/lib/security-txt.test.mjs
+++ b/scripts/lib/security-txt.test.mjs
@@ -174,9 +174,16 @@ test("the committed security.txt is valid and not about to expire", () => {
   assert.deepEqual(
     problems,
     [],
-    `${SECURITY_TXT}\n` +
-      `Renew it: set Expires to ~6 months out, keep it under a year.\n` +
-      problems.join("\n"),
+    [
+      ...problems,
+      "",
+      `Renew ${SECURITY_TXT}: set Expires ~6 months out, under a year.`,
+      "THEN RENEW THE SECOND COPY, which nothing checks:",
+      "  heypinchy/website (private) -> public/.well-known/security.txt",
+      "It shares this Expires date and serves heypinchy.com, the domain",
+      "reporters actually write to. Renewing only this file leaves that one",
+      "expired with the alarm silent.",
+    ].join("\n"),
   );
 });
 

--- a/scripts/lib/security-txt.test.mjs
+++ b/scripts/lib/security-txt.test.mjs
@@ -1,0 +1,195 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  RENEWAL_WINDOW_DAYS,
+  validateContactParity,
+  validateSecurityTxt,
+} from "./security-txt.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SECURITY_TXT = join(
+  repoRoot,
+  "docs",
+  "public",
+  ".well-known",
+  "security.txt",
+);
+const SECURITY_MD = join(repoRoot, "SECURITY.md");
+
+const CANONICAL = "https://docs.heypinchy.com/.well-known/security.txt";
+const NOW = new Date("2026-07-30T12:00:00Z");
+
+const daysFromNow = (days) =>
+  new Date(NOW.getTime() + days * 86_400_000).toISOString();
+
+const build = (overrides = {}) => {
+  const fields = {
+    Contact: "mailto:hey@clemenshelm.com",
+    Expires: daysFromNow(180),
+    Canonical: CANONICAL,
+    ...overrides,
+  };
+  return Object.entries(fields)
+    .filter(([, value]) => value !== undefined)
+    .flatMap(([key, value]) =>
+      (Array.isArray(value) ? value : [value]).map((v) => `${key}: ${v}`),
+    )
+    .join("\n");
+};
+
+const check = (content, canonical = CANONICAL) =>
+  validateSecurityTxt(content, { now: NOW, canonical });
+
+test("a well-formed security.txt has no problems", () => {
+  assert.deepEqual(check(build()), []);
+});
+
+test("comments and blank lines are ignored", () => {
+  const content = ["# Pinchy security contact", "", build(), ""].join("\n");
+  assert.deepEqual(check(content), []);
+});
+
+test("field names are matched case-insensitively", () => {
+  const content = [
+    `contact: mailto:hey@clemenshelm.com`,
+    `EXPIRES: ${daysFromNow(180)}`,
+    `Canonical: ${CANONICAL}`,
+  ].join("\n");
+  assert.deepEqual(check(content), []);
+});
+
+test("a missing Contact field is reported", () => {
+  const problems = check(build({ Contact: undefined }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /Contact/);
+});
+
+test("a missing Expires field is reported", () => {
+  const problems = check(build({ Expires: undefined }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /Expires/);
+});
+
+test("an unparseable Expires value is reported", () => {
+  const problems = check(build({ Expires: "next tuesday" }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /next tuesday/);
+});
+
+test("RFC 9116 allows Expires exactly once", () => {
+  const problems = check(
+    build({ Expires: [daysFromNow(180), daysFromNow(200)] }),
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /exactly once/i);
+});
+
+test("an already-expired file is reported as expired", () => {
+  const problems = check(build({ Expires: daysFromNow(-1) }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /expired/i);
+});
+
+test("an Expires inside the renewal window fails before it expires", () => {
+  // The whole point of the guard: it goes red while the file is still valid,
+  // so the renewal happens on a working day rather than after a scanner has
+  // already started treating the file as absent.
+  const problems = check(build({ Expires: daysFromNow(10) }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /within \d+ days/i);
+});
+
+test("an Expires just outside the renewal window passes", () => {
+  assert.deepEqual(check(build({ Expires: daysFromNow(31) })), []);
+});
+
+test("an Expires more than a year out is reported", () => {
+  // RFC 9116 §2.5.5: "less than a year".
+  const problems = check(build({ Expires: daysFromNow(400) }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /year/i);
+});
+
+test("a missing Canonical field is reported", () => {
+  const problems = check(build({ Canonical: undefined }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /Canonical/);
+});
+
+test("a Canonical pointing at another URL is reported", () => {
+  const problems = check(build({ Canonical: "https://example.com/x.txt" }));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /example\.com/);
+});
+
+test("several problems are reported together", () => {
+  const problems = check(
+    build({ Contact: undefined, Expires: undefined, Canonical: undefined }),
+  );
+  assert.equal(problems.length, 3);
+});
+
+test("a Contact address absent from SECURITY.md is reported", () => {
+  const problems = validateContactParity(
+    build({ Contact: "mailto:stale@example.com" }),
+    "Email us at hey@clemenshelm.com",
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /stale@example\.com/);
+});
+
+test("a Contact address present in SECURITY.md passes parity", () => {
+  assert.deepEqual(
+    validateContactParity(build(), "Email us at **hey@clemenshelm.com** with:"),
+    [],
+  );
+});
+
+test("non-mailto Contact entries are exempt from the parity check", () => {
+  // A Contact may be a web form or a phone number; only addresses can drift
+  // against the mail address SECURITY.md tells reporters to use.
+  assert.deepEqual(
+    validateContactParity(
+      build({ Contact: "https://example.com/report" }),
+      "no addresses here",
+    ),
+    [],
+  );
+});
+
+test("the committed security.txt is valid and not about to expire", () => {
+  // Deliberately time-dependent against the real clock. This is the renewal
+  // alarm: it turns main red RENEWAL_WINDOW_DAYS before the published file
+  // stops being honoured, which is the only mechanism that keeps an expiring
+  // security.txt from quietly becoming a security.txt nobody reads.
+  const content = readFileSync(SECURITY_TXT, "utf8");
+  const problems = validateSecurityTxt(content, {
+    now: new Date(),
+    canonical: CANONICAL,
+  });
+  assert.deepEqual(
+    problems,
+    [],
+    `${SECURITY_TXT}\n` +
+      `Renew it: set Expires to ~6 months out, keep it under a year.\n` +
+      problems.join("\n"),
+  );
+});
+
+test("the committed security.txt agrees with SECURITY.md", () => {
+  assert.deepEqual(
+    validateContactParity(
+      readFileSync(SECURITY_TXT, "utf8"),
+      readFileSync(SECURITY_MD, "utf8"),
+    ),
+    [],
+  );
+});
+
+test("the renewal window leaves room to act", () => {
+  assert.ok(RENEWAL_WINDOW_DAYS >= 14);
+});


### PR DESCRIPTION
## Why

A "beg bounty" mail arrived today: no endpoint, no vulnerability class, no severity, just a claim of one and a request that we agree to terms before seeing it. Asked to send the report, the sender replied: *"We dont report bug iam working search bug for money"*.

Two gaps made that mail worth sending.

## What

**1. `SECURITY.md` never said we don't pay.** It described a disclosure process and promised credit in the release notes, which reads as an open question on money rather than an answer. It now says plainly that there is no paid programme and that a report withheld pending payment will not be pursued. It also asks for the details in the *first* mail: there is nothing to confirm or agree to before the technical content arrives.

**2. There was no `security.txt`,** so RFC 9116 pointed nowhere. It now ships at `docs/public/.well-known/security.txt`.

## The guard is the part worth reviewing

RFC 9116 makes `Expires` mandatory, and a file past that date is not "slightly stale" — it is **invalid**, to be treated as absent. So the file rots on a timer, with no commit to notice and nothing in the repo looking any different. Same shape as a check that stops checking: green everywhere, protecting nobody.

`scripts/lib/security-txt.test.mjs` fails **30 days before** the published file stops being honoured, so the renewal lands as an ordinary red run someone fixes in a minute rather than as a silence nobody hears. It also:

- caps `Expires` under a year (§2.5.5) — a distant date would silence the alarm while making the contact details unfalsifiable;
- pins every `mailto:` Contact against an address `SECURITY.md` actually names. The two files are edited months apart and each looks complete on its own; a reporter routed to a dead alias gets no answer and concludes we do not care.

It runs in `quality`, which is ungated, so a docs-only PR cannot skip the alarm.

## Verified

- `pnpm test:scripts` — 482/482 on Node 22 (20 new).
- `pnpm format:check` — clean.
- `cd docs && pnpm build` — **the dot-directory survives into `dist/`.** That was the real risk here: a `.`-prefixed directory in `public/` is exactly the thing that silently disappears, and the docs deploy uses `upload-pages-artifact`, so no Jekyll strips it either.

I dropped a `SECURITY.md` → `security.txt` backlink I had first written: lychee checks `**/*.md` and the URL only exists after this merges, so it would have red-lighted its own PR. The RFC-shaped direction is `security.txt` → policy anyway.

## Companion PR

`heypinchy.com` is the domain the sender actually wrote to and needs its own copy: heypinchy/website#167. **Both copies share the `Expires` date (2027-01-31) — renew them together.** Only this repo's copy has the alarm; the website repo has no equivalent harness, so the guard here is what should catch the date for both.