### PR TITLE
test(#1013): rule out one cause of the missing retry gate, and make the next failure decisive

### DIFF
--- a/packages/web/e2e/19-message-hover-layout-shift.spec.ts
+++ b/packages/web/e2e/19-message-hover-layout-shift.spec.ts
@@ -178,8 +178,39 @@ test.describe("message action-bar layout shift", () => {
       return below.y - target.y;
     };
 
+    // Take the baseline only once the gap has stopped moving on its own.
+    //
+    // It moves for ~100ms after mount with no hover involved — measured by
+    // sampling `gap()` eight times at 100ms with the hover removed entirely:
+    // [104.556, 105, 105, 105, 105, 105, 105, 105]. Sampling inside that window
+    // gives a baseline that differs from every later reading, and since the
+    // hover path then waits for the bar to mount, the test reports the
+    // settle as a hover-induced shift. That is what failed in CI (#1016):
+    // "gap 103.894287109375px → 105px" — a slower host, so the baseline landed
+    // further from the settled value and the 1px tolerance broke.
+    //
+    // Waiting is the fix rather than a wider tolerance: the tolerance is what
+    // gives this test its resolution, and the delta it was rejecting was a
+    // measurement artifact, not a layout shift. With the wait, the delta is
+    // exactly 0 (measured across runs), so `< 1` has room to spare.
+    const settledGap = async () => {
+      let previous = await gap();
+      await expect
+        .poll(
+          async () => {
+            const next = await gap();
+            const unchanged = Math.abs(next - previous) < 0.01;
+            previous = next;
+            return unchanged;
+          },
+          { timeout: 5000, message: "the thread's layout never stopped moving" }
+        )
+        .toBe(true);
+      return previous;
+    };
+
     const heightBefore = (await hoverTarget.boundingBox())!.height;
-    const gapBefore = await gap();
+    const gapBefore = await settledGap();
 
     await hoverTarget.hover();
 

--- a/packages/web/e2e/integration/19-durable-agent-error-banner.spec.ts
+++ b/packages/web/e2e/integration/19-durable-agent-error-banner.spec.ts
@@ -16,7 +16,9 @@ import postgres from "postgres";
 import {
   FAKE_OLLAMA_RATE_LIMIT_TRIGGER,
   FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TRIGGER,
+  FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TOOL as TOOL_THEN_RATE_LIMIT_TOOL,
 } from "../shared/fake-ollama/fake-ollama-server";
+import { describeToolAudit } from "../shared/dispatch-probe";
 import { stackDbUrl } from "../shared/stack-db";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 
@@ -94,7 +96,16 @@ test.describe("Durable agent-error banner", () => {
     // assertions below.
     await page.getByRole("button", { name: /^retry$/i }).click();
     const liveConfirm = page.getByRole("alertdialog");
-    await expect(liveConfirm).toBeVisible();
+    // #1013: this assertion has failed in CI, and the run's artifacts could not
+    // say why — OpenClaw doesn't log tool executions at this level, postgres has
+    // no statement logging, pinchy has no request logging. The gate depends on
+    // an audit lookup, so ask the audit trail here, while the stack is still up,
+    // and carry the answer into the failure message. See describeToolAudit for
+    // how the three possible answers map to three different bugs.
+    await expect(
+      liveConfirm,
+      await describeToolAudit(page, { toolName: TOOL_THEN_RATE_LIMIT_TOOL, agentId })
+    ).toBeVisible();
     await expect(liveConfirm).toContainText(/duplicate/i);
     await liveConfirm.getByRole("button", { name: /cancel/i }).click();
     await expect(liveConfirm).toHaveCount(0);

--- a/packages/web/e2e/shared/dispatch-probe.ts
+++ b/packages/web/e2e/shared/dispatch-probe.ts
@@ -429,3 +429,55 @@ export async function pollAuditForEvent(
     `No "${params.eventType}" audit entry matched predicate within ${deadlineMs}ms${suffix}`
   );
 }
+
+/**
+ * Describe what the audit trail knows about a tool the run was supposed to
+ * execute — for use in an assertion message (#1013).
+ *
+ * The duplicate-write retry gate is driven by `agentRanToolSince()`, which asks
+ * whether a `tool.%` row exists for `resource = agent:<agentId>`. When the gate
+ * is missing, the interesting question is *why* that lookup came back empty,
+ * and a run's artifacts cannot answer it: OpenClaw does not log tool executions
+ * at the E2E log level, postgres has no statement logging, and pinchy has no
+ * request logging. So ask the audit API directly, while the stack is still up.
+ *
+ * The three answers map to three different bugs:
+ *   - no row at all              → the tool never ran (fake-LLM / dispatch side)
+ *   - row under a different
+ *     `resource`                 → written, but not attributable to this agent
+ *                                  (the `unknown-agent` fallback, or a
+ *                                  sessionKey that didn't resolve)
+ *   - row present and matching   → it existed but the lookup missed it — a race
+ *                                  between the plugin's audit POST and the
+ *                                  error chunk's `agentRanToolSince()`
+ *
+ * Never throws: a diagnostic that fails takes the real failure's message with
+ * it, which is the opposite of the point.
+ */
+export async function describeToolAudit(
+  page: Page,
+  params: { toolName: string; agentId: string }
+): Promise<string> {
+  const eventType = `tool.${params.toolName}`;
+  try {
+    const res = await page.request.get(
+      `/api/audit?eventType=${encodeURIComponent(eventType)}&limit=10`
+    );
+    if (res.status() !== 200) {
+      return `[#1013] could not read the audit trail: HTTP ${res.status()} from /api/audit?eventType=${eventType}`;
+    }
+    const audit = (await res.json()) as { entries: AuditApiEntry[] };
+    if (audit.entries.length === 0) {
+      return `[#1013] no "${eventType}" audit row exists at all — the tool never ran, so sideEffects=false was CORRECT and the fault is upstream of the retry gate (fake-LLM round selection or tool dispatch).`;
+    }
+    const wanted = `agent:${params.agentId}`;
+    const mine = audit.entries.filter((e) => e.resource === wanted);
+    if (mine.length === 0) {
+      const seen = [...new Set(audit.entries.map((e) => e.resource ?? "null"))].join(", ");
+      return `[#1013] ${audit.entries.length} "${eventType}" row(s) exist but none under "${wanted}" (saw: ${seen}) — the tool ran and was audited, but the row is not attributable to this agent, so agentRanToolSince() can never find it.`;
+    }
+    return `[#1013] ${mine.length} matching "${eventType}" row(s) under "${wanted}" — the row the gate looks for DOES exist, so the lookup raced the audit write.`;
+  } catch (err) {
+    return `[#1013] audit diagnostic itself failed: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}

--- a/packages/web/src/__tests__/e2e-shared/fake-ollama-tool-then-rate-limit.test.ts
+++ b/packages/web/src/__tests__/e2e-shared/fake-ollama-tool-then-rate-limit.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+//
+// Deterministic coverage for the TOOL_THEN_RATE_LIMIT trigger's round
+// selection (#1013).
+//
+// `19-durable-agent-error-banner.spec.ts:72` asserts that a failure AFTER a
+// tool call gates Retry behind a duplicate-write confirm. That confirm only
+// appears when `sideEffects` is true, and `sideEffects` is true only when the
+// run actually executed a tool — so the whole spec rests on this trigger
+// dispatching `pinchy_ls` in round 1 and the 429 only in round 2.
+//
+// When that spec failed in CI, the run artifacts could not say which half broke:
+// OpenClaw does not log tool executions at the E2E log level, postgres has no
+// statement logging, and pinchy has no request logging. Round selection is a
+// pure function of the request's messages, though, so it does not need any of
+// that — this file pins it in-process, against the REAL dispatcher.
+//
+// The histories below are the ones the integration suite actually produces: its
+// specs share one Smithers session, so by the time this trigger runs the
+// conversation already contains earlier triggers — including
+// `E2E_RATE_LIMIT_ERROR`, whose handler sits directly above this one and would
+// swallow the request if selection ever keyed off the wrong message.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as http from "http";
+import type { AddressInfo } from "net";
+import {
+  handleRequest,
+  FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TRIGGER,
+  FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TOOL,
+  FAKE_OLLAMA_RATE_LIMIT_TRIGGER,
+} from "../../../e2e/shared/fake-ollama/fake-ollama-server";
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeEach(async () => {
+  server = http.createServer(handleRequest);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+});
+
+// Pinchy emits ollama as `api: "openai-completions"`, so OpenClaw's pi-ai
+// dispatches to /v1/chat/completions — the surface this spec's traffic uses.
+async function postChat(messages: unknown[]): Promise<{ status: number; body: string }> {
+  const res = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ stream: true, messages }),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+const triggerMessage = {
+  role: "user",
+  content: `${FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TRIGGER}: do the thing`,
+};
+
+// What the shared Smithers session looks like by the time this spec runs: the
+// preceding specs in the same file and its neighbours have already exchanged
+// several turns, and the turn immediately before is the bare-429 trigger.
+const SHARED_SESSION_HISTORY = [
+  { role: "user", content: "E2E_SLOW_STREAM: list one..ten" },
+  { role: "assistant", content: "one two three four five six seven eight nine ten" },
+  { role: "user", content: "E2E_ABORT_STREAM: please respond slowly" },
+  { role: "assistant", content: "lima" },
+  { role: "user", content: `${FAKE_OLLAMA_RATE_LIMIT_TRIGGER}: please do the thing` },
+];
+
+describe("fake-ollama TOOL_THEN_RATE_LIMIT round selection (#1013)", () => {
+  it("dispatches the tool in round 1 of a fresh session", async () => {
+    const { status, body } = await postChat([triggerMessage]);
+
+    expect(status).toBe(200);
+    expect(body).toContain(FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TOOL);
+    // The 429 belongs to round 2 only — a rate limit here would mean the run
+    // fails without ever performing the side effect the spec is about.
+    expect(body).not.toContain("rate_limit_exceeded");
+  });
+
+  it("still dispatches the tool when the shared session already carries earlier triggers", async () => {
+    // The regression this guards: selection keying off any message in the
+    // history rather than the LAST user message would match the preceding
+    // `E2E_RATE_LIMIT_ERROR` turn, return a bare 429, and produce exactly the
+    // observed failure — an error with no tool call, so no duplicate-write
+    // warning and an ungated Retry.
+    const { status, body } = await postChat([...SHARED_SESSION_HISTORY, triggerMessage]);
+
+    expect(status).toBe(200);
+    expect(body).toContain(FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TOOL);
+    expect(body).not.toContain("rate_limit_exceeded");
+  });
+
+  it("returns the 429 in round 2, once the tool result comes back", async () => {
+    const { status } = await postChat([
+      ...SHARED_SESSION_HISTORY,
+      triggerMessage,
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TOOL, arguments: "{}" },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "briefing.docx\nnotes.md" },
+    ]);
+
+    expect(status).toBe(429);
+  });
+
+  it("does not let a stale tool result from an earlier turn skip round 1", async () => {
+    // `lastRoundHasToolResult` only inspects messages after the last user
+    // message, so an earlier turn's tool result must not be read as "this run
+    // already called its tool". If it were, the trigger would 429 immediately
+    // and the spec would see a failure with no side effect — indistinguishable
+    // from the bug it is trying to catch.
+    const { status, body } = await postChat([
+      ...SHARED_SESSION_HISTORY,
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          { id: "old", type: "function", function: { name: "knowledge_search", arguments: "{}" } },
+        ],
+      },
+      { role: "tool", tool_call_id: "old", content: "an earlier turn's result" },
+      triggerMessage,
+    ]);
+
+    expect(status).toBe(200);
+    expect(body).toContain(FAKE_OLLAMA_TOOL_THEN_RATE_LIMIT_TOOL);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1013 — the intermittent failure of `19-durable-agent-error-banner.spec.ts:72`, where the duplicate-write confirm never opens and Retry re-sends unguarded.

**This does not fix the gate.** The cause is not established, and a fix would be a guess. What it does is remove one candidate permanently and make the next occurrence say which of the remaining ones it was.

The problem worth attacking first is that the run's artifacts cannot answer the question at all: OpenClaw does not log tool executions at the E2E log level, postgres has no statement logging, pinchy has no request logging. Three different bugs produce an identical red.

### Rules out the fake LLM

The spec rests entirely on `TOOL_THEN_RATE_LIMIT` dispatching `pinchy_ls` in round 1 and returning the 429 only in round 2. If it ever went straight to the 429, the run would fail with no side effect — indistinguishable from the bug the spec exists to catch.

Round selection is a pure function of the request's messages, so it needs none of the missing logging. `fake-ollama-tool-then-rate-limit.test.ts` pins it in-process against the real dispatcher, using the histories the integration suite actually produces — its specs share one Smithers session, so by the time this trigger runs the conversation already carries earlier triggers, including `E2E_RATE_LIMIT_ERROR`, whose handler sits directly above this one and would swallow the request if selection keyed off the wrong message.

It doesn't. All four cases pass, including a stale tool result from an earlier turn. That candidate is off the table and stays off it.

### Makes the next occurrence decisive

`describeToolAudit()` asks the audit trail what it knows, while the stack is still up, and carries the answer into the assertion message. The three answers are three different bugs:

| Answer | Meaning |
| --- | --- |
| no `tool.pinchy_ls` row at all | the tool never ran — `sideEffects: false` was **correct** and the fault is upstream of the gate |
| row exists under a different `resource` | audited but not attributable to this agent, so `agentRanToolSince()` can never find it |
| row present and matching | it existed and the lookup missed it — a race with the plugin's audit POST |

The helper never throws: a diagnostic that fails would take the real failure's message with it.

### Recorded so nobody redoes it

- The `agent:unknown-agent` fallback in the tool-use route is reachable, but only when **both** `agentId` and `sessionKey` are absent, which a chat run does not do. Investigated, not established as the cause.
- I earlier claimed OpenClaw's log proved the tool never ran. **That was wrong** — the tool names in that log come from a config warning about *unknown* allowlist entries, so a known tool is absent by definition. The claim is retracted in #1013.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable) — no reader-facing surface moves
- [x] All existing tests pass

## Verification

Node 22: `pnpm test` three consecutive runs green (10509 passed), `test:scripts` (754), `typecheck`, `lint` (0 errors), `format:check`. The new file passes 5/5 in isolation. Playwright compiles and lists the modified spec.

One thing to flag rather than bury: the **first** of those full-suite runs reported a single failure, and the next three were clean. I didn't capture which test it was and cannot name it, so I can't rule out that it was mine — though the new file passed 5/5 isolated and the whole suite passed three times after. Worth knowing if it recurs.