### PR TITLE
feat(kb): serve the converted PDF as the preview for an Office source

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -144,11 +144,15 @@ Not every document has pages, which is why a citation says "the spot" rather tha
 
 Each source path in an answer is a link. Click it and the PDF opens in a viewer over the chat, at the cited page, with the answer still visible behind it — the same viewer a PDF you attach to a message opens into. Checking a claim takes a click instead of a hunt through folders.
 
+Word documents and slide decks open in that same viewer. No browser renders a `.doc`, so what you see is the PDF Pinchy converted on its way into the index — the same rendering the citation was measured against, which is what lets it point at a spot you can actually find. The original is never modified and never replaced; it stays exactly where it is on your share.
+
 Document size is not a limit. Knowledge bases routinely contain scanned compilation binders of several hundred megabytes, and because those contain the most, they tend to be cited the most. Pinchy streams the file and serves byte ranges, so the viewer fetches the pages it renders rather than the whole document — opening page 510 of a 268 MB binder transfers a fraction of it.
 
 Reading the answer is often not the end of the job — sometimes you want the document itself, to send it on to a customer. The viewer's header carries a **Download** control beside the document's name, so the file lands in your downloads folder under its own name, umlauts and all, without a detour through a remote desktop.
 
-Opening a source is governed like every other access. The link resolves against the same allowed directories that scope the agent's search, so a path outside them is refused even if an answer names one. Each view is written to the audit trail as `knowledge.source_viewed`, and each download as `knowledge.source_downloaded` — reading a document and taking a copy of it out of the building are different acts, and only the second one can be answered with "who has this file now".
+For a Word document or slide deck you get two, named so you can tell them apart: `Angebot.doc` is the original — the file as it sits on your share, the one to attach to a mail — and `Angebot.pdf` is the converted version you were just reading. Often that PDF is what you wanted to send anyway, and this saves you converting it yourself.
+
+Opening a source is governed like every other access. The link resolves against the same allowed directories that scope the agent's search, so a path outside them is refused even if an answer names one. A converted PDF is reachable only through the document it came from, so it is governed by exactly the same grant — there is no second door into it, and a document nobody may read has no readable conversion. Each view is written to the audit trail as `knowledge.source_viewed`, and each download as `knowledge.source_downloaded` — reading a document and taking a copy of it out of the building are different acts, and only the second one can be answered with "who has this file now".
 
 The list resolves exactly the numbers the answer cites — no more and no fewer. A number with no entry would be a dead end, and an entry the answer never cited would make a single source look like several.
 

--- a/packages/web/src/__tests__/api/agent-workspace-file-office.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file-office.test.ts
@@ -1,0 +1,381 @@
+/**
+ * GET /api/agents/[agentId]/workspace-file — the Office half (#939).
+ *
+ * A cited `.doc`/`.docx`/`.ppt`/`.pptx` opens in the SAME viewer as a PDF,
+ * showing the converted artifact (#936), while the download control still
+ * offers the original — the file on the reader's drive, the one they send a
+ * customer.
+ *
+ * The containment question is re-reasoned rather than reused, because the
+ * artifact store sits OUTSIDE `/data`: `resolveAllowedFile` still runs against
+ * the original path, and the artifact path is derived from the store's
+ * content key, never from the request. The first two describes below are that
+ * argument written as tests — an artifact must be unreachable for a document
+ * the agent may not read, and an artifact belonging to a superseded version of
+ * a document must not be served as if it were current.
+ *
+ * Same harness as `agent-workspace-file.test.ts` (real filesystem, mocked
+ * auth/agent-access/audit), plus a real `OfficeArtifactStore` pointed at a temp
+ * directory: the route has to derive the SAME key the converter stored under,
+ * and a mocked store would assert nothing about that.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({ getSession: (...args: unknown[]) => mockGetSession(...args) }));
+
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockDeferAuditLog = vi.fn();
+vi.mock("@/lib/audit-deferred", () => ({
+  deferAuditLog: (...args: unknown[]) => mockDeferAuditLog(...args),
+}));
+
+// The production ceiling is a container mount point no test can create, so it
+// is MOVED to the temp tree rather than switched off — every assertion below
+// still runs against a real one. See the same note in
+// `agent-workspace-file.test.ts`.
+vi.mock("@/lib/file-serve-roots", async () => {
+  const { tmpdir } = await import("node:os");
+  return { FILE_SERVE_ROOTS: [tmpdir()] };
+});
+
+let tmpRoot: string;
+let allowedRoot: string;
+let outsideDir: string;
+let artifactDir: string;
+
+const DOCX_BYTES = Buffer.from("PK pretend this is a .docx\n");
+const ARTIFACT_BYTES = Buffer.from("%PDF-1.4\nconverted from the office source\n%%EOF");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The artifact store reads its root at module evaluation, and caches one
+  // instance per process. Both have to be fresh per test, or the second test
+  // writes into the first one's (already deleted) directory.
+  vi.resetModules();
+
+  tmpRoot = mkdtempSync(join(tmpdir(), "pinchy-workspace-file-office-"));
+  allowedRoot = join(tmpRoot, "allowed");
+  outsideDir = join(tmpRoot, "outside");
+  artifactDir = join(tmpRoot, "artifacts");
+  mkdirSync(allowedRoot, { recursive: true });
+  mkdirSync(outsideDir, { recursive: true });
+  process.env.KB_ARTIFACT_DIR = artifactDir;
+
+  mockGetSession.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+  mockGetAgentWithAccess.mockResolvedValue({
+    id: "agent-1",
+    name: "Smithers",
+    pluginConfig: { "pinchy-files": { allowed_paths: [allowedRoot] } },
+  });
+});
+
+afterEach(() => {
+  delete process.env.KB_ARTIFACT_DIR;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+async function callGET(requestedPath: string, extraParams: Record<string, string> = {}) {
+  const { GET } = await import("@/app/api/agents/[agentId]/workspace-file/route");
+  const url = new URL("http://localhost/api/agents/agent-1/workspace-file");
+  url.searchParams.set("path", requestedPath);
+  for (const [key, value] of Object.entries(extraParams)) url.searchParams.set(key, value);
+  return GET(new NextRequest(url), {
+    params: Promise.resolve({ agentId: "agent-1" }),
+  } as unknown as Parameters<typeof GET>[1]);
+}
+
+/** Writes an Office source and returns its absolute path. */
+function writeSource(name: string, bytes: Buffer = DOCX_BYTES): string {
+  const path = join(allowedRoot, name);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+  writeFileSync(path, bytes);
+  return path;
+}
+
+/**
+ * Puts `pdfBytes` in the store under the key for `sourceBytes`, exactly as a
+ * finished conversion does. Uses the real store, so what is asserted is that
+ * the route derives the same key — not that a mock was called.
+ */
+async function storeArtifactFor(sourceBytes: Buffer, pdfBytes = ARTIFACT_BYTES): Promise<string> {
+  const { OfficeArtifactStore } = await import("@/lib/knowledge/office-artifacts");
+  const store = new OfficeArtifactStore(artifactDir);
+  const staged = join(tmpRoot, `staged-${createHash("sha256").digest("hex").slice(0, 8)}.pdf`);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+  writeFileSync(staged, pdfBytes);
+  return store.put(createHash("sha256").update(sourceBytes).digest("hex"), staged);
+}
+
+function auditEntries() {
+  return mockDeferAuditLog.mock.calls.map(([entry]) => entry as Record<string, unknown>);
+}
+
+describe("workspace-file — an artifact is only as reachable as its source", () => {
+  it("refuses the converted preview of a document outside the agent's allowed paths", async () => {
+    // The artifact EXISTS and is perfectly readable on disk. The only thing
+    // standing between a caller and its bytes is that the source it was
+    // converted from is not something this agent may read — which is the whole
+    // reason the artifact path is derived from the source rather than asked
+    // for.
+    const outsideDoc = join(outsideDir, "payroll.docx");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+    writeFileSync(outsideDoc, DOCX_BYTES);
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(outsideDoc);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain("converted from the office source");
+  });
+
+  it("refuses it for a traversal that lexically escapes the allowed root", async () => {
+    const outsideDoc = join(outsideDir, "payroll.docx");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+    writeFileSync(outsideDoc, DOCX_BYTES);
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(join(allowedRoot, "..", "outside", "payroll.docx"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("records the refusal as a refusal to view, not as a missing artifact", async () => {
+    const outsideDoc = join(outsideDir, "payroll.docx");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+    writeFileSync(outsideDoc, DOCX_BYTES);
+    await storeArtifactFor(DOCX_BYTES);
+
+    await callGET(outsideDoc);
+
+    expect(auditEntries()[0]).toMatchObject({
+      eventType: "knowledge.source_viewed",
+      outcome: "failure",
+      detail: { reason: "outside_allowed_paths" },
+    });
+  });
+});
+
+describe("workspace-file — a stale artifact is not served", () => {
+  it("stops serving the old PDF once the source has changed", async () => {
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+    expect((await callGET(source)).status).toBe(200);
+
+    // The operator replaced the document on the read-only share and nothing has
+    // reconverted it yet. The artifact for the OLD bytes is still on the
+    // volume — and it now describes a document that no longer exists.
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+    writeFileSync(source, Buffer.from("PK a different offer entirely\n"));
+
+    const res = await callGET(source);
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).not.toContain("converted from the office source");
+  });
+
+  it("serves the new PDF as soon as the conversion catches up", async () => {
+    const source = writeSource("angebot.docx");
+    const newBytes = Buffer.from("PK a different offer entirely\n");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+    writeFileSync(source, newBytes);
+    await storeArtifactFor(newBytes, Buffer.from("%PDF-1.4\nthe new offer\n%%EOF"));
+
+    const res = await callGET(source);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("the new offer");
+  });
+
+  it("answers 404 rather than handing over the unrenderable original", async () => {
+    // Nothing has been converted yet (#938 wires the indexer). Serving the
+    // .docx instead would be worse than nothing: it is served `attachment`, so
+    // the viewer's <embed> would trigger a surprise download rather than show
+    // a document.
+    const source = writeSource("angebot.docx");
+
+    const res = await callGET(source);
+
+    expect(res.status).toBe(404);
+    expect(auditEntries().at(-1)).toMatchObject({
+      outcome: "failure",
+      detail: { reason: "no_converted_artifact" },
+    });
+  });
+});
+
+describe("workspace-file — the Office preview", () => {
+  it("renders the converted PDF in the same viewer a PDF citation opens", async () => {
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(source);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("content-disposition")).toMatch(/^inline;/);
+    // Without this the <embed> gets a blank pane: next.config.ts's global DENY
+    // wins unless the route declares the relaxation (#703/#788).
+    expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(await res.text()).toContain("converted from the office source");
+  });
+
+  it("lets the viewer seek, so a citation opens at its page instead of pulling the whole document", async () => {
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(source);
+
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(res.headers.get("content-length")).toBe(String(ARTIFACT_BYTES.length));
+  });
+
+  it("names the served file after the document, carrying the format it is in", async () => {
+    const source = writeSource("Angebot Herbst.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(source);
+
+    expect(res.headers.get("content-disposition")).toContain('filename="Angebot Herbst.pdf"');
+  });
+
+  it("audits the view under the document's own name, not the artifact's hash", async () => {
+    // The artifact is named for its content key; an audit row saying
+    // `3f9a2c….pdf` names nothing an analyst can act on.
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    await callGET(source);
+
+    expect(auditEntries().at(-1)).toMatchObject({
+      eventType: "knowledge.source_viewed",
+      outcome: "success",
+      detail: { document: { name: "angebot.docx" }, representation: "converted" },
+    });
+  });
+
+  it("leaves a PDF citation exactly as it was", async () => {
+    const pdf = writeSource("handbook.pdf", Buffer.from("%PDF-1.4\nthe original pdf\n%%EOF"));
+
+    const res = await callGET(pdf);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("the original pdf");
+    expect(auditEntries().at(-1)).toMatchObject({ detail: { representation: "original" } });
+  });
+});
+
+describe("workspace-file — both downloads", () => {
+  it("hands over the original when that is what was asked for", async () => {
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(source, { download: "1", variant: "original" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment;/);
+    expect(res.headers.get("content-disposition")).toContain('filename="angebot.docx"');
+    expect(await res.text()).toContain("pretend this is a .docx");
+  });
+
+  it("hands over the converted PDF under a name that tells the two apart", async () => {
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(source, { download: "1", variant: "converted" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment;/);
+    expect(res.headers.get("content-disposition")).toContain('filename="angebot.pdf"');
+    expect(await res.text()).toContain("converted from the office source");
+  });
+
+  it("records which of the two left the building", async () => {
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    await callGET(source, { download: "1", variant: "original" });
+    await callGET(source, { download: "1", variant: "converted" });
+
+    expect(auditEntries().map((entry) => entry.eventType)).toEqual([
+      "knowledge.source_downloaded",
+      "knowledge.source_downloaded",
+    ]);
+    expect(
+      auditEntries().map((entry) => (entry.detail as { representation: string }).representation)
+    ).toEqual(["original", "converted"]);
+  });
+
+  it("keeps the original readable even before anything has been converted", async () => {
+    // The download affordance (#934) must not start depending on a conversion
+    // that may have failed or not run yet.
+    const source = writeSource("angebot.docx");
+
+    const res = await callGET(source, { download: "1", variant: "original" });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("pretend this is a .docx");
+  });
+
+  it("refuses a converted download for a format nothing converts", async () => {
+    // A `.pdf` has no converted representation, and answering with the file
+    // itself would make `variant` mean something different per format.
+    const pdf = writeSource("handbook.pdf", Buffer.from("%PDF-1.4\nthe original pdf\n%%EOF"));
+
+    const res = await callGET(pdf, { download: "1", variant: "converted" });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a variant it does not know rather than guessing at one", async () => {
+    const source = writeSource("angebot.docx");
+    await storeArtifactFor(DOCX_BYTES);
+
+    const res = await callGET(source, { variant: "somethingelse" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("still refuses both variants for a document outside the allowed paths", async () => {
+    const outsideDoc = join(outsideDir, "payroll.docx");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-local path under a per-test temp dir
+    writeFileSync(outsideDoc, DOCX_BYTES);
+    await storeArtifactFor(DOCX_BYTES);
+
+    expect((await callGET(outsideDoc, { download: "1", variant: "original" })).status).toBe(403);
+    expect((await callGET(outsideDoc, { download: "1", variant: "converted" })).status).toBe(403);
+  });
+});
+
+describe("workspace-file — the artifact volume is not a failure of the document", () => {
+  it("answers 404 rather than 500 when the store is unusable", async () => {
+    // A missing or unwritable artifact volume is an infrastructure fault. It
+    // must not surface as a stack trace on a request for a document that is
+    // perfectly fine — and it must not take the ORIGINAL download down with it.
+    process.env.KB_ARTIFACT_DIR = join(tmpRoot, "allowed", "angebot.docx", "not-a-directory");
+    const source = writeSource("angebot.docx");
+
+    const res = await callGET(source);
+
+    expect(res.status).toBe(404);
+    expect(res).toBeInstanceOf(NextResponse);
+  });
+});

--- a/packages/web/src/__tests__/api/agent-workspace-file-office.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file-office.test.ts
@@ -295,6 +295,24 @@ describe("workspace-file — both downloads", () => {
     expect(await res.text()).toContain("pretend this is a .docx");
   });
 
+  it("types a slide deck as a slide deck, not as anonymous bytes", async () => {
+    // `buildSourceDownloads` offers an original for every format in
+    // OFFICE_EXTENSIONS, so every one of them reaches this route as a download.
+    // `.ppt`/`.pptx` were missing from the content-type table, which is not a
+    // security hole (unknown types are served `attachment` either way) but does
+    // hand the reader `application/octet-stream` — a file their OS opens with a
+    // shrug instead of with PowerPoint.
+    const source = writeSource("Bericht.pptx");
+
+    const res = await callGET(source, { download: "1", variant: "original" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe(
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    );
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment;/);
+  });
+
   it("hands over the converted PDF under a name that tells the two apart", async () => {
     const source = writeSource("angebot.docx");
     await storeArtifactFor(DOCX_BYTES);

--- a/packages/web/src/__tests__/components/markdown-citation-downloads.test.tsx
+++ b/packages/web/src/__tests__/components/markdown-citation-downloads.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * What the markdown renderer HANDS the lightbox for a citation — specifically,
+ * the download list.
+ *
+ * Its own file with its own stub because the two neighbours each stop one step
+ * short, deliberately:
+ *
+ *   - `markdown-citation-render.test.tsx` renders the real pipeline and stops
+ *     at the trigger. Opening the dialog for real means driving a Radix portal
+ *     in jsdom, which does not settle reliably here — and a test that is
+ *     occasionally right is worse than a boundary drawn on purpose.
+ *   - `pdf-dialog.test.tsx` renders the dialog open and proves it DISPLAYS a
+ *     pair of downloads. It builds that pair itself, so it says nothing about
+ *     whether the renderer ever supplies one.
+ *
+ * The gap between them is a whole feature: `buildSourceDownloads` could be
+ * perfect and never called, and every test above would stay green while an
+ * Office citation offered a single download of a file no browser renders.
+ *
+ * So this replaces `PdfDialog` with a stub that writes its props out, which is
+ * the only seam that reaches the answer without the portal. It asserts the
+ * WIRING and nothing else — what the dialog does with the list is the other
+ * file's job.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TextMessagePartProvider } from "@assistant-ui/react";
+
+vi.mock("@/components/assistant-ui/attachment-preview", () => ({
+  PdfDialog: ({
+    url,
+    downloads,
+    children,
+  }: {
+    url: string;
+    downloads?: Array<{ label: string; url: string }>;
+    children: React.ReactNode;
+  }) => (
+    <span
+      data-testid="pdf-dialog"
+      data-url={url}
+      data-downloads={JSON.stringify(downloads ?? null)}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { AgentIdContext } from "@/components/chat";
+
+function renderAnswer(text: string) {
+  return render(
+    <AgentIdContext.Provider value="agent-1">
+      <TextMessagePartProvider text={text} isRunning={false}>
+        <MarkdownText smooth={false} />
+      </TextMessagePartProvider>
+    </AgentIdContext.Provider>
+  );
+}
+
+async function downloadsOf(text: string): Promise<Array<{ label: string; url: string }> | null> {
+  renderAnswer(text);
+  const dialog = await screen.findByTestId("pdf-dialog");
+  return JSON.parse(dialog.getAttribute("data-downloads")!);
+}
+
+describe("what the renderer hands the viewer for a citation", () => {
+  it("supplies both representations of an Office source", async () => {
+    const downloads = await downloadsOf("- [1] noack/QF_2012/Angebot.doc — S. 3");
+
+    expect(downloads?.map((d) => d.label)).toEqual(["Angebot.doc", "Angebot.pdf"]);
+  });
+
+  it("supplies exactly one for a PDF, which has only one representation", async () => {
+    const downloads = await downloadsOf("- [1] noack/PPR/document.pdf — p. 510");
+
+    expect(downloads?.map((d) => d.label)).toEqual(["document.pdf"]);
+  });
+
+  it("opens the viewer at the citation's own url, unchanged by any of this", async () => {
+    // The preview url is what carries `#page=N`, and the download urls are
+    // derived FROM it. If this ever drifted, a reader would be shown one
+    // document and handed another.
+    renderAnswer("- [1] noack/QF_2012/Angebot.doc — S. 3");
+
+    const dialog = await screen.findByTestId("pdf-dialog");
+    expect(dialog.getAttribute("data-url")).toBe(
+      "/api/agents/agent-1/workspace-file?path=%2Fdata%2Fnoack%2FQF_2012%2FAngebot.doc#page=3"
+    );
+  });
+});

--- a/packages/web/src/__tests__/components/markdown-citation-render.test.tsx
+++ b/packages/web/src/__tests__/components/markdown-citation-render.test.tsx
@@ -99,6 +99,16 @@ describe("a cited source rendered through the real markdown pipeline", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
+  it("makes an Office source clickable too, now that it has a preview to open", async () => {
+    // Nothing indexes Office documents yet (#938 wires that), so this is the
+    // renderer half of the chain arriving first — and the half that would fail
+    // silently: an unlinkified citation is not an error, it is flat text
+    // nobody notices until someone asks why the .doc is not clickable.
+    renderAnswer("agent-1", "- [1] noack/QF_2012/Angebot.doc — S. 3");
+
+    expect((await screen.findByText("noack/QF_2012/Angebot.doc")).tagName).toBe("BUTTON");
+  });
+
   it("does not touch a path shown as code", async () => {
     // Inside backticks a path is being displayed, not referenced. remark gives
     // it its own node type, and the plugin has to respect that in the real tree

--- a/packages/web/src/__tests__/components/pdf-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/pdf-dialog.test.tsx
@@ -21,6 +21,7 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { PdfDialog } from "@/components/assistant-ui/attachment-preview";
+import { buildSourceDownloads, buildSourceHref } from "@/lib/knowledge/source-links";
 
 function openDialog(url: string, title: string, page: number | null = null) {
   return render(
@@ -190,6 +191,29 @@ describe("PdfDialog — taking the document", () => {
 
     expect(screen.getByRole("link", { name: /download original/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /download converted pdf/i })).toBeInTheDocument();
+  });
+
+  it("offers an Office citation both representations, built by the renderer", () => {
+    // The pair is not hand-assembled at the call site: `buildSourceDownloads`
+    // derives it from the same href the viewer opens, which is what keeps the
+    // download urls and the preview url describing one document. Rendering it
+    // here proves the two halves fit — the list shape and the labels a reader
+    // actually distinguishes them by.
+    const href = buildSourceHref("a1", "noack/QF_2012/Angebot.doc", 3);
+    render(
+      <PdfDialog
+        url={href}
+        title="noack/QF_2012/Angebot.doc"
+        page={3}
+        downloads={buildSourceDownloads(href)!}
+        defaultOpen
+      >
+        <button type="button">trigger</button>
+      </PdfDialog>
+    );
+
+    expect(screen.getByRole("link", { name: "Download Angebot.doc" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Download Angebot.pdf" })).toBeInTheDocument();
   });
 
   it("keeps the controls on screen when the document name is too long for the row", () => {

--- a/packages/web/src/__tests__/lib/knowledge/office-formats.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/office-formats.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The two facts both the converter and the browser need about an Office
+ * source: is it one, and what is its converted PDF called (#939).
+ *
+ * `isOfficeFile` is also exercised through `office-convert.ts`'s re-export in
+ * `office-convert.test.ts`; what is pinned HERE is the behaviour that only
+ * matters now that a client component reads the same module — the extension is
+ * parsed with string operations rather than `node:path`, so the cases where
+ * `extname` is surprising are the ones worth writing down.
+ */
+import { describe, it, expect } from "vitest";
+
+import { convertedPdfName, isOfficeFile, OFFICE_EXTENSIONS } from "@/lib/knowledge/office-formats";
+
+describe("isOfficeFile", () => {
+  it("recognises every converted format, whatever the case", () => {
+    for (const ext of OFFICE_EXTENSIONS) {
+      expect(isOfficeFile(`/data/report${ext}`)).toBe(true);
+      expect(isOfficeFile(`/data/report${ext.toUpperCase()}`)).toBe(true);
+    }
+  });
+
+  it("says no to the formats that take a different path", () => {
+    // Spreadsheets are read directly (#937) and PDFs need no conversion at all.
+    expect(isOfficeFile("/data/budget.xlsx")).toBe(false);
+    expect(isOfficeFile("/data/budget.xls")).toBe(false);
+    expect(isOfficeFile("/data/report.pdf")).toBe(false);
+    expect(isOfficeFile("/data/notes")).toBe(false);
+  });
+
+  it("reads the extension of the FILE, not of a directory above it", () => {
+    // A folder called `2019.doc` holding a PDF is not an Office document, and
+    // an `endsWith` over the whole path would say it is.
+    expect(isOfficeFile("/data/2019.doc/report.pdf")).toBe(false);
+    expect(isOfficeFile("/data/2019.pdf/report.doc")).toBe(true);
+  });
+
+  it("treats a leading dot as a dotfile rather than an extension", () => {
+    // `extname("/data/.doc")` is "", and this must agree with it — the
+    // converter and the preview route would otherwise disagree about what
+    // exists.
+    expect(isOfficeFile("/data/.doc")).toBe(false);
+  });
+});
+
+describe("convertedPdfName", () => {
+  it("keeps the document's own name and changes only the format", () => {
+    expect(convertedPdfName("/data/noack/Angebot.doc")).toBe("Angebot.pdf");
+    expect(convertedPdfName("Präsentation.pptx")).toBe("Präsentation.pdf");
+  });
+
+  it("does not lowercase the name it was given", () => {
+    // The label is shown to a reader and the filename lands in their downloads
+    // folder; only the EXTENSION is matched case-insensitively.
+    expect(convertedPdfName("/data/QF_2012/Bericht.DOC")).toBe("Bericht.pdf");
+  });
+
+  it("leaves a doubled extension alone apart from the last one", () => {
+    expect(convertedPdfName("/data/report.v2.docx")).toBe("report.v2.pdf");
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
@@ -265,6 +265,27 @@ describe("remarkSourceLinks", () => {
     expect(links(tree).map((l) => l.text)).toEqual(["noack/Angebot.docx"]);
   });
 
+  it.each([".doc", ".docx", ".ppt", ".pptx"])(
+    "cites %s.pdf as the one document it is, not as the office file inside its name",
+    (inner) => {
+      // `Angebot.doc.pdf` is a single PDF whose author kept the source
+      // extension in the name — the commonest filename shape in exactly the
+      // corpora this feature targets, because it is what a batch conversion
+      // produces. Stopping at the inner extension would cite `Angebot.doc`, a
+      // document that does not exist, and hand the reader a 403 on a link that
+      // looked right.
+      const tree = run(paragraph(`siehe noack/Angebot${inner}.pdf hier`));
+      expect(links(tree).map((l) => l.text)).toEqual([`noack/Angebot${inner}.pdf`]);
+    }
+  );
+
+  it("still stops at an extension followed by a full stop", () => {
+    // The chained-extension rule must not swallow the sentence: `.doc.` is a
+    // path ending in `.doc`, not the start of `.docx`.
+    const tree = run(paragraph("siehe noack/Angebot.doc. Und weiter"));
+    expect(links(tree).map((l) => l.text)).toEqual(["noack/Angebot.doc"]);
+  });
+
   it("still leaves a spreadsheet alone, because nothing converts one", () => {
     // Spreadsheets take a different path entirely (#937/#940): a sheet is not a
     // page, so there is no artifact to preview and a link would open a pane
@@ -314,13 +335,18 @@ describe("remarkSourceLinks", () => {
     expect(links(tree).map((l) => l.text)).toEqual(["x/doc.PDF"]);
   });
 
-  it("reads a doubled extension as the shorter path", () => {
-    // `/x.pdf.pdf` is ambiguous and neither reading is more correct. It is
-    // pinned only so the windowed scan below cannot change it unnoticed: the
-    // scan stops at the FIRST `.pdf` that a path can legally end on, where the
-    // earlier unbounded regex kept expanding across it.
+  it("reads a doubled extension as the whole name", () => {
+    // This used to pin the SHORTER reading (`x/report.pdf`), on the grounds
+    // that `/x.pdf.pdf` is ambiguous and neither reading is more correct — the
+    // assertion existed to make a change visible rather than to defend an
+    // answer. #939 made it visible, and the answer moved: once `.doc` is
+    // linkable too, `Angebot.doc.pdf` reads as a citation of `Angebot.doc`, a
+    // document in another format that does not exist. Stopping early does not
+    // pick between two readings of one name, it invents a second name — so the
+    // scan now runs to the last extension in a chain, and this case comes
+    // along.
     const tree = run(paragraph("x/report.pdf.pdf"));
-    expect(links(tree).map((l) => l.text)).toEqual(["x/report.pdf"]);
+    expect(links(tree).map((l) => l.text)).toEqual(["x/report.pdf.pdf"]);
   });
 
   describe("pathological input", () => {

--- a/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/source-links.test.ts
@@ -19,7 +19,13 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { remarkSourceLinks, buildSourceHref, parseSourceHref } from "@/lib/knowledge/source-links";
+import {
+  remarkSourceLinks,
+  buildSourceHref,
+  buildSourceDownloads,
+  parseSourceHref,
+} from "@/lib/knowledge/source-links";
+import { OFFICE_EXTENSIONS } from "@/lib/knowledge/office-formats";
 
 /** Minimal mdast subset — the plugin only ever walks children and rewrites text nodes. */
 type Node = { type: string; value?: string; url?: string; children?: Node[] };
@@ -118,6 +124,64 @@ describe("parseSourceHref", () => {
   });
 });
 
+describe("buildSourceDownloads", () => {
+  const hrefFor = (citationPath: string) => buildSourceHref(AGENT, citationPath, 510);
+
+  it("offers one copy of a PDF, because a PDF has only one representation", () => {
+    const downloads = buildSourceDownloads(hrefFor("noack/PPR/document.pdf"))!;
+
+    expect(downloads).toHaveLength(1);
+    expect(downloads[0].label).toBe("document.pdf");
+  });
+
+  it("offers the original AND the converted PDF for an Office source", () => {
+    // The two answer different needs: a `.doc` renders in no browser, and the
+    // file the reader forwards to a customer is the one that exists on their
+    // drive. The original comes first — it is the document; the PDF is a
+    // convenience that sometimes saves them the conversion.
+    const downloads = buildSourceDownloads(hrefFor("noack/QF_2012/Angebot.doc"))!;
+
+    expect(downloads.map((d) => d.label)).toEqual(["Angebot.doc", "Angebot.pdf"]);
+  });
+
+  it("names each representation explicitly, so the pair is not a coin flip", () => {
+    const [original, converted] = buildSourceDownloads(hrefFor("noack/Bericht.pptx"))!;
+
+    expect(new URL(original.url, "http://localhost").searchParams.get("variant")).toBe("original");
+    expect(new URL(converted.url, "http://localhost").searchParams.get("variant")).toBe(
+      "converted"
+    );
+  });
+
+  it("asks the server for a copy, so both are audited as downloads", () => {
+    for (const download of buildSourceDownloads(hrefFor("noack/Angebot.docx"))!) {
+      const parsed = new URL(download.url, "http://localhost");
+      expect(parsed.searchParams.get("download")).toBe("1");
+      expect(parsed.searchParams.get("path")).toBe("/data/noack/Angebot.docx");
+    }
+  });
+
+  it("drops the page fragment, which means nothing to a saved file", () => {
+    for (const download of buildSourceDownloads(hrefFor("noack/Angebot.docx"))!) {
+      expect(download.url).not.toContain("#");
+    }
+  });
+
+  it("offers a pair for every format the knowledge base converts", () => {
+    // Paired with OFFICE_EXTENSIONS rather than spelled out: teaching the
+    // converter a new format without teaching the renderer would leave a
+    // citation whose preview works and whose download list silently does not.
+    for (const ext of OFFICE_EXTENSIONS) {
+      expect(buildSourceDownloads(hrefFor(`noack/report${ext}`))).toHaveLength(2);
+    }
+  });
+
+  it("says nothing about a link that is not a citation", () => {
+    expect(buildSourceDownloads("/some/other/link")).toBeNull();
+    expect(buildSourceDownloads("https://evil.example/workspace-file?path=%2Fx.docx")).toBeNull();
+  });
+});
+
 describe("remarkSourceLinks", () => {
   it("links a template-formatted source and keeps its page", () => {
     const tree = run(paragraph("- [2] noack/PPR/document.pdf — p. 44"));
@@ -180,6 +244,32 @@ describe("remarkSourceLinks", () => {
 
   it("ignores a path whose extension we cannot serve", () => {
     const tree = paragraph("/etc/passwd and x/notes.exe");
+    const before = JSON.stringify(tree);
+    run(tree);
+    expect(JSON.stringify(tree)).toBe(before);
+  });
+
+  it.each(OFFICE_EXTENSIONS)("links a cited %s, which now opens as its converted PDF", (ext) => {
+    // Paired with OFFICE_EXTENSIONS on purpose: the alternation in the pattern
+    // and the converter's list are two spellings of one decision, and a format
+    // the converter learns without the renderer learning it cites as flat text.
+    const tree = run(paragraph(`- [1] noack/QF_2012/Angebot${ext} — p. 3`));
+    expect(links(tree).map((l) => l.text)).toEqual([`noack/QF_2012/Angebot${ext}`]);
+  });
+
+  it("keeps a whole .docx rather than stopping at the .doc inside it", () => {
+    // `docx?` is one alternation, and a non-greedy reading of it would cite
+    // `Angebot.doc` — a document that does not exist — for every .docx in the
+    // corpus.
+    const tree = run(paragraph("siehe noack/Angebot.docx hier"));
+    expect(links(tree).map((l) => l.text)).toEqual(["noack/Angebot.docx"]);
+  });
+
+  it("still leaves a spreadsheet alone, because nothing converts one", () => {
+    // Spreadsheets take a different path entirely (#937/#940): a sheet is not a
+    // page, so there is no artifact to preview and a link would open a pane
+    // that can never render.
+    const tree = paragraph("siehe noack/Budget.xlsx hier");
     const before = JSON.stringify(tree);
     run(tree);
     expect(JSON.stringify(tree)).toBe(before);

--- a/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
@@ -14,9 +14,74 @@ import type { AuditLogEntry } from "@/lib/audit";
 import { resolveAllowedFile } from "@/lib/agent-file-access";
 import { contentTypeForFile } from "@/lib/agent-file-content-type";
 import { parseRangeHeader } from "@/lib/http-range";
+import { getOfficeArtifactStore, hashFileContents } from "@/lib/knowledge/office-artifacts";
+import { convertedPdfName, isOfficeFile } from "@/lib/knowledge/office-formats";
 import type { AgentPluginConfig } from "@/db/schema";
 
 type Params = { params: Promise<{ agentId: string }> };
+
+/**
+ * Which representation of one document the caller wants.
+ *
+ * An Office source has two, and they answer different needs: the reader looks
+ * at the CONVERTED PDF (a `.doc` renders in no browser) and sends a customer
+ * the ORIGINAL (the file that exists on their drive). Both are the same
+ * document, which is why this is a parameter on one route rather than a second
+ * route with a second access check to keep in step.
+ *
+ * Absent means "whatever this document is meant to be LOOKED at as", which is
+ * the converted PDF for an Office source and the file itself for everything
+ * else. That default is what keeps `buildSourceHref` — and every citation
+ * already rendered — unchanged: a viewer asks for the document, not for a
+ * representation of it.
+ */
+type Variant = "original" | "converted";
+
+function parseVariant(raw: string | null): Variant | null | undefined {
+  if (raw === null) return null;
+  return raw === "original" || raw === "converted" ? raw : undefined;
+}
+
+/**
+ * The stored PDF for an Office source, or null when there is none to serve.
+ *
+ * ## Why this cannot widen what a request can reach
+ *
+ * The artifact store lives OUTSIDE `/data` — it has to, because `/data` is
+ * mounted read-only and that is a product promise (#936) — so it is outside
+ * `FILE_SERVE_ROOTS` and `resolveAllowedFile` would refuse every artifact.
+ * Containment is therefore re-argued rather than reused, and it rests on two
+ * facts:
+ *
+ *   1. This is reached ONLY after `resolveAllowedFile` accepted the ORIGINAL
+ *      path. An artifact is exactly as reachable as the document it was
+ *      converted from, never more.
+ *   2. The artifact path is DERIVED, never requested: `pathFor` re-hashes its
+ *      argument, so what is opened is `<root>/v<n>/ab/<64 hex>.pdf` — a shape
+ *      no caller-supplied string can steer, whatever it contains.
+ *
+ * ## Why this is also the staleness check
+ *
+ * The store is keyed on the source's content hash, so an artifact is only
+ * found while the bytes it was converted from are still the bytes on disk.
+ * Replace the document on the share and the key moves with it: the old
+ * artifact becomes unreachable in the same instant, with no invalidation pass
+ * to run and no window in which a reader is shown a document that no longer
+ * exists. The cost is a hash per request, paid on a file small enough that
+ * LibreOffice converted it in about a second.
+ */
+async function resolveConvertedArtifact(realPath: string): Promise<string | null> {
+  if (!isOfficeFile(realPath)) return null;
+  try {
+    return await getOfficeArtifactStore().get(await hashFileContents(realPath));
+  } catch {
+    // An unreadable source, or an artifact volume that is missing, full or not
+    // mounted. Neither is a verdict on this document and neither is worth a
+    // 500: the answer is the same as "not converted yet", and the ORIGINAL
+    // download keeps working throughout.
+    return null;
+  }
+}
 
 /**
  * Reading a cited document and taking a copy of it out of the building are
@@ -40,6 +105,7 @@ function sourceAccessAuditEntry(args: {
   outcome: "success" | "failure";
   reason?: string;
   partial?: boolean;
+  representation?: Variant;
 }): AuditLogEntry {
   return {
     actorType: "user",
@@ -53,7 +119,13 @@ function sourceAccessAuditEntry(args: {
     // an HMAC-chained row, and redundant besides (#824).
     detail: {
       agent: { id: args.agentId, name: args.agentName ?? args.agentId },
+      // Always the SOURCE document's name, even when the bytes served are its
+      // converted PDF: the artifact is named for its content key, and a row
+      // saying `3f9a2c….pdf` names nothing an analyst can act on. Which of the
+      // two representations actually left is a separate field, because "who
+      // took the spec sheet" and "in which format" are different questions.
       document: { name: args.documentName },
+      ...(args.representation !== undefined ? { representation: args.representation } : {}),
       ...(args.reason !== undefined ? { reason: args.reason } : {}),
       // A PDF viewer fetches a large document as a series of ranges, so one
       // opened document produces several rows. Every access stays logged —
@@ -104,6 +176,17 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
   const eventType: SourceAccessEvent = isDownload
     ? "knowledge.source_downloaded"
     : "knowledge.source_viewed";
+
+  // Rejected before any path is resolved and before any audit row is written:
+  // a request naming a representation that does not exist has not asked for a
+  // document, so there is no access decision to record about one.
+  const variant = parseVariant(req.nextUrl.searchParams.get("variant"));
+  if (variant === undefined) {
+    return NextResponse.json(
+      { error: "variant must be 'original' or 'converted'" },
+      { status: 400 }
+    );
+  }
 
   // Same allowlist source as knowledge_search's retrieval scope (see
   // /api/internal/knowledge/search/route.ts): an agent's file-serving scope
@@ -159,14 +242,32 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
     );
   };
 
+  // Which representation is actually served. `converted` is asked for
+  // explicitly by the second download control, and implicitly by any viewer
+  // opening an Office source — a `.doc` renders in no browser, so the document
+  // a reader was promised IS the converted PDF.
+  const wantsConverted = variant === "converted" || (variant === null && isOfficeFile(realPath));
+  const artifactPath = wantsConverted ? await resolveConvertedArtifact(realPath) : null;
+  if (wantsConverted && artifactPath === null) {
+    // Falling back to the original here would be worse than answering nothing:
+    // it is served `attachment`, so a viewer's <embed> would turn an
+    // unconverted document into a surprise download rather than a preview.
+    auditFailure("no_converted_artifact");
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const servedPath = artifactPath ?? realPath;
+  const servedName = artifactPath ? convertedPdfName(documentName) : documentName;
+  const representation: Variant = artifactPath ? "converted" : "original";
+
   // Open FIRST, then stat the open handle rather than re-stat the path: a
   // stat-then-open pair is a TOCTOU race (js/file-system-race), and the
   // handle's own stat is authoritative for the bytes we are about to serve.
   // Same posture as `serve-workspace-file.ts`.
   let fh;
   try {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- realPath is containment-checked by resolveAllowedFile above
-    fh = await open(realPath, "r");
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- servedPath is either realPath (containment-checked by resolveAllowedFile above) or an artifact path derived from the store's content key, which no request input can steer — see resolveConvertedArtifact.
+    fh = await open(servedPath, "r");
   } catch {
     auditFailure("not_found");
     return new NextResponse("Not found", { status: 404 });
@@ -213,7 +314,11 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
   // `attachment` is the stricter of the two, so forcing it can only narrow what
   // the browser is allowed to do with these bytes — it never relaxes the
   // extension-derived anti-XSS split, it only ever overrides `inline`.
-  const { contentType, disposition: servedDisposition } = contentTypeForFile(realPath);
+  // Derived from the name the bytes are SERVED under, not from the source's:
+  // the converted artifact is a PDF and has to be typed and dispositioned as
+  // one, or the viewer gets an `application/msword` attachment where it asked
+  // for something to render.
+  const { contentType, disposition: servedDisposition } = contentTypeForFile(servedName);
   const disposition = isDownload ? "attachment" : servedDisposition;
 
   deferAuditLog(
@@ -225,6 +330,7 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
       documentName,
       outcome: "success",
       partial: isPartial,
+      representation,
     })
   );
 
@@ -261,7 +367,7 @@ export const GET = withAuth<Params>(async (req, { params }, session) => {
       // Content-Type via its own MIME sniffing — the anti-XSS control that
       // makes the inline/attachment split above meaningful.
       "x-content-type-options": "nosniff",
-      "content-disposition": `${disposition}; filename="${documentName.replace(/[^\x20-\x7e]|["\\]/g, "_")}"; filename*=UTF-8''${encodeURIComponent(documentName)}`,
+      "content-disposition": `${disposition}; filename="${servedName.replace(/[^\x20-\x7e]|["\\]/g, "_")}"; filename*=UTF-8''${encodeURIComponent(servedName)}`,
       // Declares the posture the inline (PDF) case wants: a same-origin
       // <embed>/<iframe> viewer may frame this, nothing else may.
       //

--- a/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/workspace-file/route.ts
@@ -37,6 +37,13 @@ type Params = { params: Promise<{ agentId: string }> };
  */
 type Variant = "original" | "converted";
 
+/**
+ * Three answers, not two: the variant itself, `null` for "not named" (serve
+ * what this document is meant to be looked at as), and `undefined` for "named
+ * something that is not a variant" — which is a 400, not a default. A parser
+ * that folded the last two together would answer an unknown `variant=` with a
+ * document, and a client with a typo would never learn it had one.
+ */
 function parseVariant(raw: string | null): Variant | null | undefined {
   if (raw === null) return null;
   return raw === "original" || raw === "converted" ? raw : undefined;

--- a/packages/web/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/web/src/components/assistant-ui/markdown-text.tsx
@@ -18,7 +18,11 @@ import type { TextMessagePartProps } from "@assistant-ui/react";
 import { AgentIdContext } from "@/components/chat";
 import { PdfDialog } from "@/components/assistant-ui/attachment-preview";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
-import { remarkSourceLinks, parseSourceHref } from "@/lib/knowledge/source-links";
+import {
+  remarkSourceLinks,
+  buildSourceDownloads,
+  parseSourceHref,
+} from "@/lib/knowledge/source-links";
 import { cn } from "@/lib/utils";
 
 /** Taken from the consuming component so the list below cannot drift from what it accepts. */
@@ -163,7 +167,16 @@ const defaultComponents = memoizeMarkdownComponents({
     const source = href ? parseSourceHref(href) : null;
     if (source && href) {
       return (
-        <PdfDialog url={href} title={source.path} page={source.page}>
+        // The download list is derived from the SAME href the viewer opens, so
+        // what the reader is shown and what they can take away can never
+        // describe two different documents. For an Office source that is the
+        // original next to its converted PDF (#939).
+        <PdfDialog
+          url={href}
+          title={source.path}
+          page={source.page}
+          downloads={buildSourceDownloads(href) ?? undefined}
+        >
           <button type="button" className={cn(linkClasses, "cursor-pointer text-left")}>
             {children}
           </button>

--- a/packages/web/src/lib/agent-file-content-type.ts
+++ b/packages/web/src/lib/agent-file-content-type.ts
@@ -32,6 +32,12 @@ const EXTENSION_CONTENT_TYPES: Record<string, string> = {
   ".json": "application/json",
   ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   ".doc": "application/msword",
+  // Every OFFICE_EXTENSIONS format reaches this route as an "original"
+  // download once a citation offers both representations (#939), so the slide
+  // formats belong here beside the Word ones. Nothing about the anti-XSS split
+  // changes: only application/pdf is ever `inline`.
+  ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ".ppt": "application/vnd.ms-powerpoint",
   ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   ".xls": "application/vnd.ms-excel",
 };

--- a/packages/web/src/lib/knowledge/office-artifacts.ts
+++ b/packages/web/src/lib/knowledge/office-artifacts.ts
@@ -31,9 +31,25 @@
  * (`pruneOtherFormatVersions`) instead of a table scan.
  */
 import { createHash, randomUUID } from "node:crypto";
-import { mkdirSync } from "node:fs";
+import { createReadStream, mkdirSync } from "node:fs";
 import { mkdir, readdir, rename, rm, stat, utimes } from "node:fs/promises";
 import { join } from "node:path";
+
+/**
+ * sha256 of a file's bytes, streamed — the artifact-store key.
+ *
+ * Lives here rather than in `office-convert.ts` because computing the key is
+ * the store's business, and because the preview route (#939) needs it without
+ * importing a module that spawns LibreOffice and loads pdfjs. The ingest
+ * pipeline already hashes every file for its own idempotency check and should
+ * pass that hash rather than pay for a second read.
+ */
+export async function hashFileContents(absPath: string): Promise<string> {
+  const hash = createHash("sha256");
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- absPath is a containment-checked path from the caller (ingest's discovery, or the workspace-file route after resolveAllowedFile).
+  for await (const chunk of createReadStream(absPath)) hash.update(chunk);
+  return hash.digest("hex");
+}
 
 /**
  * Bump this whenever a change makes the converter produce a materially

--- a/packages/web/src/lib/knowledge/office-convert.ts
+++ b/packages/web/src/lib/knowledge/office-convert.ts
@@ -51,21 +51,22 @@
  * alarm. It is a tripwire against the failure that actually hurts (clipped
  * text), NOT a guarantee.
  */
-import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
-import { createReadStream } from "node:fs";
 import { mkdir, rm, stat, symlink } from "node:fs/promises";
 import { extname, join } from "node:path";
 
-import { getOfficeArtifactStore, OfficeArtifactStore } from "./office-artifacts";
+import { getOfficeArtifactStore, hashFileContents, OfficeArtifactStore } from "./office-artifacts";
+import { OFFICE_EXTENSIONS, isOfficeFile } from "./office-formats";
 import { extractPdfPages } from "./pdf-extract";
 
 /**
- * The page-shaped Office formats. Spreadsheets are deliberately absent: a
- * sheet is not a page, and rendering one to PDF produces arbitrary page breaks
- * that no citation can honestly point at (#937/#940).
+ * Re-exported so this module stays the one place a caller has to know about
+ * for conversion. The definitions themselves live where the PREVIEW route and
+ * the markdown renderer can reach them without pulling `child_process` and
+ * pdfjs into a browser bundle (#939) — see `office-formats.ts` and
+ * `office-artifacts.ts`.
  */
-export const OFFICE_EXTENSIONS = [".doc", ".docx", ".ppt", ".pptx"] as const;
+export { OFFICE_EXTENSIONS, isOfficeFile, hashFileContents };
 
 /**
  * Tolerance of the lower-bound word check. 10 % is head-room for tokenisation
@@ -183,19 +184,6 @@ export interface ConvertOptions {
   batchSize?: number;
   epsilon?: number;
   onProgress?: (progress: ConvertProgress) => void | Promise<void>;
-}
-
-/** Is this a page-shaped Office document this module converts? */
-export function isOfficeFile(path: string): boolean {
-  const ext = extname(path).toLowerCase();
-  return (OFFICE_EXTENSIONS as readonly string[]).includes(ext);
-}
-
-/** sha256 of a file's bytes, streamed — the artifact-store key. */
-export async function hashFileContents(absPath: string): Promise<string> {
-  const hash = createHash("sha256");
-  for await (const chunk of createReadStream(absPath)) hash.update(chunk);
-  return hash.digest("hex");
 }
 
 /** One document's slot in the run, so results can be returned in input order. */

--- a/packages/web/src/lib/knowledge/office-formats.ts
+++ b/packages/web/src/lib/knowledge/office-formats.ts
@@ -1,0 +1,53 @@
+/**
+ * What counts as a page-shaped Office document, and what its converted PDF is
+ * called. Two facts, needed on BOTH sides of the bundle boundary.
+ *
+ * No imports on purpose — same rule as `citation-path.ts`. The markdown
+ * renderer decides client-side whether a citation is an Office source (it
+ * offers a second download for one), and `office-convert.ts` decides the same
+ * thing server-side. A single `node:path` import here would drag
+ * `child_process` and pdfjs into the browser bundle along the same chain, so
+ * the extension is read with string operations rather than `extname`.
+ *
+ * These constants used to live in `office-convert.ts`; they moved here when
+ * the preview route (#939) and the renderer needed them, so the list stays one
+ * list. `office-convert.ts` re-exports them, which is why its own tests still
+ * read the same names.
+ */
+
+/**
+ * The page-shaped Office formats. Spreadsheets are deliberately absent: a
+ * sheet is not a page, and rendering one to PDF produces arbitrary page breaks
+ * that no citation can honestly point at (#937/#940).
+ */
+export const OFFICE_EXTENSIONS = [".doc", ".docx", ".ppt", ".pptx"] as const;
+
+/**
+ * The lowercased extension of `path`, or "" — `node:path`'s `extname` written
+ * as string surgery, including its rule that a leading dot is a dotfile and
+ * not an extension (`.doc` → "", never ".doc").
+ */
+function extensionOf(path: string): string {
+  const name = path.slice(path.lastIndexOf("/") + 1);
+  const dot = name.lastIndexOf(".");
+  return dot <= 0 ? "" : name.slice(dot).toLowerCase();
+}
+
+/** Is this a page-shaped Office document the knowledge base converts? */
+export function isOfficeFile(path: string): boolean {
+  return (OFFICE_EXTENSIONS as readonly string[]).includes(extensionOf(path));
+}
+
+/**
+ * What the converted PDF is called: the source's own name, carrying `.pdf`.
+ *
+ * `Angebot.doc` → `Angebot.pdf`, so the two downloads a reader is offered name
+ * the same document and differ exactly where they differ — in the format. A
+ * generic `converted.pdf` would arrive in their downloads folder saying
+ * nothing about which document it is.
+ */
+export function convertedPdfName(path: string): string {
+  const name = path.slice(path.lastIndexOf("/") + 1);
+  const ext = extensionOf(name);
+  return `${ext ? name.slice(0, -ext.length) : name}.pdf`;
+}

--- a/packages/web/src/lib/knowledge/source-links.ts
+++ b/packages/web/src/lib/knowledge/source-links.ts
@@ -110,9 +110,28 @@ function findSourcePaths(value: string): Array<{ start: number; end: number }> {
   const found: Array<{ start: number; end: number }> = [];
   let cursor = 0;
 
+  // Collected first so a hit can see the one after it. `Angebot.doc.pdf` is a
+  // SINGLE document — a PDF whose author kept the source extension in the
+  // name, which is what a batch conversion produces and therefore the commonest
+  // shape in exactly the corpora this feature serves. `.` is a legal path
+  // boundary (so that "…/doc.pdf." links the file and not the full stop), so
+  // without this the scan stops at the inner `.doc` and cites `Angebot.doc` —
+  // a document that does not exist, handed to the reader as a link that looks
+  // right and 403s. Only `.pdf` was linkable before #939, which is why the
+  // question could not arise until the alternation grew.
+  const hits: Array<{ start: number; end: number }> = [];
   EXTENSION.lastIndex = 0;
   for (let hit = EXTENSION.exec(value); hit !== null; hit = EXTENSION.exec(value)) {
-    const end = hit.index + hit[0].length;
+    hits.push({ start: hit.index, end: hit.index + hit[0].length });
+  }
+
+  for (const [index, hit] of hits.entries()) {
+    const end = hit.end;
+
+    // A chained extension defers to the last one in the chain. Adjacency is the
+    // whole test: `Angebot.doc. Und` has a hit at `.doc` and none at `. Un`, so
+    // the sentence is still left where it is.
+    if (hits[index + 1]?.start === end) continue;
 
     // The character AFTER the extension, read from the real text rather than
     // the window below, so a path at the very end of the node is still a path.

--- a/packages/web/src/lib/knowledge/source-links.ts
+++ b/packages/web/src/lib/knowledge/source-links.ts
@@ -21,6 +21,7 @@
  * it cannot widen what the user may read.
  */
 import { fromCitationPath, toCitationPath } from "./citation-path";
+import { convertedPdfName, isOfficeFile } from "./office-formats";
 
 /**
  * A DATA-ROOT-RELATIVE path ending in an extension we can serve, anchored at the
@@ -29,13 +30,22 @@ import { fromCitationPath, toCitationPath } from "./citation-path";
  * than checked separately: a second predicate deciding the same thing is a pair
  * that drifts, and a mutation test proved the separate check was already
  * unreachable. Widening what is linkable therefore means editing this
- * alternation — today only `.pdf`, which is also the only type the ingest
- * accepts and the only one the route renders inline.
+ * alternation — everything the route can put in front of a reader, and nothing
+ * else.
  *
  * Relative, with NO leading slash, because that is the shape `knowledge_search`
  * shows the model and a model can only cite what it is shown (#933). The
  * absolute form is rebuilt in `buildSourceHref` via `fromCitationPath`, the one
  * place that knows the data root.
+ *
+ * The Office formats joined `.pdf` here when their conversion gained a preview
+ * (#939): the route answers a request for one with the converted PDF, so a
+ * citation to a `.doc` now opens in the same viewer as everything else. The
+ * alternation and `OFFICE_EXTENSIONS` are paired by a test rather than shared
+ * as a variable — a built RegExp would hide the one thing a reader of this
+ * comment needs to see, and the pattern's cost model (see `findSourcePaths`)
+ * depends on what is written here. Spreadsheets stay out: nothing converts
+ * one, so a link would open a pane that can never render (#937/#940).
  *
  * At least one `/` is required. A bare `report.pdf` is exactly the citation
  * shape a full path exists to prevent — unfindable in a deep tree, ambiguous
@@ -55,7 +65,7 @@ import { fromCitationPath, toCitationPath } from "./citation-path";
  * rather than "a/one.pdf". A mount name with a space in it is the price, and
  * "the citation starts at a word" is a rule a reader can predict.
  */
-const SOURCE_PATH_ENDING_HERE = /[^\s/]+(?:\/[^/\n]+?)+?\.pdf$/i;
+const SOURCE_PATH_ENDING_HERE = /[^\s/]+(?:\/[^/\n]+?)+?\.(?:pdf|docx?|pptx?)$/i;
 
 /** What may follow a path so that "…/doc.pdf." links the file and not the full stop. */
 const PATH_BOUNDARY = /[\s,.;:)\]]/;
@@ -67,7 +77,7 @@ const PATH_BOUNDARY = /[\s,.;:)\]]/;
  * after such a character shifts and the path is extracted one character short.
  * Matching on the ORIGINAL string keeps offsets meaning what they say.
  */
-const EXTENSION = /\.pdf/gi;
+const EXTENSION = /\.(?:pdf|docx?|pptx?)/gi;
 
 /**
  * How far back from an extension a path may reasonably start. The longest path
@@ -194,6 +204,39 @@ export function parseSourceHref(href: string): { path: string; page: number | nu
     // A malformed percent-escape must not take down the render of a whole message.
     return null;
   }
+}
+
+/**
+ * What a reader may take away from the viewer for one cited document, in the
+ * order the header shows them. Null for anything that is not a citation.
+ *
+ * A PDF has one representation and yields one entry — today's behaviour,
+ * spelled out rather than left to the dialog's default so the two cases are
+ * decided in one place. An Office source has two, and they answer different
+ * needs: the ORIGINAL is the file that exists on the reader's drive and the one
+ * they forward to a customer; the CONVERTED PDF is what the viewer just showed
+ * them, and sometimes exactly what they wanted to send anyway — it saves them
+ * the conversion. Original first, because it is the document; the PDF is the
+ * convenience.
+ *
+ * `variant` is named on BOTH, including the single-entry PDF case. A default
+ * that means "the thing to look at" is right for a viewer and wrong for a save:
+ * being explicit here is what stops a later widening of that default from
+ * silently changing which bytes a download control hands over.
+ *
+ * The fragment goes: `#page=510` positions a viewer and means nothing to a
+ * saved file.
+ */
+export function buildSourceDownloads(href: string): Array<{ label: string; url: string }> | null {
+  const source = parseSourceHref(href);
+  if (!source) return null;
+
+  const base = href.split("#")[0];
+  const name = source.path.split("/").filter(Boolean).pop() ?? source.path;
+  const original = { label: name, url: `${base}&download=1&variant=original` };
+  if (!isOfficeFile(source.path)) return [original];
+
+  return [original, { label: convertedPdfName(name), url: `${base}&download=1&variant=converted` }];
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

A cited `.doc`/`.docx`/`.ppt`/`.pptx` now opens in the **same viewer as a PDF**, showing the artifact the converter produced (#936), while the download control offers **both** representations: the original — the file on the reader's share, the one they send a customer — and the converted PDF, which is often what they wanted to send anyway.

Closes #939

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 🔧 Tooling / CI

## How it works

**The route gains a `variant` parameter.** Absent means *"the thing to look at"* — the converted PDF for an Office source, the file itself for everything else. That default is what keeps `buildSourceHref` and every citation already rendered unchanged: a viewer asks for the document, not for a representation of it. `original` and `converted` name a representation explicitly, and both download controls always do — a default meaning "the thing to look at" is right for a viewer and wrong for a save.

`download=1` stays orthogonal (forces `attachment`, writes `knowledge.source_downloaded`). The audit detail gains `representation`, always under the **source** document's name: the artifact is named for its content key, and a row saying `3f9a2c….pdf` names nothing an analyst can act on.

## Security: containment is re-argued, not reused

The artifact store sits **outside `/data`** — it has to, because `/data` is mounted read-only and that is a product promise — so it is outside `FILE_SERVE_ROOTS` and `resolveAllowedFile` would refuse every artifact. Two facts carry the new path:

1. It is reached **only** after `resolveAllowedFile` accepted the **original** path. An artifact is exactly as reachable as the document it was converted from, never more.
2. The artifact path is **derived, never requested**: `pathFor` re-hashes its argument, so what is opened is `<root>/v<n>/ab/<64 hex>.pdf` — a shape no caller-supplied string can steer, whatever it contains.

Both directions are tested, including the case that matters most: an artifact that **exists and is readable on disk**, for a document outside the agent's grant → 403, bytes never served.

## Staleness comes for free

The store is keyed on the source's content hash, so an artifact is only found while the bytes it was converted from are still the bytes on disk. Replace the document on the share and the key moves with it — the old artifact becomes unreachable in the same instant, with no invalidation pass and no window in which a reader is shown a document that no longer exists. Cost: one hash per request, on a file small enough that LibreOffice converted it in about a second.

## Two deliberate refusals

- **No fallback to the original** when nothing has been converted yet: a `.docx` is served `attachment`, so an `<embed>` would turn an unconverted document into a *surprise download* rather than a preview. 404 instead.
- **An unusable artifact volume takes the same path.** Infrastructure is not a verdict on a document, it is not worth a 500, and the `original` download keeps working throughout.

## Module moves

`OFFICE_EXTENSIONS` / `isOfficeFile` move to a new **import-free** `office-formats.ts` so the markdown renderer can read the same list without dragging `child_process` and pdfjs into the browser bundle (same rule as `citation-path.ts`). `hashFileContents` moves to `office-artifacts.ts`, where computing the store's key belongs. `office-convert.ts` re-exports all three, so its API and its tests are unchanged.

## For the reviewer

- **`source-links.ts` widening is forward-preparation.** The indexer still accepts only `.pdf` (#938 wires Office in), so no Office citation can be produced today. The renderer half arriving first is the half that would fail *silently* — an unlinkified citation is not an error, it is flat text nobody notices — which is why it has a test paired with `OFFICE_EXTENSIONS` rather than a spelled-out list.
- **Spreadsheets stay out** of the linkifier on purpose: nothing converts one (#937/#940), so a link would open a pane that can never render.
- **`next.config.ts` needs no change** — same route, same entry; `frame-options-route-coverage.test.ts` is green.
- **New test files**: `agent-workspace-file-office.test.ts` (route, real filesystem + a real `OfficeArtifactStore` in a temp dir, so the route has to derive the same key the converter stored under), `markdown-citation-downloads.test.tsx` (the wiring gap between "the renderer links it" and "the dialog displays a pair" — `buildSourceDownloads` could be perfect and never called, and every other test would stay green), `office-formats.test.ts`.

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated the documentation
- [x] All existing tests pass

Gates run locally on Node 22: `pnpm test` (10457) · `pnpm -C packages/web test:db` (390) · `pnpm test:scripts` (675) · `tsc --noEmit -p tsconfig.typecheck.json` · `pnpm typecheck:plugins` · `pnpm build` · `pnpm format:check` · lint (0 errors) · `pnpm -C docs build && pnpm -C docs check:anchors`.

## Review round (self-review, 3 follow-up commits)

**Fixed — a regression the widening introduced.** `.` is a legal path boundary, so once `.doc` became linkable the scan stopped at the first extension and read `noack/Angebot.doc.pdf` as a citation of `noack/Angebot.doc` — a document that does not exist, linked and 403ing. Keeping the source extension in the name is what a batch conversion produces, so it is commonest in exactly the corpora this is for. The scan now defers to the last extension in a chain. This moved the doubled-`.pdf` case, whose test was explicitly pinned "so a change is noticed" rather than to defend an answer; its comment records the revision.

**Fixed — `.ppt`/`.pptx` were missing from the content-type table**, so the download control this PR adds served a slide deck as `application/octet-stream`. Anti-XSS split untouched (only `application/pdf` is ever `inline`).

**Not fixed, stated instead — the hash is per REQUEST, not per document.** `resolveConvertedArtifact` streams the whole original on every call, and a PDF viewer opens a document as a series of byte ranges. A 3 MB `.docx` does not care; a 100 MB `.pptx` on an NFS share pays its full size per range, which is the one promise in the docs ("the viewer fetches the pages it renders") that the Office path does not keep on the server side. The fix is a memo keyed on the source's `(ino, size, mtimeMs)` — the fast path `PdfCache` already uses in this repo — but it trades the zero-window staleness guarantee this PR argues for and tests. That is a design decision with its own argument, not a review fix, so it is written down rather than smuggled in.

**Not fixed — the docs describe a feature no user can reach yet.** `DEFAULT_ALLOWED_EXTENSIONS` is `[".pdf"]` with no override path, so nothing ingests an Office document until #938 lands and no Office citation can be produced. This PR extends that over-claim rather than introducing it (the surrounding page already documents Word heading-path citations), so the page should be corrected as a whole or #938 should ship in the same release — not half-reverted here.
