### PR TITLE
fix(#1013): ask the duplicate-write question when Retry is pressed, not when the run fails

### DIFF
--- a/docs/src/content/docs/guides/retry-messages.mdx
+++ b/docs/src/content/docs/guides/retry-messages.mdx
@@ -22,6 +22,8 @@ When Pinchy sees that the failed run already performed an action, Retry asks fir
 
 It's the same prompt wherever you retry: the live error bubble in the thread and the paused banner you see after a reload both ask the same question before re-running anything.
 
+The check happens when you press Retry, not when the run failed. A tool call is recorded in the audit trail a moment after it finishes, and a run can fail before that record has landed — so asking at the moment of failure could miss an action the agent had genuinely taken. By the time you reach for Retry, the record is there. If Pinchy cannot check at all, it asks for confirmation rather than assuming nothing happened.
+
 ## What you don't need to do
 
 You don't need to copy your message, refresh the page, or figure out what went wrong. Click Retry — Pinchy picks up from the right place.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -330,6 +330,18 @@ Dismiss the error the banner is showing. Scoped to the owning user, so one user 
 
 - `404` — no un-dismissed error with that id belongs to the caller
 
+### `GET /api/agents/:agentId/retry-gate`
+
+Whether retrying the caller's last failed run in this conversation could duplicate actions the agent already performed. Pass `?chatId=` to address one specific chat; omit it for the default per-user session.
+
+**Response:**
+
+| Field         | Type      | Description                                                            |
+| ------------- | --------- | ---------------------------------------------------------------------- |
+| `sideEffects` | `boolean` | `true` when the failed run had already executed at least one tool call |
+
+The chat asks this when you press Retry, not when the run failed — see [Retrying after the agent already acted](/guides/retry-messages/#retrying-after-the-agent-already-acted). The time window comes from the stored run, never from the request, so this cannot be used to query an agent's tool history.
+
 ### `GET /api/agents/:agentId/uploads/:filename`
 
 Download a file the caller uploaded to this agent.

--- a/packages/web/drizzle/0064_wide_captain_stacy.sql
+++ b/packages/web/drizzle/0064_wide_captain_stacy.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "chat_session_errors" ADD COLUMN "run_started_at" timestamp;--> statement-breakpoint
+ALTER TABLE "chat_session_errors" ADD COLUMN "show_banner" boolean DEFAULT true NOT NULL;

--- a/packages/web/drizzle/meta/0064_snapshot.json
+++ b/packages/web/drizzle/meta/0064_snapshot.json
@@ -1,0 +1,3649 @@
+{
+  "id": "3a7a8068-a8db-4fe7-aa24-04081ad6307d",
+  "prevId": "9df5f8f1-9e74-416a-9911-16ad027d04b9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_delivered_files": {
+      "name": "agent_delivered_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_delivered_files_lookup": {
+          "name": "idx_agent_delivered_files_lookup",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_delivered_files_session": {
+          "name": "idx_agent_delivered_files_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_delivered_files_user_id_user_id_fk": {
+          "name": "agent_delivered_files_user_id_user_id_fk",
+          "tableFrom": "agent_delivered_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_delivered_files_agent_id_agents_id_fk": {
+          "name": "agent_delivered_files_agent_id_agents_id_fk",
+          "tableFrom": "agent_delivered_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_groups_group_id_idx": {
+          "name": "agent_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_visibility_check": {
+          "name": "agents_visibility_check",
+          "value": "\"agents\".\"visibility\" IN ('restricted', 'all')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_timestamp": {
+          "name": "idx_audit_resource_timestamp",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_integrity_violation": {
+          "name": "idx_audit_integrity_violation",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"event_type\" = 'audit.integrity_check' AND \"audit_log\".\"outcome\" = 'failure'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_verify_state": {
+      "name": "audit_verify_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified_id": {
+          "name": "last_verified_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_verified_hmac": {
+          "name": "last_verified_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_banner": {
+          "name": "show_banner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_connection_cursors": {
+      "name": "email_connection_cursors",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_connection_cursors_connection_id_integration_connections_id_fk": {
+          "name": "email_connection_cursors_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_connection_cursors",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflow_connections": {
+      "name": "email_workflow_connections",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since_ts": {
+          "name": "since_ts",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_workflow_connections_workflow_id_email_workflows_id_fk": {
+          "name": "email_workflow_connections_workflow_id_email_workflows_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflow_connections_connection_id_integration_connections_id_fk": {
+          "name": "email_workflow_connections_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_workflow_connections_workflow_id_connection_id_pk": {
+          "name": "email_workflow_connections_workflow_id_connection_id_pk",
+          "columns": ["workflow_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflows": {
+      "name": "email_workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_every": {
+          "name": "poll_every",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'5m'"
+        },
+        "sweep_window_days": {
+          "name": "sweep_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "openclaw_job_id": {
+          "name": "openclaw_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_workflows_agent_idx": {
+          "name": "email_workflows_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_workflows_enabled_idx": {
+          "name": "email_workflows_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_workflows\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_workflows_agent_id_agents_id_fk": {
+          "name": "email_workflows_agent_id_agents_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflows_created_by_user_id_fk": {
+          "name": "email_workflows_created_by_user_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_workflows_status_check": {
+          "name": "email_workflows_status_check",
+          "value": "\"email_workflows\".\"status\" IN ('pending', 'active', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_type_check": {
+          "name": "integration_connections_type_check",
+          "value": "\"integration_connections\".\"type\" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')"
+        },
+        "integration_connections_status_check": {
+          "name": "integration_connections_status_check",
+          "value": "\"integration_connections\".\"status\" IN ('active', 'pending', 'auth_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_claimed_by_user_id_idx": {
+          "name": "invites_claimed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_email_expires_at_idx": {
+          "name": "invites_email_expires_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_role_check": {
+          "name": "invites_role_check",
+          "value": "\"invites\".\"role\" IN ('admin', 'member')"
+        },
+        "invites_type_check": {
+          "name": "invites_type_check",
+          "value": "\"invites\".\"type\" IN ('invite', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kb_chunks": {
+      "name": "kb_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator": {
+          "name": "locator",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kb_chunks_doc": {
+          "name": "idx_kb_chunks_doc",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_chunks_org_path": {
+          "name": "idx_kb_chunks_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_chunks_document_id_kb_documents_id_fk": {
+          "name": "kb_chunks_document_id_kb_documents_id_fk",
+          "tableFrom": "kb_chunks",
+          "tableTo": "kb_documents",
+          "columnsFrom": ["document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_documents": {
+      "name": "kb_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_kb_doc_org_path": {
+          "name": "uq_kb_doc_org_path",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_doc_org_hash": {
+          "name": "idx_kb_doc_org_hash",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kb_index_jobs": {
+      "name": "kb_index_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paths": {
+          "name": "paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_bytes": {
+          "name": "total_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_bytes": {
+          "name": "processed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_kb_index_jobs_active": {
+          "name": "uq_kb_index_jobs_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kb_index_jobs\".\"status\" IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_status_created": {
+          "name": "idx_kb_index_jobs_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kb_index_jobs_agent_created": {
+          "name": "idx_kb_index_jobs_agent_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kb_index_jobs_agent_id_agents_id_fk": {
+          "name": "kb_index_jobs_agent_id_agents_id_fk",
+          "tableFrom": "kb_index_jobs",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kb_index_jobs_status_check": {
+          "name": "kb_index_jobs_status_check",
+          "value": "\"kb_index_jobs\".\"status\" IN ('pending', 'running', 'succeeded', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipients": {
+      "name": "notification_recipients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_recipients_user_unread_idx": {
+          "name": "notification_recipients_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipients_user_id_user_id_fk": {
+          "name": "notification_recipients_user_id_user_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_recipients_notification_id_notifications_id_fk": {
+          "name": "notification_recipients_notification_id_notifications_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notification_recipients_user_id_notification_id_pk": {
+          "name": "notification_recipients_user_id_notification_id_pk",
+          "columns": ["user_id", "notification_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_agent_created_idx": {
+          "name": "notifications_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_agent_id_agents_id_fk": {
+          "name": "notifications_agent_id_agents_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_status_check": {
+          "name": "notifications_status_check",
+          "value": "\"notifications\".\"status\" IN ('success', 'failure')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.openai_compatible_providers": {
+      "name": "openai_compatible_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models": {
+          "name": "models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "openai_compatible_providers_slug_unique": {
+          "name": "openai_compatible_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.processed_emails": {
+      "name": "processed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id_header": {
+          "name": "message_id_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "processed_emails_claim_uniq": {
+          "name": "processed_emails_claim_uniq",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "processed_emails_status_idx": {
+          "name": "processed_emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "processed_emails_workflow_id_email_workflows_id_fk": {
+          "name": "processed_emails_workflow_id_email_workflows_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "processed_emails_status_check": {
+          "name": "processed_emails_status_check",
+          "value": "\"processed_emails\".\"status\" IN ('processing', 'done', 'no_action', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user_timestamp": {
+          "name": "idx_usage_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent_timestamp": {
+          "name": "idx_usage_agent_timestamp",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_groups_group_id_idx": {
+          "name": "user_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_pseudonym": {
+          "name": "audit_pseudonym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_audit_pseudonym_unique": {
+          "name": "user_audit_pseudonym_unique",
+          "nullsNotDistinct": false,
+          "columns": ["audit_pseudonym"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"user\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"starter_prompts\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1785423989404,
       "tag": "0063_kb_index_job_byte_progress",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1785529569209,
+      "tag": "0064_wide_captain_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/e2e/integration/19-durable-agent-error-banner.spec.ts
+++ b/packages/web/e2e/integration/19-durable-agent-error-banner.spec.ts
@@ -88,20 +88,24 @@ test.describe("Durable agent-error banner", () => {
 
     await expect(page.getByTestId("error-warning-icon").last()).toBeVisible({ timeout: 60000 });
 
-    // In-session (the live path, before any reload): the LIVE error frame
-    // carries the audit-derived sideEffects flag, so the inline bubble's Retry
+    // In-session (the live path, before any reload): the inline bubble's Retry
     // is gated behind the SAME duplicate-write confirm as the durable banner —
-    // not just the post-reload banner. Clicking it opens the confirm instead of
-    // resending. Cancel here so the run's durable error survives to the reload
-    // assertions below.
+    // not just the post-reload banner. Clicking it asks the server whether this
+    // run already acted (#1013) and opens the confirm instead of resending.
+    // Cancel here so the run's durable error survives to the reload assertions
+    // below.
+    //
+    // The click-time question is the point. The flag the error frame carried is
+    // derived the instant the run fails, and OpenClaw fires `after_tool_call`
+    // without awaiting it — so the `tool.*` audit row can still be in flight
+    // then. This assertion used to fail in CI for exactly that reason, and the
+    // artifacts could not say why: OpenClaw doesn't log tool executions at this
+    // level, postgres has no statement logging, pinchy has no request logging.
     await page.getByRole("button", { name: /^retry$/i }).click();
     const liveConfirm = page.getByRole("alertdialog");
-    // #1013: this assertion has failed in CI, and the run's artifacts could not
-    // say why — OpenClaw doesn't log tool executions at this level, postgres has
-    // no statement logging, pinchy has no request logging. The gate depends on
-    // an audit lookup, so ask the audit trail here, while the stack is still up,
-    // and carry the answer into the failure message. See describeToolAudit for
-    // how the three possible answers map to three different bugs.
+    // Ask the audit trail here, while the stack is still up, and carry the
+    // answer into the failure message. See describeToolAudit for how the three
+    // possible answers map to three different bugs.
     await expect(
       liveConfirm,
       await describeToolAudit(page, { toolName: TOOL_THEN_RATE_LIMIT_TOOL, agentId })

--- a/packages/web/src/__tests__/api/agent-active-error.test.ts
+++ b/packages/web/src/__tests__/api/agent-active-error.test.ts
@@ -17,9 +17,11 @@ vi.mock("@/lib/agent-access", () => ({
 
 const mockGetActive = vi.fn();
 const mockDismiss = vi.fn();
+const mockResolveRetryGate = vi.fn();
 vi.mock("@/server/chat-session-errors", () => ({
   getActiveChatSessionError: (...args: unknown[]) => mockGetActive(...args),
   dismissChatSessionError: (...args: unknown[]) => mockDismiss(...args),
+  resolveRetryGate: (...args: unknown[]) => mockResolveRetryGate(...args),
 }));
 
 const mockAppendAuditLog = vi.fn().mockResolvedValue(undefined);
@@ -58,6 +60,7 @@ describe("/api/agents/[agentId]/active-error", () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue({ user: { id: "user-1", role: "member" } });
     mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Penny" });
+    mockResolveRetryGate.mockResolvedValue(true);
     const mod = await import("@/app/api/agents/[agentId]/active-error/route");
     GET = mod.GET;
     DELETE = mod.DELETE;
@@ -137,6 +140,24 @@ describe("/api/agents/[agentId]/active-error", () => {
       const res = await GET(getRequest(), ctx as never);
       const body = await res.json();
       expect(body.error).toBeNull();
+      // Nothing to gate, so don't pay for the audit lookup.
+      expect(mockResolveRetryGate).not.toHaveBeenCalled();
+    });
+
+    it("re-derives sideEffects instead of trusting the stored flag (#1013)", async () => {
+      // The row was written while the run's `tool.*` audit row could still have
+      // been in flight, so `row.sideEffects` may be a false `false`. The banner
+      // is fetched a reload later at the earliest — long enough for the truth.
+      mockGetActive.mockResolvedValueOnce({ ...activeRow, sideEffects: false });
+      mockResolveRetryGate.mockResolvedValueOnce(true);
+
+      const res = await GET(getRequest(), ctx as never);
+
+      expect((await res.json()).error.sideEffects).toBe(true);
+      expect(mockResolveRetryGate).toHaveBeenCalledWith({
+        sessionKey: "agent:agent-1:direct:user-1",
+        agentId: "agent-1",
+      });
     });
   });
 

--- a/packages/web/src/__tests__/api/agent-retry-gate.test.ts
+++ b/packages/web/src/__tests__/api/agent-retry-gate.test.ts
@@ -1,0 +1,104 @@
+// The duplicate-write retry gate, asked at the moment the user reaches for
+// Retry rather than at the moment the run failed (#1013).
+//
+// The window this answers over comes from the stored run, never from the
+// caller. A `?since=` parameter would have been simpler and would also have
+// turned this into an oracle: "did agent X run a tool between T1 and T2" is a
+// question a non-admin cannot otherwise ask (`/api/audit` is admin-only), and
+// on a SHARED agent the answer is about a colleague's activity.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
+const mockResolveRetryGate = vi.fn();
+vi.mock("@/server/chat-session-errors", () => ({
+  resolveRetryGate: (...args: unknown[]) => mockResolveRetryGate(...args),
+}));
+
+function getRequest(url = "http://localhost/api/agents/agent-1/retry-gate") {
+  return new NextRequest(url, { method: "GET" });
+}
+const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
+
+describe("/api/agents/[agentId]/retry-gate", () => {
+  let GET: typeof import("@/app/api/agents/[agentId]/retry-gate/route").GET;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Penny" });
+    mockResolveRetryGate.mockResolvedValue(false);
+    const mod = await import("@/app/api/agents/[agentId]/retry-gate/route");
+    GET = mod.GET;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(getRequest(), ctx as never);
+    expect(res.status).toBe(401);
+    expect(mockResolveRetryGate).not.toHaveBeenCalled();
+  });
+
+  it("propagates the access decision without answering", async () => {
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    );
+    const res = await GET(getRequest(), ctx as never);
+    expect(res.status).toBe(403);
+    expect(mockResolveRetryGate).not.toHaveBeenCalled();
+  });
+
+  it("reports that a retry may duplicate writes", async () => {
+    mockResolveRetryGate.mockResolvedValueOnce(true);
+    const res = await GET(getRequest(), ctx as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sideEffects: true });
+  });
+
+  it("asks about the caller's OWN session, built server-side", async () => {
+    // The session key embeds the caller's id, so one user can never read
+    // another's run — and the caller has no way to name a different one.
+    await GET(getRequest(), ctx as never);
+    expect(mockResolveRetryGate).toHaveBeenCalledWith({
+      sessionKey: "agent:agent-1:direct:user-1",
+      agentId: "agent-1",
+    });
+  });
+
+  it("scopes to the chat the user is looking at", async () => {
+    await GET(
+      getRequest("http://localhost/api/agents/agent-1/retry-gate?chatId=chat-7"),
+      ctx as never
+    );
+    expect(mockResolveRetryGate).toHaveBeenCalledWith({
+      sessionKey: "agent:agent-1:direct:user-1:chat-7",
+      agentId: "agent-1",
+    });
+  });
+
+  it("takes no time window from the caller", async () => {
+    // A `since` in the query string must change nothing. If it ever does, this
+    // endpoint has become a queryable history of a shared agent's tool use.
+    await GET(
+      getRequest("http://localhost/api/agents/agent-1/retry-gate?since=1970-01-01T00:00:00.000Z"),
+      ctx as never
+    );
+    expect(mockResolveRetryGate).toHaveBeenCalledWith({
+      sessionKey: "agent:agent-1:direct:user-1",
+      agentId: "agent-1",
+    });
+  });
+});

--- a/packages/web/src/__tests__/components/chat-error-banner.test.tsx
+++ b/packages/web/src/__tests__/components/chat-error-banner.test.tsx
@@ -125,11 +125,38 @@ describe("ChatErrorBanner", () => {
 
   it("retries directly (no confirm) for a read-only run", async () => {
     const onRetry = vi.fn();
-    mockApiGet.mockResolvedValue({ error: { ...transientRow, sideEffects: false } });
+    // Two different endpoints now: the banner's own fetch, and the retry gate
+    // re-asked at click time (#1013). Answer each for what it is.
+    mockApiGet.mockImplementation((url: string) =>
+      url.includes("/retry-gate")
+        ? Promise.resolve({ sideEffects: false })
+        : Promise.resolve({ error: { ...transientRow, sideEffects: false } })
+    );
     render(<ChatErrorBanner agentId="agent-1" onRetry={onRetry} />);
     await waitFor(() => expect(screen.getByText("Penny paused")).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
-    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("confirms after all when the gate has flipped since the banner was fetched (#1013)", async () => {
+    // The banner is fetched on mount and clicked whenever the user gets round
+    // to it. Between those two moments the audit row proving the agent acted can
+    // land — so the row's flag is a floor, never the last word.
+    const onRetry = vi.fn();
+    mockApiGet.mockImplementation((url: string) =>
+      url.includes("/retry-gate")
+        ? Promise.resolve({ sideEffects: true })
+        : Promise.resolve({ error: { ...transientRow, sideEffects: false } })
+    );
+    render(<ChatErrorBanner agentId="agent-1" onRetry={onRetry} />);
+    await waitFor(() => expect(screen.getByText("Penny paused")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
+
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+    expect(onRetry).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/components/gated-retry.test.tsx
+++ b/packages/web/src/__tests__/components/gated-retry.test.tsx
@@ -1,0 +1,151 @@
+// The retry gate as the user meets it: a question asked when Retry is pressed,
+// not when the run failed (#1013).
+//
+// The failure frame's own `sideEffects` is provisional — OpenClaw fires
+// `after_tool_call` without awaiting it, so the audit row proving the agent
+// acted may not have landed when the flag was computed. A `false` there is not
+// evidence of a read-only run, which is why this component asks again.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { GatedRetry } from "@/components/chat/gated-retry";
+
+const mockApiGet = vi.fn();
+vi.mock("@/lib/api-client", () => ({
+  apiGet: (...args: unknown[]) => mockApiGet(...args),
+}));
+
+function renderGate(props: Partial<React.ComponentProps<typeof GatedRetry>> = {}) {
+  const onRetry = vi.fn();
+  render(
+    <GatedRetry
+      agentId="agent-1"
+      agentName="Penny"
+      sideEffects={false}
+      onRetry={onRetry}
+      {...props}
+    >
+      {(start) => (
+        <button type="button" onClick={start}>
+          Retry
+        </button>
+      )}
+    </GatedRetry>
+  );
+  return { onRetry, click: () => userEvent.click(screen.getByRole("button", { name: "Retry" })) };
+}
+
+const confirmDialog = () => screen.queryByRole("alertdialog");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApiGet.mockResolvedValue({ sideEffects: false });
+});
+
+describe("GatedRetry", () => {
+  it("retries directly when neither the frame nor the server reports a tool call", async () => {
+    const { onRetry, click } = renderGate();
+    await click();
+    await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+    expect(confirmDialog()).not.toBeInTheDocument();
+  });
+
+  it("warns about duplicates when the server says a tool ran after all", async () => {
+    // The bug: the frame said false because the audit row was still in flight.
+    mockApiGet.mockResolvedValue({ sideEffects: true });
+    const { onRetry, click } = renderGate();
+
+    await click();
+
+    await waitFor(() => expect(confirmDialog()).toBeInTheDocument());
+    expect(screen.getByText(/may create duplicates/i)).toBeInTheDocument();
+    // Crucially NOT retried behind the user's back while we asked.
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("runs the retry once the user confirms", async () => {
+    mockApiGet.mockResolvedValue({ sideEffects: true });
+    const { onRetry, click } = renderGate();
+    await click();
+    await waitFor(() => expect(confirmDialog()).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /retry anyway/i }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when the user cancels", async () => {
+    mockApiGet.mockResolvedValue({ sideEffects: true });
+    const { onRetry, click } = renderGate();
+    await click();
+    await waitFor(() => expect(confirmDialog()).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => expect(confirmDialog()).not.toBeInTheDocument());
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("skips the round trip when the failure already reported a tool call", async () => {
+    // Already-true needs no confirmation from the server: the gate is monotonic,
+    // and a user staring at a warned failure should not wait on a fetch.
+    const { onRetry, click } = renderGate({ sideEffects: true });
+
+    await click();
+
+    await waitFor(() => expect(confirmDialog()).toBeInTheDocument());
+    expect(mockApiGet).not.toHaveBeenCalled();
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("warns rather than proceeding when the gate cannot be checked", async () => {
+    // Fail closed. The cost of a needless confirm is one click; the cost of a
+    // missing one is a duplicated booking.
+    mockApiGet.mockRejectedValue(new Error("offline"));
+    const { onRetry, click } = renderGate();
+
+    await click();
+
+    await waitFor(() => expect(confirmDialog()).toBeInTheDocument());
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("asks about the chat the user is looking at", async () => {
+    const { click } = renderGate({ chatId: "chat 7" });
+    await click();
+    await waitFor(() =>
+      expect(mockApiGet).toHaveBeenCalledWith("/api/agents/agent-1/retry-gate?chatId=chat%207")
+    );
+  });
+
+  it("addresses the default session when there is no chatId", async () => {
+    const { click } = renderGate();
+    await click();
+    await waitFor(() => expect(mockApiGet).toHaveBeenCalledWith("/api/agents/agent-1/retry-gate"));
+  });
+
+  it("retries without asking when there is no agent to ask about", async () => {
+    // Defensive: a missing agentId is a context wiring bug, not a signal that
+    // the run wrote something. Blocking every retry behind a confirm there
+    // would teach users to click through the one that matters.
+    const { onRetry, click } = renderGate({ agentId: undefined });
+    await click();
+    await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it("ignores repeat clicks while the check is in flight", async () => {
+    let resolve!: (v: { sideEffects: boolean }) => void;
+    mockApiGet.mockReturnValue(new Promise((r) => (resolve = r)));
+    const { onRetry, click } = renderGate();
+
+    await click();
+    await click();
+    await click();
+    resolve({ sideEffects: false });
+
+    await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/__tests__/components/gated-retry.test.tsx
+++ b/packages/web/src/__tests__/components/gated-retry.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 // The retry gate as the user meets it: a question asked when Retry is pressed,
 // not when the run failed (#1013).
 //

--- a/packages/web/src/__tests__/server/chat-error-gc.integration.test.ts
+++ b/packages/web/src/__tests__/server/chat-error-gc.integration.test.ts
@@ -54,15 +54,19 @@ describe("sweepResolvedChatErrors", () => {
       { ...base, createdAt: daysAgo(100) }, // UNRESOLVED but past the 90d hard cap → swept
       { ...base, createdAt: daysAgo(40) }, // UNRESOLVED, within 90d → kept
       { ...base, createdAt: daysAgo(5), dismissedAt: daysAgo(5) }, // resolved but <30d → kept
+      // Recorded only to answer the retry gate (#1013), never shown as a
+      // banner — so it follows the SHORT window, not the 90d banner cap.
+      { ...base, createdAt: daysAgo(40), showBanner: false }, // → swept
+      { ...base, createdAt: daysAgo(5), showBanner: false }, // still retryable-recent → kept
     ]);
 
     const res = await sweepResolvedChatErrors();
 
-    expect(res.swept).toBe(2);
+    expect(res.swept).toBe(3);
     expect(res.sweepId).toMatch(/[0-9a-f-]{36}/);
 
     const remaining = await db.select().from(chatSessionErrors);
-    expect(remaining).toHaveLength(2);
+    expect(remaining).toHaveLength(3);
 
     // One summary audit row carrying the sweepId.
     const gcRows = await db.select().from(auditLog).where(eq(auditLog.eventType, "chat.error_gc"));

--- a/packages/web/src/__tests__/server/chat-session-errors.integration.test.ts
+++ b/packages/web/src/__tests__/server/chat-session-errors.integration.test.ts
@@ -12,6 +12,7 @@ import {
   supersedeChatSessionErrors,
   dismissChatSessionError,
   agentRanToolSince,
+  resolveRetryGate,
 } from "@/server/chat-session-errors";
 
 async function seedUser(overrides?: Partial<typeof users.$inferInsert>) {
@@ -154,6 +155,189 @@ describe("chat session errors persistence", () => {
 
     const active = await getActiveChatSessionError(sessionKey);
     expect(active!.providerError).toBe("newer");
+  });
+});
+
+describe("banner visibility is separate from recording the run (#1013)", () => {
+  it("records a non-banner failure but keeps it out of the banner", async () => {
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const input = { ...base(user, agent), showBanner: false };
+
+    const row = await recordChatSessionError(input);
+
+    // The row exists — it carries the window the retry gate needs …
+    expect(row.showBanner).toBe(false);
+    // … but the banner, which exists to re-surface a MISSED error, must not
+    // start showing failures it never showed before.
+    expect(await getActiveChatSessionError(input.sessionKey)).toBeNull();
+  });
+});
+
+describe("resolveRetryGate (#1013)", () => {
+  it("re-derives sideEffects when the tool audit row lands AFTER the error was stored", async () => {
+    // The #1013 race, reproduced in the order it actually happens: OpenClaw
+    // fires `after_tool_call` without awaiting it, so the run can fail and the
+    // error row can be written while `pinchy-audit`'s POST is still in flight.
+    // The stored flag is therefore `false` for a run that DID act.
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const runStartedAt = new Date(Date.now() - 5000);
+    const sessionKey = `agent:${agent.id}:direct:${user.id}`;
+
+    await recordChatSessionError({
+      ...base(user, agent),
+      sideEffects: false,
+      runStartedAt,
+    });
+
+    // At error time the gate is open — that is the bug, and it is what the
+    // stored row still says.
+    expect((await getActiveChatSessionError(sessionKey))!.sideEffects).toBe(false);
+
+    // The audit row lands late.
+    await db.insert(auditLog).values({
+      actorType: "user",
+      actorId: user.id,
+      eventType: "tool.odoo_create",
+      resource: `agent:${agent.id}`,
+      rowHmac: "test-hmac",
+      outcome: "success",
+    });
+
+    // Asked again — at Retry-click time — the answer is now the true one.
+    expect(await resolveRetryGate({ sessionKey, agentId: agent.id })).toBe(true);
+  });
+
+  it("never downgrades a stored true, even with no audit row in range", async () => {
+    // Monotonic on purpose: the stored `true` was derived from a row that
+    // existed. A later window that finds nothing (GC, a clock jump) must not
+    // turn a warned retry into an unwarned one.
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const sessionKey = `agent:${agent.id}:direct:${user.id}`;
+
+    await recordChatSessionError({
+      ...base(user, agent),
+      sideEffects: true,
+      runStartedAt: new Date(Date.now() - 5000),
+    });
+
+    expect(await resolveRetryGate({ sessionKey, agentId: agent.id })).toBe(true);
+  });
+
+  it("falls back to the stored flag for a row written before the window existed", async () => {
+    // Pre-existing data (AGENTS.md §"Test Migrations Against Pre-Existing
+    // Data"): rows written before 0064 have no `runStartedAt`. There is no
+    // honest window to re-derive over, so the gate must report exactly what the
+    // old code decided — not invent a bound and answer over the wrong range.
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const sessionKey = `agent:${agent.id}:direct:${user.id}`;
+
+    await db.insert(chatSessionErrors).values({
+      userId: user.id,
+      agentId: agent.id,
+      sessionKey,
+      agentName: agent.name,
+      errorClass: "transient",
+      providerError: "API rate limit reached",
+      sideEffects: false,
+      runStartedAt: null,
+    });
+
+    // A tool row for this agent exists, and an unbounded re-derivation would
+    // find it. The row predates the window, so the gate must not use it.
+    await db.insert(auditLog).values({
+      actorType: "user",
+      actorId: user.id,
+      eventType: "tool.odoo_create",
+      resource: `agent:${agent.id}`,
+      rowHmac: "test-hmac",
+      outcome: "success",
+    });
+
+    expect(await resolveRetryGate({ sessionKey, agentId: agent.id })).toBe(false);
+  });
+
+  it("serves a failure that gets no banner, and stays scoped to the exact session", async () => {
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const sessionKey = `agent:${agent.id}:direct:${user.id}`;
+
+    await recordChatSessionError({
+      ...base(user, agent),
+      errorClass: "unknown",
+      sideEffects: true,
+      showBanner: false,
+      runStartedAt: new Date(Date.now() - 5000),
+    });
+
+    // No banner for this class, but the inline bubble still offers Retry — so
+    // the gate must still have an answer. This is the hole that gating the
+    // INSERT on `shouldPersistDurableError` left open.
+    expect(await resolveRetryGate({ sessionKey, agentId: agent.id })).toBe(true);
+    expect(await resolveRetryGate({ sessionKey: `${sessionKey}:other`, agentId: agent.id })).toBe(
+      false
+    );
+  });
+
+  it("answers false when the session has no recorded failure at all", async () => {
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    expect(
+      await resolveRetryGate({
+        sessionKey: `agent:${agent.id}:direct:${user.id}`,
+        agentId: agent.id,
+      })
+    ).toBe(false);
+  });
+
+  it("uses the NEWEST failure's window, not an older one", async () => {
+    // Two failures in one session: an old one that ran a tool, and a fresh one
+    // that did not. Re-deriving over the old window would warn about writes the
+    // run the user is retrying never made — noise that trains users to click
+    // through the confirm.
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const sessionKey = `agent:${agent.id}:direct:${user.id}`;
+
+    await db.insert(auditLog).values({
+      actorType: "user",
+      actorId: user.id,
+      eventType: "tool.odoo_create",
+      resource: `agent:${agent.id}`,
+      rowHmac: "test-hmac",
+      outcome: "success",
+      timestamp: new Date("2026-06-18T09:01:00Z"),
+    });
+
+    await db.insert(chatSessionErrors).values([
+      {
+        userId: user.id,
+        agentId: agent.id,
+        sessionKey,
+        agentName: agent.name,
+        errorClass: "transient",
+        providerError: "older",
+        sideEffects: false,
+        runStartedAt: new Date("2026-06-18T09:00:00Z"),
+        createdAt: new Date("2026-06-18T09:02:00Z"),
+      },
+      {
+        userId: user.id,
+        agentId: agent.id,
+        sessionKey,
+        agentName: agent.name,
+        errorClass: "transient",
+        providerError: "newer",
+        sideEffects: false,
+        runStartedAt: new Date("2026-06-18T10:00:00Z"),
+        createdAt: new Date("2026-06-18T10:02:00Z"),
+      },
+    ]);
+
+    expect(await resolveRetryGate({ sessionKey, agentId: agent.id })).toBe(false);
   });
 });
 

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -337,6 +337,100 @@ describe("ClientRouter", () => {
       );
     });
 
+    it("stores the run window so the gate can be re-derived later (#1013)", async () => {
+      // `sideEffects: false` above is exactly the answer #1013 says may be
+      // wrong — the audit row can still be in flight. Persisting the window it
+      // was derived over is what lets the retry gate ask again at click time;
+      // without it the stale `false` is the final word.
+      async function* stream() {
+        yield { type: "error" as const, text: "the model is overloaded", runId: "r1" };
+      }
+      mockChat.mockReturnValue(stream());
+      const before = Date.now();
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "hi",
+        agentId: "agent-1",
+        clientMessageId: "cm-window",
+      });
+
+      const [entry] = mockRecordChatSessionError.mock.calls.at(-1)!;
+      const runStartedAt = (entry as { runStartedAt: Date }).runStartedAt;
+      expect(runStartedAt).toBeInstanceOf(Date);
+      // The same bound `agentRanToolSince` was asked with, so re-deriving later
+      // covers the same run rather than a wider or narrower slice of history.
+      expect(mockAgentRanToolSince).toHaveBeenLastCalledWith("agent-1", runStartedAt);
+      // Starts before the run and not in the future — a window that opens after
+      // the first tool call would miss exactly what it exists to find.
+      expect(runStartedAt.getTime()).toBeLessThanOrEqual(before);
+    });
+
+    it("records an inline-only class too, but keeps it out of the banner", async () => {
+      // `unknown` shows no banner (nothing actionable to put in one) — but the
+      // inline bubble still offers Retry, so the gate still needs a window.
+      // Gating the INSERT on `shouldPersistDurableError` left that retry with
+      // nothing to re-derive from.
+      async function* stream() {
+        yield { type: "error" as const, text: "LLM request failed.", runId: "r1" };
+      }
+      mockChat.mockReturnValue(stream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "hi",
+        agentId: "agent-1",
+        clientMessageId: "cm-unknown",
+      });
+
+      expect(mockRecordChatSessionError).toHaveBeenCalledWith(
+        expect.objectContaining({ errorClass: "unknown", showBanner: false })
+      );
+    });
+
+    it("marks a banner-worthy class as banner-eligible", async () => {
+      async function* stream() {
+        yield { type: "error" as const, text: "⚠️ API rate limit reached", runId: "r1" };
+      }
+      mockChat.mockReturnValue(stream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "hi",
+        agentId: "agent-1",
+        clientMessageId: "cm-transient",
+      });
+
+      expect(mockRecordChatSessionError).toHaveBeenCalledWith(
+        expect.objectContaining({ errorClass: "transient", showBanner: true })
+      );
+    });
+
+    it("records a window for a thrown failure too generic to show, without storing its text", async () => {
+      // The #882 security gate: a thrown failure whose message isn't
+      // provider-facing gets the generic bubble and is deliberately NOT stored,
+      // because the banner would re-render the raw text. That bubble is still
+      // retryable, so the retry gate had no window here at all. Store the
+      // window — never the text — and keep it off the banner.
+      async function* stream(): AsyncGenerator<never> {
+        throw new Error("connect ECONNREFUSED 10.1.2.3:5432");
+      }
+      mockChat.mockReturnValue(stream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "hi",
+        agentId: "agent-1",
+        clientMessageId: "cm-generic",
+      });
+
+      expect(mockRecordChatSessionError).toHaveBeenCalledWith(
+        expect.objectContaining({ showBanner: false, runStartedAt: expect.any(Date) })
+      );
+      const [entry] = mockRecordChatSessionError.mock.calls.at(-1)!;
+      expect((entry as { providerError: string }).providerError).not.toContain("10.1.2.3");
+    });
+
     it("supersedes the triggering message's durable error once its run succeeds", async () => {
       async function* stream() {
         yield {
@@ -521,9 +615,22 @@ describe("ClientRouter", () => {
         // No cause-specific fields that would carry the raw text.
         expect(errorFrame.providerError).toBeUndefined();
 
-        // Nothing persisted: the durable banner re-renders the stored raw text on
-        // reload, so an unsafe thrown error must never create a row.
-        expect(mockRecordChatSessionError).not.toHaveBeenCalled();
+        // A row IS written now — the generic bubble is retryable, and #1013's
+        // gate needs this run's window to answer for that retry. What must never
+        // happen is the leak this branch exists to prevent, so assert the row's
+        // WHOLE payload rather than its absence: no secret in any field, and no
+        // path to the banner that would re-render it.
+        expect(mockRecordChatSessionError).toHaveBeenCalledTimes(1);
+        const [persisted] = mockRecordChatSessionError.mock.calls[0];
+        const stored = JSON.stringify(persisted);
+        for (const secret of secrets) {
+          expect(stored).not.toContain(secret);
+        }
+        expect(persisted).toMatchObject({
+          showBanner: false,
+          providerError: "Something went wrong. Please try again.",
+          runStartedAt: expect.any(Date),
+        });
 
         // But it IS audited server-side (PII-scrubbed) — the diagnosability trail
         // #882 asks for is kept even for the failures we won't show the user.

--- a/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
@@ -4,7 +4,11 @@ import { getAgentWithAccess } from "@/lib/agent-access";
 import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { directSessionKey } from "@/lib/session-key";
-import { getActiveChatSessionError, dismissChatSessionError } from "@/server/chat-session-errors";
+import {
+  getActiveChatSessionError,
+  dismissChatSessionError,
+  resolveRetryGate,
+} from "@/server/chat-session-errors";
 import { getErrorHint, presentProviderError } from "@/server/error-hints";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
@@ -26,6 +30,11 @@ export const GET = withAuth<RouteContext>(async (request, { params }, session) =
   const sessionKey = directSessionKey(agentId, session.user.id!, chatId);
 
   const row = await getActiveChatSessionError(sessionKey);
+  // Re-derived, not read off the row (#1013). The stored flag was decided while
+  // the run's `tool.*` audit row could still have been in flight; by the time a
+  // banner is being fetched — a reload later, at the earliest — the answer has
+  // settled. Skipped entirely when there's no banner to render.
+  const sideEffects = row ? await resolveRetryGate({ sessionKey, agentId }) : false;
   return NextResponse.json({
     error: row
       ? {
@@ -43,7 +52,7 @@ export const GET = withAuth<RouteContext>(async (request, { params }, session) =
           // guidance the live error frame gets (client-router) so a durable
           // provider-rejection points an admin at their provider config (#584).
           hint: getErrorHint(row.providerError, session.user.role),
-          sideEffects: row.sideEffects,
+          sideEffects,
           clientMessageId: row.clientMessageId,
           createdAt: row.createdAt,
         }

--- a/packages/web/src/app/api/agents/[agentId]/retry-gate/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/retry-gate/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api-auth";
+import { getAgentWithAccess } from "@/lib/agent-access";
+import { directSessionKey } from "@/lib/session-key";
+import { resolveRetryGate } from "@/server/chat-session-errors";
+
+type RouteContext = { params: Promise<{ agentId: string }> };
+
+/**
+ * Would retrying this session's last failed run risk DUPLICATING writes?
+ *
+ * Asked when the user presses Retry, not when the run failed — that timing IS
+ * the fix for #1013. OpenClaw fires its `after_tool_call` hook without awaiting
+ * it, so the `tool.*` audit row that proves the agent acted can still be in
+ * flight when the error reaches Pinchy. The answer computed then can be a false
+ * `false`, and a false `false` means an unguarded Retry on a run that already
+ * booked an invoice. Seconds later, at click time, the row has landed.
+ *
+ * The run window comes from the stored row, never from the caller. A `?since=`
+ * parameter would turn this into an oracle over a shared agent's tool activity,
+ * which a non-admin has no other way to query (`/api/audit` is admin-only). The
+ * session key is built from the caller's own id for the same reason.
+ *
+ * Read-only, hence no audit entry.
+ */
+export const GET = withAuth<RouteContext>(async (request, { params }, session) => {
+  const { agentId } = await params;
+
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+
+  const chatId = request.nextUrl.searchParams.get("chatId") ?? undefined;
+  const sessionKey = directSessionKey(agentId, session.user.id!, chatId);
+
+  return NextResponse.json({ sideEffects: await resolveRetryGate({ sessionKey, agentId }) });
+});

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -551,18 +551,98 @@ describe("AssistantMessage retryable error bubble", () => {
       id: "msg-err-nose",
     });
 
+    // The gate is re-checked at click time (#1013), so this needs a real agent
+    // in context and a server that answers "no tool ran". Without the provider
+    // the component takes its no-agent shortcut and the test would pass while
+    // proving nothing about the read-only case.
+    const { apiGet } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockResolvedValue({ sideEffects: false });
+
     const mockRetryContinue = vi.fn();
-    const { RetryContinueContext } = await import("@/components/chat");
+    const { RetryContinueContext, AgentIdContext } = await import("@/components/chat");
     const { AssistantMessage } = await import("@/components/assistant-ui/thread");
     render(
-      <RetryContinueContext.Provider value={mockRetryContinue}>
-        <AssistantMessage />
-      </RetryContinueContext.Provider>
+      <AgentIdContext.Provider value="agent-1">
+        <RetryContinueContext.Provider value={mockRetryContinue}>
+          <AssistantMessage />
+        </RetryContinueContext.Provider>
+      </AgentIdContext.Provider>
     );
 
     fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
-    expect(mockRetryContinue).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockRetryContinue).toHaveBeenCalledTimes(1));
+    expect(apiGet).toHaveBeenCalledWith("/api/agents/agent-1/retry-gate");
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("gates the live Retry when the frame said no but the server knows better (#1013)", async () => {
+    // The failure that made this a bug: OpenClaw fires `after_tool_call`
+    // without awaiting it, so the frame's flag was derived before the audit row
+    // landed. The bubble says "no tool ran" and the run had already booked.
+    const { useMessage } = await import("@assistant-ui/react");
+    stubUseMessage(useMessage, {
+      metadata: {
+        custom: {
+          error: { providerError: "rate limit", agentName: "Penny", sideEffects: false },
+          retryable: true,
+        },
+      },
+      isLast: true,
+      id: "msg-err-race",
+    });
+
+    const { apiGet } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockResolvedValue({ sideEffects: true });
+
+    const mockRetryContinue = vi.fn();
+    const { RetryContinueContext, AgentIdContext } = await import("@/components/chat");
+    const { AssistantMessage } = await import("@/components/assistant-ui/thread");
+    render(
+      <AgentIdContext.Provider value="agent-1">
+        <RetryContinueContext.Provider value={mockRetryContinue}>
+          <AssistantMessage />
+        </RetryContinueContext.Provider>
+      </AgentIdContext.Provider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
+
+    expect(await screen.findByRole("alertdialog")).toHaveTextContent(/duplicate/i);
+    expect(mockRetryContinue).not.toHaveBeenCalled();
+  });
+
+  it("warns rather than retrying when the gate check fails (#1013)", async () => {
+    // Fail closed: an unreachable gate is not evidence the run was read-only.
+    const { useMessage } = await import("@assistant-ui/react");
+    stubUseMessage(useMessage, {
+      metadata: {
+        custom: {
+          error: { providerError: "rate limit", agentName: "Penny", sideEffects: false },
+          retryable: true,
+        },
+      },
+      isLast: true,
+      id: "msg-err-gate-down",
+    });
+
+    const { apiGet } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockRejectedValue(new Error("offline"));
+
+    const mockRetryContinue = vi.fn();
+    const { RetryContinueContext, AgentIdContext } = await import("@/components/chat");
+    const { AssistantMessage } = await import("@/components/assistant-ui/thread");
+    render(
+      <AgentIdContext.Provider value="agent-1">
+        <RetryContinueContext.Provider value={mockRetryContinue}>
+          <AssistantMessage />
+        </RetryContinueContext.Provider>
+      </AgentIdContext.Provider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^retry$/i }));
+
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+    expect(mockRetryContinue).not.toHaveBeenCalled();
   });
 
   it("disables Retry button and sets tooltip when ChatStatusContext is unavailable", async () => {

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -61,7 +61,7 @@ import { normalizeStarterPrompts } from "@/lib/schemas/starter-prompts";
 import { Progress } from "@/components/ui/progress";
 import type { PendingUpload } from "@/hooks/use-ws-runtime";
 import { RetryButton } from "@/components/chat/retry-button";
-import { DuplicateRetryConfirm } from "@/components/chat/duplicate-retry-confirm";
+import { GatedRetry } from "@/components/chat/gated-retry";
 import { useComposerRuntime } from "@assistant-ui/react";
 import { getDraft, saveDraft, draftKey } from "@/lib/draft-store";
 import { useShareIntake } from "@/components/share/use-share-intake";
@@ -663,9 +663,11 @@ export const AssistantMessage: FC = () => {
       "partial_stream_failure"
   );
   const isLast = useMessage((s) => s.isLast);
-  // The failed run already ran a tool → gate retry behind a duplicate-write
-  // confirm, matching the durable banner (the live retry is the most common
-  // retry moment, so it must be gated too).
+  // What the error frame claimed about tool use. Provisional: the flag is
+  // derived from an audit row that OpenClaw's unawaited `after_tool_call` hook
+  // may not have written yet (#1013), so `false` here means "not proven", not
+  // "read-only". GatedRetry re-asks the server on click, where the answer has
+  // had time to settle. `true` short-circuits — the gate never re-opens.
   const sideEffects = useMessage(
     (s) => !!(s.metadata?.custom?.error as ChatError | undefined)?.sideEffects
   );
@@ -673,19 +675,20 @@ export const AssistantMessage: FC = () => {
     (s) => (s.metadata?.custom?.error as ChatError | undefined)?.agentName
   );
   const onRetryContinue = useContext(RetryContinueContext);
+  const retryAgentId = useContext(AgentIdContext);
+  const retryChatId = useContext(ChatIdContext);
 
   const showRetry = isRetryable && isLast;
   const retryButton = showRetry ? (
-    sideEffects ? (
-      <DuplicateRetryConfirm
-        agentName={errorAgentName}
-        onConfirm={() => onRetryContinue(retryReason)}
-      >
-        {(open) => <RetryButton onClick={open} />}
-      </DuplicateRetryConfirm>
-    ) : (
-      <RetryButton onClick={() => onRetryContinue(retryReason)} />
-    )
+    <GatedRetry
+      agentId={retryAgentId ?? undefined}
+      chatId={retryChatId}
+      agentName={errorAgentName}
+      sideEffects={sideEffects}
+      onRetry={() => onRetryContinue(retryReason)}
+    >
+      {(start, pending) => <RetryButton onClick={start} checking={pending} />}
+    </GatedRetry>
   ) : null;
 
   return (

--- a/packages/web/src/components/chat-error-banner.tsx
+++ b/packages/web/src/components/chat-error-banner.tsx
@@ -6,7 +6,7 @@ import { useChatSessionHasInlineError } from "@/components/chat-session-provider
 import { ChatErrorMessage, type ChatError } from "@/components/assistant-ui/chat-error-message";
 import type { TransientReason } from "@/lib/schemas/chat-frames";
 import { Button } from "@/components/ui/button";
-import { DuplicateRetryConfirm } from "@/components/chat/duplicate-retry-confirm";
+import { GatedRetry } from "@/components/chat/gated-retry";
 
 interface ActiveError {
   id: string;
@@ -105,18 +105,29 @@ export function ChatErrorBanner({
     onRetry();
   };
 
-  const retryControl = error.sideEffects ? (
-    <DuplicateRetryConfirm agentName={error.agentName} onConfirm={handleRetry}>
-      {(open) => (
-        <Button variant="outline" size="sm" className="h-7 text-xs" onClick={open}>
+  // The row's `sideEffects` was already re-derived server-side when this banner
+  // was fetched, but the fetch happened on mount and the click can come minutes
+  // later — so ask once more here, on the same terms as the inline bubble.
+  const retryControl = (
+    <GatedRetry
+      agentId={agentId}
+      chatId={chatId}
+      agentName={error.agentName}
+      sideEffects={error.sideEffects}
+      onRetry={handleRetry}
+    >
+      {(start, pending) => (
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={start}
+          disabled={pending}
+        >
           Retry
         </Button>
       )}
-    </DuplicateRetryConfirm>
-  ) : (
-    <Button variant="outline" size="sm" className="h-7 text-xs" onClick={handleRetry}>
-      Retry
-    </Button>
+    </GatedRetry>
   );
 
   return (

--- a/packages/web/src/components/chat/duplicate-retry-confirm.tsx
+++ b/packages/web/src/components/chat/duplicate-retry-confirm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,27 +13,33 @@ import {
 } from "@/components/ui/alert-dialog";
 
 /**
- * Gate a retry behind a duplicate-write confirmation when the failed run had
- * already executed a tool. `children` receives an `open` callback to wire to the
- * trigger (a RetryButton, a plain Button, …) — a controlled dialog rather than
- * an `asChild` trigger so it works with any control regardless of ref/prop
- * forwarding. Shared by the durable "paused" banner AND the live in-chat error
- * bubble so the duplicate-write copy is identical on both retry paths.
+ * The duplicate-write confirmation itself: copy plus dialog, nothing else.
+ * Shared by the durable "paused" banner AND the live in-chat error bubble so
+ * both retry paths say the same thing.
+ *
+ * Fully controlled — whether to show it is decided by `GatedRetry`, which asks
+ * the server at click time (#1013) rather than trusting a flag computed while
+ * the evidence was still in flight. `children` renders the trigger alongside
+ * the dialog; it is a plain node rather than an `asChild` trigger so it works
+ * with any control regardless of ref/prop forwarding.
  */
 export function DuplicateRetryConfirm({
   agentName,
+  open,
+  onOpenChange,
   onConfirm,
   children,
 }: {
   agentName?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
-  children: (open: () => void) => ReactNode;
+  children: ReactNode;
 }) {
-  const [open, setOpen] = useState(false);
   return (
     <>
-      {children(() => setOpen(true))}
-      <AlertDialog open={open} onOpenChange={setOpen}>
+      {children}
+      <AlertDialog open={open} onOpenChange={onOpenChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Retry may duplicate actions</AlertDialogTitle>
@@ -47,7 +53,7 @@ export function DuplicateRetryConfirm({
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
-                setOpen(false);
+                onOpenChange(false);
                 onConfirm();
               }}
             >

--- a/packages/web/src/components/chat/gated-retry.tsx
+++ b/packages/web/src/components/chat/gated-retry.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback, useState, type ReactNode } from "react";
+import { apiGet } from "@/lib/api-client";
+import { DuplicateRetryConfirm } from "@/components/chat/duplicate-retry-confirm";
+
+/**
+ * Retry, gated behind a duplicate-write confirmation when the failed run had
+ * already executed a tool — with the gate decided at CLICK time (#1013).
+ *
+ * The `sideEffects` prop is what the failure already claimed: the live error
+ * frame's flag, or the durable banner's row. It is provisional. OpenClaw fires
+ * its `after_tool_call` hook without awaiting it, so `pinchy-audit`'s `tool.*`
+ * row is ordered against nothing and can still be in flight when Pinchy derives
+ * that flag. A `false` there is not evidence of a read-only run — it may simply
+ * be an answer that arrived before the truth did, and it opens an unguarded
+ * Retry on a run that already booked an invoice.
+ *
+ * So a `false` is re-checked against the server, which by now can see the row.
+ * A `true` is taken at face value: the gate is monotonic (nothing un-runs a
+ * tool), and a user looking at a warned failure should not wait on a fetch.
+ *
+ * Failing to check fails CLOSED. A needless confirm costs one click; a missing
+ * one costs a duplicate.
+ *
+ * `children` receives the trigger's `onClick` plus a `pending` flag for the
+ * window where the check is in flight — a controlled dialog rather than an
+ * `asChild` trigger, so it works with any control regardless of ref forwarding.
+ */
+export function GatedRetry({
+  agentId,
+  chatId,
+  agentName,
+  sideEffects,
+  onRetry,
+  children,
+}: {
+  agentId?: string;
+  chatId?: string | null;
+  agentName?: string;
+  /** What the failure frame or durable row already reported. Provisional. */
+  sideEffects: boolean;
+  onRetry: () => void;
+  children: (start: () => void, pending: boolean) => ReactNode;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  const start = useCallback(() => {
+    if (sideEffects) {
+      setConfirming(true);
+      return;
+    }
+    // No agent to ask about is a context-wiring bug, not evidence the run wrote
+    // something. Gating every retry on it would train users to click through
+    // the confirm that matters.
+    if (!agentId) {
+      onRetry();
+      return;
+    }
+    // One check per click-through. Callers also disable their control while
+    // `pending`, so this only has to survive the gap before that lands.
+    if (pending) return;
+    setPending(true);
+
+    const url = chatId
+      ? `/api/agents/${agentId}/retry-gate?chatId=${encodeURIComponent(chatId)}`
+      : `/api/agents/${agentId}/retry-gate`;
+
+    apiGet<{ sideEffects: boolean }>(url)
+      .then((res) => {
+        if (res.sideEffects) setConfirming(true);
+        else onRetry();
+      })
+      .catch(() => setConfirming(true))
+      .finally(() => setPending(false));
+  }, [agentId, chatId, sideEffects, onRetry, pending]);
+
+  return (
+    <DuplicateRetryConfirm
+      agentName={agentName}
+      open={confirming}
+      onOpenChange={setConfirming}
+      onConfirm={onRetry}
+    >
+      {children(start, pending)}
+    </DuplicateRetryConfirm>
+  );
+}

--- a/packages/web/src/components/chat/retry-button.tsx
+++ b/packages/web/src/components/chat/retry-button.tsx
@@ -5,14 +5,21 @@ import { Button } from "@/components/ui/button";
 
 interface RetryButtonProps {
   onClick: () => void;
+  /**
+   * The duplicate-write gate is being checked with the server (#1013). Short —
+   * one GET — but it must not be clickable twice, and the click has visibly
+   * done something.
+   */
+  checking?: boolean;
 }
 
-export function RetryButton({ onClick }: RetryButtonProps) {
+export function RetryButton({ onClick, checking = false }: RetryButtonProps) {
   const status = useContext(ChatStatusContext);
-  const disabled = status.kind !== "ready";
-  const loading = status.kind === "responding";
-  const tooltip =
-    status.kind === "unavailable"
+  const disabled = status.kind !== "ready" || checking;
+  const loading = status.kind === "responding" || checking;
+  const tooltip = checking
+    ? "Checking whether this retry could duplicate actions"
+    : status.kind === "unavailable"
       ? "Agent unavailable"
       : status.kind === "responding"
         ? "Waiting for the current response"

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -897,6 +897,20 @@ export const agentDeliveredFiles = pgTable(
  * the triggering user message, the anchor for both supersede (the same message
  * later succeeds) and a safe retry. `sideEffects` records whether the failed
  * run already executed a tool call, so the UI can warn about duplicate writes.
+ *
+ * `runStartedAt` is the lower bound `sideEffects` was derived over, and it is
+ * what makes the answer re-derivable LATER (#1013). OpenClaw fires its
+ * `after_tool_call` hook without awaiting it, so `pinchy-audit`'s `tool.*` row
+ * is ordered against nothing and can land after the run has already failed —
+ * the derivation at error time therefore reads `false` for a run that did act.
+ * Storing the window lets the retry gate ask the same question again when the
+ * user actually presses Retry, by which point the row is long committed.
+ *
+ * `showBanner` separates "record this failed run" from "re-surface it as a
+ * paused banner". They used to be the same decision (`shouldPersistDurableError`
+ * gated the INSERT), which meant the classes that get no banner also got no
+ * stored window — and therefore no re-derivable retry gate. Every failed run is
+ * recorded now; only banner-worthy ones are read back by the banner.
  */
 export const chatSessionErrors = pgTable(
   "chat_session_errors",
@@ -919,6 +933,11 @@ export const chatSessionErrors = pgTable(
     transientReason: text("transient_reason"),
     providerError: text("provider_error").notNull(),
     sideEffects: boolean("side_effects").notNull().default(false),
+    // Nullable on purpose: rows written before #1013 have no window, and the
+    // retry gate must fall back to the stored `sideEffects` for them rather
+    // than invent a bound and re-derive over the wrong range.
+    runStartedAt: timestamp("run_started_at"),
+    showBanner: boolean("show_banner").notNull().default(true),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     supersededAt: timestamp("superseded_at"),
     dismissedAt: timestamp("dismissed_at"),

--- a/packages/web/src/server/chat-error-gc.ts
+++ b/packages/web/src/server/chat-error-gc.ts
@@ -1,16 +1,17 @@
 /**
  * Retention sweep for the durable chat-error store. Rows are tiny (one per agent
  * error), but resolved ones — superseded by a later success or dismissed by the
- * user — accumulate. Two windows: resolved rows are reaped after
- * RESOLVED_RETENTION_DAYS; un-resolved rows (the live banner state) are kept far
- * longer but still reaped after a hard UNRESOLVED_RETENTION_DAYS cap so an error
- * a user neither retried nor dismissed can't leak forever.
+ * user — accumulate. Two windows: rows that are resolved OR were never
+ * banner-eligible are reaped after RESOLVED_RETENTION_DAYS; un-resolved rows
+ * (the live banner state) are kept far longer but still reaped after a hard
+ * UNRESOLVED_RETENTION_DAYS cap so an error a user neither retried nor dismissed
+ * can't leak forever.
  *
  * Mirrors `upload-gc.ts`: an hourly interval plus a post-startup kick, and a
  * single `sweepId` UUID per run on the summary audit row so an analyst can
  * correlate the sweep (AGENTS.md §"Audit logging rules").
  */
-import { and, lt, or, isNotNull } from "drizzle-orm";
+import { and, eq, lt, or, isNotNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { chatSessionErrors } from "@/db/schema";
@@ -35,10 +36,17 @@ export async function sweepResolvedChatErrors(): Promise<ChatErrorSweepResult> {
     .delete(chatSessionErrors)
     .where(
       or(
-        // Resolved (superseded/dismissed) past the short window…
+        // Resolved (superseded/dismissed) past the short window — plus rows
+        // that never show a banner at all (#1013). Those exist only to answer
+        // the retry gate for their run, and nobody retries a run a month later;
+        // they are not the live banner state the 90-day cap protects.
         and(
           lt(chatSessionErrors.createdAt, resolvedCutoff),
-          or(isNotNull(chatSessionErrors.supersededAt), isNotNull(chatSessionErrors.dismissedAt))
+          or(
+            isNotNull(chatSessionErrors.supersededAt),
+            isNotNull(chatSessionErrors.dismissedAt),
+            eq(chatSessionErrors.showBanner, false)
+          )
         ),
         // …or anything (incl. un-resolved/abandoned) past the hard cap.
         lt(chatSessionErrors.createdAt, hardCutoff)

--- a/packages/web/src/server/chat-session-errors.ts
+++ b/packages/web/src/server/chat-session-errors.ts
@@ -63,6 +63,19 @@ export interface RecordChatSessionErrorInput {
   transientReason?: string | null;
   providerError: string;
   sideEffects: boolean;
+  /**
+   * Lower bound `sideEffects` was derived over, so the question can be asked
+   * again later (#1013). Omitted only by callers that genuinely have no run
+   * window; the gate then falls back to the stored flag.
+   */
+  runStartedAt?: Date | null;
+  /**
+   * Whether this failure may re-surface as the durable "paused" banner.
+   * Defaults to true — every caller that records a banner-worthy error keeps
+   * its existing behaviour, and only the two that must NOT show a banner say so
+   * explicitly.
+   */
+  showBanner?: boolean;
 }
 
 export type ChatSessionError = typeof chatSessionErrors.$inferSelect;
@@ -84,13 +97,17 @@ export async function recordChatSessionError(
       transientReason: input.transientReason ?? null,
       providerError: input.providerError,
       sideEffects: input.sideEffects,
+      runStartedAt: input.runStartedAt ?? null,
+      showBanner: input.showBanner ?? true,
     })
     .returning();
   return row;
 }
 
 /**
- * The newest un-superseded, un-dismissed error for the exact session, or null.
+ * The newest un-superseded, un-dismissed, banner-eligible error for the exact
+ * session, or null. `showBanner` is what keeps the classes recorded only for
+ * the retry gate (#1013) out of a surface they were never shown on.
  */
 export async function getActiveChatSessionError(
   sessionKey: string
@@ -101,6 +118,7 @@ export async function getActiveChatSessionError(
     .where(
       and(
         eq(chatSessionErrors.sessionKey, sessionKey),
+        eq(chatSessionErrors.showBanner, true),
         isNull(chatSessionErrors.supersededAt),
         isNull(chatSessionErrors.dismissedAt)
       )
@@ -108,6 +126,56 @@ export async function getActiveChatSessionError(
     .orderBy(desc(chatSessionErrors.createdAt))
     .limit(1);
   return row ?? null;
+}
+
+/**
+ * Does retrying this session's latest failed run risk DUPLICATING writes?
+ *
+ * The same question `persistDurableChatError` answers when the error arrives —
+ * asked again, later. That is the whole fix for #1013: OpenClaw fires
+ * `after_tool_call` without awaiting it, so `pinchy-audit`'s `tool.*` row is
+ * ordered against nothing and can still be in flight when the run fails. The
+ * derivation at error time therefore reads `false` for a run that already
+ * acted, and the user is offered an unguarded Retry. By the time somebody has
+ * read an error and reached for Retry, the row is long committed.
+ *
+ * Two properties are load-bearing:
+ *
+ *  - **Monotonic.** A stored `true` is never re-opened. It was derived from a
+ *    row that existed; a later window that finds nothing (GC, a clock jump)
+ *    must not turn a warned retry into an unwarned one.
+ *  - **Newest failure only, whatever its resolution state.** Falling back to an
+ *    older row's window would warn about writes the run being retried never
+ *    made, and a confirm that cries wolf is one users learn to click through.
+ *    Superseded/dismissed rows are NOT filtered out: dismissing a banner does
+ *    not un-run a tool, and the newest row is by construction the failure the
+ *    user is looking at.
+ *
+ * Rows written before migration 0064 carry no `runStartedAt`. There is no
+ * honest window for them, so they report their stored flag rather than
+ * re-deriving over an invented range.
+ */
+export async function resolveRetryGate({
+  sessionKey,
+  agentId,
+}: {
+  sessionKey: string;
+  agentId: string;
+}): Promise<boolean> {
+  const [row] = await db
+    .select({
+      sideEffects: chatSessionErrors.sideEffects,
+      runStartedAt: chatSessionErrors.runStartedAt,
+    })
+    .from(chatSessionErrors)
+    .where(eq(chatSessionErrors.sessionKey, sessionKey))
+    .orderBy(desc(chatSessionErrors.createdAt))
+    .limit(1);
+
+  if (!row) return false;
+  if (row.sideEffects) return true;
+  if (!row.runStartedAt) return false;
+  return agentRanToolSince(agentId, row.runStartedAt);
 }
 
 /**

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -2003,35 +2003,46 @@ export class ClientRouter {
     providerError: string;
     errorClass: AgentErrorClass;
     runStartedAt: Date;
+    /**
+     * Force the row off the banner regardless of class. The #882 generic path
+     * needs it: the class can say "banner-worthy" while the text is not safe to
+     * re-render, and the row is written there only to carry the retry-gate
+     * window.
+     */
+    suppressBanner?: boolean;
   }): Promise<boolean> {
     try {
       // Derive sideEffects from the audit trail: OpenClaw doesn't signal tool
       // execution as a chat chunk, so a `tool.*` audit row since this run began
-      // is the reliable "the agent already acted" signal. Computed for EVERY
-      // class — the live inline retry's duplicate-write gate needs it even when
-      // we skip the durable row below.
+      // is the reliable "the agent already acted" signal.
+      //
+      // This answer is provisional. OpenClaw fires `after_tool_call` WITHOUT
+      // awaiting it, so `pinchy-audit`'s row is ordered against nothing and can
+      // still be in flight right now — `false` here does not mean the run was
+      // read-only (#1013). `runStartedAt` goes into the row so `resolveRetryGate`
+      // can ask the same question again when the user reaches for Retry.
       const sideEffects = await agentRanToolSince(args.agent.id, args.runStartedAt);
-      // Only persist a durable "paused" banner for retryable/intermittent
-      // classes. A persistent problem (retired model, over-large prompt, bad
-      // provider config → `unknown`/`provider_config`) recurs every attempt, so
-      // a sticky banner that reappears on every navigation is annoyance, not
-      // help — the inline turn-failure is enough. See shouldPersistDurableError.
-      if (shouldPersistDurableError(args.errorClass)) {
-        await recordChatSessionError({
-          userId: this.userId,
-          agentId: args.agent.id,
-          sessionKey: args.sessionKey,
-          clientMessageId: args.clientMessageId ?? null,
-          runId: args.runId ?? null,
-          agentName: args.agent.name,
-          model: args.agent.model ?? null,
-          errorClass: args.errorClass,
-          transientReason:
-            args.errorClass === "transient" ? classifyTransientReason(args.providerError) : null,
-          providerError: safeProviderError(args.providerError),
-          sideEffects,
-        });
-      }
+      // EVERY failed run is recorded, because every failed run can be retried
+      // and every retry needs the gate. Whether it also re-surfaces as a
+      // "paused" banner is a separate question: a persistent problem with
+      // nothing actionable to say (`unknown`) is inline-only, and so is a
+      // failure whose text we must not re-render. See shouldPersistDurableError.
+      await recordChatSessionError({
+        userId: this.userId,
+        agentId: args.agent.id,
+        sessionKey: args.sessionKey,
+        clientMessageId: args.clientMessageId ?? null,
+        runId: args.runId ?? null,
+        agentName: args.agent.name,
+        model: args.agent.model ?? null,
+        errorClass: args.errorClass,
+        transientReason:
+          args.errorClass === "transient" ? classifyTransientReason(args.providerError) : null,
+        providerError: safeProviderError(args.providerError),
+        sideEffects,
+        runStartedAt: args.runStartedAt,
+        showBanner: !args.suppressBanner && shouldPersistDurableError(args.errorClass),
+      });
       return sideEffects;
     } catch (err) {
       console.error("Failed to persist durable chat error:", err);
@@ -2102,6 +2113,20 @@ export class ClientRouter {
     // none of this: `chunk.text` is provider-facing by construction. (#882)
     const safeMessage = cannedProviderMessage(args.providerError, args.agent.model ?? undefined);
     if (safeMessage === null) {
+      // The generic bubble is still RETRYABLE, and this run may already have
+      // written to Odoo before it died. Record the run window — with the canned
+      // text, never `err.message` — so `resolveRetryGate` can answer for this
+      // retry too. `suppressBanner` keeps the row where it was: off screen.
+      await this.persistDurableChatError({
+        agent: args.agent,
+        sessionKey: args.sessionKey,
+        clientMessageId: args.clientMessageId,
+        runId: args.runId,
+        providerError: GENERIC_RUN_FAILURE_MESSAGE,
+        errorClass,
+        runStartedAt: args.runStartedAt,
+        suppressBanner: true,
+      });
       this.broadcastForRun(args.sessionKey, args.clientWs, {
         type: "error",
         message: GENERIC_RUN_FAILURE_MESSAGE,


### PR DESCRIPTION
Closes #1013.

## The bug

OpenClaw fires `runAgentHarnessAfterToolCallHook` **without awaiting it** — three call sites in `provider-capabilities-*.js` in `openclaw@2026.7.1-2`, one of them inside `setImmediate`, and the helper describes itself as running "best-effort" hooks "while isolating hook failures from the runtime path". The decoupling is deliberate upstream.

The consequence on our side is not. `pinchy-audit`'s POST to `/api/internal/audit/tool-use` is therefore ordered against nothing, so when a run fails the `tool.*` row that proves the agent acted may still be in flight. `agentRanToolSince()` is asked at exactly that moment, can answer `false` for a run that already wrote — and a `false` means Retry is offered **with no duplicate-write warning**. For an Odoo agent that is a second booking of the same invoice.

`agentRanToolSince`'s own docblock claimed the dangerous false-negative was impossible. The time bound it relies on guards against clock skew, not against ordering.

This is also why the live-confirm assertion in `19-durable-agent-error-banner.spec.ts` failed intermittently in CI.

## The fix

Move the question to where it is answerable. By the time somebody has read an error and reached for Retry, seconds have passed and the row has landed.

- **`resolveRetryGate()`** re-derives the flag from the newest recorded failure's window.
  - _Monotonic_ — a stored `true` is never re-opened, because nothing un-runs a tool.
  - _Newest failure only_ — re-deriving over an older window would warn about writes the run being retried never made, and a confirm that cries wolf is one users learn to click through.
- **`chat_session_errors`** gains `run_started_at` (the window; nullable, so rows written before this fall back to their stored flag rather than re-derive over an invented range) and `show_banner`.
- **Every failed run is recorded now**, not only banner-worthy classes. Gating the INSERT on `shouldPersistDurableError` meant `unknown` — and the #882 path that must not store its own error text — had no window at all, so those retries could never be gated in the first place. `show_banner` keeps the banner showing exactly what it showed before; the #882 row stores the canned text, never `err.message`.
- **`GatedRetry`** asks `GET /api/agents/:agentId/retry-gate` on click, for both the inline bubble and the durable banner.
- **Non-banner rows follow the 30-day GC window** rather than the 90-day banner cap. They are not live banner state, and nobody retries a run a month later.

### Two decisions worth arguing with

**The window comes from the stored run, never from the request.** A `?since=` parameter would have been simpler — and would have made this endpoint a queryable history of a shared agent's tool activity, which a non-admin cannot otherwise obtain (`/api/audit` is admin-only). A test pins that a `since` in the query string changes nothing.

**Failing to check fails closed.** An unreachable gate is not evidence the run was read-only. A needless confirm costs one click.

## Tests

The deterministic proof is `chat-session-errors.integration.test.ts`, which writes the error row first and the audit row after — the order the race actually happens in — and asserts the gate flips. Alongside it: the pre-existing-data case (`run_started_at IS NULL` falls back rather than re-deriving over the wrong range, per AGENTS.md §"Test Migrations Against Pre-Existing Data"), monotonicity, newest-window-only, and session scoping.

Two existing tests changed behaviour rather than being weakened:

- The #882 leak test asserted "nothing is persisted". A row **is** written now, so it instead asserts the whole persisted payload: no secret in any field, `show_banner: false`, canned text only. That is the invariant the old assertion was a proxy for.
- `thread.test.tsx`'s "retries directly (no confirm)" passed after my change for the wrong reason — no `AgentIdContext`, so the component took its no-agent shortcut. It now provides the context and a server that answers, so it proves the read-only case again.

Local: full vitest suite (10534 passed / 20 skipped), `test:db` (406), `test:scripts`, typecheck incl. tests, lint (0 errors), `format:check`, `pnpm build`, docs build + `check:anchors` + `check:rendered` + `check:tables`.

## What this does not fix

The root cause is upstream and stays there: OpenClaw does not await the hook, so **any** logic that asks the audit trail about tool use at run-end has the same race. This change fixes the retry gate, which is the one place the race has a data-integrity consequence. Worth an upstream issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)