### PR TITLE
docs: forward-port the frozen v0.9.0 upgrade section to main

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -185,7 +185,7 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
-## Upgrading from v0.8.0 to %%PINCHY_VERSION%%
+## Upgrading from v0.8.0 to v0.9.0
 
 ### Breaking changes
 
@@ -205,8 +205,8 @@ Re-fetch the compose file **before** pulling images:
 
 ```bash
 cd /opt/pinchy
-curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
-sed -i 's/^PINCHY_VERSION=.*/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.9.0/docker-compose.yml -o docker-compose.yml
+sed -i 's/^PINCHY_VERSION=.*/PINCHY_VERSION=v0.9.0/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
 


### PR DESCRIPTION
Post-release step for v0.9.0 (`cut-pinchy-release` skill § "Release branches" → *Forward-port `upgrading.mdx` after release*).

`pnpm release` freezes the current `%%PINCHY_VERSION%%` placeholders inside the `chore: release` commit — **on the release branch**. That commit never reaches `main`, so without this `main` keeps `## Upgrading from v0.8.0 to %%PINCHY_VERSION%%`, and the section silently re-renders as whatever the *next* version turns out to be. Same time-bomb as the v0.5.8 incident, arriving through the release-branch model rather than a forgotten manual edit.

Only the `upgrading.mdx` hunk of `086161f9` is taken. The version bumps (`package.json`, `packages/web/package.json`, `.env.example`, `README.md`, the two marketplace pins) stay on `release/0.9` by design — `main` re-bumps at its own next cut.

The two remaining `%%PINCHY_VERSION%%` occurrences are the preamble's "Standard upgrade" display placeholders, deliberately outside the freshness guard's scope.

**Verified:** `pnpm test:scripts` 675 pass / 0 fail (the `upgrading-mdx-freshness` guard among them), `format:check` clean.

Note for whoever lands the next upgrade-affecting change: it should add a fresh `## Upgrading from v0.9.0 to %%PINCHY_VERSION%%` section. If nobody does, the next release's gate fails loudly at the start — which is the safety net, not a surprise.