### PR TITLE
docs: stop promising KB search for scans, and name the mount uid

### DIFF
--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -97,6 +97,16 @@ If your NAS is mounted on the host at `/mnt/nas/shared`, mount a subdirectory:
 - /mnt/nas/shared/finance:/data/finance:ro
 ```
 
+**Mount the share for the container user.** The `pinchy` container runs as uid 999. A network share mounted without an owner mapping belongs to `root`, so Pinchy can't read it — and indexing then fails with a permission error that never mentions the mount. For an SMB/CIFS share, pass `uid=999,gid=999`:
+
+```
+//fileserver/share/suppliers /mnt/suppliers cifs ro,_netdev,credentials=/etc/smb.cred,uid=999,gid=999,iocharset=utf8,vers=3.0 0 0
+```
+
+`_netdev` matters just as much: it holds the mount back until the network is up, so a reboot doesn't leave the containers pointing at an empty directory.
+
+Mount the share read-only — `ro` on both the host mount and the Compose volume. Pinchy never writes to `/data/`, and a read-only mount makes that structural rather than a promise.
+
 ### Multiple directories
 
 You can mount as many directories as you need:
@@ -149,7 +159,13 @@ Nothing is re-indexed or re-uploaded by this — the mounts point at the same ho
 
 ## Supported file types
 
-Knowledge Base agents can read text files, Markdown, **Word documents** (`.docx`), and **PDF documents** — including scanned PDFs, which are analyzed using the configured model's vision capabilities. See [Create a Knowledge Base Agent — Scope in this release](/guides/create-knowledge-base-agent/#scope-in-this-release) for what is and isn't searchable today.
+Two different paths read the files under `/data/`, and they support different formats. The distinction matters when you plan a corpus, so it's worth knowing before you mount one.
+
+**Knowledge Base search** (`knowledge_search`) indexes **text-based PDFs**, plain text and Markdown. Scanned PDFs and Office documents are not indexed today — see [Create a Knowledge Base Agent — Scope in this release](/guides/create-knowledge-base-agent/#scope-in-this-release).
+
+**Reading a file directly** (the agent's file tools) additionally handles **Word documents** (`.docx`) and **scanned PDFs**, which are analyzed using the configured model's vision capabilities.
+
+So a scanned certificate under `/data/` can be opened and read on request, but it won't come back as a search hit — the agent has to be pointed at it. If a large part of your corpus is scans, the reindex report tells you so: it counts them under `unsearchable` rather than `indexed`.
 
 ## Knowledge Base vs. workspace files
 


### PR DESCRIPTION
Two corrections in `mount-data-directories.mdx`, both on the path an IT service provider walks when setting Pinchy up for a customer. Found while preparing a handover to a customer's IT partner.

## 1. The Knowledge Base does not read scans — the agent's file tools do

"Supported file types" claimed the KB reads `.docx` and scanned PDFs "using the configured model's vision capabilities". Three sources disagree:

- `create-knowledge-base-agent.mdx` → "Scanned/image-only PDFs and Office documents are on the roadmap, **not indexed today**"
- `packages/web/src/lib/knowledge/pdf-extract.ts` → "Text-only: no OCR, no image extraction"
- the reindex report, which counts a scan as `unsearchable` rather than `indexed`

The claim isn't wrong in general — it's wrong about the **index**. The agent's file tools genuinely do handle `.docx` and scanned PDFs. So this isn't a deletion but a distinction: what `knowledge_search` finds, versus what the agent can open when pointed at it. A reader who only opens this page now leaves with the right expectation.

Why it matters beyond tidiness: certificates are exactly the document class that tends to be scanned, and exactly what a customer asks about first. A page that promises search over them sets up a demo to fail.

## 2. `uid=999` was missing from the network-drive section

The section assumed the share is already mounted and said nothing about the container user. A CIFS share mounted without an owner mapping belongs to `root`; `pinchy` (uid 999) can't read it, and indexing fails with a permission error that never mentions the mount — a cause that appeared nowhere in the docs. Adds the fstab line, plus `_netdev`, whose absence turns a single reboot into an empty corpus.

## Verification

- `pnpm -C docs build` → 66 pages
- `pnpm -C docs check:anchors` → 69 pages checked, no broken internal links
- `prettier --check` on the changed file

Docs-only; no code paths touched.

## Release timing

Either 0.9.0 or 0.9.1 — your call. Correction 1 is the one that benefits from landing sooner: it's a promise the docs currently make that a scanned-heavy corpus disproves immediately.