### PR TITLE
fix(eval): make the Layer-3 KB sweep produce a number worth reading

### DIFF
--- a/packages/web/eval/kb/chunk-texts.ts
+++ b/packages/web/eval/kb/chunk-texts.ts
@@ -1,0 +1,48 @@
+/**
+ * The groundedness premise lookup for the Layer-3 sweep, extracted from
+ * `kb-eval-models.spec.ts` so a DB-backed test can reach it.
+ *
+ * It lives outside `kb-eval-shared.ts` on purpose: that module imports
+ * `@playwright/test`, and pulling Playwright into the vitest integration lane
+ * to test one SQL statement would be a much larger dependency than the thing
+ * under test.
+ */
+
+/**
+ * Fetches every chunk's `chunk_text` for the given `sourcePaths`, keyed by
+ * path — the groundedness premise material for whichever sources the answer's
+ * Sources list actually cited (`citedSourcePaths`, not the full retrieved set
+ * — see that function's doc comment for why). A direct SELECT against the
+ * already-seeded corpus, not a re-run of `retrieve()`: we already know exactly
+ * which paths were retrieved (from the audit row), so this needs no new
+ * search/embedding call, only the stored text.
+ */
+export async function fetchChunkTexts(
+  dbUrl: string,
+  orgId: string,
+  sourcePaths: string[]
+): Promise<Map<string, string[]>> {
+  const map = new Map<string, string[]>();
+  if (sourcePaths.length === 0) return map;
+
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl);
+  try {
+    // Interpolate the array directly. `sql.array(paths)` reads like the more
+    // explicit spelling and is the one that does not work: postgres.js already
+    // infers `text[]` from a string array, while `sql.array` produces a
+    // parameter Postgres rejects on the right side of ANY (#869).
+    const rows = await sql<{ source_path: string; chunk_text: string }[]>`
+      SELECT source_path, chunk_text FROM kb_chunks
+      WHERE org_id = ${orgId} AND source_path = ANY(${sourcePaths})
+    `;
+    for (const row of rows) {
+      const texts = map.get(row.source_path) ?? [];
+      texts.push(row.chunk_text);
+      map.set(row.source_path, texts);
+    }
+    return map;
+  } finally {
+    await sql.end();
+  }
+}

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -209,9 +209,11 @@ function seedNoackCorpus(): never {
  * Creates a fresh **Knowledge Base** agent scoped to `knowledge_search` + the
  * eval corpus root, waits for it to be dispatchable.
  *
- * The template is the measurement, not a detail: it is what carries the
- * cite-then-answer instructions the graders enforce. See `sweep-agent.ts` for
- * why a bare `custom` agent made the first sweep unreadable (#869 item 4).
+ * The template is the measurement, not a detail: it is what brings in the
+ * cite-then-answer instructions the graders enforce — today through the
+ * `knowledge-search` skill it declares, which agent creation copies onto the
+ * agent row. See `sweep-agent.ts` for why a bare `custom` agent made the first
+ * sweep unreadable (#869 item 4).
  */
 async function setupKbSweepAgent(cookie: string): Promise<{ agentId: string }> {
   const createRes = await pinchyPost(

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -34,8 +34,12 @@
 //      diagnostics export) — see that file's own "NEEDS VALIDATION" note.
 //   4. `createOllamaCloudChatFn`'s judge wiring (llm-nli.ts) — needs a real
 //      key + confirming the pinned judge model id is available.
-//   5. `fetchChunkTexts`'s raw SQL against `kb_chunks` for the groundedness
-//      premise material.
+//   5. (NO LONGER UNVALIDATED) `fetchChunkTexts`'s raw SQL against `kb_chunks`
+//      for the groundedness premise material now lives in `chunk-texts.ts` and
+//      is covered by `kb-eval-chunk-texts.integration.test.ts` against a real
+//      Postgres. It was broken the whole time this note called it unvalidated
+//      (#869): `sql.array(...)` on the right side of `ANY` throws, so the
+//      premise material never loaded.
 import { test } from "@playwright/test";
 import { randomUUID } from "node:crypto";
 
@@ -83,6 +87,7 @@ import {
 } from "../../src/lib/eval/kb/llm-nli";
 import { DEFAULT_ORG_ID } from "../../src/lib/knowledge/constants";
 import { fetchChunkTexts } from "./chunk-texts";
+import { KB_SWEEP_TEMPLATE_ID } from "./sweep-agent";
 import { KB_EVAL_CORPUS } from "./corpus/manifest";
 import { GOLD_QA } from "./corpus/gold-qa";
 import { loadEmbeddings } from "./embeddings-fixture";
@@ -200,11 +205,18 @@ function seedNoackCorpus(): never {
   );
 }
 
-/** Creates a fresh custom agent scoped to `knowledge_search` + the eval corpus root, waits for it to be dispatchable. */
+/**
+ * Creates a fresh **Knowledge Base** agent scoped to `knowledge_search` + the
+ * eval corpus root, waits for it to be dispatchable.
+ *
+ * The template is the measurement, not a detail: it is what carries the
+ * cite-then-answer instructions the graders enforce. See `sweep-agent.ts` for
+ * why a bare `custom` agent made the first sweep unreadable (#869 item 4).
+ */
 async function setupKbSweepAgent(cookie: string): Promise<{ agentId: string }> {
   const createRes = await pinchyPost(
     "/api/agents",
-    { name: `KB-Sweep-${Date.now()}`, templateId: "custom" },
+    { name: `KB-Sweep-${Date.now()}`, templateId: KB_SWEEP_TEMPLATE_ID },
     cookie
   );
   if (!createRes.ok)

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -82,6 +82,7 @@ import {
   createOllamaCloudChatFn,
 } from "../../src/lib/eval/kb/llm-nli";
 import { DEFAULT_ORG_ID } from "../../src/lib/knowledge/constants";
+import { fetchChunkTexts } from "./chunk-texts";
 import { KB_EVAL_CORPUS } from "./corpus/manifest";
 import { GOLD_QA } from "./corpus/gold-qa";
 import { loadEmbeddings } from "./embeddings-fixture";
@@ -197,40 +198,6 @@ function seedNoackCorpus(): never {
       "from inside the stack (it binds to @/db) with a live embedder, not this external Playwright " +
       "process. Use --corpus=synthetic (default) for the harness's own committed corpus."
   );
-}
-
-/**
- * Fetches every chunk's `chunk_text` for the given `sourcePaths`, keyed by
- * path — the groundedness premise material for whichever sources the
- * answer's Sources list actually cited (`citedSourcePaths`, not the full
- * retrieved set — see that function's doc comment for why). A direct SELECT
- * against the already-seeded corpus, not a re-run of `retrieve()`: we
- * already know exactly which paths were retrieved (from the audit row), so
- * this needs no new search/embedding call, only the stored text.
- */
-async function fetchChunkTexts(
-  dbUrl: string,
-  sourcePaths: string[]
-): Promise<Map<string, string[]>> {
-  const map = new Map<string, string[]>();
-  if (sourcePaths.length === 0) return map;
-
-  const { default: postgres } = await import("postgres");
-  const sql = postgres(dbUrl);
-  try {
-    const rows = await sql<{ source_path: string; chunk_text: string }[]>`
-      SELECT source_path, chunk_text FROM kb_chunks
-      WHERE org_id = ${DEFAULT_ORG_ID} AND source_path = ANY(${sql.array(sourcePaths)})
-    `;
-    for (const row of rows) {
-      const texts = map.get(row.source_path) ?? [];
-      texts.push(row.chunk_text);
-      map.set(row.source_path, texts);
-    }
-    return map;
-  } finally {
-    await sql.end();
-  }
 }
 
 /** Creates a fresh custom agent scoped to `knowledge_search` + the eval corpus root, waits for it to be dispatchable. */
@@ -428,7 +395,7 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
 
         const retrieved = retrievedSourcesFromAuditEntries(auditEntries);
         const citedPaths = citedSourcePaths(answer);
-        const chunkTextsByPath = await fetchChunkTexts(dbUrl, citedPaths);
+        const chunkTextsByPath = await fetchChunkTexts(dbUrl, DEFAULT_ORG_ID, citedPaths);
         const citedPassageTexts = citedPaths.flatMap((p) => chunkTextsByPath.get(p) ?? []);
 
         const trajectory: KbRunTrajectory = {

--- a/packages/web/eval/kb/sweep-agent.ts
+++ b/packages/web/eval/kb/sweep-agent.ts
@@ -19,10 +19,13 @@
  * and `citation-unresolved` for exactly that reason — a setup artifact wearing
  * the costume of a quality signal.
  *
- * The graders encode the KB template's contract clause for clause, so the
- * agent under test has to be the one that carries it. Keeping the two pinned
- * together is what the accompanying test is for: if the template's
- * instructions lose the contract, the sweep stops measuring what it claims to
- * and the test says so.
+ * The graders encode the cited-answer contract clause for clause, so the agent
+ * under test has to be the one that carries it. Since the skill-layer
+ * migration (#543/#544) that contract is delivered by the `knowledge-search`
+ * SKILL.md the template declares, not by its `defaultAgentsMd` — which is why
+ * the accompanying test reads the union of both rather than one file. Keeping
+ * them pinned together is what that test is for: if the contract disappears
+ * from everything the agent is told, the sweep stops measuring what it claims
+ * to and the test says so.
  */
 export const KB_SWEEP_TEMPLATE_ID = "knowledge-base";

--- a/packages/web/eval/kb/sweep-agent.ts
+++ b/packages/web/eval/kb/sweep-agent.ts
@@ -1,0 +1,28 @@
+/**
+ * Which agent the Layer-3 sweep measures.
+ *
+ * A constant in its own module, not a literal in the spec, so the methodology
+ * invariant it carries can be asserted by a unit test that does not need
+ * Playwright, a stack, or an API key — see
+ * `src/__tests__/lib/eval/kb-sweep-template.test.ts`.
+ */
+
+/**
+ * The sweep measures the shipped **Knowledge Base** template, instructions and
+ * all — not a bare `custom` agent (#869 item 4).
+ *
+ * `custom` has `defaultAgentsMd: null`: no cite-then-answer rule, no Sources
+ * list, no closed-set constraint. Grading its answers against the cited-answer
+ * contract measured whether a model invents that contract unprompted, which is
+ * not a groundedness property and not something any Pinchy user is exposed to.
+ * The first sweep read `passRate 0` for capable models on `ungrounded-claim`
+ * and `citation-unresolved` for exactly that reason — a setup artifact wearing
+ * the costume of a quality signal.
+ *
+ * The graders encode the KB template's contract clause for clause, so the
+ * agent under test has to be the one that carries it. Keeping the two pinned
+ * together is what the accompanying test is for: if the template's
+ * instructions lose the contract, the sweep stops measuring what it claims to
+ * and the test says so.
+ */
+export const KB_SWEEP_TEMPLATE_ID = "knowledge-base";

--- a/packages/web/src/__tests__/lib/eval/kb-sweep-template.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-sweep-template.test.ts
@@ -15,33 +15,67 @@
  * template tomorrow and the sweep would go on reporting groundedness numbers
  * for an agent that was never told to cite. So the assertions below read the
  * rendered instructions and check the clauses the graders actually enforce.
+ *
+ * "The rendered instructions" means everything the agent is actually told, not
+ * one file. The skill-layer migration (#543/#544) moved the retrieval and
+ * citation workflow out of `defaultAgentsMd` and into the `knowledge-search`
+ * SKILL.md, leaving the template with persona only — a move that changes where
+ * the contract lives and not whether it holds. A guard reading only AGENTS.md
+ * went red on all of it, which is the right alarm for the wrong reason: it
+ * cannot tell "the contract moved" from "the contract is gone". So it reads the
+ * union of AGENTS.md and every body in `defaultSkills`, and stays red only when
+ * a clause is in neither.
+ *
+ * What this file does NOT assert is the hand-off: that creating an agent from
+ * the template actually copies `defaultSkills` onto the agent row, and that the
+ * build materializes those SKILL.md files. Both are pinned one level down, in
+ * `__tests__/api/agents-create.test.ts` — a second copy here would only decay
+ * out of step with the first.
  */
 
 import { describe, expect, it } from "vitest";
 
 import { getTemplate } from "@/lib/agent-templates/registry";
 import { generateAgentsMd } from "@/lib/agent-templates/generate-agents-md";
+import { getSkillBody, isKnownSkill } from "@/lib/skills";
 
 import { KB_SWEEP_TEMPLATE_ID } from "../../../../eval/kb/sweep-agent";
 
 const CORPUS_ROOT = "/data/kb-eval-corpus";
 const PLUGIN_CONFIG = { "pinchy-files": { allowed_paths: [CORPUS_ROOT] } };
 
+/**
+ * Everything the sweep agent is told: its rendered AGENTS.md plus the body of
+ * every skill its template declares. Joined rather than checked file by file —
+ * the graders do not care which file a clause arrives in, only that the model
+ * read it.
+ */
+function renderedInstructions(templateId: string): string {
+  const template = getTemplate(templateId);
+  expect(template, `template "${templateId}" is not a known template`).toBeDefined();
+
+  const skillBodies = (template!.defaultSkills ?? []).map((id) => {
+    // `throw`, not `expect`: this narrows `string` to `SkillId` for the call
+    // below, where an assertion would leave a cast behind.
+    if (!isKnownSkill(id)) {
+      throw new Error(`template "${templateId}" declares unknown skill "${id}"`);
+    }
+    return getSkillBody(id);
+  });
+
+  return [generateAgentsMd(template!, PLUGIN_CONFIG) ?? "", ...skillBodies].join("\n\n");
+}
+
 function sweepInstructions(): string {
-  const template = getTemplate(KB_SWEEP_TEMPLATE_ID);
+  const instructions = renderedInstructions(KB_SWEEP_TEMPLATE_ID);
   expect(
-    template,
-    `KB_SWEEP_TEMPLATE_ID "${KB_SWEEP_TEMPLATE_ID}" is not a known template`
-  ).toBeDefined();
+    instructions.trim(),
+    `The sweep agent's template has no instructions at all — neither AGENTS.md ` +
+      `nor a skill. Grading its answers against the cited-answer contract ` +
+      `measures nothing about groundedness.`
+  ).not.toBe("");
 
-  const agentsMd = generateAgentsMd(template!, PLUGIN_CONFIG);
-  expect(
-    agentsMd,
-    `The sweep agent's template has no instructions at all. Grading its answers ` +
-      `against the cited-answer contract measures nothing about groundedness.`
-  ).not.toBeNull();
-
-  return agentsMd!;
+  return instructions;
 }
 
 describe("the Layer-3 sweep agent is instructed to do what the graders grade", () => {
@@ -85,7 +119,8 @@ describe("the Layer-3 sweep agent is instructed to do what the graders grade", (
   it("instructs answering only from the returned sources (the premise of ungrounded-claim)", () => {
     const md = sweepInstructions();
 
-    expect(md).toMatch(/only using the numbered sources/i);
+    expect(md).toMatch(/only from the returned passages/i);
+    expect(md).toMatch(/never cite a number that wasn't in the returned list/i);
     expect(md).toMatch(/never fabricate/i);
   });
 
@@ -96,11 +131,14 @@ describe("the Layer-3 sweep agent is instructed to do what the graders grade", (
   it("discriminates: the bare custom template would fail every assertion above", () => {
     // The guard is only worth having if it would have caught the original
     // setup. `custom` is what the sweep used, and it carries no instructions
-    // whatsoever — `generateAgentsMd` returns null rather than a weaker
-    // prompt, so there is nothing for a model to follow.
+    // whatsoever — `generateAgentsMd` returns null rather than a weaker prompt,
+    // and it declares no skill either, so there is nothing for a model to
+    // follow from either source.
     const custom = getTemplate("custom");
 
     expect(custom).toBeDefined();
     expect(generateAgentsMd(custom!, PLUGIN_CONFIG)).toBeNull();
+    expect(custom!.defaultSkills ?? []).toEqual([]);
+    expect(renderedInstructions("custom").trim()).toBe("");
   });
 });

--- a/packages/web/src/__tests__/lib/eval/kb-sweep-template.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-sweep-template.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The Layer-3 sweep's methodology invariant: **the agent under test must be
+ * instructed to do what the graders grade** (#869 item 4).
+ *
+ * The sweep used to create a `templateId: "custom"` agent, whose
+ * `defaultAgentsMd` is `null` — no cite-then-answer rule, no Sources list, no
+ * closed-set constraint. Its answers were then graded against the cited-answer
+ * contract, so capable models scored `passRate 0` on `ungrounded-claim` and
+ * `citation-unresolved`. That is not a groundedness measurement; it measures
+ * whether a model invents an unstated contract, which no Pinchy user depends
+ * on because every KB agent ships with the instructions.
+ *
+ * A test that only asserted `KB_SWEEP_TEMPLATE_ID === "knowledge-base"` would
+ * pin the string and miss the point: the contract could be edited out of the
+ * template tomorrow and the sweep would go on reporting groundedness numbers
+ * for an agent that was never told to cite. So the assertions below read the
+ * rendered instructions and check the clauses the graders actually enforce.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { getTemplate } from "@/lib/agent-templates/registry";
+import { generateAgentsMd } from "@/lib/agent-templates/generate-agents-md";
+
+import { KB_SWEEP_TEMPLATE_ID } from "../../../../eval/kb/sweep-agent";
+
+const CORPUS_ROOT = "/data/kb-eval-corpus";
+const PLUGIN_CONFIG = { "pinchy-files": { allowed_paths: [CORPUS_ROOT] } };
+
+function sweepInstructions(): string {
+  const template = getTemplate(KB_SWEEP_TEMPLATE_ID);
+  expect(
+    template,
+    `KB_SWEEP_TEMPLATE_ID "${KB_SWEEP_TEMPLATE_ID}" is not a known template`
+  ).toBeDefined();
+
+  const agentsMd = generateAgentsMd(template!, PLUGIN_CONFIG);
+  expect(
+    agentsMd,
+    `The sweep agent's template has no instructions at all. Grading its answers ` +
+      `against the cited-answer contract measures nothing about groundedness.`
+  ).not.toBeNull();
+
+  return agentsMd!;
+}
+
+describe("the Layer-3 sweep agent is instructed to do what the graders grade", () => {
+  it("uses a template that exists and carries instructions", () => {
+    expect(sweepInstructions().length).toBeGreaterThan(0);
+  });
+
+  it("grants knowledge_search — the one tool the sweep's audit probe reads", () => {
+    const template = getTemplate(KB_SWEEP_TEMPLATE_ID);
+
+    expect(template?.allowedTools).toContain("knowledge_search");
+  });
+
+  it("instructs inline numbered citations (the premise of citation-unresolved)", () => {
+    const md = sweepInstructions();
+
+    expect(md).toMatch(/cite/i);
+    expect(md).toMatch(/\[1\]/);
+  });
+
+  it("instructs a Sources list (the premise of source-uncited and sources-format)", () => {
+    const md = sweepInstructions();
+
+    expect(md).toMatch(/Sources/);
+    expect(md).toMatch(/bullet/i);
+  });
+
+  it("instructs that inline citations and the Sources list match exactly", () => {
+    const md = sweepInstructions();
+
+    expect(md).toMatch(/no more and no fewer/i);
+  });
+
+  it("instructs the document path and its position per entry (the premise of path-not-cited)", () => {
+    const md = sweepInstructions();
+
+    expect(md).toMatch(/document path/i);
+    expect(md).toMatch(/position/i);
+  });
+
+  it("instructs answering only from the returned sources (the premise of ungrounded-claim)", () => {
+    const md = sweepInstructions();
+
+    expect(md).toMatch(/only using the numbered sources/i);
+    expect(md).toMatch(/never fabricate/i);
+  });
+
+  it("renders the corpus root, so the agent knows where its documents are", () => {
+    expect(sweepInstructions()).toContain(CORPUS_ROOT);
+  });
+
+  it("discriminates: the bare custom template would fail every assertion above", () => {
+    // The guard is only worth having if it would have caught the original
+    // setup. `custom` is what the sweep used, and it carries no instructions
+    // whatsoever — `generateAgentsMd` returns null rather than a weaker
+    // prompt, so there is nothing for a model to follow.
+    const custom = getTemplate("custom");
+
+    expect(custom).toBeDefined();
+    expect(generateAgentsMd(custom!, PLUGIN_CONFIG)).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/kb-eval-chunk-texts.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/kb-eval-chunk-texts.integration.test.ts
@@ -27,7 +27,17 @@ const ORG_ID = "org-kb-eval-chunk-texts";
 const PATH_A = "/data/eval/alpha.pdf";
 const PATH_B = "/data/eval/beta.pdf";
 
-const DB_URL = process.env.DATABASE_URL ?? "";
+// The same URL the integration harness points `db` at (vitest.integration.
+// config.ts sets it). Read it strictly rather than `?? ""`: postgres.js treats
+// an empty connection string as "use libpq defaults", so a missing env var
+// would silently point this test at whatever Postgres the host happens to run
+// — including another worktree's — instead of saying what went wrong.
+const DB_URL = process.env.DATABASE_URL;
+if (!DB_URL) {
+  throw new Error(
+    "DATABASE_URL is unset. This suite must run through vitest.integration.config.ts (pnpm test:db)."
+  );
+}
 
 async function seed(sourcePath: string, texts: string[]) {
   const [doc] = await db

--- a/packages/web/src/__tests__/lib/knowledge/kb-eval-chunk-texts.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/kb-eval-chunk-texts.integration.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Layer-3's groundedness premise lookup, against a real Postgres (#869 item 3).
+ *
+ * This has to be DB-backed, and that is the whole point: the defect it pins is
+ * a *serialization* fault, invisible to any mock. `sql.array(paths)` sends a
+ * parameter Postgres does not accept on the right side of `ANY`, so the query
+ * throws `op ANY/ALL (array) requires array on right side` — every time, for
+ * any non-empty input. Nothing about the TypeScript is wrong, which is why it
+ * survived review and a full unit suite.
+ *
+ * It read as an intermittent bug ("on some runs") for a reason worth keeping in
+ * mind when triaging the next one: `fetchChunkTexts` returns early on an empty
+ * path list, and in that first sweep most answers cited nothing resolvable, so
+ * most runs never reached the query at all. The runs that DID reach it were
+ * exactly the ones with a well-formed Sources list — the answers the sweep
+ * exists to grade. A defect that only fires on the good cases still looks rare.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "@/db";
+import { kbChunks, kbDocuments } from "@/db/schema";
+
+import { fetchChunkTexts } from "../../../../eval/kb/chunk-texts";
+
+const ORG_ID = "org-kb-eval-chunk-texts";
+const PATH_A = "/data/eval/alpha.pdf";
+const PATH_B = "/data/eval/beta.pdf";
+
+const DB_URL = process.env.DATABASE_URL ?? "";
+
+async function seed(sourcePath: string, texts: string[]) {
+  const [doc] = await db
+    .insert(kbDocuments)
+    .values({ orgId: ORG_ID, sourcePath, contentHash: `hash-${sourcePath}`, status: "active" })
+    .returning();
+
+  for (const [i, chunkText] of texts.entries()) {
+    await db.insert(kbChunks).values({
+      documentId: doc.id,
+      orgId: ORG_ID,
+      sourcePath,
+      chunkText,
+      locator: { kind: "page", page: i + 1 },
+    });
+  }
+}
+
+describe("fetchChunkTexts", () => {
+  // Seeding belongs in `beforeEach`, not `beforeAll`: the integration harness
+  // TRUNCATEs every application table between tests (test-helpers/integration/
+  // setup.ts), so a `beforeAll` seed is gone by the time the first test runs.
+  beforeEach(async () => {
+    await seed(PATH_A, ["Alpha first passage.", "Alpha second passage."]);
+    await seed(PATH_B, ["Beta only passage."]);
+  });
+
+  it("returns every chunk text for the cited paths, keyed by path", async () => {
+    const texts = await fetchChunkTexts(DB_URL, ORG_ID, [PATH_A, PATH_B]);
+
+    expect(texts.get(PATH_A)).toEqual(
+      expect.arrayContaining(["Alpha first passage.", "Alpha second passage."])
+    );
+    expect(texts.get(PATH_A)).toHaveLength(2);
+    expect(texts.get(PATH_B)).toEqual(["Beta only passage."]);
+  });
+
+  it("handles a single cited path — the shape a minimal Sources list produces", async () => {
+    const texts = await fetchChunkTexts(DB_URL, ORG_ID, [PATH_B]);
+
+    expect(texts.get(PATH_B)).toEqual(["Beta only passage."]);
+    expect(texts.has(PATH_A)).toBe(false);
+  });
+
+  it("scopes to the org, so another tenant's identical path cannot ground an answer", async () => {
+    const [otherDoc] = await db
+      .insert(kbDocuments)
+      .values({
+        orgId: "org-kb-eval-chunk-texts-other",
+        sourcePath: PATH_A,
+        contentHash: "hash-other",
+        status: "active",
+      })
+      .returning();
+    await db.insert(kbChunks).values({
+      documentId: otherDoc.id,
+      orgId: "org-kb-eval-chunk-texts-other",
+      sourcePath: PATH_A,
+      chunkText: "Another tenant's passage.",
+      locator: { kind: "page", page: 1 },
+    });
+
+    const texts = await fetchChunkTexts(DB_URL, ORG_ID, [PATH_A]);
+
+    expect(texts.get(PATH_A)).not.toContain("Another tenant's passage.");
+    expect(texts.get(PATH_A)).toHaveLength(2);
+  });
+
+  it("returns an empty map without querying when nothing was cited", async () => {
+    const texts = await fetchChunkTexts("postgres://invalid:1/nope", ORG_ID, []);
+
+    expect(texts.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes both open items in #869. Together they are what stands between the sweep and its first trustworthy measurement — one made it fail, the other made it lie.

Both landed on one branch on purpose: split, the second would have to stack on the first, and they are two halves of the same claim ("this sweep measures groundedness").

---

## Item 3 — the premise lookup never returned a row

`fetchChunkTexts` built its filter as `= ANY(${sql.array(sourcePaths)})`. postgres.js already infers `text[]` from a string array; `sql.array` produces a parameter Postgres rejects there:

```
PostgresError: op ANY/ALL (array) requires array on right side
```

Reproduced against a real Postgres before changing anything — both spellings, two elements and one:

```
❌ sql.array(paths)  [current]        op ANY/ALL (array) requires array on right side
✅ direct interpolation               2 rows
❌ sql.array, single element          op ANY/ALL (array) requires array on right side
✅ direct, single element             1 row
```

**It is not intermittent — the observation was.** #869 records it firing "on some runs", which points triage at a data-dependent trigger. There isn't one. The function returns early on an empty path list, and most answers in that first sweep cited nothing resolvable, so most runs never reached the SQL. The runs that did were the ones whose Sources list parsed cleanly: the answers the sweep exists to grade. They were filed as `run-infra-error` and dropped from the scorecard.

Worth carrying into the next triage: **an early return in front of a broken statement turns "always" into "sometimes."**

The query moves to `eval/kb/chunk-texts.ts` so a DB-backed test can reach it — deliberately not into `kb-eval-shared.ts`, which imports `@playwright/test`; dragging Playwright into the vitest integration lane to test one SQL statement is a bigger dependency than the thing under test. It takes `orgId` as a parameter instead of closing over `DEFAULT_ORG_ID`, which is what lets the test assert org scoping with a tenant of its own.

`kb-eval-chunk-texts.integration.test.ts` covers multi-path lookup, the single-path shape a minimal Sources list produces, org scoping (another tenant's identical path must not ground an answer), and the empty-input early return. It has to be an integration test: this is a serialization fault between driver and database, and **no mock can see it**. Nothing about the TypeScript was wrong, which is how it survived review and a full unit suite.

## Item 4 — the sweep graded a contract nobody had stated

The sweep created its agent with `templateId: "custom"`. That template's `defaultAgentsMd` is **`null`** — no cite-then-answer rule, no Sources list, no closed-set constraint — and then the run was graded against precisely that contract. kimi-k2.6 and qwen3.5:397b scored `passRate 0`, dominated by `ungrounded-claim` and `citation-unresolved`.

That measures whether a model invents an unstated contract. No Pinchy user depends on it, because every KB agent ships with the instructions. The sweep now creates a **`knowledge-base`** agent, so it measures what we ship.

**The guard is the interesting half.** Asserting `KB_SWEEP_TEMPLATE_ID === "knowledge-base"` would pin a string and miss the point: the contract could be edited out of the template tomorrow and the sweep would keep publishing groundedness numbers for an agent that was never told to cite. So the test renders the template's AGENTS.md and checks the clauses the graders enforce — one assertion per grader premise:

| Assertion | Grader premise |
|---|---|
| inline `[N]` citations | `citation-unresolved` |
| a Sources list, rendered as bullets | `source-uncited`, `sources-format` |
| inline ↔ list match "no more and no fewer" | both directions |
| document path + position per entry | `path-not-cited` |
| answer only from the returned sources | `ungrounded-claim` |
| the corpus root is rendered | the agent can find its documents |

Verified red before green: with the constant still on `"custom"`, **8 of 9 fail**. The 9th is the discrimination test, which asserts `custom` renders no instructions at all — the property that made the original setup silently wrong.

---

## Gates

- `format:check`, `lint` (0 errors), `typecheck` — green
- Full unit suite: **738 files, 10 422 tests** green
- `src/__tests__/lib/knowledge/` integration folder against a real pgvector Postgres: **6 files, 70 tests** green, including the Layer-1 retrieval gate

## Also corrected

The spec's file header still listed `fetchChunkTexts` under "NEEDS VALIDATION AGAINST THE RUNNING STACK". It is validated now — and it had been broken for the entire time that note stood, which is the argument for validating rather than noting.

## Noted, not changed

`setupKbSweepAgent` still uses the non-recovering `waitForAgentDispatchable`, while `kb-eval-shared.ts` next door uses `ensureAgentDispatchable`. Same class as #901. Out of scope here; worth a look when the sweep starts running regularly.

## What this does not claim

The sweep still has not produced a scorecard. This makes it *able* to — the premise material loads and the agent is instructed to do what is graded. The first real run comes next, and per the operational note in #869, `eval/kb/results/` must be cleared first so pre-fix `run-infra-error` rows do not mix into it.