### PR TITLE
test(server): bound the WS handshake so a stall cannot read as a timeout

### DIFF
--- a/packages/web/src/__tests__/server/ws-frame-limit.test.ts
+++ b/packages/web/src/__tests__/server/ws-frame-limit.test.ts
@@ -14,32 +14,96 @@ import { SERVER_WS_MAX_PAYLOAD_BYTES } from "@/lib/limits";
  * a 5 MB JSON frame, and asserts the server delivers the message instead of
  * closing with code 1009 ("Message too big").
  */
+
 /**
- * Open a WebSocket to the local test server, retrying the CONNECT phase on
- * transient handshake failures (bounded, fresh socket per attempt).
+ * Bound for ONE connect attempt — the fix for this file's load-induced flake.
  *
- * Why: under full-suite load (many vitest forks + local Docker stacks) a
- * single-shot localhost TCP/WS handshake can fail with `socket hang up`
- * (ECONNRESET during the HTTP upgrade) — pure environmental noise that has
- * nothing to do with this file's contract, which is the server's `maxPayload`
- * behaviour AFTER a connection exists. Retrying only the connect phase removes
- * that noise without weakening the contract: every assertion still runs
- * against a real connection, and a maxPayload regression fails exactly as
- * before.
+ * The flake reported it as "Test timed out", which reads as "5 MB is slow under
+ * load". It is not. Measured end-to-end (connect plus the full 5 MB round trip):
+ * 22 ms in isolation, 52–94 ms under 2.5× CPU oversubscription, and 28–61 ms
+ * inside a full `pnpm test` run at load average 25 — that last one with ~0 ms
+ * event-loop lag. Contention moves this test by a factor of 4. A timeout needs
+ * a factor of 200, so what ends it is a stall, not a slowdown.
+ *
+ * `ws` sets no handshake timeout by default, and that is where a stall used to
+ * become unbounded: a stalled upgrade — the loaded-loopback sibling of the
+ * `socket hang up` the retry loop below was written for — emits neither `open`
+ * nor `error`, so the loop could never retry the one failure shape it exists
+ * for, and the wait was bounded only by the suite's testTimeout. Verified
+ * against a server that accepts TCP and never answers the upgrade: still
+ * hanging after 20 s without this option, "Opening handshake has timed out"
+ * after 6.6 s with it.
+ *
+ * 2 s is ~75× the observed handshake (4–27 ms, isolated and under 2.5× CPU
+ * oversubscription), so a merely slow handshake is still awaited to completion.
+ * Only a stall is cut short and retried.
+ *
+ * The worst case this can cost — 3 attempts × 2 s plus 100/200 ms backoff =
+ * 6.3 s — has to stay comfortably inside vitest.config.ts's `testTimeout`
+ * (20 s). A retry budget that cannot finish inside the deadline is not bounded
+ * at all: the run reports a timeout and hides the error that names the cause.
  */
-async function connectWithRetry(port: number, attempts = 3): Promise<WebSocket> {
+const HANDSHAKE_TIMEOUT_MS = 2_000;
+
+const CONNECT_ATTEMPTS = 3;
+
+/**
+ * Open a WebSocket to the local test server and return BOTH ends, retrying the
+ * CONNECT phase on transient handshake failures (bounded, fresh socket per
+ * attempt).
+ *
+ * Why retry: under full-suite load (many vitest forks + local Docker stacks) a
+ * single-shot localhost TCP/WS handshake can fail with `socket hang up`
+ * (ECONNRESET during the HTTP upgrade) or stall outright — environmental noise
+ * that has nothing to do with this file's contract, which is the server's
+ * `maxPayload` behaviour AFTER a connection exists. Retrying only the connect
+ * phase removes that noise without weakening the contract: every assertion
+ * still runs against a real connection, and a maxPayload regression fails
+ * exactly as before.
+ *
+ * Why it hands back the server-side socket too: an attempt that fails after the
+ * server already accepted leaves a socket behind, and that socket emits `close`
+ * when we discard it. A test listening to `wss` at large cannot tell that
+ * `close` apart from the live connection being dropped — it would fail with
+ * "server closed before message" on a connection that is perfectly healthy.
+ * Returning the socket that belongs to the connection we keep lets each test
+ * listen to that one only.
+ */
+async function connectPair(
+  wss: WebSocketServer,
+  port: number,
+  attempts = CONNECT_ATTEMPTS
+): Promise<{ client: WebSocket; server: WebSocket }> {
   let lastError: unknown;
   for (let i = 0; i < attempts; i++) {
-    const client = new WebSocket(`ws://127.0.0.1:${port}`);
+    // Claim this attempt's server-side socket before the client exists, so a
+    // socket accepted for this attempt can never be picked up by a later one.
+    let onConnection!: (ws: WebSocket) => void;
+    const serverSocket = new Promise<WebSocket>((resolve) => {
+      onConnection = resolve;
+      wss.once("connection", onConnection);
+    });
+    const client = new WebSocket(`ws://127.0.0.1:${port}`, {
+      handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
+    });
     try {
       await new Promise<void>((resolve, reject) => {
         client.once("open", () => resolve());
         client.once("error", reject);
       });
-      return client;
+      // The server emits "connection" when it writes the 101 response, i.e.
+      // before the client can see "open" — this await is already settled.
+      return { client, server: await serverSocket };
     } catch (err) {
       lastError = err;
       client.terminate();
+      // Drop this attempt's listener so it cannot consume the next attempt's
+      // connection, and discard the socket if the server did accept one.
+      wss.off("connection", onConnection);
+      void serverSocket.then((ws) => {
+        ws.on("error", () => {});
+        ws.terminate();
+      });
       await new Promise((r) => setTimeout(r, 100 * (i + 1)));
     }
   }
@@ -71,16 +135,18 @@ describe("WebSocket server frame limit (regression guard)", () => {
   });
 
   it("accepts a 5 MB JSON frame (representative of a high-res image attachment)", async () => {
-    const received = new Promise<string>((resolve, reject) => {
-      wss.on("connection", (ws) => {
-        ws.on("message", (data) => resolve(data.toString()));
-        ws.on("close", (code, reason) =>
-          reject(new Error(`server closed before message: code=${code} reason=${reason}`))
-        );
-      });
-    });
+    const { client, server } = await connectPair(wss, port);
 
-    const client = await connectWithRetry(port);
+    const received = new Promise<string>((resolve, reject) => {
+      server.on("message", (data) => resolve(data.toString()));
+      server.on("close", (code, reason) =>
+        reject(new Error(`server closed before message: code=${code} reason=${reason}`))
+      );
+      // A maxPayload regression makes the receiver emit "error" besides
+      // closing with 1009. Without a listener that is an unhandled 'error'
+      // event, and the run reports a timeout instead of naming the cause.
+      server.on("error", (err) => reject(err));
+    });
 
     // 5 MB of base64-ish content, wrapped in a JSON message so it mirrors what
     // the real router parses.
@@ -102,19 +168,17 @@ describe("WebSocket server frame limit (regression guard)", () => {
     // the limit must be rejected with 1009 ("Message too big"), which is what
     // the client-side handler in use-ws-runtime.ts uses to surface "Image too
     // large".
-    let messageReceived = false;
-    wss.on("connection", (ws) => {
-      ws.on("message", () => {
-        messageReceived = true;
-      });
-      // The `ws` library emits an "error" event with WS_ERR_UNSUPPORTED_MESSAGE_LENGTH
-      // when an oversized frame arrives. Without a listener Node treats it as
-      // unhandled and Vitest fails the test even though the close code is what
-      // we're asserting on. Swallow it — the close code is the contract.
-      ws.on("error", () => {});
-    });
+    const { client, server } = await connectPair(wss, port);
 
-    const client = await connectWithRetry(port);
+    let messageReceived = false;
+    server.on("message", () => {
+      messageReceived = true;
+    });
+    // The `ws` library emits an "error" event with WS_ERR_UNSUPPORTED_MESSAGE_LENGTH
+    // when an oversized frame arrives. Without a listener Node treats it as
+    // unhandled and Vitest fails the test even though the close code is what
+    // we're asserting on. Swallow it — the close code is the contract.
+    server.on("error", () => {});
 
     const closeEvent = new Promise<{ code: number }>((resolve) => {
       client.once("close", (code) => resolve({ code }));

--- a/packages/web/src/__tests__/server/ws-frame-limit.test.ts
+++ b/packages/web/src/__tests__/server/ws-frame-limit.test.ts
@@ -32,20 +32,31 @@ import { SERVER_WS_MAX_PAYLOAD_BYTES } from "@/lib/limits";
  * for, and the wait was bounded only by the suite's testTimeout. Verified
  * against a server that accepts TCP and never answers the upgrade: still
  * hanging after 20 s without this option, "Opening handshake has timed out"
- * after 6.6 s with it.
+ * after 6.3 s with it.
  *
  * 2 s is ~75× the observed handshake (4–27 ms, isolated and under 2.5× CPU
  * oversubscription), so a merely slow handshake is still awaited to completion.
  * Only a stall is cut short and retried.
  *
- * The worst case this can cost — 3 attempts × 2 s plus 100/200 ms backoff =
- * 6.3 s — has to stay comfortably inside vitest.config.ts's `testTimeout`
- * (20 s). A retry budget that cannot finish inside the deadline is not bounded
- * at all: the run reports a timeout and hides the error that names the cause.
+ * The worst case this can cost — 3 attempts × 2 s plus the 100/200 ms backoff
+ * BETWEEN them = 6.3 s, measured against the black-hole server — has to stay
+ * comfortably inside vitest.config.ts's `testTimeout` (20 s). A retry budget
+ * that cannot finish inside the deadline is not bounded at all: the run reports
+ * a timeout and hides the error that names the cause.
  */
 const HANDSHAKE_TIMEOUT_MS = 2_000;
 
 const CONNECT_ATTEMPTS = 3;
+
+/**
+ * Drop a socket we are not going to use. The `error` listener is what keeps a
+ * terminate on an already-broken socket from surfacing as an unhandled 'error'
+ * event, which vitest reports against whichever test happens to be running.
+ */
+function discardSocket(ws: WebSocket): void {
+  ws.on("error", () => {});
+  ws.terminate();
+}
 
 /**
  * Open a WebSocket to the local test server and return BOTH ends, retrying the
@@ -68,6 +79,16 @@ const CONNECT_ATTEMPTS = 3;
  * "server closed before message" on a connection that is perfectly healthy.
  * Returning the socket that belongs to the connection we keep lets each test
  * listen to that one only.
+ *
+ * Why each attempt tags itself with a subprotocol: dropping the listener on
+ * failure is not enough to keep attempts apart. It stops THIS attempt's
+ * listener from eating the NEXT attempt's connection, but not the reverse — a
+ * server that completes the upgrade late (the stall resolving after we gave up)
+ * emits `connection` while attempt i+1 is already listening, and that attempt
+ * would await a dead socket while sending over a live one. `ws` echoes the
+ * first offered protocol back on `ws.protocol` with no handleProtocols
+ * configuration, so matching on it identifies the socket that belongs to this
+ * attempt, and a stale one is discarded rather than handed on.
  */
 async function connectPair(
   wss: WebSocketServer,
@@ -76,14 +97,21 @@ async function connectPair(
 ): Promise<{ client: WebSocket; server: WebSocket }> {
   let lastError: unknown;
   for (let i = 0; i < attempts; i++) {
-    // Claim this attempt's server-side socket before the client exists, so a
-    // socket accepted for this attempt can never be picked up by a later one.
+    // Claim this attempt's server-side socket before the client exists, and
+    // identify it by the attempt's own subprotocol so neither a late socket
+    // from an earlier attempt nor this attempt's socket arriving after we gave
+    // up can be mistaken for the connection we return.
+    const attemptId = `connect-attempt-${i}`;
     let onConnection!: (ws: WebSocket) => void;
     const serverSocket = new Promise<WebSocket>((resolve) => {
-      onConnection = resolve;
+      onConnection = (ws) => {
+        if (ws.protocol === attemptId) return resolve(ws);
+        discardSocket(ws);
+        wss.once("connection", onConnection);
+      };
       wss.once("connection", onConnection);
     });
-    const client = new WebSocket(`ws://127.0.0.1:${port}`, {
+    const client = new WebSocket(`ws://127.0.0.1:${port}`, [attemptId], {
       handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
     });
     try {
@@ -100,11 +128,12 @@ async function connectPair(
       // Drop this attempt's listener so it cannot consume the next attempt's
       // connection, and discard the socket if the server did accept one.
       wss.off("connection", onConnection);
-      void serverSocket.then((ws) => {
-        ws.on("error", () => {});
-        ws.terminate();
-      });
-      await new Promise((r) => setTimeout(r, 100 * (i + 1)));
+      void serverSocket.then(discardSocket);
+      // No backoff after the final attempt — it would only delay the throw,
+      // and the budget the constant above states has to be the real one.
+      if (i < attempts - 1) {
+        await new Promise((r) => setTimeout(r, 100 * (i + 1)));
+      }
     }
   }
   throw lastError;


### PR DESCRIPTION
## What does this PR do?

Fixes the load-induced flake in `packages/web/src/__tests__/server/ws-frame-limit.test.ts`, where the 5 MB frame test intermittently failed with `Test timed out` during a full `pnpm test` run while passing in ~60 ms in isolation.

**The obvious reading is wrong.** "5 MB over a loopback socket is slow under parallel load" does not survive measurement:

| Condition | connect + full 5 MB round trip |
| --- | --- |
| isolated | 22 ms |
| isolated, 2.5× CPU oversubscription (28 hogs, load 11) | 52–94 ms |
| inside a full `pnpm test` run, load average 25 | 28–61 ms, ~0 ms event-loop lag |

Contention moves this test by a factor of 4. A timeout needs a factor of 200. So what ends the test is a **stall**, not a slowdown — and in 6 instrumented full-suite runs the slow case never appeared at all.

**The actual gap:** `ws` sets no handshake timeout by default. A stalled upgrade emits neither `open` nor `error`, so the retry loop this file already had — written for exactly this environmental noise, `socket hang up` during the upgrade under load — could never fire for the one failure shape that needs it. The wait was bounded only by the suite's `testTimeout`. Measured against a server that accepts TCP and never answers the upgrade: **still hanging after 20 s** before, `Opening handshake has timed out` after 6.6 s now.

The fix is `handshakeTimeout: 2000` per attempt (~75× the observed 4–27 ms handshake, so a merely slow handshake is still awaited to completion — only a stall is cut short and retried). Worst case 3 × 2 s + backoff = 6.3 s, which stays inside `vitest.config.ts`'s 20 s `testTimeout`.

Two consequences of making that retry actually work:

- **The helper returns both socket ends.** An attempt that fails after the server already accepted leaves a socket behind, and a test listening to `wss` at large cannot tell that socket's `close` apart from the live connection being dropped — it would fail with "server closed before message" on a perfectly healthy connection.
- **The server socket gets an `error` listener in the positive test too**, as the negative test already had.

## The guard got stronger, not weaker

With `maxPayload` temporarily reverted to 1 MB:

| | reported as |
| --- | --- |
| before | `Error: server closed before message: code=1006` **plus** an unhandled error that vitest flags with "might cause false positive tests" |
| after | `RangeError: Max payload size exceeded`, in 28 ms, no unhandled error |

The 5 MB payload is unchanged — it is the regression space this test covers, and it costs ~15 ms of the budget. Net test count is unchanged (2 → 2).

## Type of change

- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable) — n/a, this repairs an existing guard
- [x] I've updated the documentation (if applicable) — n/a, no user-visible surface (`analyzeChangedPaths` → `surfaces: []`)
- [x] All existing tests pass

Verified: full `pnpm test` green on this base (745 files, 10557 tests, exit 0), plus 4 consecutive green full runs at load average 21–26 on the pre-rebase base. `typecheck` (incl. test files), `lint` (0 errors), `prettier --check` and `pnpm test:scripts` (754 passed) all green.

## One note for the reviewer

`main` moved under this work: `2d4da371` raised the suite-wide `testTimeout` from vitest's 5 s default to 20 s. That already changes the *symptom* — a stall now costs 20 s instead of 5 s — so an earlier draft of this fix carried a per-test timeout override that the new base made pointless. It was dropped. The unbounded wait itself is unaffected by any deadline, which is why the handshake bound is still the fix.


## Follow-up from review (`c99c7130`)

Two findings, both verified against `ws` rather than reasoned about:

- **The stated budget was wrong.** The backoff sat unconditionally in the `catch`, so it also ran after the *final* attempt: 3 × 2 s + 100 + 200 + 300 = **6.6 s**, not the 6.3 s the comment claimed — and the black-hole measurement quoted three paragraphs above it in the same comment already said 6.6 s. The backoff is now skipped after the last attempt, and the documented 6.3 s is the measured 6.31 s.
- **Attempts are now identified, not just separated.** Dropping the listener on failure only closed one direction. It stops this attempt's listener from eating the next attempt's connection, but not the reverse: a server completing the upgrade *late* — the stall resolving after we gave up — emits `connection` while attempt i+1 is already listening, and that attempt would await a dead socket while sending over a live one. Symptom: the same 20 s timeout, from a narrower cause. Each attempt now offers its own subprotocol and matches on `ws.protocol`; a foreign socket is discarded and the listener re-arms.

Proven empirically: `ws` echoes the first offered protocol onto the server-side `ws.protocol` with no `handleProtocols` configuration; an injected foreign socket is terminated while the real one is still returned and still round-trips; worst case measures 6.31 s. The `maxPayload` regression check still names its cause (`RangeError: Max payload size exceeded`, 24 ms, no unhandled error). Full `pnpm test` green (745 files, 10557 tests), net test count still unchanged.
