### PR TITLE
test(web): spy on the clipboard instead of replacing it

### DIFF
--- a/packages/web/src/__tests__/components/audit-log-table.test.tsx
+++ b/packages/web/src/__tests__/components/audit-log-table.test.tsx
@@ -635,30 +635,40 @@ describe("AuditLogTable", () => {
     renderWithEntriesLoaded();
     await openFirstEntryDetail();
 
-    // Install the clipboard mock AFTER openFirstEntryDetail: userEvent.setup()
-    // attaches its own navigator.clipboard stub and would otherwise shadow ours.
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      value: { writeText },
-      writable: true,
-      configurable: true,
-    });
+    // Spy AFTER openFirstEntryDetail, whose userEvent.setup() is what defines
+    // `navigator.clipboard` in the first place (Clipboard.js:
+    // `attachClipboardStubToView`) — there is nothing to spy on before it.
+    //
+    // A spy rather than a wholesale Object.defineProperty: redefining the
+    // property shadows the stub user-event will later look for, so its per-test
+    // `resetClipboardStubOnView` silently does nothing and this mock leaks into
+    // every later test in the file.
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
-    // fireEvent (not userEvent) — the button lives inside the Radix Sheet, whose
-    // open state sets pointer-events:none on body, which userEvent rejects.
-    fireEvent.click(screen.getByRole("button", { name: /copy json/i }));
+    try {
+      // fireEvent (not userEvent) — the button lives inside the Radix Sheet, whose
+      // open state sets pointer-events:none on body, which userEvent rejects.
+      fireEvent.click(screen.getByRole("button", { name: /copy json/i }));
 
-    // entry 1 detail is { email: "admin@example.com" }, pretty-printed.
-    await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        JSON.stringify({ email: "admin@example.com" }, null, 2)
-      );
-    });
+      // entry 1 detail is { email: "admin@example.com" }, pretty-printed.
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          JSON.stringify({ email: "admin@example.com" }, null, 2)
+        );
+      });
+    } finally {
+      // In a `finally` so a failing assertion above still restores the spy —
+      // otherwise one red test leaves it in place for the rest of the file.
+      writeText.mockRestore();
+    }
   });
 
   it("surfaces a toast.error when copying the JSON detail fails", async () => {
     const originalExec = document.execCommand;
     document.execCommand = vi.fn().mockReturnValue(false);
+    // Captured inside the try, right before the property is redefined, so the
+    // restore below runs only if the redefinition actually happened.
+    let clipboardDescriptor: PropertyDescriptor | undefined;
 
     try {
       renderWithEntriesLoaded();
@@ -666,6 +676,15 @@ describe("AuditLogTable", () => {
 
       // After openFirstEntryDetail (userEvent.setup attaches a working clipboard
       // stub) simulate a non-secure context: no clipboard API, execCommand fails.
+      //
+      // This is the one clipboard test in the tree that cannot use a spy: the
+      // branch under test is `navigator.clipboard` being ABSENT, and a spy can
+      // only change what an existing method does. So the property is redefined
+      // here — and handed back in the `finally`, because leaving the
+      // redefinition in place shadows the stub user-event tracks, which makes
+      // its per-test `resetClipboardStubOnView` a silent no-op and leaks an
+      // undefined clipboard into every later test in the file.
+      clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
       Object.defineProperty(navigator, "clipboard", {
         value: undefined,
         writable: true,
@@ -679,6 +698,9 @@ describe("AuditLogTable", () => {
       });
     } finally {
       document.execCommand = originalExec;
+      if (clipboardDescriptor) {
+        Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+      }
     }
   });
 

--- a/packages/web/src/__tests__/components/audit-log-table.test.tsx
+++ b/packages/web/src/__tests__/components/audit-log-table.test.tsx
@@ -666,9 +666,10 @@ describe("AuditLogTable", () => {
   it("surfaces a toast.error when copying the JSON detail fails", async () => {
     const originalExec = document.execCommand;
     document.execCommand = vi.fn().mockReturnValue(false);
-    // Captured inside the try, right before the property is redefined, so the
-    // restore below runs only if the redefinition actually happened.
-    let clipboardDescriptor: PropertyDescriptor | undefined;
+    // Assigned inside the try, immediately before the property is redefined, so
+    // the `finally` restores only if the redefinition actually happened — a
+    // throw earlier in the try must not touch a clipboard this test never took.
+    let restoreClipboard: (() => void) | undefined;
 
     try {
       renderWithEntriesLoaded();
@@ -684,7 +685,17 @@ describe("AuditLogTable", () => {
       // redefinition in place shadows the stub user-event tracks, which makes
       // its per-test `resetClipboardStubOnView` a silent no-op and leaks an
       // undefined clipboard into every later test in the file.
-      clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+      //
+      // Both restore branches are spelled out rather than guarded with an `if`:
+      // "no descriptor" is not a reason to skip the restore, it is a different
+      // restore — skipping it would leave `clipboard: undefined` behind, which
+      // is the very leak this whole change removes.
+      const previousClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+      restoreClipboard = previousClipboard
+        ? () => Object.defineProperty(navigator, "clipboard", previousClipboard)
+        : () => {
+            delete (navigator as { clipboard?: unknown }).clipboard;
+          };
       Object.defineProperty(navigator, "clipboard", {
         value: undefined,
         writable: true,
@@ -698,9 +709,7 @@ describe("AuditLogTable", () => {
       });
     } finally {
       document.execCommand = originalExec;
-      if (clipboardDescriptor) {
-        Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
-      }
+      restoreClipboard?.();
     }
   });
 

--- a/packages/web/src/__tests__/components/report-issue-link.test.tsx
+++ b/packages/web/src/__tests__/components/report-issue-link.test.tsx
@@ -24,14 +24,16 @@ vi.mock("next/navigation", () => ({
 describe("ReportIssueLink", () => {
   let windowOpenSpy: ReturnType<typeof vi.spyOn>;
 
+  // No clipboard stub here on purpose. Every test that clicks calls
+  // `userEvent.setup()` first, and `setup()` defines `navigator.clipboard`
+  // itself (Clipboard.js: `attachClipboardStubToView`) with a `writeText` that
+  // resolves — which is all the success path needs. Redefining the property on
+  // top of that shadows the stub user-event will later look for, so its
+  // per-test `resetClipboardStubOnView` silently does nothing and the mock
+  // leaks into every later test in the file.
   beforeEach(() => {
     vi.clearAllMocks();
     windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
-    Object.defineProperty(navigator, "clipboard", {
-      value: { writeText: vi.fn().mockResolvedValue(undefined) },
-      writable: true,
-      configurable: true,
-    });
   });
 
   afterEach(() => {
@@ -141,17 +143,28 @@ describe("ReportIssueLink", () => {
   it("should still open GitHub URL when clipboard write fails", async () => {
     const user = userEvent.setup();
     mockFetchDiagnostics.mockResolvedValueOnce(null);
-    Object.defineProperty(navigator, "clipboard", {
-      value: { writeText: vi.fn().mockRejectedValue(new Error("Clipboard denied")) },
-      writable: true,
-      configurable: true,
-    });
+    // Spy on user-event's own stub rather than redefining the property (see the
+    // note on beforeEach above): a rejecting `writeText` is exactly the denial
+    // this test needs, and the descriptor user-event tracks stays intact.
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockRejectedValue(new Error("Clipboard denied"));
 
-    render(<ReportIssueLink error="Test error" />);
-    await user.click(screen.getByRole("button", { name: /report this issue/i }));
+    try {
+      render(<ReportIssueLink error="Test error" />);
+      await user.click(screen.getByRole("button", { name: /report this issue/i }));
 
-    await waitFor(() => {
-      expect(windowOpenSpy).toHaveBeenCalled();
-    });
+      await waitFor(() => {
+        expect(windowOpenSpy).toHaveBeenCalled();
+      });
+      // The write really was attempted and really did reject — otherwise this
+      // would pass just as well against a clipboard that was never touched.
+      expect(writeText).toHaveBeenCalled();
+      expect(screen.queryByText(/copied/i)).not.toBeInTheDocument();
+    } finally {
+      // In a `finally` so a failing assertion above still restores the spy —
+      // otherwise one red test leaves a rejecting clipboard in place.
+      writeText.mockRestore();
+    }
   });
 });

--- a/packages/web/src/__tests__/components/settings-users.test.tsx
+++ b/packages/web/src/__tests__/components/settings-users.test.tsx
@@ -294,36 +294,52 @@ describe("SettingsUsers", () => {
 
   it("should show copied feedback when invite link Copy button is clicked", async () => {
     const user = userEvent.setup();
-    Object.defineProperty(navigator, "clipboard", {
-      value: { writeText: vi.fn().mockResolvedValue(undefined) },
-      writable: true,
-      configurable: true,
-    });
+    // Spy on the clipboard user-event installed, rather than replacing
+    // `navigator.clipboard` wholesale with Object.defineProperty. `setup()`
+    // above defines the property itself (Clipboard.js: `attachClipboardStubToView`),
+    // so redefining it shadows the stub user-event will later look for, and
+    // `resetClipboardStubOnView` then silently does nothing between tests —
+    // leaving this test's mock in place for every later test in the file.
+    // A spy leaves that descriptor intact and `mockRestore` hands it back.
+    // Same pattern as add-integration-google-wizard.test.tsx.
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
-    mockFetchForUsers(mockUsers, mockInvites);
-    render(<SettingsUsers currentUserId="user-1" />);
+    try {
+      mockFetchForUsers(mockUsers, mockInvites);
+      render(<SettingsUsers currentUserId="user-1" />);
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Invite User" })).toBeInTheDocument();
-    });
-    await user.click(screen.getByRole("button", { name: "Invite User" }));
-    await waitFor(() => expect(screen.getByLabelText("Role")).toBeInTheDocument());
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Invite User" })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: "Invite User" }));
+      await waitFor(() => expect(screen.getByLabelText("Role")).toBeInTheDocument());
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ token: "invite-token-abc" }),
-    } as Response);
-    await user.click(screen.getByRole("button", { name: "Create Invite" }));
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: "invite-token-abc" }),
+      } as Response);
+      await user.click(screen.getByRole("button", { name: "Create Invite" }));
 
-    await waitFor(() =>
-      expect(screen.getByText("http://localhost:7777/invite/invite-token-abc")).toBeInTheDocument()
-    );
+      await waitFor(() =>
+        expect(
+          screen.getByText("http://localhost:7777/invite/invite-token-abc")
+        ).toBeInTheDocument()
+      );
 
-    await user.click(screen.getByRole("button", { name: "Copy" }));
+      await user.click(screen.getByRole("button", { name: "Copy" }));
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Copied!" })).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Copied!" })).toBeInTheDocument();
+      });
+      // The spy is what makes the success path deterministic, so assert it was
+      // really the invite link that went to the clipboard — otherwise the spy
+      // is decoration and only the button label is under test.
+      expect(writeText).toHaveBeenCalledWith("http://localhost:7777/invite/invite-token-abc");
+    } finally {
+      // In a `finally` so a failing assertion above still restores the spy —
+      // otherwise one red test leaves it in place for the rest of the file.
+      writeText.mockRestore();
+    }
   });
 
   it("should render group badges for users", async () => {

--- a/packages/web/src/__tests__/components/settings-users.test.tsx
+++ b/packages/web/src/__tests__/components/settings-users.test.tsx
@@ -301,7 +301,9 @@ describe("SettingsUsers", () => {
     // `resetClipboardStubOnView` then silently does nothing between tests —
     // leaving this test's mock in place for every later test in the file.
     // A spy leaves that descriptor intact and `mockRestore` hands it back.
-    // Same pattern as add-integration-google-wizard.test.tsx.
+    // add-integration-google-wizard.test.tsx spies for the same reason, but
+    // installs it describe-wide in beforeEach/afterEach; only this one test in
+    // this file needs a clipboard, so the spy is scoped to the test instead.
     const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
     try {

--- a/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
+++ b/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
@@ -410,7 +410,9 @@ describe("UserDetailSheet", () => {
     // `resetClipboardStubOnView` then silently does nothing between tests —
     // leaving this test's mock in place for every later test in the file.
     // A spy leaves that descriptor intact and `mockRestore` hands it back.
-    // Same pattern as add-integration-google-wizard.test.tsx.
+    // add-integration-google-wizard.test.tsx spies for the same reason, but
+    // installs it describe-wide in beforeEach/afterEach; only this one test in
+    // this file needs a clipboard, so the spy is scoped to the test instead.
     const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
     try {

--- a/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
+++ b/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
@@ -403,36 +403,49 @@ describe("UserDetailSheet", () => {
 
   it("should show copied feedback when reset link Copy button is clicked", async () => {
     const user = userEvent.setup();
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      value: { writeText },
-      writable: true,
-      configurable: true,
-    });
+    // Spy on the clipboard user-event installed, rather than replacing
+    // `navigator.clipboard` wholesale with Object.defineProperty. `setup()`
+    // above defines the property itself (Clipboard.js: `attachClipboardStubToView`),
+    // so redefining it shadows the stub user-event will later look for, and
+    // `resetClipboardStubOnView` then silently does nothing between tests —
+    // leaving this test's mock in place for every later test in the file.
+    // A spy leaves that descriptor intact and `mockRestore` hands it back.
+    // Same pattern as add-integration-google-wizard.test.tsx.
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
-    vi.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ token: "reset-token-xyz" }),
-    } as Response);
+    try {
+      vi.spyOn(global, "fetch").mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: "reset-token-xyz" }),
+      } as Response);
 
-    render(
-      <UserDetailSheet
-        user={mockUser}
-        allGroups={allGroups}
-        isEnterprise={true}
-        currentUserId="admin-1"
-        open={true}
-        onOpenChange={vi.fn()}
-        onSaved={vi.fn()}
-      />
-    );
+      render(
+        <UserDetailSheet
+          user={mockUser}
+          allGroups={allGroups}
+          isEnterprise={true}
+          currentUserId="admin-1"
+          open={true}
+          onOpenChange={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      );
 
-    await user.click(screen.getByRole("button", { name: /reset password/i }));
+      await user.click(screen.getByRole("button", { name: /reset password/i }));
 
-    await screen.findByText(/reset-token-xyz/);
+      await screen.findByText(/reset-token-xyz/);
 
-    await user.click(screen.getByRole("button", { name: "Copy" }));
+      await user.click(screen.getByRole("button", { name: "Copy" }));
 
-    await screen.findByRole("button", { name: "Copied!" });
+      await screen.findByRole("button", { name: "Copied!" });
+      // The spy is what makes the success path deterministic, so assert the
+      // reset link really reached the clipboard — otherwise the spy is
+      // decoration and only the button label is under test.
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining("reset-token-xyz"));
+    } finally {
+      // In a `finally` so a failing assertion above still restores the spy —
+      // otherwise one red test leaves it in place for the rest of the file.
+      writeText.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## What does this PR do?

Four component tests called `userEvent.setup()` and then redefined `navigator.clipboard` wholesale with `Object.defineProperty`. `setup()` defines that property itself (`attachClipboardStubToView` in user-event's `Clipboard.js`), so redefining it shadows the stub user-event tracks: `isClipboardStub` stops recognising what is there, the module-level `resetClipboardStubOnView` becomes a silent no-op, and the test's own mock leaks into every later test in the file. Verified directly — after such a test the property's getter is gone, and the next `setup()` captures the leaked mock as the "real" clipboard it will later restore.

### What this is *not*

It is not a flake fix, and the PR should not be read as one. The failure this pattern gets blamed for —

```
Failed Suites 1
  TypeError: Cannot read properties of undefined (reading 'navigator')
    ❯ detachClipboardStubFromView .../dataTransfer/Clipboard.js:120
Failed Tests 16
  ReferenceError: document is not defined
```

— is **a file running without jsdom**. user-event registers that `afterAll` at import time and reads `globalThis.window`, which does not exist in the node environment; the throw lands at SUITE level, so every test in the file reports the downstream `document is not defined`, including the ones that never touch a clipboard.

The real CI log for that failure (run `30613578614` on #747) shows the *very first* test failing too, which no clipboard teardown could explain. `3c3b0626` on `feat/572-agent-provisioning-api` tried this exact spy change as the fix and CI failed again identically; `0c4b21aa` records the correction and pins that file to jsdom instead. **All four files here already declare `// @vitest-environment jsdom`**, so none of them ever had that failure.

So: hygiene, worth doing on its own terms, with the comments saying so plainly rather than leaving the next reader to inherit the wrong explanation.

### Per file

- **`settings-users`, `user-detail-sheet`** — spy on `navigator.clipboard.writeText`, restored in a `finally` so one red assertion doesn't leave it in place for the rest of the file. The captured mock was never asserted in either test, so the spy now checks the value that actually reached the clipboard rather than only the button label.
- **`report-issue-link`** — the `beforeEach` stub is gone entirely: every clicking test calls `setup()` first, and its stub already resolves. The denial test uses a rejecting spy and now also asserts the write was attempted (previously it would have passed against a clipboard that was never touched).
- **`audit-log-table`** — the copy test spies, after `openFirstEntryDetail`, whose `setup()` is what creates the property in the first place (jsdom 29 has no `navigator.clipboard` of its own — so the existing "install AFTER setup" comment was right, for a different reason). The non-secure-context test still redefines, because the branch under test is the clipboard being **absent** and a spy cannot express that; it now hands the descriptor back in the `finally`.

## Type of change

- [x] 🧪 Tests

## Verification

Mutation, not a green suite. Each component's copy call was emptied, the tests run, and the change reverted:

| Mutation | Result |
| --- | --- |
| `invite-dialog.tsx` `handleCopy` emptied | settings-users test red |
| `user-detail-sheet.tsx` `onClick` emptied | red |
| `report-issue-link.tsx` `writeText` removed | 3 tests red |
| `audit-log-table.tsx` handler emptied | both tests red |
| only `if (!ok) toast.error(...)` removed | exactly the failure-path test red |

Worth knowing for review: the invite-link **Copy** button lives in `invite-dialog.tsx`, not `settings-users.tsx`. Mutating the latter leaves the test green and would have mis-read the probe as proving nothing bites.

Gates: `pnpm test` 10551 passed / 20 skipped, `pnpm -C packages/web typecheck` clean, ESLint 0 errors, `pnpm format:check` clean.

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable) — test-only change, no net test removal
- [x] I've updated the documentation (if applicable) — no user-visible surface moved
- [x] All existing tests pass
