### PR TITLE
test(web): fix the pattern #1017 points at, and cover the button it found untested

### DIFF
--- a/packages/web/src/__tests__/components/add-integration-google-wizard.test.tsx
+++ b/packages/web/src/__tests__/components/add-integration-google-wizard.test.tsx
@@ -176,49 +176,61 @@ describe("Add Integration Dialog — Google flow", () => {
   });
 
   describe("Copy redirect URI button", () => {
-    let clipboardWriteTextSpy: ReturnType<typeof vi.spyOn>;
-
     beforeEach(() => {
       vi.stubGlobal("location", { ...window.location, protocol: "https:" });
       vi.mocked(apiGet).mockResolvedValue({ configured: false, clientId: "" });
-
-      // Mock clipboard API
-      clipboardWriteTextSpy = vi
-        .spyOn(navigator.clipboard, "writeText")
-        .mockResolvedValue(undefined);
     });
 
     afterEach(() => {
       vi.unstubAllGlobals();
-      clipboardWriteTextSpy.mockRestore();
     });
 
     it("shows success feedback when copy button is clicked", async () => {
       const user = userEvent.setup();
-      renderDialog();
-      await selectGoogle(user);
+      // Spy AFTER setup(), not describe-wide in beforeEach. jsdom has no
+      // `navigator.clipboard` of its own — `userEvent.setup()` is what defines
+      // the property (Clipboard.js: `attachClipboardStubToView`), and it stays
+      // attached for the rest of the file. A beforeEach spy therefore found an
+      // object only because some *earlier, unrelated* test in this file had
+      // already called setup(): run this block alone (`vitest -t`, `.only`, or
+      // any reordering) and it died with "The vi.spyOn() function could not
+      // find an object to spy upon", plus a second failure from the afterEach
+      // dereferencing the spy that was never assigned. Two red tests that look
+      // like a clipboard bug and are an ordering dependency.
+      const clipboardWriteTextSpy = vi
+        .spyOn(navigator.clipboard, "writeText")
+        .mockResolvedValue(undefined);
 
-      await waitFor(() => {
-        expect(screen.getByText(/Set up Google OAuth/i)).toBeInTheDocument();
-      });
+      try {
+        renderDialog();
+        await selectGoogle(user);
 
-      const codeElement = screen.getByText(/\/api\/integrations\/oauth\/callback/);
-      const copyButton = codeElement.parentElement?.querySelector("button");
-      expect(copyButton).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByText(/Set up Google OAuth/i)).toBeInTheDocument();
+        });
 
-      // Click to copy
-      await user.click(copyButton!);
+        const codeElement = screen.getByText(/\/api\/integrations\/oauth\/callback/);
+        const copyButton = codeElement.parentElement?.querySelector("button");
+        expect(copyButton).toBeInTheDocument();
 
-      // Verify clipboard.writeText was called
-      await waitFor(() => {
-        expect(clipboardWriteTextSpy).toHaveBeenCalledWith(
-          expect.stringContaining("/api/integrations/oauth/callback")
-        );
-      });
+        // Click to copy
+        await user.click(copyButton!);
 
-      // After click, button should show checkmark icon
-      const checkIcon = copyButton?.querySelector("svg");
-      expect(checkIcon?.closest("svg")).toBeInTheDocument();
+        // Verify clipboard.writeText was called
+        await waitFor(() => {
+          expect(clipboardWriteTextSpy).toHaveBeenCalledWith(
+            expect.stringContaining("/api/integrations/oauth/callback")
+          );
+        });
+
+        // After click, button should show checkmark icon
+        const checkIcon = copyButton?.querySelector("svg");
+        expect(checkIcon?.closest("svg")).toBeInTheDocument();
+      } finally {
+        // In a `finally` so a failing assertion above still restores the spy —
+        // otherwise one red test leaves it in place for the rest of the file.
+        clipboardWriteTextSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/web/src/__tests__/components/settings-users.test.tsx
+++ b/packages/web/src/__tests__/components/settings-users.test.tsx
@@ -773,6 +773,67 @@ describe("SettingsUsers", () => {
       });
     });
 
+    // The test above only proves the link is *rendered*. Its Copy button is a
+    // second one, in settings-users.tsx rather than invite-dialog.tsx, and it
+    // was covered by nothing: emptying its onClick left all 34 tests in this
+    // file green.
+    it("copies the invite link offered after a Resend", async () => {
+      const user = userEvent.setup();
+      // Spy on user-event's own clipboard stub rather than redefining the
+      // property — same reason as the invite-dialog copy test above.
+      const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+      try {
+        mockFetchForUsers(mockUsers, [expiredInvite]);
+        render(<SettingsUsers currentUserId="user-1" />);
+
+        await waitFor(() => {
+          expect(screen.getAllByText("expired@example.com").length).toBeGreaterThanOrEqual(1);
+        });
+
+        vi.mocked(global.fetch).mockImplementation(async (url, init) => {
+          if (String(url) === "/api/users/invites/inv-2" && init?.method === "DELETE") {
+            return { ok: true, json: async () => ({ success: true }) } as Response;
+          }
+          if (String(url) === "/api/users/invite" && init?.method === "POST") {
+            return { ok: true, json: async () => ({ token: "resend-token-xyz" }) } as Response;
+          }
+          if (String(url) === "/api/users") {
+            return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+          }
+          if (String(url) === "/api/users/invites") {
+            return { ok: true, json: async () => ({ invites: [] }) } as Response;
+          }
+          if (String(url) === "/api/groups") {
+            return { ok: true, json: async () => [] } as Response;
+          }
+          if (String(url) === "/api/enterprise/status") {
+            return { ok: true, json: async () => ({ enterprise: false }) } as Response;
+          }
+          return { ok: false } as Response;
+        });
+
+        const table = screen.getByRole("table");
+        const inviteRow = within(table).getAllByText("expired@example.com")[0].closest("tr")!;
+        await user.click(within(inviteRow).getByRole("button", { name: "Resend" }));
+
+        // Scope to the link panel: the button carries the bare label "Copy",
+        // which is not unique on this screen once a dialog is open.
+        const link = await screen.findByText("http://localhost:7777/invite/resend-token-xyz");
+        const panel = link.closest("div")!;
+        await user.click(within(panel).getByRole("button", { name: "Copy" }));
+
+        await waitFor(() => {
+          expect(within(panel).getByRole("button", { name: "Copied!" })).toBeInTheDocument();
+        });
+        expect(writeText).toHaveBeenCalledWith("http://localhost:7777/invite/resend-token-xyz");
+      } finally {
+        // In a `finally` so a failing assertion above still restores the spy —
+        // otherwise one red test leaves it in place for the rest of the file.
+        writeText.mockRestore();
+      }
+    });
+
     it("reports which resend step failed: revoking the old invite", async () => {
       const user = userEvent.setup();
       mockFetchForUsers(mockUsers, [expiredInvite]);


### PR DESCRIPTION
## What does this PR do?

Two follow-ups from reviewing #1017. Both are things that review found and the PR left open — neither is a defect in what it changed.

### 1. The file #1017 cites as the model is broken in isolation

#1017 converted four files to `vi.spyOn(navigator.clipboard, "writeText")` and points readers at `add-integration-google-wizard.test.tsx` three times as the pattern to copy. That file installs its spy describe-wide in `beforeEach`, which finds an object only because an earlier, unrelated test in the same file already called `userEvent.setup()` — the call that defines `navigator.clipboard` in the first place, jsdom having none of its own.

Run the block alone and it fails, on `main`, today:

```
$ pnpm exec vitest run src/__tests__/components/add-integration-google-wizard.test.tsx \
    -t "shows success feedback when copy button is clicked"

Error: The vi.spyOn() function could not find an object to spy upon. The first argument must be defined.
 ❯ add-integration-google-wizard.test.tsx:187
TypeError: Cannot read properties of undefined (reading 'mockRestore')
 ❯ add-integration-google-wizard.test.tsx:193
```

Two red tests that read as a clipboard bug and are an ordering dependency — the same red-herring shape #1017's own description warns about. And `vitest -t` is exactly how you run a single failing test, so the trap springs on the first person who tries.

The spy moves into the test, after `setup()`, restored in a `finally`. That is the shape the four converted files already have, and the one that survives `-t`, `.only` and reordering.

### 2. There is a second Copy button, and nothing tested it

#1017's mutation matrix records that emptying `settings-users.tsx` leaves the invite-link copy test green, because the button that test clicks lives in `invite-dialog.tsx`. True, and useful — but it is also a finding the note stops short of: `settings-users.tsx` has a Copy button of its own, beside the link offered after a **Resend**, and it was covered by nothing. `onClick={() => {}}` on line 203 left all 34 tests in the file green.

The existing resend test asserts only that the link is *rendered*. This adds one that clicks the button next to it and asserts the link really reached the clipboard, scoped to the panel because `Copy` is not a unique label on that screen.

### Not changed

`use-copy-to-clipboard.test.ts` still redefines `navigator.clipboard` wholesale, and that is correct: it never calls `userEvent.setup()`, so there is no stub to shadow, and two of its cases test the API being *absent*, which a spy cannot express. #1017 was right to leave it.

`resetLink` in `settings-users.tsx` holds an invite URL and renders under the label "Invite link:" — a misleading name, but renaming production state does not belong in a test PR.

## Type of change

- [x] 🧪 Tests

## Verification

Mutation, not a green suite:

| Probe | Before | After |
| --- | --- | --- |
| google-wizard copy test run alone (`-t`) | 2 failed | 1 passed |
| `settings-users.tsx:203` `onClick={() => {}}` | 34 passed (gap) | 1 failed \| 34 passed |
| new test run alone (`-t`) | — | 1 passed |

Gates: `pnpm test` 10568 passed / 20 skipped (was 10567 — net +1 test, no removals), `pnpm -C packages/web typecheck` clean, ESLint 0 errors, `pnpm format:check` clean.

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable) — one added, none removed
- [x] I've updated the documentation (if applicable) — test-only, no user-visible surface moved
- [x] All existing tests pass
