### PR TITLE
fix(eval): stop both sweeps dispatching models Ollama no longer serves

### DIFF
--- a/packages/web/eval/README.md
+++ b/packages/web/eval/README.md
@@ -361,7 +361,7 @@ DB_PASSWORD=eval_dev_pw OLLAMA_CLOUD_API_KEY=... pnpm -C packages/web eval:model
 Override the candidate set or run count with env vars:
 
 ```bash
-EVAL_CANDIDATE_MODELS="ollama-cloud/kimi-k2.6,ollama-cloud/glm-4.7" \
+EVAL_CANDIDATE_MODELS="ollama-cloud/kimi-k2.6,ollama-cloud/gemma4:31b" \
 EVAL_N=10 \
 OLLAMA_CLOUD_API_KEY=... pnpm -C packages/web eval:models
 ```
@@ -577,16 +577,36 @@ what it is: evidence-based, and what it does not name is allowed.
 
 ## Current candidate set and why
 
-The default candidates in `eval-models.spec.ts` are `kimi-k2.6`, `gemma4:31b`, and
-`glm-4.7` — the three models named in the model-selection methodology's R1
-evidence (the 2026-07-07 staging incident: `gemma4:31b` corrupted a Graph
-message id across turns while the audit trail showed green; `glm-4.7` loops
-when `reasoning_content` is dropped; `kimi-k2.6` is the current
-`balanced.general` / `balanced.vision` pick per the methodology's "Current
-standing decision"). Running Eval-v1 against this exact set is the action
-item the methodology names under `kimi-k2.6`: _"Eval-v1 (the Hetzner
-scenario) quantifies its residual false-success rate before any deeper
-intervention."_ A scorecard produced here is the evidence tier-1 input the
+**Both sweeps' defaults live in `eval/candidates.ts`** — not in the spec files,
+which import them. They sit in a Playwright-free module so a vitest guard can
+reach them: `src/__tests__/lib/eval/sweep-candidates.test.ts` asserts every id
+still exists in `src/lib/ollama-cloud-models.ts`. That rule was prose for two
+sweeps and was broken by the 2026-07-15 retirement wave before anything checked
+it (a dispatched-but-retired id 404s into `run-infra-error` rows the exporter
+drops from `n`, so the scorecard quietly holds fewer models than intended).
+
+The set started as three models — `kimi-k2.6`, `gemma4:31b` and `glm-4.7` — the
+ones named in the model-selection methodology's R1 evidence (the 2026-07-07
+staging incident: `gemma4:31b` corrupted a Graph message id across turns while
+the audit trail showed green; `glm-4.7` loops when `reasoning_content` is
+dropped; `kimi-k2.6` is the current `balanced.general` / `balanced.vision` pick
+per the methodology's "Current standing decision"). It reached eight, then 14
+with a breadth expansion (new vendors + intra-family pairs: does the
+bigger/newer sibling behave better on a real tool-using workflow?), and all 14
+are what the published sweep in `data/` measured. Ollama's 2026-07-15
+retirement wave then took `glm-4.7` and `deepseek-v3.2` out of the serving
+path, leaving the **12** a sweep dispatches today. Their measured numbers stay
+published — see `data/CHANGELOG.md`'s legacy policy; only what a future sweep
+dispatches changed.
+
+The KB Layer-3 sweep (`eval/kb/`) keeps a deliberately smaller set of 4, plus a
+pinned NLI judge (`DEFAULT_KB_JUDGE_MODEL` in `src/lib/eval/kb/llm-nli.ts`),
+because its groundedness gate multiplies calls by `models × goldQAs ×
+sentences × k`.
+
+Running Eval-v1 against this set is the action item the methodology names under
+`kimi-k2.6`: _"Eval-v1 (the Hetzner scenario) quantifies its residual
+false-success rate before any deeper intervention."_ A scorecard produced here is the evidence tier-1 input the
 methodology expects for any future rule change — see
 `packages/web/eval/model-selection-methodology.md` for the full evidence
 hierarchy and how a scorecard is meant to feed back into the resolver

--- a/packages/web/eval/candidates.ts
+++ b/packages/web/eval/candidates.ts
@@ -9,6 +9,11 @@
  * a Playwright-free module is what lets that guard run in `pnpm test`, the same
  * move `eval/kb/sweep-agent.ts` and `eval/kb/chunk-texts.ts` made.
  *
+ * Removing a retired id here governs only what a FUTURE sweep dispatches. The
+ * numbers already measured for it stay published and citable — that is
+ * `data/CHANGELOG.md`'s legacy policy, and the reason this file is not the
+ * place to "clean up" a model's history.
+ *
  * Both are overridable per run with `EVAL_CANDIDATE_MODELS`.
  */
 
@@ -22,19 +27,18 @@ export const OLLAMA_CLOUD_PREFIX = "ollama-cloud/";
  * tool-using workflow?).
  */
 export const DEFAULT_INVOICE_CANDIDATES = [
-  // — original 8-model sweep (2026-07-11) —
+  // — the original eight, now seven: `glm-4.7` sat here until Ollama retired
+  //   it on 2026-07-15. (The published 2026-07-11 sweep in `data/` already ran
+  //   all 14, expansion included — this block is a lineage, not a sweep.) —
   "ollama-cloud/kimi-k2.6",
   "ollama-cloud/gemma4:31b",
-  // `glm-4.7` and `deepseek-v3.2` sat here until Ollama retired both on
-  // 2026-07-15. Their measured numbers stay published (`data/CHANGELOG.md`);
-  // only the serving path lost them, and a sweep that still dispatched them
-  // collected 404s.
   "ollama-cloud/glm-5.2",
   "ollama-cloud/qwen3.5:397b",
   "ollama-cloud/minimax-m3",
   "ollama-cloud/gpt-oss:120b",
   "ollama-cloud/mistral-large-3:675b",
-  // — breadth expansion: new vendors (DeepSeek, NVIDIA) + intra-family pairs —
+  // — breadth expansion: new vendors (DeepSeek, NVIDIA) + intra-family pairs.
+  //   `deepseek-v3.2` sat here, retired in the same 2026-07-15 wave —
   "ollama-cloud/deepseek-v4-pro",
   "ollama-cloud/nemotron-3-ultra",
   "ollama-cloud/gpt-oss:20b",
@@ -54,6 +58,14 @@ export const DEFAULT_KB_CANDIDATES = [
   // the same family's successor rather than dropped: the four entries buy
   // vendor breadth (Moonshot / Z.ai / Alibaba / OpenAI), and removing one
   // would narrow what the sweep can say about groundedness across vendors.
+  //
+  // Read a weak glm-5.2 score here with that in mind: the family is
+  // thinking-by-default and emits tool calls in its own format, and over
+  // ollama-cloud's OpenAI `/v1` path we have already observed the result —
+  // `odoo_create` reported success while nothing persisted (2026-06-25).
+  // A KB run that never lands its `knowledge_search` call scores ungrounded
+  // for a transport reason, not a groundedness one. That is a finding worth
+  // having, but only if it is attributed correctly.
   "ollama-cloud/glm-5.2",
   "ollama-cloud/qwen3.5:397b",
   "ollama-cloud/gpt-oss:120b",

--- a/packages/web/eval/candidates.ts
+++ b/packages/web/eval/candidates.ts
@@ -1,0 +1,60 @@
+/**
+ * The default candidate model sets the two sweeps dispatch.
+ *
+ * These lived as `const`s inside their spec files, where nothing could check
+ * them: a spec imports `@playwright/test`, so a vitest guard cannot reach it.
+ * The rule they have to satisfy — every id exists in
+ * `src/lib/ollama-cloud-models.ts` — was stated as a comment and broken twice
+ * (see `src/__tests__/lib/eval/sweep-candidates.test.ts`). Extracting them into
+ * a Playwright-free module is what lets that guard run in `pnpm test`, the same
+ * move `eval/kb/sweep-agent.ts` and `eval/kb/chunk-texts.ts` made.
+ *
+ * Both are overridable per run with `EVAL_CANDIDATE_MODELS`.
+ */
+
+/** Provider prefix every candidate id carries, stripped to index the catalog. */
+export const OLLAMA_CLOUD_PREFIX = "ollama-cloud/";
+
+/**
+ * The curated candidate set for the public open-weight agent-reliability
+ * benchmark (pinchy#669). Chosen for vendor breadth AND intra-family
+ * comparisons (does the bigger/newer sibling actually behave better on a real
+ * tool-using workflow?).
+ */
+export const DEFAULT_INVOICE_CANDIDATES = [
+  // — original 8-model sweep (2026-07-11) —
+  "ollama-cloud/kimi-k2.6",
+  "ollama-cloud/gemma4:31b",
+  // `glm-4.7` and `deepseek-v3.2` sat here until Ollama retired both on
+  // 2026-07-15. Their measured numbers stay published (`data/CHANGELOG.md`);
+  // only the serving path lost them, and a sweep that still dispatched them
+  // collected 404s.
+  "ollama-cloud/glm-5.2",
+  "ollama-cloud/qwen3.5:397b",
+  "ollama-cloud/minimax-m3",
+  "ollama-cloud/gpt-oss:120b",
+  "ollama-cloud/mistral-large-3:675b",
+  // — breadth expansion: new vendors (DeepSeek, NVIDIA) + intra-family pairs —
+  "ollama-cloud/deepseek-v4-pro",
+  "ollama-cloud/nemotron-3-ultra",
+  "ollama-cloud/gpt-oss:20b",
+  "ollama-cloud/glm-5.1",
+  "ollama-cloud/minimax-m2.7",
+];
+
+/**
+ * The KB Layer-3 candidate set. Deliberately SMALLER than the invoice set —
+ * the groundedness gate is per-sentence NLI-judged, k=3 by default
+ * (`nli.ts`'s `DEFAULT_NLI_K`), against every GOLD_QA item, so the call count
+ * multiplies fast (models × goldQAs × sentences × k).
+ */
+export const DEFAULT_KB_CANDIDATES = [
+  "ollama-cloud/kimi-k2.6",
+  // Z.ai's slot, held by `glm-4.7` until its 2026-07-15 retirement. Kept as
+  // the same family's successor rather than dropped: the four entries buy
+  // vendor breadth (Moonshot / Z.ai / Alibaba / OpenAI), and removing one
+  // would narrow what the sweep can say about groundedness across vendors.
+  "ollama-cloud/glm-5.2",
+  "ollama-cloud/qwen3.5:397b",
+  "ollama-cloud/gpt-oss:120b",
+];

--- a/packages/web/eval/eval-models.spec.ts
+++ b/packages/web/eval/eval-models.spec.ts
@@ -56,36 +56,11 @@ import {
   injectOdooCreateFailure,
   injectOdooCreateSilentSuccess,
 } from "./run-eval";
+import { DEFAULT_INVOICE_CANDIDATES } from "./candidates";
 import { captureRunFingerprint } from "./fingerprint";
 import { makeTokenCollector } from "./token-usage";
 import { setupHetznerAgent } from "./eval-shared";
 import type { PromptVariantId, RunResult } from "../src/lib/eval/types";
-
-// The curated candidate set for a public open-weight agent-reliability
-// benchmark (pinchy#669). Chosen for vendor breadth AND intra-family
-// comparisons (does the bigger/newer sibling actually behave better on a real
-// tool-using workflow?). Every id must exist in
-// src/lib/ollama-cloud-models.ts TOOL_CAPABLE_OLLAMA_CLOUD_MODELS — that file
-// is the source of truth for which models the /v1 path actually serves with
-// working tool calls. Override per-run with EVAL_CANDIDATE_MODELS.
-const DEFAULT_CANDIDATES = [
-  // — original 8-model sweep (2026-07-11) —
-  "ollama-cloud/kimi-k2.6",
-  "ollama-cloud/gemma4:31b",
-  "ollama-cloud/glm-4.7",
-  "ollama-cloud/glm-5.2",
-  "ollama-cloud/qwen3.5:397b",
-  "ollama-cloud/minimax-m3",
-  "ollama-cloud/gpt-oss:120b",
-  "ollama-cloud/mistral-large-3:675b",
-  // — breadth expansion: new vendors (DeepSeek, NVIDIA) + intra-family pairs —
-  "ollama-cloud/deepseek-v3.2",
-  "ollama-cloud/deepseek-v4-pro",
-  "ollama-cloud/nemotron-3-ultra",
-  "ollama-cloud/gpt-oss:20b",
-  "ollama-cloud/glm-5.1",
-  "ollama-cloud/minimax-m2.7",
-];
 
 /**
  * The scenarios the sweep runs for every candidate model. `label` becomes
@@ -204,7 +179,7 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
     `;
     await sql.end();
 
-    const candidates = candidateModelsFromEnv(DEFAULT_CANDIDATES);
+    const candidates = candidateModelsFromEnv(DEFAULT_INVOICE_CANDIDATES);
     const n = runsPerModelFromEnv(5);
 
     // Paraphrase-variant opt-in (#803, PR 3): EVAL_PROMPT_VARIANTS selects

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -81,6 +81,7 @@ import { gradeKbRun } from "../../src/lib/eval/kb/answer-graders";
 import type { KbRunTrajectory, KbRunResult } from "../../src/lib/eval/kb/answer-graders";
 import { citedSourcePaths } from "../../src/lib/eval/kb/attribution-graders";
 import {
+  DEFAULT_KB_JUDGE_MODEL,
   LlmNliClient,
   LlmRelevanceJudge,
   createOllamaCloudChatFn,
@@ -319,8 +320,10 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
     // separate model from the candidates under test, same reasoning as
     // groundedness-grader.ts's DEFAULT_TAU comment: keep the JUDGE fixed so
     // score drift over a long sweep reflects the candidate's behavior, not
-    // the judge's. Overridable via KB_EVAL_JUDGE_MODEL.
-    const judgeModel = process.env.KB_EVAL_JUDGE_MODEL || "ollama-cloud/gpt-oss:20b";
+    // the judge's. The default lives in llm-nli.ts (one literal, checked
+    // against the catalog by sweep-candidates.test.ts); override per run with
+    // KB_EVAL_JUDGE_MODEL.
+    const judgeModel = process.env.KB_EVAL_JUDGE_MODEL || DEFAULT_KB_JUDGE_MODEL;
     const chat = createOllamaCloudChatFn({ apiKey: ollamaKey, model: judgeModel });
     const nli = new LlmNliClient(chat);
     const relevance = new LlmRelevanceJudge(chat);

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -87,26 +87,13 @@ import {
 } from "../../src/lib/eval/kb/llm-nli";
 import { DEFAULT_ORG_ID } from "../../src/lib/knowledge/constants";
 import { fetchChunkTexts } from "./chunk-texts";
+import { DEFAULT_KB_CANDIDATES } from "../candidates";
 import { KB_SWEEP_TEMPLATE_ID } from "./sweep-agent";
 import { KB_EVAL_CORPUS } from "./corpus/manifest";
 import { GOLD_QA } from "./corpus/gold-qa";
 import { loadEmbeddings } from "./embeddings-fixture";
 
 const RESULT_LABEL = "kb-groundedness-sweep";
-
-// The KB Layer-3 candidate set. Deliberately a SMALLER list than the
-// invoice sweep's `DEFAULT_CANDIDATES` (`../eval-models.spec.ts`) — the
-// groundedness gate is per-sentence NLI-judged, k=3 by default
-// (`nli.ts`'s `DEFAULT_NLI_K`), against every GOLD_QA item, so the call
-// count multiplies fast (models x goldQAs x sentences x k). Override with
-// EVAL_CANDIDATE_MODELS, same env var the invoice sweep reads
-// (`candidateModelsFromEnv`).
-const DEFAULT_KB_CANDIDATES = [
-  "ollama-cloud/kimi-k2.6",
-  "ollama-cloud/glm-4.7",
-  "ollama-cloud/qwen3.5:397b",
-  "ollama-cloud/gpt-oss:120b",
-];
 
 const KB_ALLOWED_TOOLS = ["knowledge_search"];
 const CORPUS_ROOT = "/data";

--- a/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
+++ b/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Every sweep's default candidate list must name models Ollama still serves.
+ *
+ * `eval-models.spec.ts` has stated this rule in prose since the first sweep —
+ * "Every id must exist in src/lib/ollama-cloud-models.ts
+ * TOOL_CAPABLE_OLLAMA_CLOUD_MODELS" — and nothing checked it. By the time this
+ * guard was written the rule was broken twice over: Ollama retired
+ * `deepseek-v3.2` and `glm-4.7` on 2026-07-15, both stayed in the invoice
+ * default, and `glm-4.7` was one of only four KB Layer-3 candidates.
+ *
+ * The cost is not abstract. A sweep dispatches the retired id anyway, every
+ * run 404s, and the rows land as `run-infra-error` — which the exporter
+ * excludes from `n`, so the published scorecard simply has one fewer model
+ * than the operator believes they measured. On the KB sweep that is a quarter
+ * of the candidate set failing silently, discovered only by reading the
+ * results by hand.
+ *
+ * The `run-model-eval` skill's iron rule 1 ("refresh the catalog first") is
+ * the live half of this: `pnpm models:discover` asks the provider what it
+ * serves today. This is the offline half — it costs nothing, needs no key, and
+ * runs in `pnpm test`, so a catalog refresh that removes a model can no longer
+ * leave a sweep default pointing at it.
+ *
+ * Retired models keep their published numbers (`eval/data/README.md`); this
+ * guard only governs what a FUTURE sweep would dispatch.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS } from "@/lib/ollama-cloud-models";
+
+import {
+  DEFAULT_INVOICE_CANDIDATES,
+  DEFAULT_KB_CANDIDATES,
+  OLLAMA_CLOUD_PREFIX,
+} from "../../../../eval/candidates";
+
+const SERVED_IDS = new Set<string>(TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m) => m.id));
+
+const SWEEPS: Array<{ name: string; candidates: readonly string[] }> = [
+  { name: "invoice (eval-models.spec.ts)", candidates: DEFAULT_INVOICE_CANDIDATES },
+  { name: "KB Layer-3 (kb/kb-eval-models.spec.ts)", candidates: DEFAULT_KB_CANDIDATES },
+];
+
+describe.each(SWEEPS)("the $name sweep's default candidates", ({ candidates }) => {
+  it("names at least one model", () => {
+    expect(candidates.length).toBeGreaterThan(0);
+  });
+
+  it("carries the ollama-cloud provider prefix on every id", () => {
+    const unprefixed = candidates.filter((id) => !id.startsWith(OLLAMA_CLOUD_PREFIX));
+
+    expect(unprefixed).toEqual([]);
+  });
+
+  it("names only models the curated catalog still serves", () => {
+    const retired = candidates
+      .map((id) => id.slice(OLLAMA_CLOUD_PREFIX.length))
+      .filter((bare) => !SERVED_IDS.has(bare));
+
+    expect(
+      retired,
+      `Not in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS: ${retired.join(", ")}. ` +
+        `A sweep would dispatch these and collect run-infra-error rows the ` +
+        `exporter drops, so the scorecard would quietly measure fewer models ` +
+        `than intended. Remove them here — their already-published numbers stay.`
+    ).toEqual([]);
+  });
+
+  it("lists each model once, so a cell cannot be measured twice", () => {
+    expect(new Set(candidates).size).toBe(candidates.length);
+  });
+});

--- a/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
+++ b/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
@@ -21,13 +21,15 @@
  * runs in `pnpm test`, so a catalog refresh that removes a model can no longer
  * leave a sweep default pointing at it.
  *
- * Retired models keep their published numbers (`eval/data/README.md`); this
- * guard only governs what a FUTURE sweep would dispatch.
+ * Retired models keep their published numbers — every superseded version stays
+ * published and citable, per `eval/data/CHANGELOG.md`. This guard only governs
+ * what a FUTURE sweep would dispatch.
  */
 
 import { describe, expect, it } from "vitest";
 
 import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS } from "@/lib/ollama-cloud-models";
+import { DEFAULT_KB_JUDGE_MODEL } from "@/lib/eval/kb/llm-nli";
 
 import {
   DEFAULT_INVOICE_CANDIDATES,
@@ -69,5 +71,35 @@ describe.each(SWEEPS)("the $name sweep's default candidates", ({ candidates }) =
 
   it("lists each model once, so a cell cannot be measured twice", () => {
     expect(new Set(candidates).size).toBe(candidates.length);
+  });
+});
+
+/**
+ * The KB sweep dispatches one model the candidate lists do not name: the
+ * NLI/relevance judge (`llm-nli.ts`). It is deliberately pinned and separate
+ * from the models under test, so score drift over a long sweep reflects the
+ * candidate's behavior rather than the judge's — which is exactly why it is
+ * the id nobody thinks to re-check after a retirement wave.
+ *
+ * Its failure is louder than a candidate's (`createOllamaCloudChatFn` throws
+ * on a non-2xx, and the spec's `withRetry` gives up after 4 attempts) but it
+ * arrives later and costs more: the sweep has already booted the stack, seeded
+ * the corpus and spent a real key by the time the first sentence is judged.
+ */
+describe("the KB sweep's pinned NLI judge", () => {
+  it("carries the ollama-cloud provider prefix", () => {
+    expect(DEFAULT_KB_JUDGE_MODEL.startsWith(OLLAMA_CLOUD_PREFIX)).toBe(true);
+  });
+
+  it("names a model the curated catalog still serves", () => {
+    const bare = DEFAULT_KB_JUDGE_MODEL.slice(OLLAMA_CLOUD_PREFIX.length);
+
+    expect(
+      SERVED_IDS.has(bare),
+      `The pinned judge \`${bare}\` is not in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS. ` +
+        `Every NLI verdict would fail against a retired judge, so no KB run ` +
+        `can be graded at all — after the stack is up and the key is spent. ` +
+        `Repin DEFAULT_KB_JUDGE_MODEL in src/lib/eval/kb/llm-nli.ts.`
+    ).toBe(true);
   });
 });

--- a/packages/web/src/lib/eval/kb/llm-nli.ts
+++ b/packages/web/src/lib/eval/kb/llm-nli.ts
@@ -235,6 +235,20 @@ export class LlmRelevanceJudge implements RelevanceJudge {
 }
 
 /**
+ * The pinned NLI/relevance judge. Kept FIXED while candidates vary, so score
+ * drift over a long sweep reflects the candidate's behavior and not the
+ * judge's (same reasoning as `groundedness-grader.ts`'s `DEFAULT_TAU`).
+ *
+ * Exported rather than inlined so `kb-eval-models.spec.ts` reads the same
+ * constant instead of repeating the literal, and so
+ * `src/__tests__/lib/eval/sweep-candidates.test.ts` can check it against the
+ * curated catalog. A judge Ollama has retired fails every verdict, so no KB
+ * run is gradeable at all — and it surfaces only after the stack is up and a
+ * real key has been spent. Override per run with `KB_EVAL_JUDGE_MODEL`.
+ */
+export const DEFAULT_KB_JUDGE_MODEL = "ollama-cloud/gpt-oss:20b";
+
+/**
  * Wires an `LlmChatFn` to a real Ollama Cloud model via its OpenAI-compatible
  * `/v1/chat/completions` endpoint (same endpoint `src/lib/providers.ts` and
  * `src/lib/openclaw-config/build.ts` use for provider validation/config —
@@ -256,7 +270,7 @@ export function createOllamaCloudChatFn(opts: {
   model?: string;
   baseUrl?: string;
 }): LlmChatFn {
-  const model = opts.model ?? "ollama-cloud/gpt-oss:20b";
+  const model = opts.model ?? DEFAULT_KB_JUDGE_MODEL;
   const baseUrl = opts.baseUrl ?? "https://ollama.com";
 
   return async (prompt: string): Promise<string> => {


### PR DESCRIPTION
## What this fixes

`eval-models.spec.ts` has carried the rule in prose since the first sweep — *"Every id must exist in `src/lib/ollama-cloud-models.ts` TOOL_CAPABLE_OLLAMA_CLOUD_MODELS"* — and nothing checked it.

It was broken twice over. Ollama retired `deepseek-v3.2` and `glm-4.7` on 2026-07-15; both stayed in the invoice sweep's default, and `glm-4.7` was **one of only four** KB Layer-3 candidates.

## Why it matters

This does not fail loudly. The sweep dispatches the retired id, every run 404s, the rows land as `run-infra-error` — and the exporter drops those from `n`. So the published scorecard simply contains one fewer model than the operator believes they measured. On the KB sweep that would have been a quarter of the candidate set, findable only by reading the results by hand.

Found while preparing the first real Layer-3 groundedness sweep, by following the `run-model-eval` skill's iron rule 1 (`pnpm models:discover`). The catalog itself is clean — 17/17 curated models still served. The **sweep defaults** were not.

## The change

- **`eval/candidates.ts`** (new) — both default lists move here. This is what makes them checkable at all: a spec imports `@playwright/test`, which a vitest guard cannot load. Same extraction `eval/kb/sweep-agent.ts` and `eval/kb/chunk-texts.ts` already made.
- **`sweep-candidates.test.ts`** (new) — the offline half of iron rule 1. `models:discover` asks the provider what it serves today; this asserts no sweep default points at something the curated catalog dropped. Costs nothing, needs no key, runs in `pnpm test`.
- Retired ids removed. `glm-5.2` takes `glm-4.7`'s Z.ai slot in the KB set, so the sweep can still say something about groundedness across four vendors rather than three.

**Published numbers for both retired models stay exactly as they are** (`data/README.md`'s legacy policy). This governs only what a *future* sweep dispatches.

## Verification

- Guard verified **red first**: reported `deepseek-v3.2, glm-4.7` for the invoice list and `glm-4.7` for the KB list.
- `pnpm test` — 744 files / 10 513 tests passed
- `pnpm -C packages/web typecheck`, `pnpm format:check` — green