### PR TITLE
docs(e2e): cite the flake the config.apply recovery actually fixes

### DIFF
--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -502,7 +502,7 @@ test.describe.serial("Plugin behavior — pinchy-knowledge", () => {
       // Wait for OC to settle after the create+PATCH regens, then confirm the
       // new agent is actually in OC's runtime agents.list before dispatching —
       // with recovery from OC's hardcoded config.apply rate limit
-      // (heypinchy/pinchy#881).
+      // (heypinchy/pinchy#901).
       await ensureAgentDispatchable({
         agentId,
         allowedTools: ["knowledge_search"],

--- a/packages/web/e2e/shared/dispatch-probe.ts
+++ b/packages/web/e2e/shared/dispatch-probe.ts
@@ -217,7 +217,8 @@ export interface EnsureAgentDispatchableParams {
  * `waitForOpenClawStable` reports settled (the fallback drained
  * `configPushesPending`) while the agent is NOT yet in OC's runtime, and a
  * plain `waitForAgentDispatchable` times out — the kb-attribution /
- * pinchy-knowledge `beforeAll` flake (heypinchy/pinchy#881).
+ * pinchy-knowledge `beforeAll` flake (heypinchy/pinchy#901; the class fix — an
+ * explicit `config.apply` readiness signal instead of a probe — is #465).
  *
  * The recovery works because this runs inside a BLOCKING `beforeAll`: no other
  * `config.apply` competes, so the rate-limit window drains within ~60 s.

--- a/packages/web/eval/kb/kb-eval-shared.ts
+++ b/packages/web/eval/kb/kb-eval-shared.ts
@@ -49,7 +49,7 @@ export async function setupKbAgent(page: Page): Promise<{ agentId: string }> {
   expect(patchRes.status(), await patchRes.text()).toBe(200);
 
   // Wait for OC to settle, then confirm the agent is in OC's runtime — with
-  // recovery from OC's hardcoded config.apply rate limit (heypinchy/pinchy#881).
+  // recovery from OC's hardcoded config.apply rate limit (heypinchy/pinchy#901).
   await ensureAgentDispatchable({
     agentId,
     allowedTools: KB_EVAL_ALLOWED_TOOLS,


### PR DESCRIPTION
While working #901 I found the flake it describes is already fixed — and that the code documenting the fix points at the wrong issue.

## The finding: #901 no longer reproduces

The error in #901 is

```
OpenClaw runtime did not see agent <id> as dispatchable within deadline — config.apply likely stuck in file-watcher debounce
```

That string is `waitForAgentDispatchable`'s (`dispatch-probe.ts:172`). `ensureAgentDispatchable` catches it and **always** rethrows its own, attempt-counted message (`… as dispatchable after N recovery attempt(s) — …`). So the two are distinguishable by shape alone.

| | |
|---|---|
| Flake fired | 2026-07-23, PR #897 |
| `ensureAgentDispatchable` written | 2026-07-24, `ebff473e0` — *"recover KB dispatch setup from OpenClaw's config.apply rate limit"* |
| Bounded by wall-clock budget | 2026-07-25, `506e0fde8` |
| `kb-attribution.spec.ts` today | calls `ensureAgentDispatchable`; does not import the plain helper |

The spec can no longer emit that error. #901 is closed with this evidence.

Stated plainly, because it is a limit and not a proof: the *condition* still exists. The rate limit is a compiled-in OpenClaw constant and the file-watcher fallback still lags — the suite now recovers from it (toggle the grant, force a clean WS `config.apply`) rather than being immune to it. The class fix is #465.

## What this PR changes

Three comments cited `heypinchy/pinchy#881` for the `config.apply` rate-limit flake. #881 is *"Retired/failed chat model never self-heals"* — a different mechanism (the same-provider fallback chain). A reader following that number lands on an unrelated, closed issue.

- `e2e/shared/dispatch-probe.ts` — the `ensureAgentDispatchable` docblock, now #901, and naming #465 as the class fix
- `e2e/integration/agent-chat.spec.ts`
- `eval/kb/kb-eval-shared.ts`

The **nine** other `#881` references — `model-self-heal.ts`, `chat-model-fallback.ts`, `build.ts`, `resolve-available.ts` (×2), the four `openclaw-config.test.ts` cases — are correct and untouched. Checked each rather than sweeping the string.

Comments only. `format:check` green, `test:related` green (3 files, 13 tests).

## Noted, not changed

Eight specs still call the non-recovering `waitForAgentDispatchable` (`web-search`, both `odoo`, four `telegram`, and `agent-chat` alongside the recovering one). `web-search.spec.ts` has the same shape that flaked here — create agent, PATCH `allowedTools`, dispatch — but a different pressure: the integration suite shares one OpenClaw session and mutates config far more, which is what exhausts the 3-per-60s window. Whether the others need the recovery is an empirical question, not one to answer with a sweep.