### PR TITLE
docs(providers): say that the last provider cannot be removed

### DIFF
--- a/docs/src/content/docs/guides/llm-providers.mdx
+++ b/docs/src/content/docs/guides/llm-providers.mdx
@@ -68,6 +68,8 @@ The **very first** provider you configure — built-in or custom — automatical
 
 Agents pinned to a model from the removed provider are moved to a still-configured one, so no agent is left on a model that no longer exists. The confirmation dialog states the outcome before you commit: how many agents are affected, and which provider and model they'll be moved to. If you removed your default provider, the provider those agents moved to becomes the new default.
 
+Pinchy refuses to remove the **last** configured provider — add another one first. That is what keeps the sentence above true: there is always somewhere for an orphaned agent to go.
+
 The move is a starting point, not a verdict: pick a different model for any agent afterwards — see [Change an agent's model](#change-an-agents-model).
 
 ## OpenAI-compatible providers


### PR DESCRIPTION
## What

One sentence in `guides/llm-providers.mdx`:

> Pinchy refuses to remove the **last** configured provider — add another one first. That is what keeps the sentence above true: there is always somewhere for an orphaned agent to go.

## Why

`release/0.9` gained this in #1005 and `main` never did — the upstream-first invariant ("main never loses a fix") failing in miniature. `main`'s own route carries the refusal:

```
"Cannot remove the last configured provider. Add another provider first."
```

…and `main`'s docs were the ones not saying so.

It is load-bearing next to the paragraph above it. "Agents are moved to a still-configured provider" reads as unconditional only because there is always another provider to move them to. Without the refusal stated, the promise has a hole exactly where a reader would most want it kept.

## How it was found

By diffing `release/0.9` against `main` file-by-file after #1005 merged, rather than assuming a release-branch PR carried nothing `main` needs. Two other files diverge and correctly stay that way:

- `upgrading.mdx` — `main` deep-links a `mount-data-directories` section `release/0.9` has no anchor for; a blind cherry-pick would break the anchor check.
- the `deletion-preview` sentence — that route is `main`-only.

## Verification

`pnpm format:check` and `pnpm test:scripts` (754 tests) green locally.