### PR TITLE
fix(openclaw-config): keep per-agent config dirs owned by Pinchy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,46 +757,54 @@ jobs:
           # dies with `Unknown model: …` — what the user sees is the agent going
           # silent (setup-wizard E2E, CI run 30554860337).
           #
-          # This probes the real thing rather than a mode: write a file, as the
-          # pinchy user, in the directory it actually has to write. Polls because
-          # the repair is a 50 ms tick and OpenClaw may be mid-restart.
-          PROBE='
-            found=0
-            for d in /openclaw-config/agents/*/; do
-              [ -d "$d" ] || continue
-              found=1
-              mkdir -p "$d/agent" || exit 1
-              touch "$d/agent/.pinchy-write-probe" || exit 1
-              rm -f "$d/agent/.pinchy-write-probe"
-            done
-            [ "$found" = 1 ]
-          '
-          LAST_ERROR="no agent directories present"
+          # This reproduces the condition rather than waiting for it. Observing
+          # the live directories is not a check: the smoke wizard configures no
+          # provider, so Pinchy writes no auth-profiles.json and OpenClaw has no
+          # catalog to derive — the first version of this step found nothing to
+          # probe on every run and warned instead of verifying. So create exactly
+          # what OpenClaw creates (root-owned, mode 0700) and assert the tick
+          # hands it back.
+          # Use the REAL Smithers id, never an invented one: OpenClaw's
+          # listGatewayAgentIds unions the on-disk agents/ directory names into
+          # agents.list, so a made-up probe id would surface as a phantom agent
+          # in the runtime we are smoke-testing.
+          AGENT_ID=$(docker compose exec -T db psql -U pinchy -d pinchy -tAc \
+            'SELECT id FROM agents ORDER BY created_at LIMIT 1' | tr -d '\r\n')
+          if [ -z "$AGENT_ID" ]; then
+            echo "::error::no agent row found — the setup wizard step above should have created Smithers"
+            exit 1
+          fi
+
+          docker compose exec -T openclaw sh -c "
+            rm -rf /root/.openclaw/agents/$AGENT_ID/agent
+            mkdir -p -m 700 /root/.openclaw/agents/$AGENT_ID/agent
+            chown -R root:root /root/.openclaw/agents/$AGENT_ID/agent
+          "
+          # Sanity-check the fixture itself: a directory that starts out
+          # writable would pass no matter what the tick does.
+          OWNER=$(docker compose exec -T openclaw stat -c '%u' "/root/.openclaw/agents/$AGENT_ID/agent" | tr -d '\r\n')
+          if [ "$OWNER" != "0" ]; then
+            echo "::error::probe fixture is not root-owned (uid $OWNER) — this step would pass vacuously"
+            exit 1
+          fi
+
+          # 20 s: the repair is a 50 ms tick, so this only has to ride out a
+          # gateway restart that has the loop paused.
+          OK=0
           for i in $(seq 1 20); do
-            if OUT=$(docker compose exec -T --user pinchy pinchy sh -c "$PROBE" 2>&1); then
-              echo "Per-agent directories are writable by Pinchy (attempt $i)"
-              exit 0
-            fi
-            # Distinguish "denied" from "nothing to check yet": only the former
-            # is a failure. A denied write keeps failing, so polling rides out a
-            # slow boot or a mid-flight restart without turning it into a red.
-            if docker compose exec -T --user pinchy pinchy sh -c 'ls -d /openclaw-config/agents/*/ >/dev/null 2>&1'; then
-              LAST_ERROR="$OUT"
+            if OUT=$(docker compose exec -T --user pinchy pinchy sh -c \
+              "touch /openclaw-config/agents/$AGENT_ID/agent/.write-probe && rm -f /openclaw-config/agents/$AGENT_ID/agent/.write-probe" 2>&1); then
+              echo "Pinchy can write a root-created agent directory (attempt $i)"
+              OK=1
+              break
             fi
             sleep 1
           done
-          if [ "$LAST_ERROR" = "no agent directories present" ]; then
-            # The wizard above creates Smithers but configures no provider, so
-            # Pinchy writes no auth-profiles.json and OpenClaw may not derive a
-            # models.json either — leaving nothing on disk to probe. Say so out
-            # loud instead of reporting a pass we didn't earn; the setup-wizard
-            # E2E exercises the same invariant with a provider configured.
-            echo "::warning::no /openclaw-config/agents/<id>/ directory appeared within 20s — per-agent write access was NOT verified"
-            exit 0
+          if [ "$OK" != 1 ]; then
+            echo "::error::Pinchy (uid 999) cannot write /openclaw-config/agents/<id>/agent — auth-profiles.json writes will fail with EACCES: $OUT"
+            docker compose exec -T openclaw sh -c 'ls -lan /root/.openclaw/agents; ls -lan /root/.openclaw/agents/*/' || true
           fi
-          echo "::error::Pinchy (uid 999) cannot write /openclaw-config/agents/<id>/agent — auth-profiles.json writes will fail with EACCES: $LAST_ERROR"
-          docker compose exec -T openclaw sh -c 'ls -lan /root/.openclaw/agents; ls -lan /root/.openclaw/agents/*/' || true
-          exit 1
+          [ "$OK" = 1 ]
 
       - name: Verify clean startup (production)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,6 +745,59 @@ jobs:
           docker compose exec -T openclaw ls -la /root/.openclaw/openclaw.json
           exit 1
 
+      - name: Verify Pinchy can write per-agent auth-profiles (#934)
+        run: |
+          # agents/<id>/agent is shared: Pinchy (uid 999) writes auth-profiles.json
+          # there, OpenClaw (root) derives models.json in the same directory —
+          # creating it at mode 0700 and re-asserting that mode on every write.
+          # Root ignores mode bits, so the ONLY thing keeping Pinchy able to write
+          # is OWNERSHIP, repaired by start-openclaw.sh's fix_config_permissions
+          # tick. Without that repair the next provider save fails with EACCES,
+          # regenerateOpenClawConfig never pushes openclaw.json, and every dispatch
+          # dies with `Unknown model: …` — what the user sees is the agent going
+          # silent (setup-wizard E2E, CI run 30554860337).
+          #
+          # This probes the real thing rather than a mode: write a file, as the
+          # pinchy user, in the directory it actually has to write. Polls because
+          # the repair is a 50 ms tick and OpenClaw may be mid-restart.
+          PROBE='
+            found=0
+            for d in /openclaw-config/agents/*/; do
+              [ -d "$d" ] || continue
+              found=1
+              mkdir -p "$d/agent" || exit 1
+              touch "$d/agent/.pinchy-write-probe" || exit 1
+              rm -f "$d/agent/.pinchy-write-probe"
+            done
+            [ "$found" = 1 ]
+          '
+          LAST_ERROR="no agent directories present"
+          for i in $(seq 1 20); do
+            if OUT=$(docker compose exec -T --user pinchy pinchy sh -c "$PROBE" 2>&1); then
+              echo "Per-agent directories are writable by Pinchy (attempt $i)"
+              exit 0
+            fi
+            # Distinguish "denied" from "nothing to check yet": only the former
+            # is a failure. A denied write keeps failing, so polling rides out a
+            # slow boot or a mid-flight restart without turning it into a red.
+            if docker compose exec -T --user pinchy pinchy sh -c 'ls -d /openclaw-config/agents/*/ >/dev/null 2>&1'; then
+              LAST_ERROR="$OUT"
+            fi
+            sleep 1
+          done
+          if [ "$LAST_ERROR" = "no agent directories present" ]; then
+            # The wizard above creates Smithers but configures no provider, so
+            # Pinchy writes no auth-profiles.json and OpenClaw may not derive a
+            # models.json either — leaving nothing on disk to probe. Say so out
+            # loud instead of reporting a pass we didn't earn; the setup-wizard
+            # E2E exercises the same invariant with a provider configured.
+            echo "::warning::no /openclaw-config/agents/<id>/ directory appeared within 20s — per-agent write access was NOT verified"
+            exit 0
+          fi
+          echo "::error::Pinchy (uid 999) cannot write /openclaw-config/agents/<id>/agent — auth-profiles.json writes will fail with EACCES: $LAST_ERROR"
+          docker compose exec -T openclaw sh -c 'ls -lan /root/.openclaw/agents; ls -lan /root/.openclaw/agents/*/' || true
+          exit 1
+
       - name: Verify clean startup (production)
         run: |
           LOGS=$(docker compose logs 2>&1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -775,18 +775,21 @@ jobs:
             exit 1
           fi
 
-          docker compose exec -T openclaw sh -c "
-            rm -rf /root/.openclaw/agents/$AGENT_ID/agent
-            mkdir -p -m 700 /root/.openclaw/agents/$AGENT_ID/agent
-            chown -R root:root /root/.openclaw/agents/$AGENT_ID/agent
-          "
-          # Sanity-check the fixture itself: a directory that starts out
-          # writable would pass no matter what the tick does.
-          OWNER=$(docker compose exec -T openclaw stat -c '%u' "/root/.openclaw/agents/$AGENT_ID/agent" | tr -d '\r\n')
-          if [ "$OWNER" != "0" ]; then
-            echo "::error::probe fixture is not root-owned (uid $OWNER) — this step would pass vacuously"
-            exit 1
-          fi
+          # The fixture is root-owned BY CONSTRUCTION: root runs chmod 700 and an
+          # explicit chown, both under `set -e`, so a fixture that didn't take
+          # fails the exec. A post-hoc `stat` from a second exec cannot be the
+          # guard — the repair is a 50 ms tick and a docker exec round-trip is
+          # slower, so it reports uid 999 and fails on the fix working (first run
+          # of this step did exactly that). The uid is logged for diagnostics;
+          # either value is expected, and the write below is the assertion.
+          OWNER=$(docker compose exec -T openclaw sh -c "
+            set -e
+            mkdir -p /root/.openclaw/agents/$AGENT_ID/agent
+            chmod 700 /root/.openclaw/agents/$AGENT_ID/agent
+            chown root:root /root/.openclaw/agents/$AGENT_ID/agent
+            stat -c '%u' /root/.openclaw/agents/$AGENT_ID/agent
+          " | tr -d '\r\n')
+          echo "fixture created root-owned 0700; uid observed right after chown: $OWNER (999 = the tick already won)"
 
           # 20 s: the repair is a 50 ms tick, so this only has to ride out a
           # gateway restart that has the loop paused.

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -232,11 +232,17 @@ COPY config/install-plugin-deps.sh /install-plugin-deps.sh
 # the staging contract is unit-testable — see
 # packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts.
 COPY config/stage-llama-cpp-provider.sh /stage-llama-cpp-provider.sh
+# Cross-uid permission repair for the shared openclaw-config volume, sourced by
+# start-openclaw.sh and re-run on a 50 ms tick. Kept as a separate script (same
+# pattern as install-plugin-deps.sh) so the per-agent directory-ownership
+# invariant that keeps Pinchy able to write auth-profiles.json is unit-testable —
+# see packages/web/src/__tests__/lib/fix-config-permissions.test.ts.
+COPY config/fix-config-permissions.sh /fix-config-permissions.sh
 # Device-pairing auto-approver invoked per tick by start-openclaw.sh. Kept as a
 # separate Node module so its requestId-churn convergence is unit-testable
 # (config/__tests__/auto-approve-once.test.mjs) instead of embedded bash.
 COPY config/auto-approve-once.mjs /auto-approve-once.mjs
-RUN chmod +x /start-openclaw.sh /install-plugin-deps.sh /stage-llama-cpp-provider.sh
+RUN chmod +x /start-openclaw.sh /install-plugin-deps.sh /stage-llama-cpp-provider.sh /fix-config-permissions.sh
 
 # Bake Pinchy's user-facing docs into the image so Smithers' docs_list /
 # docs_read tools (pinchy-docs plugin) work in every deploy. Previously

--- a/config/fix-config-permissions.sh
+++ b/config/fix-config-permissions.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Cross-uid permission repair for the shared `openclaw-config` volume, extracted
+# from start-openclaw.sh (same pattern as install-plugin-deps.sh and
+# stage-llama-cpp-provider.sh) so its invariants are unit-testable — see
+# packages/web/src/__tests__/lib/fix-config-permissions.test.ts.
+#
+# Two containers share this volume: OpenClaw mounts it at /root/.openclaw and
+# runs as root, Pinchy mounts it at /openclaw-config and runs as uid 999. Only
+# root can chown, so this script — running in the OpenClaw container — is the
+# only place in the stack that can repair cross-uid state. start-openclaw.sh
+# calls it on every gateway start AND on a 50 ms background tick, because
+# OpenClaw rewrites these paths on every internal reload.
+#
+# Paths and the target uid are env-overridable so the unit test can drive the
+# real function against temp dirs; production uses the defaults.
+
+OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-/root/.openclaw}"
+SECRETS_FILE="${SECRETS_FILE:-${OPENCLAW_SECRETS_PATH:-/openclaw-secrets/secrets.json}}"
+# The pinchy user inside the Pinchy container (Dockerfile.pinchy: useradd -u 999).
+PINCHY_UID="${PINCHY_UID:-999}"
+PINCHY_GID="${PINCHY_GID:-999}"
+
+fix_config_permissions() {
+    chmod 666 "$OPENCLAW_STATE_DIR/openclaw.json" 2>/dev/null || true
+    # Use a glob so we also catch any sibling credential files OpenClaw
+    # writes alongside the pairing file (allowFrom stores etc.) — they too
+    # are written by root and consumed by Pinchy.
+    # a+rX: r for all files, x only for directories (capital X) so uid 999
+    # can both enter the credentials/ dir (exec bit) and read files inside it.
+    chmod -R a+rX "$OPENCLAW_STATE_DIR/credentials" 2>/dev/null || true
+    # Re-take ownership of secrets.json. Pinchy writes it as uid 999 (the
+    # pinchy user inside its container); OpenClaw's secret-resolver requires
+    # owner == process uid (root) and refuses to reload otherwise. The 30 s
+    # mtime watch loop in start-openclaw.sh further chowns it after a write,
+    # but the [reload] pipeline triggered by inotify on openclaw.json fires
+    # within ~100 ms of Pinchy's regenerateOpenClawConfig() — long before that
+    # loop wakes up. Without this fast tick, a freshly created agent surfaces
+    # as `unknown agent id` because the reload fails on secrets and the new
+    # agents.list never enters runtime. See issue #200.
+    if [ -f "$SECRETS_FILE" ]; then
+        chown root:root "$SECRETS_FILE" 2>/dev/null || true
+        chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
+    fi
+
+    # Per-agent auth-profiles.json files are written by Pinchy (uid 999) into
+    # agents/<id>/agent/. OpenClaw (root) reads uid-999-owned files fine, so the
+    # files themselves only need tightening — but the DIRECTORIES have to be
+    # pinchy-OWNED, and that is the whole of issue #934.
+    #
+    # The trap: agents/<id>/agent is not exclusively Pinchy's. OpenClaw derives
+    # each agent's models.json there, creating the directory with
+    # `mkdir(…, { mode: 0o700 })` and then re-asserting 0700 on every subsequent
+    # write (its `enforcePrivatePathMode` chmods and verifies). So whoever gets
+    # there first sets the owner:
+    #
+    #   Pinchy first → 999-owned, and OpenClaw's 0700 reads as "pinchy rwx".
+    #                  Both sides keep working; root ignores mode bits anyway.
+    #   OpenClaw first → root-owned 0700, and Pinchy is locked out FOREVER.
+    #                  writeAgentAuthProfiles() gets EACCES, which aborts
+    #                  regenerateOpenClawConfig() before it pushes openclaw.json,
+    #                  so OpenClaw never learns the provider and every dispatch
+    #                  dies with `Unknown model: <provider>/<model>`. What the
+    #                  user sees is that Smithers stopped answering.
+    #
+    # This used to chown only the agents/ root, on the reasoning that Pinchy
+    # creates the subdirectories itself — true only when Pinchy wins the race.
+    # Repairing the MODE cannot substitute: OpenClaw undoes it on the next
+    # models.json write, and root-owned 0755 still denies uid 999 the write.
+    # Ownership is the only durable lever.
+    #
+    # `! -uid` gates the chown so an already-correct directory is left alone:
+    # chown rewrites ctime, and OpenClaw's session-takeover detector reads a
+    # ctime change as external modification (same reason the `-not -perm` gates
+    # below exist). At a 50 ms tick an ungated chown would be ~20 ctime bumps a
+    # second, per agent, forever.
+    #
+    # -maxdepth 1 covers the agents/ root (so new agent dirs can be created) and
+    # agents/<id>; the second find covers exactly agents/<id>/agent.
+    find "$OPENCLAW_STATE_DIR/agents" -maxdepth 1 -type d ! -uid "$PINCHY_UID" \
+        -exec chown "$PINCHY_UID:$PINCHY_GID" {} \; 2>/dev/null || true
+    find "$OPENCLAW_STATE_DIR/agents" -mindepth 2 -maxdepth 2 -type d -name agent ! -uid "$PINCHY_UID" \
+        -exec chown "$PINCHY_UID:$PINCHY_GID" {} \; 2>/dev/null || true
+    find "$OPENCLAW_STATE_DIR/agents" -name "auth-profiles.json" -type f -not -perm 0600 \
+        -exec chmod 0600 {} \; 2>/dev/null || true
+
+    # Cross-uid read access for Pinchy's self-service diagnostics export.
+    # OpenClaw writes per-agent sessions.json and *.trajectory.jsonl as root
+    # under agents/<agentId>/sessions/ — with default umask these emerge
+    # 0644/0755, but OpenClaw 2026.5.x ships with a tighter umask that
+    # produces 0600/0700, so Pinchy (uid 999) gets EACCES on the dir traversal.
+    # Diagnostics is read-only against these files; 0755/0644 is sufficient.
+    # The 50 ms tick catches runtime-created sessions (same pattern as the
+    # openclaw.json mode race).
+    #
+    # `-not -perm` gates: skip files that already have the right mode. chmod
+    # would otherwise rewrite the inode's ctime on every tick, and OpenClaw's
+    # embedded-prompt session-takeover detector treats any ctime change as
+    # "session file modified externally" and aborts the in-flight turn with
+    # EmbeddedAttemptSessionTakeoverError. Without the gate, every chat turn
+    # races our 50 ms loop against the assistant's response.
+    find "$OPENCLAW_STATE_DIR/agents" -mindepth 1 -maxdepth 1 -type d -not -perm 0755 -exec chmod 0755 {} \; 2>/dev/null || true
+    find "$OPENCLAW_STATE_DIR/agents" -type d -name sessions -not -perm 0755 -exec chmod 0755 {} \; 2>/dev/null || true
+    find "$OPENCLAW_STATE_DIR/agents" \( -name "sessions.json" -o -name "*.trajectory.jsonl" \) -type f -not -perm 0644 -exec chmod 0644 {} \; 2>/dev/null || true
+}

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -86,57 +86,18 @@ fi
 # OpenClaw creates openclaw.json with 600 (root-only). Pinchy needs write access
 # to update provider keys and agent configuration via regenerateOpenClawConfig().
 #
-# Also fix the telegram-pairing.json file: OpenClaw 2026.4.12 writes it as
-# root:0600, but Pinchy (uid 999) needs to read it to look up Telegram user
-# IDs from pairing codes. Without this chmod, every linkTelegram POST returns
-# "Invalid or expired pairing code" because readFileSync throws EACCES inside
-# resolvePairingCode and the bare catch returns { found: false } silently.
-fix_config_permissions() {
-    chmod 666 /root/.openclaw/openclaw.json 2>/dev/null || true
-    # Use a glob so we also catch any sibling credential files OpenClaw
-    # writes alongside the pairing file (allowFrom stores etc.) — they too
-    # are written by root and consumed by Pinchy.
-    # a+rX: r for all files, x only for directories (capital X) so uid 999
-    # can both enter the credentials/ dir (exec bit) and read files inside it.
-    chmod -R a+rX /root/.openclaw/credentials 2>/dev/null || true
-    # Re-take ownership of secrets.json. Pinchy writes it as uid 999 (the
-    # pinchy user inside its container); OpenClaw's secret-resolver requires
-    # owner == process uid (root) and refuses to reload otherwise. The 30 s
-    # mtime watch loop further down chowns it after a write, but the [reload]
-    # pipeline triggered by inotify on openclaw.json fires within ~100 ms of
-    # Pinchy's regenerateOpenClawConfig() — long before that loop wakes up.
-    # Without this fast tick, a freshly created agent surfaces as
-    # `unknown agent id` because the reload fails on secrets and the new
-    # agents.list never enters runtime. See issue #200.
-    if [ -f "$SECRETS_FILE" ]; then
-        chown root:root "$SECRETS_FILE" 2>/dev/null || true
-        chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
-    fi
-    # Per-agent auth-profiles.json files written by Pinchy (uid 999).
-    # OpenClaw (root) can read uid-999-owned files directly — no chown needed.
-    # The agents/ directory must stay writable by Pinchy (uid 999) so new
-    # agent subdirectories can be created. Only secure the files themselves.
-    chown 999:999 /root/.openclaw/agents 2>/dev/null || true
-    find /root/.openclaw/agents -name "auth-profiles.json" -type f -exec chmod 0600 {} \; 2>/dev/null || true
-    # Cross-uid read access for Pinchy's self-service diagnostics export.
-    # OpenClaw writes per-agent sessions.json and *.trajectory.jsonl as root
-    # under agents/<agentId>/sessions/ — with default umask these emerge
-    # 0644/0755, but OpenClaw 2026.5.x ships with a tighter umask that
-    # produces 0600/0700, so Pinchy (uid 999) gets EACCES on the dir traversal.
-    # Diagnostics is read-only against these files; 0755/0644 is sufficient.
-    # The 50 ms fix_config_permissions tick catches runtime-created sessions
-    # (same pattern as the openclaw.json mode race).
-    #
-    # `-not -perm` gates: skip files that already have the right mode. chmod
-    # would otherwise rewrite the inode's ctime on every tick, and OpenClaw's
-    # embedded-prompt session-takeover detector treats any ctime change as
-    # "session file modified externally" and aborts the in-flight turn with
-    # EmbeddedAttemptSessionTakeoverError. Without the gate, every chat turn
-    # races our 50 ms loop against the assistant's response.
-    find /root/.openclaw/agents -mindepth 1 -maxdepth 1 -type d -not -perm 0755 -exec chmod 0755 {} \; 2>/dev/null || true
-    find /root/.openclaw/agents -type d -name sessions -not -perm 0755 -exec chmod 0755 {} \; 2>/dev/null || true
-    find /root/.openclaw/agents \( -name "sessions.json" -o -name "*.trajectory.jsonl" \) -type f -not -perm 0644 -exec chmod 0644 {} \; 2>/dev/null || true
-}
+# Also fixes the telegram-pairing.json file (OpenClaw 2026.4.12 writes it as
+# root:0600, but Pinchy needs to read it to look up Telegram user IDs from
+# pairing codes) and the per-agent directory OWNERSHIP that lets Pinchy write
+# agents/<id>/agent/auth-profiles.json at all (#934).
+#
+# Extracted to config/fix-config-permissions.sh (same pattern as
+# install-plugin-deps.sh / stage-llama-cpp-provider.sh) so each of those
+# cross-uid invariants is unit-testable — see
+# packages/web/src/__tests__/lib/fix-config-permissions.test.ts. Defines
+# fix_config_permissions() into this shell; it reads $SECRETS_FILE from above.
+# shellcheck source=fix-config-permissions.sh
+source /fix-config-permissions.sh
 fix_config_permissions
 
 # Scan /data/ for available directories and write to shared config

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -254,6 +254,12 @@ A shared agent's `MEMORY.md` — what it learned in one-to-one conversations —
 
 Inbound channel media (Telegram photos, documents) is now copied into the agent workspace on arrival, and the runtime's internal media cache is swept after 48 hours instead of growing forever. Attachments received **before** this upgrade were never copied, so ones older than 48 hours are removed by the first sweep and may no longer open from old conversations. Export anything you still need from pre-upgrade chats before upgrading.
 
+#### A provider key that can't reach the runtime now says so
+
+Pinchy and the agent runtime share one config volume under two different users, and each agent has a directory in it that both of them write to. If the runtime got there first, the directory came out owned by the wrong user and Pinchy could no longer store that agent's credentials — which stopped the whole config from reaching the runtime. The agent then simply stopped answering, with the real reason only in `docker compose logs pinchy`.
+
+The runtime now hands that directory back on every tick, so the case should not arise. If it ever does, saving a provider key tells you plainly that it saved but couldn't be applied, and the affected agent says it has no API key instead of going quiet. Nothing to do on upgrade.
+
 #### Workspace terminals stay disabled
 
 The OpenClaw runtime this release ships (2026.7.1) adds an interactive terminal into agent workspaces. Pinchy pins it off: a shell would bypass agent permission allow-lists and the audit trail. It will return as an RBAC-scoped, audited feature.

--- a/packages/web/src/__tests__/lib/fix-config-permissions.test.ts
+++ b/packages/web/src/__tests__/lib/fix-config-permissions.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, delimiter } from "node:path";
+
+// config/fix-config-permissions.sh is start-openclaw.sh's 50 ms permission tick,
+// extracted into a sourceable helper (same pattern as install-plugin-deps.sh and
+// stage-llama-cpp-provider.sh) so its invariants are unit-testable. The tick is
+// the only place in the stack that can repair cross-uid state on the shared
+// `openclaw-config` volume: OpenClaw runs as root, Pinchy as uid 999, and only
+// root can chown.
+//
+// THE INVARIANT THIS FILE EXISTS FOR (#934):
+//
+//   /openclaw-config/agents/<id>/agent must be OWNED by the pinchy uid.
+//
+// Not "must have mode X" — ownership, specifically. OpenClaw's per-agent
+// models.json writer creates that directory with `mkdir(…, { mode: 0o700 })` and
+// then re-asserts 0700 on EVERY write (`enforcePrivatePathMode` chmods and
+// verifies). Root is exempt from mode bits, so a mode-only repair is both
+// pointless (OpenClaw immediately undoes it) and insufficient (0755 root-owned
+// still denies uid 999 the write). Ownership is the only durable lever: once the
+// directory is pinchy-owned, OpenClaw's 0700 reads as "pinchy rwx" and root
+// keeps writing regardless.
+//
+// When OpenClaw wins the race to create that directory, Pinchy's
+// writeAgentAuthProfiles() gets EACCES forever — which aborts
+// regenerateOpenClawConfig() before it pushes openclaw.json, so OpenClaw never
+// learns the provider and every dispatch fails `Unknown model: openai/…`. The
+// user-visible symptom is "Smithers doesn't answer" (setup-wizard E2E, CI run
+// 30554860337).
+//
+// `chown` is stubbed on PATH: a non-root test process cannot chown to uid 999,
+// and the syscall itself is the kernel's business. Everything else runs for
+// real — the real bash function, real `find` traversal, real gates, real chmod —
+// so the assertions below are about what the script actually decides to do, not
+// about a re-implementation of it.
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const SCRIPT = resolve(REPO_ROOT, "config/fix-config-permissions.sh");
+
+// A uid the temp fixtures are guaranteed NOT to be owned by, so the "skip what
+// is already correct" gate doesn't swallow the assertions.
+const PINCHY_UID = "999";
+const PINCHY_GID = "999";
+
+let root: string;
+let stateDir: string;
+let secretsFile: string;
+let binDir: string;
+let chownLog: string;
+
+/** Record every `chown` invocation instead of performing it. */
+function stubChown(): void {
+  const bin = join(binDir, "chown");
+  writeFileSync(bin, `#!/bin/bash\necho "$@" >> '${chownLog}'\nexit 0\n`);
+  chmodSync(bin, 0o755);
+}
+
+function runFix(): void {
+  execFileSync("bash", ["-c", `source '${SCRIPT}'; fix_config_permissions`], {
+    env: {
+      ...process.env,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+      OPENCLAW_STATE_DIR: stateDir,
+      SECRETS_FILE: secretsFile,
+      PINCHY_UID,
+      PINCHY_GID,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+/** Paths passed to `chown <owner> <path>`, in invocation order. */
+function chownedPaths(): string[] {
+  if (!existsSync(chownLog)) return [];
+  return readFileSync(chownLog, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split(" ").slice(1).join(" "));
+}
+
+/** Create an agent directory tree the way OpenClaw does: mode 0700 throughout. */
+function seedAgentDir(agentId: string): { agentIdDir: string; agentDir: string } {
+  const agentIdDir = join(stateDir, "agents", agentId);
+  const agentDir = join(agentIdDir, "agent");
+  mkdirSync(agentDir, { recursive: true });
+  chmodSync(agentIdDir, 0o700);
+  chmodSync(agentDir, 0o700);
+  return { agentIdDir, agentDir };
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "fix-config-perms-"));
+  stateDir = join(root, "openclaw");
+  binDir = join(root, "bin");
+  chownLog = join(root, "chown.log");
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(join(stateDir, "agents"), { recursive: true });
+  secretsFile = join(root, "secrets", "secrets.json");
+  mkdirSync(join(root, "secrets"), { recursive: true });
+  writeFileSync(join(stateDir, "openclaw.json"), "{}\n");
+  stubChown();
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("fix_config_permissions — per-agent directory ownership (#934)", () => {
+  it("chowns agents/<id>/agent to the pinchy uid so Pinchy can write auth-profiles.json", () => {
+    const { agentDir } = seedAgentDir("f18382bd-c4b3-4826-a3da-89046629f310");
+
+    runFix();
+
+    // The regression: repairing only the mode leaves the directory root-owned,
+    // and root-owned 0700 (which OpenClaw re-asserts on every models.json write)
+    // is exactly what denies uid 999 the write.
+    expect(chownedPaths()).toContain(agentDir);
+  });
+
+  it("chowns agents/<id> so Pinchy can create the agent/ subdirectory itself", () => {
+    const { agentIdDir } = seedAgentDir("agent-a");
+
+    runFix();
+
+    expect(chownedPaths()).toContain(agentIdDir);
+  });
+
+  it("covers every agent, not just the first one found", () => {
+    const a = seedAgentDir("agent-a");
+    const b = seedAgentDir("agent-b");
+
+    runFix();
+
+    const chowned = chownedPaths();
+    expect(chowned).toContain(a.agentDir);
+    expect(chowned).toContain(b.agentDir);
+  });
+
+  it("keeps chowning the agents/ root itself (new agent dirs must be creatable)", () => {
+    runFix();
+
+    expect(chownedPaths()).toContain(join(stateDir, "agents"));
+  });
+
+  it("skips directories already owned by the pinchy uid", () => {
+    // chown rewrites ctime, and start-openclaw.sh's own comments record that
+    // OpenClaw's session-takeover detector treats a ctime change as external
+    // modification. At a 50 ms tick an ungated chown is ~20 ctime bumps/second
+    // per agent directory, forever.
+    seedAgentDir("agent-a");
+
+    execFileSync("bash", ["-c", `source '${SCRIPT}'; fix_config_permissions`], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+        OPENCLAW_STATE_DIR: stateDir,
+        SECRETS_FILE: secretsFile,
+        // Everything under the temp root is already owned by the test process.
+        PINCHY_UID: String(process.getuid?.() ?? 0),
+        PINCHY_GID: String(process.getgid?.() ?? 0),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+
+    expect(chownedPaths()).toEqual([]);
+  });
+
+  it("tolerates a missing agents/ directory (pre-first-agent boot)", () => {
+    rmSync(join(stateDir, "agents"), { recursive: true, force: true });
+
+    expect(() => runFix()).not.toThrow();
+  });
+});
+
+describe("fix_config_permissions — behaviour carried over from start-openclaw.sh", () => {
+  it("makes openclaw.json writable by Pinchy (mode 666)", () => {
+    chmodSync(join(stateDir, "openclaw.json"), 0o600);
+
+    runFix();
+
+    expect(statSync(join(stateDir, "openclaw.json")).mode & 0o777).toBe(0o666);
+  });
+
+  it("tightens auth-profiles.json to 0600", () => {
+    const { agentDir } = seedAgentDir("agent-a");
+    const file = join(agentDir, "auth-profiles.json");
+    writeFileSync(file, "{}\n");
+    chmodSync(file, 0o644);
+
+    runFix();
+
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("opens agents/<id> to 0755 so Pinchy can traverse it", () => {
+    const { agentIdDir } = seedAgentDir("agent-a");
+
+    runFix();
+
+    expect(statSync(agentIdDir).mode & 0o777).toBe(0o755);
+  });
+
+  it("opens sessions/ and its session files for Pinchy's diagnostics export", () => {
+    const sessionsDir = join(stateDir, "agents", "agent-a", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    chmodSync(sessionsDir, 0o700);
+    const sessions = join(sessionsDir, "sessions.json");
+    const trajectory = join(sessionsDir, "run-1.trajectory.jsonl");
+    writeFileSync(sessions, "{}\n");
+    writeFileSync(trajectory, "\n");
+    chmodSync(sessions, 0o600);
+    chmodSync(trajectory, 0o600);
+
+    runFix();
+
+    expect(statSync(sessionsDir).mode & 0o777).toBe(0o755);
+    expect(statSync(sessions).mode & 0o777).toBe(0o644);
+    expect(statSync(trajectory).mode & 0o777).toBe(0o644);
+  });
+
+  it("re-takes ownership of the secrets file when it exists", () => {
+    writeFileSync(secretsFile, "{}\n");
+
+    runFix();
+
+    expect(chownedPaths()).toContain(secretsFile);
+    expect(statSync(secretsFile).mode & 0o777).toBe(0o600);
+  });
+
+  it("skips the secrets file when it does not exist", () => {
+    runFix();
+
+    expect(chownedPaths()).not.toContain(secretsFile);
+  });
+});
+
+describe("fix_config_permissions — wiring", () => {
+  // An extracted script that never reaches the container repairs nothing, and
+  // the tests above would stay green the whole time.
+  it("is sourced by start-openclaw.sh", () => {
+    const startScript = readFileSync(resolve(REPO_ROOT, "config/start-openclaw.sh"), "utf8");
+    expect(startScript).toContain("source /fix-config-permissions.sh");
+    expect(startScript).toContain("fix_config_permissions");
+  });
+
+  it("is copied into the OpenClaw image", () => {
+    const dockerfile = readFileSync(resolve(REPO_ROOT, "Dockerfile.openclaw"), "utf8");
+    expect(dockerfile).toContain(
+      "COPY config/fix-config-permissions.sh /fix-config-permissions.sh"
+    );
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -3544,6 +3544,95 @@ describe("regenerateOpenClawConfig", () => {
     expect(Object.keys(betaContent.profiles)).not.toContain("anthropic-default");
   });
 
+  // #934: a single agent's auth-profiles write is not allowed to decide whether
+  // OpenClaw ever hears about the config at all.
+  //
+  // agents/<id>/agent is shared with OpenClaw, which creates it root-owned 0700
+  // when it derives that agent's models.json. When it wins that race, Pinchy
+  // (uid 999) gets a permanent EACCES — and because the per-agent loop ran
+  // BEFORE `pushConfigInBackground`, the throw took the whole push with it. The
+  // provider the user had just saved never reached OpenClaw, so every dispatch
+  // for EVERY agent died with `Unknown model: openai/gpt-5.5`. What the user saw
+  // was Smithers going silent, with the real cause only in the container log.
+  //
+  // The same escalation disabled the recovery path: maybeSelfHealOnModelError
+  // re-resolves the model by calling regenerateOpenClawConfig, which threw on
+  // the identical EACCES before pushing anything.
+  describe("a per-agent auth-profiles failure does not sink the config push (#934)", () => {
+    // The denied agent comes FIRST so "the other agent still got its profiles"
+    // is a real assertion rather than an artefact of iteration order.
+    const agentsData = [
+      {
+        id: "agent-denied",
+        name: "Jeeves",
+        model: "openai/gpt-5.4",
+        allowedTools: [],
+        pluginConfig: null,
+        createdAt: new Date(),
+      },
+      {
+        id: "agent-ok",
+        name: "Smithers",
+        model: "anthropic/claude-sonnet-4-6",
+        allowedTools: [],
+        pluginConfig: null,
+        createdAt: new Date(),
+      },
+    ];
+
+    beforeEach(() => {
+      mockedDb.select.mockReturnValue({ from: mockFrom(agentsData) } as never);
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "anthropic_api_key") return "sk-ant-test";
+        if (key === "openai_api_key") return "sk-openai-test";
+        return null;
+      });
+      // Deny exactly one agent's directory, the way a root-owned 0700
+      // agents/<id>/agent does. Every other write behaves normally.
+      mockedWriteFileSync.mockImplementation((target) => {
+        if (String(target).includes("agents/agent-denied/agent/auth-profiles.json")) {
+          const err = new Error(
+            `EACCES: permission denied, open '${String(target)}.tmp-100'`
+          ) as NodeJS.ErrnoException;
+          err.code = "EACCES";
+          throw err;
+        }
+      });
+    });
+
+    it("still writes openclaw.json so OpenClaw learns the provider and the model", async () => {
+      await regenerateOpenClawConfig().catch(() => {});
+      await drainBackgroundCoroutine();
+
+      const written = findOpenClawConfigWrite(mockedWriteFileSync);
+      expect(written).toBeDefined();
+      const config = JSON.parse(String(written![1]));
+      expect(config.models.providers.openai).toBeDefined();
+    });
+
+    it("still writes the auth profiles of every other agent", async () => {
+      await regenerateOpenClawConfig().catch(() => {});
+
+      const okCall = mockedWriteFileSync.mock.calls.find((call) =>
+        String(call[0]).includes("agents/agent-ok/agent/auth-profiles.json")
+      );
+      expect(okCall).toBeDefined();
+    });
+
+    it("still reports the failure to the caller, naming the agent and what did land", async () => {
+      // Silence is the other half of the bug: the wizard turns this rejection
+      // into a warning toast and records runtimeApplied:false in the audit
+      // trail. Swallowing it would trade a loud failure for a silent one.
+      //
+      // But the message has to say what actually happened now — the raw EACCES
+      // reads as "the regenerate failed", which is no longer true: the config
+      // did reach OpenClaw, one agent just has no auth profile.
+      await expect(regenerateOpenClawConfig()).rejects.toThrow(/agent-denied/);
+      await expect(regenerateOpenClawConfig()).rejects.toThrow(/auth-profiles/);
+      await expect(regenerateOpenClawConfig()).rejects.toThrow(/rest of the config was applied/i);
+    });
+  });
+
   it("does not write auth-profiles.json for ollama-local agents (URL-based, no API key)", async () => {
     const agentsData = [
       {

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -3,24 +3,46 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as path from "path";
 import * as os from "os";
 
-// Hoist the real renameSync before mocking so we can use it as the default implementation.
-const { realRenameSync } = vi.hoisted(() => {
+// Hoist the real implementations before mocking so we can use them as defaults.
+const { realRenameSync, realWriteFileSync, realMkdirSync } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const realFs = require("fs") as typeof import("fs");
-  return { realRenameSync: realFs.renameSync.bind(realFs) };
+  return {
+    realRenameSync: realFs.renameSync.bind(realFs),
+    realWriteFileSync: realFs.writeFileSync.bind(realFs),
+    realMkdirSync: realFs.mkdirSync.bind(realFs),
+  };
 });
 
-// Mock fs so renameSync can be intercepted per-test. All other methods call
+// Mock fs so the write path can be intercepted per-test. All other methods call
 // through to the real implementation so tmpDir creation and assertions work.
 vi.mock("fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs")>();
   const renameSyncMock = vi.fn(realRenameSync);
+  const writeFileSyncMock = vi.fn(realWriteFileSync);
+  const mkdirSyncMock = vi.fn(realMkdirSync);
   return {
     ...actual,
-    default: { ...actual, renameSync: renameSyncMock },
+    default: {
+      ...actual,
+      renameSync: renameSyncMock,
+      writeFileSync: writeFileSyncMock,
+      mkdirSync: mkdirSyncMock,
+    },
     renameSync: renameSyncMock,
+    writeFileSync: writeFileSyncMock,
+    mkdirSync: mkdirSyncMock,
   };
 });
+
+/** Build the exact error Node raises when the target directory denies uid 999. */
+function eaccesError(): NodeJS.ErrnoException {
+  const err = new Error("EACCES: permission denied, open 'auth-profiles.json.tmp-100'");
+  (err as NodeJS.ErrnoException).code = "EACCES";
+  (err as NodeJS.ErrnoException).errno = -13;
+  (err as NodeJS.ErrnoException).syscall = "open";
+  return err;
+}
 
 import * as fs from "fs";
 import {
@@ -34,11 +56,15 @@ describe("writeAgentAuthProfiles", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-auth-test-"));
     vi.mocked(fs.renameSync).mockImplementation(realRenameSync);
+    vi.mocked(fs.writeFileSync).mockImplementation(realWriteFileSync);
+    vi.mocked(fs.mkdirSync).mockImplementation(realMkdirSync);
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
     vi.mocked(fs.renameSync).mockReset();
+    vi.mocked(fs.writeFileSync).mockReset();
+    vi.mocked(fs.mkdirSync).mockReset();
   });
 
   it("writes auth-profiles.json with one profile per configured provider", async () => {
@@ -127,5 +153,64 @@ describe("writeAgentAuthProfiles", () => {
     await expect(
       writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "no-file-agent", providers: [] })
     ).resolves.toBeUndefined();
+  });
+
+  // #934: agents/<id>/agent is shared with OpenClaw, which creates it root-owned
+  // at mode 0700 when it derives that agent's models.json. start-openclaw.sh's
+  // 50 ms tick chowns it back to uid 999, but a write landing INSIDE that window
+  // still gets EACCES. Same shape (and same budget) as readExistingConfig's
+  // 5 × 100 ms retry, which is what the 50 ms tick was tuned against.
+  describe("EACCES retry — rides out the permission-repair tick", () => {
+    it("retries a denied write and succeeds once the tick lands", async () => {
+      vi.mocked(fs.writeFileSync)
+        .mockImplementationOnce(() => {
+          throw eaccesError();
+        })
+        .mockImplementationOnce(() => {
+          throw eaccesError();
+        });
+
+      await writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: ["openai"] });
+
+      const target = path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json");
+      expect(fs.existsSync(target)).toBe(true);
+      expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(3);
+    });
+
+    it("retries a denied mkdir too — agents/<id> can be root-owned as well", async () => {
+      vi.mocked(fs.mkdirSync).mockImplementationOnce(() => {
+        throw eaccesError();
+      });
+
+      await writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: ["openai"] });
+
+      expect(fs.existsSync(path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json"))).toBe(
+        true
+      );
+    });
+
+    it("gives up after a bounded budget and rethrows, rather than hanging the regenerate", async () => {
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {
+        throw eaccesError();
+      });
+
+      await expect(
+        writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: ["openai"] })
+      ).rejects.toThrow(/EACCES/);
+      expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(5);
+    });
+
+    it("does not retry an error the tick cannot fix", async () => {
+      const enospc = new Error("ENOSPC: no space left on device");
+      (enospc as NodeJS.ErrnoException).code = "ENOSPC";
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {
+        throw enospc;
+      });
+
+      await expect(
+        writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: ["openai"] })
+      ).rejects.toThrow(/ENOSPC/);
+      expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(1);
+    });
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -4,13 +4,14 @@ import * as path from "path";
 import * as os from "os";
 
 // Hoist the real implementations before mocking so we can use them as defaults.
-const { realRenameSync, realWriteFileSync, realMkdirSync } = vi.hoisted(() => {
+const { realRenameSync, realWriteFileSync, realMkdirSync, realUnlinkSync } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const realFs = require("fs") as typeof import("fs");
   return {
     realRenameSync: realFs.renameSync.bind(realFs),
     realWriteFileSync: realFs.writeFileSync.bind(realFs),
     realMkdirSync: realFs.mkdirSync.bind(realFs),
+    realUnlinkSync: realFs.unlinkSync.bind(realFs),
   };
 });
 
@@ -21,6 +22,7 @@ vi.mock("fs", async (importOriginal) => {
   const renameSyncMock = vi.fn(realRenameSync);
   const writeFileSyncMock = vi.fn(realWriteFileSync);
   const mkdirSyncMock = vi.fn(realMkdirSync);
+  const unlinkSyncMock = vi.fn(realUnlinkSync);
   return {
     ...actual,
     default: {
@@ -28,10 +30,12 @@ vi.mock("fs", async (importOriginal) => {
       renameSync: renameSyncMock,
       writeFileSync: writeFileSyncMock,
       mkdirSync: mkdirSyncMock,
+      unlinkSync: unlinkSyncMock,
     },
     renameSync: renameSyncMock,
     writeFileSync: writeFileSyncMock,
     mkdirSync: mkdirSyncMock,
+    unlinkSync: unlinkSyncMock,
   };
 });
 
@@ -58,6 +62,7 @@ describe("writeAgentAuthProfiles", () => {
     vi.mocked(fs.renameSync).mockImplementation(realRenameSync);
     vi.mocked(fs.writeFileSync).mockImplementation(realWriteFileSync);
     vi.mocked(fs.mkdirSync).mockImplementation(realMkdirSync);
+    vi.mocked(fs.unlinkSync).mockImplementation(realUnlinkSync);
   });
 
   afterEach(() => {
@@ -65,6 +70,7 @@ describe("writeAgentAuthProfiles", () => {
     vi.mocked(fs.renameSync).mockReset();
     vi.mocked(fs.writeFileSync).mockReset();
     vi.mocked(fs.mkdirSync).mockReset();
+    vi.mocked(fs.unlinkSync).mockReset();
   });
 
   it("writes auth-profiles.json with one profile per configured provider", async () => {
@@ -198,6 +204,62 @@ describe("writeAgentAuthProfiles", () => {
         writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: ["openai"] })
       ).rejects.toThrow(/EACCES/);
       expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(5);
+    });
+
+    // The empty-provider path is not a side case — it is the state EVERY agent
+    // is in before a provider is configured, which is exactly when #934 strikes
+    // (Smithers exists before the wizard's provider step). And `unlink` inside a
+    // root-owned 0700 directory returns EACCES, not ENOENT. A bare catch here
+    // therefore reports the broken directory as a clean removal: nothing lands
+    // in `authProfileFailures`, no warning toast, no `runtimeApplied: false` —
+    // the permission problem stays invisible until a provider is saved, which is
+    // the very silence the rest of this fix exists to remove.
+    it("retries a denied removal and succeeds once the tick lands", async () => {
+      const agentDir = path.join(tmpDir, "agents", "a", "agent");
+      fs.mkdirSync(agentDir, { recursive: true });
+      const filePath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(filePath, "{}\n");
+
+      vi.mocked(fs.unlinkSync)
+        .mockImplementationOnce(() => {
+          throw eaccesError();
+        })
+        .mockImplementationOnce(() => {
+          throw eaccesError();
+        });
+
+      await writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: [] });
+
+      expect(fs.existsSync(filePath)).toBe(false);
+      expect(vi.mocked(fs.unlinkSync).mock.calls.length).toBe(3);
+    });
+
+    it("surfaces a persistently denied removal instead of reporting a clean agent", async () => {
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+        throw eaccesError();
+      });
+
+      await expect(
+        writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: [] })
+      ).rejects.toThrow(/EACCES/);
+      expect(vi.mocked(fs.unlinkSync).mock.calls.length).toBe(5);
+    });
+
+    it("surfaces a removal failure the tick cannot fix either", async () => {
+      // ENOENT is the one code that means "nothing to remove" — everything else
+      // is a real problem. The blanket catch swallowed all of them equally.
+      // (`empty providers — no-op when auth-profiles.json does not exist` above
+      // pins the ENOENT half of the same classification.)
+      const eisdir = new Error("EISDIR: illegal operation on a directory, unlink");
+      (eisdir as NodeJS.ErrnoException).code = "EISDIR";
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+        throw eisdir;
+      });
+
+      await expect(
+        writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: [] })
+      ).rejects.toThrow(/EISDIR/);
+      expect(vi.mocked(fs.unlinkSync).mock.calls.length).toBe(1);
     });
 
     it("does not retry an error the tick cannot fix", async () => {

--- a/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
+++ b/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
@@ -26,12 +26,12 @@ export type WriteAgentAuthProfilesParams = {
  * EACCES, and that EACCES used to take the whole config regenerate down with it
  * (#934).
  *
- * 5 × 100 ms is the same budget `readExistingConfig` uses against the same
- * tick — deliberately, since the tick's 50 ms cadence was chosen to fit inside
- * it. If the retries are exhausted, the directory is not merely mid-repair: it
- * is genuinely not ours, and the caller has to hear about it.
+ * 5 attempts × 100 ms is the same budget `readExistingConfig` uses against the
+ * same tick — deliberately, since the tick's 50 ms cadence was chosen to fit
+ * inside it. If the attempts are exhausted, the directory is not merely
+ * mid-repair: it is genuinely not ours, and the caller has to hear about it.
  */
-const EACCES_RETRIES = 5;
+const EACCES_ATTEMPTS = 5;
 const EACCES_RETRY_DELAY_MS = 100;
 
 function isPermissionError(err: unknown): boolean {
@@ -44,7 +44,7 @@ async function withPermissionRetry<T>(fn: () => T): Promise<T> {
     try {
       return fn();
     } catch (err) {
-      if (attempt >= EACCES_RETRIES || !isPermissionError(err)) throw err;
+      if (attempt >= EACCES_ATTEMPTS || !isPermissionError(err)) throw err;
       await new Promise((resolve) => setTimeout(resolve, EACCES_RETRY_DELAY_MS));
     }
   }
@@ -56,10 +56,21 @@ export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParam
 
   if (params.providers.length === 0) {
     // No profiles → remove the file so OpenClaw doesn't enter strict auth mode.
+    //
+    // Only ENOENT means "nothing to remove". A blanket catch here used to also
+    // swallow the EACCES this whole file exists to surface — and that is the
+    // common case, not an edge one: unlink inside a root-owned 0700 directory
+    // returns EACCES, and an empty provider list is the state EVERY agent is in
+    // before a provider is configured (Smithers is created before the wizard's
+    // provider step, which is precisely when OpenClaw wins the race for
+    // agents/<id>/agent). So the very moment the directory broke, the agent was
+    // reported as clean: nothing reached `authProfileFailures`, no warning
+    // toast, no `runtimeApplied: false` — invisible until someone saved a
+    // provider key.
     try {
-      fs.unlinkSync(target);
-    } catch {
-      // File doesn't exist — that's fine.
+      await withPermissionRetry(() => fs.unlinkSync(target));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException | null)?.code !== "ENOENT") throw err;
     }
     return;
   }

--- a/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
+++ b/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
@@ -17,6 +17,39 @@ export type WriteAgentAuthProfilesParams = {
   providers: AuthProfilesProvider[];
 };
 
+/**
+ * `agents/<id>/agent` is NOT exclusively ours. OpenClaw derives each agent's
+ * models.json in the same directory and, when it gets there first, creates it
+ * root-owned at mode 0700 — locking Pinchy (uid 999) out of the auth-profiles
+ * write. start-openclaw.sh's `fix_config_permissions` tick chowns it back to
+ * uid 999 within ~50 ms, but a write landing inside that window still gets
+ * EACCES, and that EACCES used to take the whole config regenerate down with it
+ * (#934).
+ *
+ * 5 × 100 ms is the same budget `readExistingConfig` uses against the same
+ * tick — deliberately, since the tick's 50 ms cadence was chosen to fit inside
+ * it. If the retries are exhausted, the directory is not merely mid-repair: it
+ * is genuinely not ours, and the caller has to hear about it.
+ */
+const EACCES_RETRIES = 5;
+const EACCES_RETRY_DELAY_MS = 100;
+
+function isPermissionError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  return code === "EACCES" || code === "EPERM";
+}
+
+async function withPermissionRetry<T>(fn: () => T): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return fn();
+    } catch (err) {
+      if (attempt >= EACCES_RETRIES || !isPermissionError(err)) throw err;
+      await new Promise((resolve) => setTimeout(resolve, EACCES_RETRY_DELAY_MS));
+    }
+  }
+}
+
 export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParams): Promise<void> {
   const dir = path.join(params.configRoot, "agents", params.agentId, "agent");
   const target = path.join(dir, "auth-profiles.json");
@@ -31,7 +64,7 @@ export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParam
     return;
   }
 
-  fs.mkdirSync(dir, { recursive: true });
+  await withPermissionRetry(() => fs.mkdirSync(dir, { recursive: true }));
 
   const profiles: Record<string, unknown> = {};
   for (const provider of params.providers) {
@@ -43,6 +76,8 @@ export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParam
   }
 
   const tmp = `${target}.tmp-${process.pid}`;
-  fs.writeFileSync(tmp, JSON.stringify({ profiles }, null, 2) + "\n", { mode: 0o600 });
+  await withPermissionRetry(() =>
+    fs.writeFileSync(tmp, JSON.stringify({ profiles }, null, 2) + "\n", { mode: 0o600 })
+  );
   fs.renameSync(tmp, target);
 }

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1806,7 +1806,19 @@ export async function regenerateOpenClawConfig() {
       .filter((p): p is AuthProfilesProvider => p !== undefined)
   );
 
+  // Per-agent failures are collected rather than thrown, because this loop sits
+  // in front of the config push and a throw here used to cancel it (#934).
+  // agents/<id>/agent is shared with OpenClaw, which creates it root-owned 0700
+  // when it derives that agent's models.json; when it wins that race, Pinchy
+  // (uid 999) gets EACCES on the auth-profiles write. Letting that abort the
+  // whole regenerate turned one agent's permission problem into "OpenClaw never
+  // heard about the provider at all" — so EVERY agent then failed with
+  // `Unknown model: <provider>/<model>`, and `maybeSelfHealOnModelError`, whose
+  // whole job is to re-resolve exactly that, died on the same EACCES before it
+  // could push anything. The blast radius is now one agent's credentials, and
+  // the recovery path no longer runs through the broken write.
   const configRoot = dirname(CONFIG_PATH);
+  const authProfileFailures: { agentId: string; error: unknown }[] = [];
   for (const agent of liveAgents) {
     const modelPrefix = agent.model?.split("/")[0] ?? "";
     const agentProfileProvider = MODEL_PREFIX_TO_AUTH_PROFILE[modelPrefix];
@@ -1814,11 +1826,15 @@ export async function regenerateOpenClawConfig() {
       agentProfileProvider && configuredAuthProviders.has(agentProfileProvider)
         ? [agentProfileProvider]
         : [];
-    await writeAgentAuthProfiles({
-      configRoot,
-      agentId: agent.id,
-      providers: agentProviders,
-    });
+    try {
+      await writeAgentAuthProfiles({
+        configRoot,
+        agentId: agent.id,
+        providers: agentProviders,
+      });
+    } catch (err) {
+      authProfileFailures.push({ agentId: agent.id, error: err });
+    }
   }
 
   // Push config to OpenClaw. When a WS client is available, config.apply
@@ -1830,4 +1846,28 @@ export async function regenerateOpenClawConfig() {
   // can take 10–30 s when a gateway restart is needed, which broke
   // interactive save flows (Odoo "Save & Restart", UI waits for 200 OK).
   pushConfigInBackground(newContent);
+
+  // Report AFTER the push, never instead of it. The caller has to hear about
+  // this — the setup wizard turns the rejection into a warning toast and records
+  // `runtimeApplied: false` in the audit trail, which is the only reason this
+  // failure is visible outside the container logs at all. But the message must
+  // describe what actually happened: the config DID reach OpenClaw, these agents
+  // just have no credentials, so they answer "No API key found" rather than
+  // going silent.
+  if (authProfileFailures.length > 0) {
+    for (const failure of authProfileFailures) {
+      console.error(
+        `[openclaw-config] auth-profiles.json write failed for agent ${failure.agentId}:`,
+        failure.error
+      );
+    }
+    const agentIds = authProfileFailures.map((f) => f.agentId).join(", ");
+    throw new Error(
+      `[openclaw-config] Could not write auth-profiles.json for ${authProfileFailures.length} ` +
+        `agent(s) (${agentIds}); the rest of the config was applied. Those agents have no ` +
+        `credentials until this is repaired — check that ${configRoot}/agents/<id>/agent is ` +
+        `owned by the pinchy uid (start-openclaw.sh's fix_config_permissions tick).`,
+      { cause: authProfileFailures[0].error }
+    );
+  }
 }


### PR DESCRIPTION
Fixes the intermittent `Setup Wizard E2E Tests` failure (CI run [30554860337](https://github.com/heypinchy/pinchy/actions/runs/30554860337/job/90914055557)). Real bug, not runner infra.

## Root cause

`agents/<id>/agent` on the shared `openclaw-config` volume is written by **both** containers: Pinchy (uid 999) writes `auth-profiles.json` there, OpenClaw (root) derives that agent's `models.json` in the same directory.

OpenClaw creates it with `fs.mkdir(agentDir, { recursive: true, mode: 0o700 })` and then **re-asserts** 0700 on every subsequent write — `enforcePrivatePathMode` chmods and verifies, throwing if the mode isn't exactly 0700. So whoever gets there first sets the owner:

| first writer | result |
| --- | --- |
| Pinchy | 999-owned; OpenClaw's 0700 reads as "pinchy rwx". Both sides work — root ignores mode bits. |
| OpenClaw | root-owned 0700. **Pinchy is locked out permanently.** |

`start-openclaw.sh` only ever chowned the `agents/` parent, one level too shallow, on the reasoning that Pinchy creates the subdirectories itself — true only when Pinchy wins the race. And no mode repair can substitute: OpenClaw undoes it on the next `models.json` write, and root-owned 0755 still denies uid 999 the write. **Ownership is the only durable lever.**

In the wizard flow OpenClaw usually wins, because Smithers is created *before* a provider exists — `writeAgentAuthProfiles` returns early on an empty provider list without creating anything, leaving the directory to OpenClaw's config apply.

## Why it turned into "Smithers doesn't answer"

The per-agent loop in `build.ts` sat **in front of** `pushConfigInBackground`, so the EACCES aborted the whole regenerate:

```
EACCES on auth-profiles.json
  -> regenerateOpenClawConfig throws before pushing
  -> openclaw.json never gets models.providers.openai
  -> FailoverError: Unknown model: openai/gpt-5.5
  -> agent errorCode=UNAVAILABLE, no assistant message
  -> the 160 s visibility assertion times out
```

One agent's permission problem decided whether OpenClaw heard about the config **at all**. And `maybeSelfHealOnModelError`, whose entire job is to re-resolve exactly that model, called the same `regenerateOpenClawConfig` and died on the same EACCES before it could push anything — the recovery path ran through the thing that was broken.

## Changes

1. **`config/fix-config-permissions.sh`** (new) — the 50 ms tick now chowns `agents/<id>` **and** `agents/<id>/agent` to the pinchy uid, gated on `! -uid` so an already-correct directory keeps its ctime (OpenClaw's session-takeover detector reads a ctime change as external modification — the same reason the existing `-not -perm` gates exist). Extracted from `start-openclaw.sh` following the `install-plugin-deps.sh` / `stage-llama-cpp-provider.sh` pattern so the invariant is unit-testable.

2. **`writeAgentAuthProfiles` retries a denied write** for 5 attempts × 100 ms — the same budget `readExistingConfig` uses against the same tick, whose 50 ms cadence was chosen to fit inside it. This closes the residual window between OpenClaw creating the directory and the tick repairing it. Only `EACCES`/`EPERM`; anything else fails on the first try.

   The same applies to the **empty-provider path**, which removes any stale file. It used to do that under a bare `catch {}` — swallowing EACCES along with ENOENT. That is where the bug is *born*, not an edge of it: `unlink` in a root-owned 0700 directory returns EACCES, and an empty provider list is the state every agent is in before a provider is configured, because Smithers exists before the wizard's provider step. So at the exact moment the directory broke, the agent was reported clean and none of the loudness below applied. Now only ENOENT means "nothing to remove".

3. **`regenerateOpenClawConfig` isolates per-agent failures** — collects them, pushes the config anyway, then throws an aggregate naming the agents. The blast radius is now one agent's credentials instead of the entire runtime config, and the self-heal completes its actual job before reporting. The failure is still **loud**: the wizard turns the rejection into a warning toast and records `runtimeApplied: false` in the audit trail, and the error message says the config *was* applied so an operator isn't misled into thinking nothing landed.

## On the guard, honestly

The invariant is cross-container ownership on a shared volume, so the load-bearing guard cannot be a pure vitest assertion:

- **Unit (12 tests)** — runs the **real** bash function against temp dirs with real `find` traversal, real gates and real chmod. Only `chown` is stubbed on `PATH` and recorded: a non-root test process cannot chown to uid 999, and the syscall itself is the kernel's business. Plus 2 wiring assertions, because an extracted script that never reaches the container repairs nothing while the other 12 stay green.
- **docker-smoke (new step)** — probes the real thing on real containers: write a file, **as the pinchy user**, in the directory it actually has to write.

  It **reproduces** the condition rather than waiting for it. The first version observed whatever directories happened to exist, and the smoke wizard configures no provider — so Pinchy writes no `auth-profiles.json`, OpenClaw derives no catalog, and the step found nothing to probe on *every* run, warning instead of verifying. A permanent no-op that reads as coverage is worse than no step at all, so it now creates exactly what OpenClaw creates — root-owned, mode 0700, on the real Smithers id from the DB — and asserts the tick hands it back. Revert the `fix-config-permissions.sh` change and all 20 attempts fail, which is what makes it a guard.

  Two details it has to get right: the fixture is root-owned **by construction** (`chmod` + `chown` under `set -e`), because a post-hoc `stat` loses the race against a 50 ms repair and would fail on the fix *working*; and the id comes from the DB, because OpenClaw's `listGatewayAgentIds` unions on-disk `agents/` directory names into `agents.list`, so an invented probe id would surface as a phantom agent in the runtime being smoke-tested.

`Setup Wizard E2E` remains the end-to-end coverage, and its diagnostics improve either way: a residual failure now trips the `no api key found` assertion at 15 s instead of timing out at 160 s with nothing but container logs to go on.

## Verification

`pnpm test` (10437 passed) · `pnpm test:scripts` (675) · `pnpm typecheck` · `pnpm typecheck:plugins` · `pnpm test:plugins` · `pnpm build` · `pnpm format:check` · `docs build` + `check:anchors` · `shellcheck -x` clean (info-level only, same as the existing sourced scripts).

Not run locally: `pnpm test:db` — no schema, migration or query changes in this PR.

Related but distinct: #878 was an upgrade path that lost the `openclaw-secrets` volume entirely. Same error class, different cause.

