### PR TITLE
fix(ci): run the docs checkers' own tests, and pin them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,14 @@ jobs:
       - name: Docs lint (no indented tables)
         run: cd docs && pnpm install --frozen-lockfile && pnpm check:tables
 
+      - name: Docs script tests
+        # The two dist/ checkers below are only as good as their own logic, and
+        # a checker rewritten to find nothing passes against a healthy dist/.
+        # These unit tests are what would notice — and they ran nowhere but on a
+        # developer's laptop until #1007. They read their own fixtures, so they
+        # need no build; keeping them ahead of it fails fast.
+        run: cd docs && pnpm test
+
       - name: Docs build
         run: cd docs && pnpm build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -569,7 +569,11 @@ It lives in `quality` because `quality` already builds the docs and is ungated (
 
 `docs/scripts/check-rendered-tables.mjs` (`pnpm -C docs check:rendered`, in `quality` after the build) is the guard, and it checks the **symptom**, not the config: a built page containing a line that both starts and ends with `|`. The next way to lose gfm will not look like this one, but it will look like this in `dist/`. `scripts/lib/docs-link-gate.mjs` pins both built-site checks — script, checker, and the ordering.
 
+The same guard also pins `pnpm -C docs test`, which runs **before** the build (it reads its own fixtures, not `dist/`). Both checkers are ordinary code, and a checker rewritten to find nothing passes cheerfully against a healthy `dist/` — their unit tests are the only thing that would notice. Until #1007 those tests ran nowhere but on a developer's laptop, which is the same shape as the gate that reports on what it looks at rather than what it should.
+
 The general rule is the one the X-Frame-Options gate follows: assert what a built page contains, not what a source file asked for. Neither check covers `<img src>`, and external links out of `docs/` stay unchecked.
+
+`check:rendered` errs loud rather than silent, deliberately: **inline** code is not stripped, so a page that documents table syntax in an inline `` `| a | b |` `` on a line of its own would be flagged. Nothing in the 69 pages does that today. If one ever needs to, rewrite it as a fenced block — do not teach the checker to skip `<code>`, because a real unrendered row containing inline code (``| `foo` | bar |``) lives in exactly that markup.
 
 ### A Hand-Maintained List That Mirrors Code Will Be Wrong
 
@@ -655,7 +659,7 @@ Do not "fix" this by deploying docs from `main` instead. Pinning the docs to the
 
 `docs.yml`'s manual dispatch takes a required `pinchy_version` input for the same reason: without it, `inject-version.sh` falls back to `packages/web/package.json`, which on `main` still carries the _previous_ release — so an "urgent typo fix" dispatched from `main` would publish install instructions pinned to an older image than the one users can run.
 
-**Verify a change to this gate with a canary, never by reading the code.** Add a link to a heading that does not exist, build, confirm the check fails on that exact link, remove it. That step is what caught the plugin being a no-op; nothing cheaper would have.
+**Verify a change to either gate with a canary, never by reading the code.** For anchors: add a link to a heading that does not exist, build, confirm the check fails on that exact link, remove it. For tables: set `gfm: false` in `docs/astro.config.mjs`, build, confirm `check:rendered` fails and names an affected route, set it back. The anchor canary is what caught `starlight-links-validator` being a no-op; nothing cheaper would have, and a passing unit suite would not have — these checkers are only ever proved by a real broken page.
 
 Unrelated to the anchors but found while building them: `pnpm -C docs build` now runs `scripts/with-restore.sh astro build` rather than `astro build && restore`. The old `&&` chain short-circuited, so a failed or interrupted build left `vX.Y.Z` injected into the six committed source files `inject-version.sh` touches — and stayed that way, because the next run found no placeholders to inject and therefore registered nothing to restore. The wrapper restores either way and forwards the exit code.
 

--- a/scripts/lib/docs-link-gate.mjs
+++ b/scripts/lib/docs-link-gate.mjs
@@ -12,20 +12,24 @@
  * `quality` job already builds the docs, `quality` is ungated (it is a required
  * check), and the same two commands an author runs locally fail the same way.
  *
- * The same three things must hold for `check:rendered`
+ * The same conditions must hold for `check:rendered`
  * (`check-rendered-tables.mjs`), which catches the other way a built page lies:
  * v0.9.0 shipped every `.mdx` table as a paragraph of `|` characters, because
  * astro@6 deprecated `markdown.gfm` and @astrojs/mdx read the now-undefined
  * option. The build was green, the anchors were fine, and 41 of 69 live pages
  * were unreadable.
  *
- * All of which holds only as long as three things stay true per check, and each
+ * All of which holds only as long as four things stay true per check, and each
  * of them can be undone while every check stays green:
  *   1. docs/package.json keeps declaring the script,
  *   2. that script keeps running the checker it is named for,
  *   3. CI's `quality` job keeps running BOTH `pnpm build` and the check, in
  *      that order — the checkers read the build's output, so a check that runs
- *      first reads a stale (or missing) dist/.
+ *      first reads a stale (or missing) dist/,
+ *   4. CI keeps running the checkers' OWN unit tests. A checker rewritten to
+ *      find nothing passes happily against a healthy dist/ — its tests are the
+ *      only thing that would notice, and until #1007 they ran nowhere but on a
+ *      developer's laptop.
  *
  * Same shape as the format-gate / web-typecheck / plugin-typecheck guards (see
  * AGENTS.md): make a silent narrowing of the gate a loud, deliberate act.
@@ -38,6 +42,16 @@ const BUILT_OUTPUT_CHECKS = [
 ];
 const BUILD_COMMAND = "cd docs && pnpm build";
 const checkCommand = (script) => `cd docs && pnpm ${script}`;
+
+/**
+ * The checkers' unit tests. The glob is pinned rather than the file list: a
+ * narrowed glob (`scripts/check-anchors.test.mjs`) would silently drop the
+ * other checkers' tests while the script name survives — the same narrowing
+ * this whole guard exists to make loud.
+ */
+const TEST_SCRIPT = "test";
+const TEST_GLOB = "scripts/*.test.mjs";
+const TEST_COMMAND = `cd docs && pnpm ${TEST_SCRIPT}`;
 
 /**
  * @param {unknown} pkg parsed docs/package.json
@@ -59,6 +73,19 @@ export function validateDocsPackage(pkg) {
       problems.push(`"${name}" must run scripts/${file} (got "${script}")`);
     }
   }
+
+  const testScript = scripts[TEST_SCRIPT];
+  if (typeof testScript !== "string") {
+    problems.push(`docs/package.json needs a "${TEST_SCRIPT}" script`);
+  } else if (
+    !testScript.includes("--test") ||
+    !testScript.includes(TEST_GLOB)
+  ) {
+    problems.push(
+      `"${TEST_SCRIPT}" must run \`node --test ${TEST_GLOB}\` (got "${testScript}")`,
+    );
+  }
+
   return problems;
 }
 
@@ -103,5 +130,11 @@ export function validateCiWiring(qualityJobBody) {
       );
     }
   }
+
+  // No ordering constraint: these tests read their own fixtures, not dist/.
+  if (code.indexOf(TEST_COMMAND) === -1) {
+    problems.push(`CI's \`quality\` job must run \`${TEST_COMMAND}\``);
+  }
+
   return problems;
 }

--- a/scripts/lib/docs-link-gate.test.mjs
+++ b/scripts/lib/docs-link-gate.test.mjs
@@ -18,9 +18,13 @@ const WIRED_JOB = [
   "",
   "      - name: Docs rendered-table check (built output)",
   "        run: cd docs && pnpm check:rendered",
+  "",
+  "      - name: Docs script tests",
+  "        run: cd docs && pnpm test",
 ].join("\n");
 
 const WIRED_SCRIPTS = {
+  test: "node --test scripts/*.test.mjs",
   "check:anchors": "node scripts/check-anchors.mjs",
   "check:rendered": "node scripts/check-rendered-tables.mjs",
 };
@@ -67,6 +71,15 @@ test("validateDocsPackage flags the rendered-table script pointed elsewhere", ()
   assert.ok(problems.some((p) => /check-rendered-tables\.mjs/.test(p)));
 });
 
+test("validateDocsPackage flags a missing test script", () => {
+  // The checkers' own unit tests are the only thing pinning their logic. A
+  // checker rewritten to return nothing passes against a healthy dist/ — the
+  // tests are what notice, so the script that runs them is part of the gate.
+  const { test: _dropped, ...withoutTests } = WIRED_SCRIPTS;
+  const problems = validateDocsPackage({ scripts: withoutTests });
+  assert.ok(problems.some((p) => /"test"/.test(p)));
+});
+
 test("validateDocsPackage reports a problem (not a throw) on a non-object", () => {
   assert.ok(validateDocsPackage(null).length > 0);
   assert.ok(validateDocsPackage("oops").length > 0);
@@ -104,6 +117,18 @@ test("validateCiWiring flags a quality job that never runs the rendered-table ch
   );
 });
 
+test("validateCiWiring flags a quality job that never runs the docs script tests", () => {
+  // Both checkers ship with unit tests that CI ignored until #1007. A gate
+  // whose own logic is unverified reports on what it happens to do, not on
+  // what it is supposed to do.
+  const checksOnly = [
+    "      - run: cd docs && pnpm build",
+    "      - run: cd docs && pnpm check:anchors",
+    "      - run: cd docs && pnpm check:rendered",
+  ].join("\n");
+  assert.ok(validateCiWiring(checksOnly).some((p) => /pnpm test/.test(p)));
+});
+
 test("validateCiWiring flags the check running BEFORE the build", () => {
   // The checker reads docs/dist/. Ahead of the build it either exits 1 on a
   // missing dist or — on a warm runner — passes against yesterday's HTML.
@@ -123,7 +148,7 @@ test("validateCiWiring flags steps that are only present as comments", () => {
     .join("\n");
   assert.equal(
     validateCiWiring(commented).length,
-    3,
+    4,
     "a commented-out step must not satisfy the guard",
   );
 });
@@ -134,7 +159,8 @@ test("validateCiWiring does not treat a '#' inside a command as a comment", () =
   const withHash =
     '      - run: echo "#docs" && cd docs && pnpm build\n' +
     "      - run: cd docs && pnpm check:anchors\n" +
-    "      - run: cd docs && pnpm check:rendered\n";
+    "      - run: cd docs && pnpm check:rendered\n" +
+    "      - run: cd docs && pnpm test\n";
   assert.deepEqual(validateCiWiring(withHash), []);
 });
 


### PR DESCRIPTION
Originally the forward-port of the gfm fix. `d1d329b36` landed that on `main` independently, so that commit is dropped and this PR is now **only** the gap the review of it found.

## The gap

`docs/scripts/check-anchors.test.mjs` (since #769) and `check-rendered-tables.test.mjs` (since `d1d329b36`) both exist, both pass, and CI ran **neither**. `grep "docs && pnpm" .github/workflows/ci.yml` on `main` returns `check:tables`, `build`, `check:anchors`, `check:rendered` — no `test`.

`scripts/lib/docs-link-gate.mjs` pins that each checker is declared, points at the right file, and runs after the build. It did not pin that the checker's own logic is ever verified. Rewrite either checker to `return []` and every check stays green: the anchors are fine, the tables are fine, `dist/` is healthy. The unit tests are the only thing that would notice, and they only ran on a laptop.

Same shape as the format gate that read one package while being named "Format check", and as a `paths-ignore` on a required check: **a gate reports on what it looks at, not on what it should look at.**

## The fix

- **`ci.yml`**: new `quality` step `cd docs && pnpm test`, placed *before* the build — these tests read their own fixtures, not `dist/`, so running them first fails fast and costs nothing.
- **`docs-link-gate.mjs`**: `validateDocsPackage` requires a `test` script running `node --test scripts/*.test.mjs`; `validateCiWiring` requires the CI step. The **glob** is pinned, not the file list — narrowing it to `scripts/check-anchors.test.mjs` would silently drop the other checkers' tests while the script name survives, which is the exact narrowing this guard exists to make loud. No ordering constraint is asserted, for the reason above.
- **`docs-link-gate.test.mjs`**: two new tests (missing script, missing CI step), written red first. The commented-out-steps count moves 3 → 4, and the `'#'`-in-a-command fixture gains the new step.

## AGENTS.md

- Documents that the guard also pins `pnpm -C docs test`, and why.
- Documents `check:rendered`'s **false-positive direction**: inline `<code>` is deliberately not stripped, so a page with a standalone inline `` `| a | b |` `` would be flagged (none of the 69 does today). Stripping `<code>` would be worse — a real unrendered row containing inline code lives in exactly that markup. Ports it to a fenced block instead.
- The canary recipe covers both gates now, and the dangling "That step is what caught the plugin being a no-op" names the anchor canary — plus the point the whole PR turns on: a passing unit suite would not have caught it either. These checkers are only ever proved by a real broken page.

## Verification

| | |
| --- | --- |
| `pnpm test:scripts` | 756 pass / 0 fail (+2) |
| `pnpm format:check` | clean |
| `pnpm -C docs test` | 42 pass / 0 fail |
| `pnpm -C docs build` + `check:anchors` + `check:rendered` | 69 pages, both green |
| `node scripts/check-docs-required.mjs --base origin/main` | nothing to ask for |

Red-first confirmed for both new tests before the implementation landed.
