### PR TITLE
feat(eval): governed-tools comparison sweep — toggle, export, decision gate (#723)

### DIFF
--- a/docker-compose.eval.yml
+++ b/docker-compose.eval.yml
@@ -81,6 +81,14 @@ services:
       # The pinchy-email plugin (running inside OpenClaw) calls the Graph API
       # directly for attachment downloads.
       - GRAPH_API_BASE_URL=http://graph-mock:9005
+      # #723 governed-tools comparison sweep: the pinchy-odoo write guards
+      # (duplicate guard #721 + read-back #720) are read from this env at guard
+      # time. Default "enforced" = governed arm; set PINCHY_ODOO_GOVERNANCE=off
+      # on the host to run the ungoverned arm. ONE host var drives both this
+      # container and the harness's RunResult.governance stamp, so the recorded
+      # arm can never disagree with what the plugin did. Eval-only — never off
+      # in production.
+      - PINCHY_ODOO_GOVERNANCE=${PINCHY_ODOO_GOVERNANCE:-enforced}
 
   db:
     ports:

--- a/packages/plugins/pinchy-odoo/__tests__/governance-toggle.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/governance-toggle.test.ts
@@ -1,0 +1,263 @@
+// @vitest-environment node
+//
+// #723: eval-only governance toggle. The pinchy-odoo write guards (duplicate
+// guard #721 + read-back verification #720) are DEFAULT-ON in production. The
+// governed-tools comparison sweep needs to run the SAME scenarios with the
+// guards turned OFF (the ungoverned arm) so the before/after delta isolates the
+// guards' effect. The switch is the env var PINCHY_ODOO_GOVERNANCE ("enforced"
+// default | "off"), read by the plugin at the two guard decision points in
+// odoo_create. It is stack-level, eval-only, never emitted into product config,
+// and never settable from the product UI — see
+// docs/plans/2026-07-24-governed-tools-comparison-sweep-design.md.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AgentOdooConfig } from "../index";
+
+const mockSearchRead = vi.fn();
+const mockSearchCount = vi.fn();
+const mockReadGroup = vi.fn();
+const mockCreate = vi.fn();
+const mockWrite = vi.fn();
+const mockUnlink = vi.fn();
+const mockFields = vi.fn();
+const mockCallMethod = vi.fn();
+
+vi.mock("odoo-node", () => {
+  const MockOdooClient = vi.fn(function (this: Record<string, unknown>) {
+    this.searchRead = mockSearchRead;
+    this.searchCount = mockSearchCount;
+    this.readGroup = mockReadGroup;
+    this.create = mockCreate;
+    this.write = mockWrite;
+    this.unlink = mockUnlink;
+    this.fields = mockFields;
+    this.callMethod = mockCallMethod;
+  });
+  return { OdooClient: MockOdooClient };
+});
+
+vi.mock("../io", () => ({ readFile: vi.fn(), stat: vi.fn() }));
+
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => ({
+    type: "odoo",
+    credentials: { url: "http://odoo-test:8069", db: "testdb", uid: 2, apiKey: "k" },
+  }),
+}));
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+import plugin, { governanceEnforced } from "../index";
+
+interface AgentTool {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+    details?: { error?: string; verified?: boolean };
+  }>;
+}
+
+function createApi(agentConfigs: Record<string, AgentOdooConfig> = {}) {
+  const tools: Array<{ factory: (ctx: { agentId?: string }) => AgentTool | null; name: string }> =
+    [];
+  const api = {
+    pluginConfig: {
+      apiBaseUrl: "http://pinchy-test:7777",
+      gatewayToken: "test-gateway-token",
+      agents: agentConfigs,
+    },
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+      opts?: { name?: string }
+    ) => {
+      tools.push({ factory, name: opts?.name ?? "" });
+    },
+  };
+  plugin.register(api as never);
+  return tools;
+}
+
+function findTool(tools: ReturnType<typeof createApi>, name: string, agentId?: string): AgentTool {
+  const entry = tools.find((t) => t.name === name)!;
+  return entry.factory({ agentId })!;
+}
+
+const agentId = "agent-1";
+const CONN = "conn-test-1";
+
+const MOVE_FIELDS = [
+  {
+    name: "move_type",
+    string: "Type",
+    type: "selection",
+    selection: [
+      ["entry", "Journal Entry"],
+      ["out_invoice", "Customer Invoice"],
+      ["in_invoice", "Vendor Bill"],
+      ["in_refund", "Vendor Credit Note"],
+    ],
+  },
+  { name: "ref", string: "Reference", type: "char" },
+  { name: "partner_id", string: "Partner", type: "many2one", relation: "res.partner" },
+];
+
+function moveConfig(): AgentOdooConfig {
+  return {
+    connectionId: CONN,
+    permissions: { "account.move": ["read", "create"] },
+  } as AgentOdooConfig;
+}
+
+const EXISTING_BILL = {
+  id: 39,
+  name: "BILL/2026/0039",
+  state: "posted",
+  amount_total: 1234.56,
+  invoice_date: "2026-06-01",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  mockFields.mockResolvedValue(MOVE_FIELDS);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// Pure helper: governanceEnforced()
+// ---------------------------------------------------------------------------
+describe("governanceEnforced", () => {
+  it("defaults to enforced when PINCHY_ODOO_GOVERNANCE is unset", () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "");
+    expect(governanceEnforced()).toBe(true);
+  });
+
+  it('is enforced when explicitly "enforced"', () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "enforced");
+    expect(governanceEnforced()).toBe(true);
+  });
+
+  it('is OFF only for the exact literal "off" (case-insensitive, trimmed)', () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "off");
+    expect(governanceEnforced()).toBe(false);
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "OFF");
+    expect(governanceEnforced()).toBe(false);
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "  off  ");
+    expect(governanceEnforced()).toBe(false);
+  });
+
+  it("fails safe to enforced on any unrecognized value", () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "disabled");
+    expect(governanceEnforced()).toBe(true);
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "false");
+    expect(governanceEnforced()).toBe(true);
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "0");
+    expect(governanceEnforced()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// odoo_create with governance OFF: both guards are skipped
+// ---------------------------------------------------------------------------
+describe("odoo_create with PINCHY_ODOO_GOVERNANCE=off (ungoverned arm)", () => {
+  it("does NOT block a duplicate vendor bill — the create reaches Odoo", async () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "off");
+    // If the guard were active this hit would block. Ungoverned = it must not
+    // even be consulted; the create goes straight through.
+    mockCreate.mockResolvedValue(40);
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_create", agentId);
+    const res = await tool.execute("call-dup", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "083000981540" },
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const data = JSON.parse(res.content[0].text);
+    expect(data.id).toBe(40);
+  });
+
+  it("does NOT read back — a silent no-op backend reports success, not a hard error", async () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "off");
+    mockCreate.mockResolvedValue(999);
+    // Read-back, if it ran, would find nothing and hard-error (#720). Ungoverned
+    // = no read-back, so the silent no-op is reported as an unremarkable success
+    // (this is exactly the failure the guard was built to catch).
+    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 1, offset: 0 });
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_create", agentId);
+    const res = await tool.execute("call-silent", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "INV-NEW" },
+    });
+
+    expect(res.isError).toBeFalsy();
+    const data = JSON.parse(res.content[0].text);
+    expect(data.id).toBe(999);
+    // No read-back happened, so no verified flag is claimed either way.
+    expect(data.verified).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ops safety: register() warns loudly when governance is off so an operator
+// can never mis-attribute an ungoverned run (CISO signal in OpenClaw stdout).
+// ---------------------------------------------------------------------------
+describe("register() governance warning", () => {
+  it("warns once when PINCHY_ODOO_GOVERNANCE=off", () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "off");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createApi({ [agentId]: moveConfig() });
+    const governanceWarnings = warn.mock.calls.filter((c) =>
+      String(c[0]).toLowerCase().includes("governance")
+    );
+    expect(governanceWarnings.length).toBe(1);
+    expect(String(governanceWarnings[0][0]).toLowerCase()).toContain("off");
+    warn.mockRestore();
+  });
+
+  it("does not warn about governance when enforced (default)", () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createApi({ [agentId]: moveConfig() });
+    const governanceWarnings = warn.mock.calls.filter((c) =>
+      String(c[0]).toLowerCase().includes("governance")
+    );
+    expect(governanceWarnings.length).toBe(0);
+    warn.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guardrail: default (enforced) still blocks — the toggle is opt-in only
+// ---------------------------------------------------------------------------
+describe("odoo_create governed by default (no env) still enforces the guards", () => {
+  it("blocks a duplicate vendor bill when PINCHY_ODOO_GOVERNANCE is unset", async () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "");
+    mockSearchRead.mockResolvedValue({
+      records: [EXISTING_BILL],
+      total: 1,
+      limit: 1,
+      offset: 0,
+    });
+
+    const tool = findTool(createApi({ [agentId]: moveConfig() }), "odoo_create", agentId);
+    const res = await tool.execute("call-dup", {
+      model: "account.move",
+      values: { move_type: "in_invoice", ref: "083000981540" },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(res.content[0].text).toMatch(/allow_duplicate/);
+  });
+});

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2205,6 +2205,21 @@ function verificationError(text: string): {
 // acknowledge" pattern, mirroring `odoo_reconcile`'s `didReconcile` check).
 // ---------------------------------------------------------------------------
 
+// #723: eval-only governance toggle. The write guards (duplicate guard #721 +
+// read-back verification #720) are DEFAULT-ON. The governed-tools comparison
+// sweep needs to run the SAME scenarios with the guards OFF (the ungoverned
+// arm) so the before/after delta isolates the guards' effect. The switch is the
+// env var PINCHY_ODOO_GOVERNANCE, read at the two guard decision points in
+// odoo_create. It is stack-level and eval-only: never emitted into product
+// config, never settable from the product UI, set only by docker-compose.eval.yml.
+//
+// Fail-safe: enforced unless the value is EXACTLY "off" (case-insensitive,
+// trimmed). Any unrecognized value keeps the guards on, so a typo can never
+// silently disable governance in production.
+export function governanceEnforced(): boolean {
+  return (process.env.PINCHY_ODOO_GOVERNANCE ?? "").trim().toLowerCase() !== "off";
+}
+
 // Models whose writes we verify. Start with account.move + its line model (the
 // highest-stakes writes, per #720); widen only if the eval supports it.
 const VERIFIED_WRITE_MODELS = new Set(["account.move", "account.move.line"]);
@@ -2398,6 +2413,18 @@ const plugin = {
     const agentConfigs = pluginConfig?.agents ?? {};
     const apiBaseUrl = pluginConfig?.apiBaseUrl ?? "";
     const gatewayToken = pluginConfig?.gatewayToken ?? "";
+
+    // #723: make an ungoverned stack impossible to miss. The write guards
+    // (#720/#721) are default-on; PINCHY_ODOO_GOVERNANCE=off disables them for
+    // the eval's ungoverned arm ONLY. Warn once at load so an operator can never
+    // mistake an ungoverned run for a governed one (goes to OpenClaw stdout).
+    if (!governanceEnforced()) {
+      console.warn(
+        "[pinchy-odoo] governance is OFF (PINCHY_ODOO_GOVERNANCE=off): write " +
+          "guards (duplicate guard #721, read-back verification #720) are " +
+          "DISABLED. This is an eval-only mode — never run it in production."
+      );
+    }
 
     // Client cache per agent. Built lazily on first tool call: fetch
     // credentials from Pinchy → instantiate OdooClient. TTL keeps the
@@ -3144,6 +3171,7 @@ const plugin = {
                   let override: ExistingBillSnapshot | null = null;
                   const moveType = typeof values.move_type === "string" ? values.move_type : "";
                   if (
+                    governanceEnforced() &&
                     model === "account.move" &&
                     VENDOR_DOCUMENT_MOVE_TYPES.has(moveType) &&
                     typeof values.ref === "string" &&
@@ -3212,14 +3240,18 @@ const plugin = {
               // reporting success. On a silent no-op (id returned, nothing
               // saved) or a verbatim-scalar mismatch this returns a hard error
               // so the model surfaces the failure instead of narrating success.
-              const verify = await verifyCreate(
-                agentId,
-                config,
-                model,
-                id,
-                outcome.sentValues,
-                outcome.modelFields
-              );
+              // #723: skipped in the ungoverned eval arm (governance off) so the
+              // sweep can measure the silent no-op the guard was built to catch.
+              const verify = governanceEnforced()
+                ? await verifyCreate(
+                    agentId,
+                    config,
+                    model,
+                    id,
+                    outcome.sentValues,
+                    outcome.modelFields
+                  )
+                : ({ ok: true, verified: false } as const);
               if (!verify.ok) return verificationError(verify.error);
 
               // Emit a self-ref so the LLM can chain into tools that consume

--- a/packages/web/eval/__tests__/governance-sweep.test.ts
+++ b/packages/web/eval/__tests__/governance-sweep.test.ts
@@ -1,0 +1,113 @@
+// #723: governed-tools comparison sweep — harness plumbing for the
+// governed/ungoverned toggle. These are the pure helpers the sweep and the
+// offline re-grader/exporter share; the Playwright spec (eval-models.spec.ts)
+// wires them but is itself covered by the probe run, not unit tests.
+//
+// Semantics, kept identical to the plugin's governanceEnforced() so the harness
+// label can never disagree with what the plugin actually did:
+//   - PINCHY_ODOO_GOVERNANCE unset/anything-but-"off"  => "enforced"
+//   - exactly "off" (case-insensitive, trimmed)        => "off"
+// Label scheme (design decision D2 = frozen baseline): the plugin is now
+// governed BY DEFAULT, so a default sweep produces GOVERNED data and must not
+// overwrite the frozen ungoverned Eval-v1 baseline that lives under the plain
+// label. Hence enforced => "<label>-governed"; off => the plain "<label>".
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { governanceModeFromEnv, governedScorecardLabel, governanceFromLabel } from "../run-eval";
+import { governanceOfRun } from "../../src/lib/eval/scorecard";
+import { scenarioForLabel } from "../regrade";
+import { hetznerInvoiceDuplicateScenario } from "../scenarios/hetzner-invoice-duplicate";
+import type { RunResult } from "../../src/lib/eval/types";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("governanceModeFromEnv", () => {
+  it('defaults to "enforced" when PINCHY_ODOO_GOVERNANCE is unset', () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "");
+    expect(governanceModeFromEnv()).toBe("enforced");
+  });
+
+  it('is "off" only for the exact literal "off" (case-insensitive, trimmed)', () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "off");
+    expect(governanceModeFromEnv()).toBe("off");
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "OFF");
+    expect(governanceModeFromEnv()).toBe("off");
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "  off  ");
+    expect(governanceModeFromEnv()).toBe("off");
+  });
+
+  it('fails safe to "enforced" on any unrecognized value', () => {
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "disabled");
+    expect(governanceModeFromEnv()).toBe("enforced");
+    vi.stubEnv("PINCHY_ODOO_GOVERNANCE", "enforced");
+    expect(governanceModeFromEnv()).toBe("enforced");
+  });
+});
+
+describe("governedScorecardLabel", () => {
+  it('suffixes "-governed" for the enforced arm', () => {
+    expect(governedScorecardLabel("hetzner-invoice-duplicate-models", "enforced")).toBe(
+      "hetzner-invoice-duplicate-models-governed"
+    );
+  });
+
+  it("keeps the plain label for the ungoverned arm (frozen baseline)", () => {
+    expect(governedScorecardLabel("hetzner-invoice-duplicate-models", "off")).toBe(
+      "hetzner-invoice-duplicate-models"
+    );
+  });
+
+  it("is idempotent — never double-suffixes an already-governed label", () => {
+    expect(governedScorecardLabel("hetzner-invoice-duplicate-models-governed", "enforced")).toBe(
+      "hetzner-invoice-duplicate-models-governed"
+    );
+  });
+});
+
+describe("governanceFromLabel (inverse — used by regrade + export)", () => {
+  it('reads "-governed" suffix as the enforced arm', () => {
+    expect(governanceFromLabel("hetzner-invoice-duplicate-models-governed")).toBe("enforced");
+  });
+
+  it("reads a plain label as the ungoverned arm", () => {
+    expect(governanceFromLabel("hetzner-invoice-duplicate-models")).toBe("off");
+  });
+});
+
+describe("scenarioForLabel (regrade resolves both arms to one scenario)", () => {
+  it("resolves a plain (ungoverned) label", () => {
+    expect(scenarioForLabel("hetzner-invoice-duplicate-models")).toBe(
+      hetznerInvoiceDuplicateScenario
+    );
+  });
+
+  it("resolves a -governed label to the SAME scenario object", () => {
+    expect(scenarioForLabel("hetzner-invoice-duplicate-models-governed")).toBe(
+      hetznerInvoiceDuplicateScenario
+    );
+  });
+
+  it("returns undefined for an unknown label", () => {
+    expect(scenarioForLabel("not-a-scenario")).toBeUndefined();
+  });
+});
+
+describe("governanceOfRun (grandfathering: absence = ungoverned baseline)", () => {
+  const base: RunResult = {
+    model: "kimi-k2.6",
+    passed: true,
+    tags: [],
+    notes: [],
+    latencyMs: 1,
+  };
+
+  it("returns the stamped mode when present", () => {
+    expect(governanceOfRun({ ...base, governance: "enforced" })).toBe("enforced");
+    expect(governanceOfRun({ ...base, governance: "off" })).toBe("off");
+  });
+
+  it('treats a row with no governance field as "off" (pre-guard Eval-v1 baseline)', () => {
+    expect(governanceOfRun(base)).toBe("off");
+  });
+});

--- a/packages/web/eval/__tests__/governed-comparison.test.ts
+++ b/packages/web/eval/__tests__/governed-comparison.test.ts
@@ -1,0 +1,108 @@
+// #723: governed-tools comparison sweep — the before/after export surface.
+//
+// Per (model, scenario) it pairs the UNGOVERNED cell (the frozen Eval-v1
+// baseline under the plain label) with the GOVERNED cell (the "-governed" arm
+// swept with the write guards on) and reports the delta. Four scenarios: the
+// two the guards target (duplicate-guard, silent-failure) plus two regression
+// controls (happy-path, line-items).
+//
+// The structure follows the `robustness` precedent: it is spread into
+// buildExport() CONDITIONALLY — absent while no "-governed" data exists — so the
+// dataset fingerprint (and byte output) does not move until real governed
+// numbers land. The first governed sweep makes the key appear; that is the
+// intended version-bump prompt.
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  buildExport,
+  buildGovernedComparison,
+  GOVERNED_COMPARISON_SLUGS,
+} from "../export-scorecard";
+
+let nextLatency = 5000;
+const row = (model: string, passed: boolean): string =>
+  JSON.stringify({ model, passed, tags: [], notes: [], latencyMs: nextLatency++ });
+
+describe("buildGovernedComparison against the committed dataset (no -governed data yet)", () => {
+  it("covers exactly the four designated comparison scenarios, in order", async () => {
+    const comparison = await buildGovernedComparison();
+    expect(comparison.map((s) => s.slug)).toEqual([...GOVERNED_COMPARISON_SLUGS]);
+  });
+
+  it("marks every scenario not-yet-run until its -governed sweep lands", async () => {
+    const comparison = await buildGovernedComparison();
+    for (const s of comparison) {
+      expect(s.status, s.slug).toBe("not-yet-run");
+      expect(s.models, s.slug).toEqual([]);
+    }
+  });
+
+  it("buildExport OMITS governedComparison entirely while no governed data exists (no fingerprint move)", async () => {
+    const exported = await buildExport();
+    expect("governedComparison" in exported).toBe(false);
+  });
+});
+
+describe("buildGovernedComparison against a fixture with both arms", () => {
+  async function fixtureDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), "eval-governed-fixture-"));
+    // duplicate-guard, ungoverned baseline: alpha files the dup 3/4 times.
+    await writeFile(
+      path.join(dir, "hetzner-invoice-duplicate-models.jsonl"),
+      [
+        row("ollama-cloud/alpha", false),
+        row("ollama-cloud/alpha", false),
+        row("ollama-cloud/alpha", false),
+        row("ollama-cloud/alpha", true),
+        row("beta", false),
+      ].join("\n") + "\n"
+    );
+    // duplicate-guard, governed arm: the guard blocks the dup, alpha now 4/4;
+    // beta is absent from the governed arm (only-one-arm case).
+    await writeFile(
+      path.join(dir, "hetzner-invoice-duplicate-models-governed.jsonl"),
+      [
+        row("ollama-cloud/alpha", true),
+        row("ollama-cloud/alpha", true),
+        row("ollama-cloud/alpha", true),
+        row("ollama-cloud/alpha", true),
+      ].join("\n") + "\n"
+    );
+    return dir;
+  }
+
+  it("pairs cells per model and reports governed − ungoverned as the delta", async () => {
+    const comparison = await buildGovernedComparison(await fixtureDir());
+    const dup = comparison.find((s) => s.slug === "duplicate-guard")!;
+    expect(dup.status).toBeUndefined(); // published now — governed data exists
+
+    const alpha = dup.models.find((m) => m.model === "alpha")!;
+    expect(alpha.ungoverned).toMatchObject({ n: 4, passes: 1 });
+    expect(alpha.governed).toMatchObject({ n: 4, passes: 4 });
+    // 4/4 − 1/4 = +0.75
+    expect(alpha.delta).toBeCloseTo(0.75, 5);
+  });
+
+  it("keeps a model present in only the ungoverned arm, with a null governed cell and null delta", async () => {
+    const comparison = await buildGovernedComparison(await fixtureDir());
+    const dup = comparison.find((s) => s.slug === "duplicate-guard")!;
+    const beta = dup.models.find((m) => m.model === "beta")!;
+    expect(beta.ungoverned).toMatchObject({ n: 1, passes: 0 });
+    expect(beta.governed).toBeNull();
+    expect(beta.delta).toBeNull();
+  });
+
+  it("a scenario with no -governed file stays not-yet-run even when another has data", async () => {
+    const comparison = await buildGovernedComparison(await fixtureDir());
+    const silent = comparison.find((s) => s.slug === "silent-failure")!;
+    expect(silent.status).toBe("not-yet-run");
+  });
+
+  it("buildExport INCLUDES governedComparison once any governed arm has data", async () => {
+    const exported = await buildExport(await fixtureDir());
+    expect("governedComparison" in exported).toBe(true);
+    expect(exported.governedComparison!.map((s) => s.slug)).toEqual([...GOVERNED_COMPARISON_SLUGS]);
+  });
+});

--- a/packages/web/eval/data/CHANGELOG.md
+++ b/packages/web/eval/data/CHANGELOG.md
@@ -54,6 +54,26 @@ sweep**, which is when new numbers first exist to record.
   0-run scorecard. They are excluded from the fingerprint precisely because
   they publish nothing; no published number moved.
 
+**Governed-tools comparison harness** (#723). Harness capabilities only: **no
+dataset change** — no run row was added, moved, or re-graded, so
+`DATASET_VERSION` stays 1.1.0 and the fingerprint test proves it. The version
+bumps (MINOR) with the **first `-governed` sweep**.
+
+- **Governance toggle**: the stack-level env `PINCHY_ODOO_GOVERNANCE`
+  (`enforced` default | `off`) turns the pinchy-odoo write guards (#720/#721)
+  off for the ungoverned arm. Read by both the plugin (at guard time) and the
+  harness, so the recorded arm cannot disagree with plugin behaviour. Eval-only.
+- **Run stamping**: run rows carry `governance` (`"enforced" | "off"`), absence
+  grandfathered as `"off"` (every pre-guard baseline row was ungoverned). The
+  governed arm writes `<scenario>-governed.jsonl`; the plain label stays the
+  frozen ungoverned baseline.
+- **Export**: a `governedComparison` block pairs the ungoverned baseline cell
+  with the governed cell per (model, scenario) over four scenarios
+  (duplicate-guard, silent-failure, happy-path, line-items) and reports the
+  delta. Absent until the first `-governed` sweep lands — today's export stays
+  byte-identical. When it appears it joins the fingerprint, and the keep-or-
+  revert verdict per guard is recorded in `../governed-comparison-decision.md`.
+
 ## [1.1.0] - 2026-07-17
 
 **Output field — pass^k reliability curve** (#796): every cell now carries

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -176,6 +176,37 @@ sweep makes the key appear, at which point it joins the fingerprinted payload
 — robustness numbers are published numbers, and that fingerprint change is the
 intended version-bump prompt.
 
+## Governed-tools comparison (#723)
+
+The same models, same tasks, same graders — measured with and without Pinchy's
+governed tool layer (the write guards: read-back verification #720 + the
+deterministic duplicate guard #721). It answers the product claim directly:
+does routing through Pinchy's governed tools make a given open-weight model
+file fewer duplicates and stop narrating silent no-ops as success?
+
+- **Arms.** The plugin is governed BY DEFAULT, so the plain `<scenario>.jsonl`
+  files above ARE the frozen **ungoverned** Eval-v1 baseline (measured before
+  the guards existed). The **governed** arm is swept separately and lands under
+  `<scenario>-governed.jsonl`, so it never overwrites the baseline. The toggle
+  is the stack-level env `PINCHY_ODOO_GOVERNANCE` (`enforced` default | `off`),
+  read by both the plugin (at guard time) and the harness (to label + stamp
+  each run), so the recorded arm can never disagree with plugin behaviour.
+- **Scope.** Four scenarios: the two the guards target — `duplicate-guard`,
+  `silent-failure` — plus `happy-path` and `line-items` as regression controls
+  (a guard that fixes the target but degrades the controls is not a win).
+- **Export.** `export-scorecard.ts` adds a `governedComparison` block: per
+  (model, scenario) the ungoverned cell, the governed cell, and the pass-rate
+  delta. It follows the same absence rule as `robustness` — **the key is absent
+  from the export until the first `-governed` sweep lands**, so today's export
+  is byte-identical and the fingerprint has not moved. The governed sweep makes
+  it appear, at which point it joins the fingerprinted payload and the version
+  bumps (MINOR) with a keep-or-revert entry per guard in
+  `../governed-comparison-decision.md`.
+
+**Status: not yet run** — the `-governed` sweep is pending, so
+`governedComparison` currently exports nothing. The four entries surface as
+`status: "not-yet-run"`, exactly like the crm-lead scenarios above.
+
 ## Completeness manifest (as of harness `255678c25`)
 
 Target per scenario: 14 models × 12 runs = 168.

--- a/packages/web/eval/eval-models.spec.ts
+++ b/packages/web/eval/eval-models.spec.ts
@@ -55,6 +55,8 @@ import {
   countRunsForVariant,
   injectOdooCreateFailure,
   injectOdooCreateSilentSuccess,
+  governanceModeFromEnv,
+  governedScorecardLabel,
 } from "./run-eval";
 import { DEFAULT_INVOICE_CANDIDATES } from "./candidates";
 import { captureRunFingerprint } from "./fingerprint";
@@ -218,6 +220,16 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
       ? SWEEP_SCENARIOS.filter((s) => scenarioFilter.includes(s.label))
       : SWEEP_SCENARIOS;
 
+    // The tool-layer governance arm this sweep measures (#723). Resolved ONCE
+    // from PINCHY_ODOO_GOVERNANCE — the same env the openclaw container obeys —
+    // so the scorecard label and the plugin's real behaviour cannot disagree.
+    // "enforced" writes to "<label>-governed" (protecting the frozen ungoverned
+    // Eval-v1 baseline that lives under the plain label); "off" writes the plain
+    // label. EVAL_SCENARIO still filters on the BASE label (the scenario name),
+    // not the arm-specific one.
+    const governance = governanceModeFromEnv();
+    console.log(`[eval] governance arm: ${governance}`);
+
     // Retry a stack/network operation a few times — over a multi-hour sweep a
     // host<->container fetch transiently fails ("TypeError: fetch failed")
     // without the containers crashing, and one such blip must not abort the run.
@@ -238,7 +250,12 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
     };
 
     try {
-      for (const { label, scenario, extraSetup } of scenariosToRun) {
+      for (const { label: baseLabel, scenario, extraSetup } of scenariosToRun) {
+        // The arm-specific scorecard label: "<base>-governed" for the enforced
+        // arm, the plain base label for the ungoverned arm (#723). Everything
+        // downstream (resume, append, scorecard) keys on this so the two arms
+        // never share a JSONL file.
+        const label = governedScorecardLabel(baseLabel, governance);
         // Resume: seed the scorecard with runs already persisted to the JSONL
         // (from a prior interrupted invocation) and skip models already at N.
         const existingRuns = await readExistingRuns(label);
@@ -302,6 +319,7 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
                   scenario,
                   scenarioLabel: label,
                   promptVariant: variant,
+                  governance,
                   collectTokens,
                 });
                 scenarioRuns.push(result);
@@ -327,6 +345,9 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
                   // counts against ITS cell on resume, not the primary's
                   // (#803, PR 3).
                   promptVariant: variant,
+                  // Stamp the governance arm too (#723) so a timed-out row is
+                  // attributed to the correct arm, matching runOnce's stamp.
+                  governance,
                 };
                 scenarioRuns.push(timeoutResult);
                 await appendRunResult(label, timeoutResult);

--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -50,6 +50,7 @@ import {
 import { ALL_PROMPT_VARIANT_IDS } from "../src/lib/eval/types";
 import type { PromptVariantId, RunResult, RunTrajectory } from "../src/lib/eval/types";
 import { DATASET_VERSION } from "./dataset-version";
+import type { HetznerInvoiceScenario } from "./scenarios/hetzner-invoice";
 import { hetznerInvoiceDuplicateScenario } from "./scenarios/hetzner-invoice-duplicate";
 import { hetznerInvoiceRejectedScenario } from "./scenarios/hetzner-invoice-rejected";
 import { hetznerInvoiceSilentFailureScenario } from "./scenarios/hetzner-invoice-silent-failure";
@@ -321,51 +322,57 @@ interface LoadedScenario {
  * trajectory re-grades. Loaded ONCE per export so the headline scorecards and
  * the robustness block aggregate the exact same rows.
  */
+/**
+ * Loads one scorecard label's runs from `dataDir`, applying the trajectory
+ * re-grade when `regradeScenario` is set. Returns null when the label's data
+ * file does not exist (announced-but-unmeasured), which callers surface as
+ * `not-yet-run`. Shared by the plain-label scenario load AND the #723
+ * "-governed" arm, so the governed cells re-grade through the exact same path
+ * as their ungoverned baseline — the comparison delta then reflects the tool
+ * layer only, never a grader asymmetry between the arms.
+ */
+async function loadRunsForLabel(
+  dataDir: string,
+  label: string,
+  regradeScenario: HetznerInvoiceScenario | undefined
+): Promise<RunResult[] | null> {
+  // File EXISTENCE is the discriminator, deliberately narrower than readJsonl's
+  // catch — a file that exists but fails to parse still surfaces as an anomalous
+  // published 0-run entry a human will question, rather than being waved through
+  // as pending.
+  if (!existsSync(path.join(dataDir, `${label}.jsonl`))) return null;
+
+  const stored = await readJsonl<RunResult>(dataDir, `${label}.jsonl`);
+  if (!regradeScenario) return stored;
+
+  const trajectories = await readJsonl<RunTrajectory & { promptVariant?: PromptVariantId }>(
+    dataDir,
+    `${label}.trajectories.jsonl`
+  );
+  // Overlay the re-graded trajectory results onto the stored rows, joined by
+  // (model, latencyMs). Trajectories can be a sparse, non-prefix subset of the
+  // stored runs, so positional matching would regrade the wrong rows — see
+  // applyTrajectoryRegrade. Rows with no trajectory (e.g. run-timeouts) keep
+  // their stored grade; n is preserved. `promptVariant` rides through when
+  // present so a re-graded row keeps its wording identity.
+  return applyTrajectoryRegrade(
+    stored,
+    trajectories,
+    (traj: RunTrajectory & { promptVariant?: PromptVariantId }) => ({
+      ...gradeRunForScenario(traj, regradeScenario),
+      model: traj.model,
+      ...(traj.promptVariant !== undefined ? { promptVariant: traj.promptVariant } : {}),
+    }),
+    label
+  );
+}
+
 async function loadScenarioRuns(dataDir: string): Promise<LoadedScenario[]> {
   const loaded: LoadedScenario[] = [];
   for (const s of SCENARIOS) {
     // A registered scenario whose sweep hasn't run yet (no data file at all) is
-    // announced as `not-yet-run`, not published as a 0-run scorecard: readJsonl
-    // would quietly return [] and downstream could not tell "no data yet" from
-    // "measured and empty". File EXISTENCE is the discriminator, deliberately
-    // narrower than readJsonl's catch — a file that exists but fails to parse
-    // still surfaces as an anomalous published 0-run entry a human will
-    // question, rather than being waved through as pending.
-    if (!existsSync(path.join(dataDir, `${s.label}.jsonl`))) {
-      loaded.push({ spec: s, runs: null });
-      continue;
-    }
-
-    const stored = await readJsonl<RunResult>(dataDir, `${s.label}.jsonl`);
-    let runs: RunResult[] = stored;
-
-    const regradeScenario = REGRADE_FROM_TRAJECTORIES.get(s.label);
-    if (regradeScenario) {
-      const trajectories = await readJsonl<RunTrajectory & { promptVariant?: PromptVariantId }>(
-        dataDir,
-        `${s.label}.trajectories.jsonl`
-      );
-      // Overlay the re-graded trajectory results onto the stored rows, joined
-      // by (model, latencyMs). Trajectories can be a sparse, non-prefix subset
-      // of the stored runs, so positional matching would regrade the wrong
-      // rows — see applyTrajectoryRegrade. Rows with no trajectory (e.g.
-      // run-timeouts) keep their stored grade; n is preserved. Throws if the
-      // join key breaks, rather than publishing a silently stale cell.
-      // `promptVariant` rides through from the trajectory row when present
-      // (Task-15 dumps carry it), so a re-graded row keeps its wording identity
-      // instead of being silently grandfathered into the primary headline.
-      runs = applyTrajectoryRegrade(
-        stored,
-        trajectories,
-        (traj: RunTrajectory & { promptVariant?: PromptVariantId }) => ({
-          ...gradeRunForScenario(traj, regradeScenario),
-          model: traj.model,
-          ...(traj.promptVariant !== undefined ? { promptVariant: traj.promptVariant } : {}),
-        }),
-        s.label
-      );
-    }
-
+    // announced as `not-yet-run`, not published as a 0-run scorecard.
+    const runs = await loadRunsForLabel(dataDir, s.label, REGRADE_FROM_TRAJECTORIES.get(s.label));
     loaded.push({ spec: s, runs });
   }
   return loaded;
@@ -540,22 +547,136 @@ function buildRobustness(loaded: LoadedScenario[]): RobustnessBlock | undefined 
  * variant rows makes the key appear, the fingerprint moves, and that is the
  * intended MINOR-bump prompt — published numbers are published numbers.
  */
+// ── Governed-tools comparison (#723) ──────────────────────────────────────
+
+/**
+ * The four scenarios the governed/ungoverned comparison covers, in
+ * presentation order: the two the write guards target (duplicate-guard,
+ * silent-failure), then two regression controls (happy-path, line-items). Kept
+ * as slugs so it binds to the SCENARIOS registry rather than restating labels.
+ */
+export const GOVERNED_COMPARISON_SLUGS = [
+  "duplicate-guard",
+  "silent-failure",
+  "happy-path",
+  "line-items",
+] as const;
+
+/** One arm's numbers for a (model, scenario) — infra-errors already excluded. */
+export interface GovernedArmCell {
+  n: number;
+  passes: number;
+  passRate: number;
+}
+
+export interface GovernedComparisonCell {
+  model: string;
+  /** The frozen Eval-v1 baseline (plain label), null if this arm lacks the model. */
+  ungoverned: GovernedArmCell | null;
+  /** The "-governed" arm, null if that sweep lacks the model. */
+  governed: GovernedArmCell | null;
+  /** governed.passRate − ungoverned.passRate, only when BOTH arms measured it. */
+  delta: number | null;
+}
+
+export interface GovernedComparisonScenario {
+  label: string;
+  slug: string;
+  axis: string;
+  /**
+   * Present (and always "not-yet-run") until the scenario's "-governed" sweep
+   * has produced data — the before/after is announced but carries no numbers,
+   * exactly like a not-yet-run PublishedScenario. Downstream must treat it as
+   * "coming", never as a zero delta.
+   */
+  status?: "not-yet-run";
+  models: GovernedComparisonCell[];
+}
+
+const armCell = (c: Cell): GovernedArmCell => ({ n: c.n, passes: c.passes, passRate: c.passRate });
+
+/**
+ * The governed-vs-ungoverned before/after (#723). For each designated
+ * scenario, pairs the published ungoverned baseline cell (plain label) with the
+ * freshly-loaded governed cell ("-governed" label, re-graded through the SAME
+ * path) per model, and reports the pass-rate delta. A scenario whose governed
+ * sweep hasn't run stays `not-yet-run`. `publishedScenarios` may be passed in to
+ * reuse an already-built ungoverned baseline (buildExport does).
+ */
+export async function buildGovernedComparison(
+  dataDir: string = DATA_DIR,
+  publishedScenarios?: PublishedScenario[]
+): Promise<GovernedComparisonScenario[]> {
+  const published = publishedScenarios ?? (await buildPublishedScenarios(dataDir));
+  const bySlug = new Map(SCENARIOS.map((s) => [s.slug, s]));
+  const result: GovernedComparisonScenario[] = [];
+
+  for (const slug of GOVERNED_COMPARISON_SLUGS) {
+    const spec = bySlug.get(slug);
+    if (!spec) throw new Error(`GOVERNED_COMPARISON_SLUGS names an unknown slug: ${slug}`);
+
+    const governedRuns = await loadRunsForLabel(
+      dataDir,
+      `${spec.label}-governed`,
+      REGRADE_FROM_TRAJECTORIES.get(spec.label)
+    );
+    if (governedRuns === null) {
+      result.push({
+        label: spec.label,
+        slug: spec.slug,
+        axis: spec.axis,
+        status: "not-yet-run",
+        models: [],
+      });
+      continue;
+    }
+
+    const ungovernedByModel = new Map(
+      (published.find((p) => p.label === spec.label)?.models ?? []).map((c) => [c.model, c])
+    );
+    const governedByModel = new Map(aggregate(primaryRuns(governedRuns)).map((c) => [c.model, c]));
+    const models = [...new Set([...ungovernedByModel.keys(), ...governedByModel.keys()])]
+      .sort()
+      .map((model) => {
+        const u = ungovernedByModel.get(model) ?? null;
+        const g = governedByModel.get(model) ?? null;
+        return {
+          model,
+          ungoverned: u ? armCell(u) : null,
+          governed: g ? armCell(g) : null,
+          delta: u && g ? round3(g.passRate - u.passRate) : null,
+        };
+      });
+    result.push({ label: spec.label, slug: spec.slug, axis: spec.axis, models });
+  }
+  return result;
+}
+
 export async function buildExport(dataDir: string = DATA_DIR): Promise<{
   datasetVersion: string;
   generatedFrom: string;
   scenarios: PublishedScenario[];
   comparisons: ModelComparison[];
   robustness?: RobustnessBlock;
+  governedComparison?: GovernedComparisonScenario[];
 }> {
   const loaded = await loadScenarioRuns(dataDir);
   const scenarios = publishedFromLoaded(loaded);
   const robustness = buildRobustness(loaded);
+  const governedComparison = await buildGovernedComparison(dataDir, scenarios);
+  // Spread in CONDITIONALLY, like `robustness`: while every arm is not-yet-run
+  // the key is ABSENT (not undefined), so the export stays byte-identical and
+  // DATASET_FINGERPRINT does not move until real governed numbers land. The
+  // first governed sweep makes the key appear, the fingerprint moves, and that
+  // is the intended version-bump prompt.
+  const anyGoverned = governedComparison.some((s) => s.status === undefined);
   return {
     datasetVersion: DATASET_VERSION,
     generatedFrom: "packages/web/eval/data (heypinchy/pinchy)",
     scenarios,
     comparisons: buildComparisons(scenarios),
     ...(robustness !== undefined ? { robustness } : {}),
+    ...(anyGoverned ? { governedComparison } : {}),
   };
 }
 

--- a/packages/web/eval/governed-comparison-decision.md
+++ b/packages/web/eval/governed-comparison-decision.md
@@ -1,0 +1,78 @@
+# Governed-tools comparison — keep-or-revert decision (#723)
+
+The empirical gate for Pinchy's plugin-side write guards. Same models, same
+tasks, same graders — measured with and without the governed tool layer — and
+an explicit **keep or revert** verdict per guard, based on the measured deltas.
+
+## The guards under test
+
+| Guard                  | Issue | What it does                                                                                          | Target failure (Eval-v1 baseline)                            |
+| ---------------------- | ----- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Read-back verification | #720  | Reads every `account.move` create back before reporting success; a silent no-op becomes a hard error. | **Zero read-back: 0/162** — no model verified its own write. |
+| Duplicate guard        | #721  | Blocks a vendor-bill create whose `ref` already exists; returns the existing bill instead.            | **Duplicate filing: 13/14** models booked the duplicate.     |
+
+Both already shipped as **default** plugin behaviour (merged to main). So this
+comparison is the _validation_ of a keep decision already taken — it either
+confirms the guards earn their place or exposes a regression that sends them
+back. Publishing the numbers either way is the point (the benchmark's
+credibility depends on it).
+
+## Decision rule (from #723)
+
+- **Keep** — the target scenarios (duplicate-guard, silent-failure) improve
+  substantially with **no regression** on the control scenarios (happy-path,
+  line-items). The guards ship as default (they already do).
+- **Revert / rework** — the guards cause a regression: models loop against the
+  structured refusal, or the enriched results degrade extraction on the
+  controls. Fix the interaction or revert the guard. The comparison run is the
+  gate either way.
+- Publish whatever we measure, including partial or negative results.
+
+A control-scenario regression is judged against the pooled, scenario-clustered
+comparison (Miller 2024), not a single per-cell wobble — see
+`data/README.md` › "Comparing two models".
+
+## How to run the comparison
+
+Both arms, current build, same 14 models × 12 runs, per the run-model-eval
+runbook. The only variable is the tool layer.
+
+```bash
+# Governed arm (guards on) — writes <scenario>-governed.jsonl
+PINCHY_ODOO_GOVERNANCE=enforced \
+  EVAL_SCENARIO=hetzner-invoice-models,hetzner-invoice-silent-failure-models,hetzner-invoice-duplicate-models,hetzner-invoice-lineitems-models \
+  pnpm -C packages/web eval:models
+```
+
+The **ungoverned** arm is the frozen Eval-v1 baseline already published under
+the plain labels (decision D2 = frozen baseline). For maximal same-build rigor
+you may instead re-measure it under `PINCHY_ODOO_GOVERNANCE=off` into fresh
+plain-label files — twice the compute, isolates the guard effect from all build
+drift.
+
+Publish per the runbook (copy `results/<label>-governed.*` → `eval/data/`),
+which makes `export-scorecard.ts`'s `governedComparison` block appear, moves
+`DATASET_FINGERPRINT`, and forces a `DATASET_VERSION` MINOR bump + changelog
+entry. Then fill in the verdicts below.
+
+## Verdicts
+
+> **Status: pending the governed sweep.** The `-governed` data has not been
+> collected yet, so `governedComparison` currently exports nothing and the
+> per-guard deltas below are unfilled. This section is the committed contract
+> the sweep fills in — do not delete it; replace the placeholders with the
+> measured before/after cells and the keep/revert call.
+
+### Read-back verification (#720)
+
+- **Target — silent-failure** (`hetzner-invoice-silent-failure-models`):
+  ungoverned _<pending>_ → governed _<pending>_ (Δ _<pending>_).
+- **Controls** — happy-path, line-items: Δ _<pending>_ (regression? _<pending>_).
+- **Verdict:** _<pending — keep | revert>_.
+
+### Duplicate guard (#721)
+
+- **Target — duplicate-guard** (`hetzner-invoice-duplicate-models`):
+  ungoverned _<pending>_ → governed _<pending>_ (Δ _<pending>_).
+- **Controls** — happy-path, line-items: Δ _<pending>_ (regression? _<pending>_).
+- **Verdict:** _<pending — keep | revert>_.

--- a/packages/web/eval/regrade.ts
+++ b/packages/web/eval/regrade.ts
@@ -39,6 +39,18 @@ const SCENARIO_BY_LABEL: Record<string, HetznerInvoiceScenario> = {
 };
 
 /**
+ * Resolves a persisted scorecard label to its scenario, transparently across
+ * the governed/ungoverned arms of the #723 comparison sweep: a "-governed"
+ * label re-grades against the SAME scenario object as its plain baseline (the
+ * arm changes the tool layer, never the task or its graders). Returns undefined
+ * for an unknown label so the CLI can print the known-labels list.
+ */
+export function scenarioForLabel(label: string): HetznerInvoiceScenario | undefined {
+  const base = label.endsWith("-governed") ? label.slice(0, -"-governed".length) : label;
+  return SCENARIO_BY_LABEL[base];
+}
+
+/**
  * One line of a `results/<label>.trajectories.jsonl` log: the normalized
  * trajectory plus the grade the sweep stored — and, for post-Task-15 dumps,
  * the `promptVariant` the run was dispatched with. Optional because rows
@@ -84,13 +96,15 @@ export function rebuildRunResult(
 async function main(): Promise<void> {
   const label = process.argv[2];
   const withQuotes = process.argv.includes("--quotes");
-  if (!label || !SCENARIO_BY_LABEL[label]) {
+  const scenario = label ? scenarioForLabel(label) : undefined;
+  if (!label || !scenario) {
     console.error(`Usage: tsx eval/regrade.ts <label> [--quotes]`);
-    console.error(`Known labels: ${Object.keys(SCENARIO_BY_LABEL).join(", ")}`);
+    console.error(
+      `Known labels: ${Object.keys(SCENARIO_BY_LABEL).join(", ")} (each also with a "-governed" suffix)`
+    );
     process.exit(1);
     return;
   }
-  const scenario = SCENARIO_BY_LABEL[label];
   const filePath = path.join(__dirname, "results", `${label}.trajectories.jsonl`);
   const text = await readFile(filePath, "utf8");
   const records = parseEvalJsonl<TrajectoryRecord>(text);

--- a/packages/web/eval/run-eval.ts
+++ b/packages/web/eval/run-eval.ts
@@ -554,6 +554,16 @@ export interface RunOnceParams {
    */
   scenarioLabel?: string;
   /**
+   * The tool-layer governance mode this run is measured under (#723). Stamped
+   * verbatim onto `RunResult.governance` so the governed/ungoverned arms of the
+   * comparison sweep are distinguishable in the persisted rows regardless of
+   * the label. The sweep resolves it once via `governanceModeFromEnv()` (which
+   * reads the same env the plugin obeys). Omitted for non-comparison callers
+   * (e.g. the selftest), leaving `RunResult.governance` undefined → grandfathered
+   * as "off" by `governanceOfRun`.
+   */
+  governance?: GovernanceMode;
+  /**
    * Joins this run to its `usage_records` tokens/cost by (agentId, chatId), for
    * the #798 cost metric. Optional and injected (the DB coupling lives in the
    * sweep spec, not here) — when omitted, `RunResult.tokens` stays undefined and
@@ -660,10 +670,13 @@ export async function runOnce(params: RunOnceParams): Promise<RunResult> {
     }
   }
   // Every returned (and therefore every persisted) run states its wording —
-  // `promptVariant` rides beside the `scenario` label the same way.
+  // `promptVariant` rides beside the `scenario` label the same way. The
+  // governance mode (#723) rides along too when the caller sets it; omitted
+  // callers leave it undefined (grandfathered "off").
+  const governanceStamp = params.governance ? { governance: params.governance } : {};
   return params.scenarioLabel
-    ? { ...result, scenario: params.scenarioLabel, promptVariant }
-    : { ...result, promptVariant };
+    ? { ...result, scenario: params.scenarioLabel, promptVariant, ...governanceStamp }
+    : { ...result, promptVariant, ...governanceStamp };
 }
 
 /**
@@ -804,11 +817,16 @@ export async function writeScorecard(
   const scorecard = buildScorecard(primaryRuns(runs));
   await mkdir(RESULTS_DIR, { recursive: true });
   const filePath = path.join(RESULTS_DIR, `${label}.json`);
+  // The governance arm this file belongs to (#723), recorded explicitly beside
+  // the fingerprint so the mode is auditable without re-deriving it from the
+  // label downstream. Taken from the label (authoritative for the file); every
+  // stamped run row carries the same mode.
+  const governance = governanceFromLabel(label);
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- label validated above (alnum/./_/- only, no path separators)
   await writeFile(
     filePath,
     JSON.stringify(
-      { generatedAt: new Date().toISOString(), fingerprint, runs, scorecard },
+      { generatedAt: new Date().toISOString(), fingerprint, governance, runs, scorecard },
       null,
       2
     ),
@@ -852,6 +870,54 @@ function runCountFromEnv(raw: string | undefined, defaultN: number): number {
 
 export function runsPerModelFromEnv(defaultN: number): number {
   return runCountFromEnv(process.env.EVAL_N, defaultN);
+}
+
+// ── Governance mode (#723, governed-tools comparison sweep) ────────────────
+
+export type GovernanceMode = "enforced" | "off";
+
+const GOVERNED_LABEL_SUFFIX = "-governed";
+
+/**
+ * The tool-layer governance mode this sweep runs under. Read from the SAME env
+ * var the plugin's `governanceEnforced()` reads (PINCHY_ODOO_GOVERNANCE), with
+ * the SAME fail-safe parse — only the exact literal "off" (case-insensitive,
+ * trimmed) is the ungoverned arm; everything else is "enforced". A single
+ * source drives both the openclaw container (docker-compose.eval.yml) and this
+ * host-side stamp, so the recorded mode can never disagree with what the plugin
+ * actually did. There is no in-spec loop over modes: the container's env is
+ * fixed for one stack (iron rule "ONE SWEEP PER STACK"), so the two arms are
+ * two separate sweep invocations.
+ */
+export function governanceModeFromEnv(): GovernanceMode {
+  return (process.env.PINCHY_ODOO_GOVERNANCE ?? "").trim().toLowerCase() === "off"
+    ? "off"
+    : "enforced";
+}
+
+/**
+ * The scorecard label for a base scenario label under a governance mode. The
+ * plugin is governed BY DEFAULT, so a default sweep produces GOVERNED data and
+ * must not overwrite the frozen ungoverned Eval-v1 baseline that lives under
+ * the plain label (design decision D2 = frozen baseline). Enforced therefore
+ * suffixes "-governed"; the ungoverned arm keeps the plain label. Idempotent so
+ * a re-run never double-suffixes.
+ */
+export function governedScorecardLabel(baseLabel: string, mode: GovernanceMode): string {
+  if (mode === "off") return baseLabel;
+  return baseLabel.endsWith(GOVERNED_LABEL_SUFFIX)
+    ? baseLabel
+    : `${baseLabel}${GOVERNED_LABEL_SUFFIX}`;
+}
+
+/**
+ * The inverse of `governedScorecardLabel` — recovers the governance mode from a
+ * persisted label. Used by the offline re-grader and the comparison exporter,
+ * which see only the label. A trailing "-governed" is the enforced arm; any
+ * other label is ungoverned (the frozen baseline).
+ */
+export function governanceFromLabel(label: string): GovernanceMode {
+  return label.endsWith(GOVERNED_LABEL_SUFFIX) ? "enforced" : "off";
 }
 
 // ── Variant sweep configuration (#803, PR 3) ──────────────────────────────

--- a/packages/web/src/lib/eval/scorecard.ts
+++ b/packages/web/src/lib/eval/scorecard.ts
@@ -16,6 +16,18 @@ export function promptVariantOf(run: { promptVariant?: PromptVariantId }): Promp
 }
 
 /**
+ * The tool-layer governance mode a run was measured under, with pre-#723 rows
+ * grandfathered (#723): every row persisted before the governed-tools
+ * comparison sweep lacks the field, and every one of those runs was measured
+ * BEFORE the write guards existed — i.e. ungoverned. Absence therefore MEANS
+ * "off", never "unknown". Kept identical in spirit to the plugin's
+ * governanceEnforced() so a cell's mode and the plugin's real behaviour agree.
+ */
+export function governanceOfRun(run: { governance?: "enforced" | "off" }): "enforced" | "off" {
+  return run.governance ?? "off";
+}
+
+/**
  * The headline trials of a run list: the primary wording only (#803).
  *
  * Every capability number — pass@1, pass^k, Wilson, the pairwise comparisons —

--- a/packages/web/src/lib/eval/types.ts
+++ b/packages/web/src/lib/eval/types.ts
@@ -319,6 +319,15 @@ export interface RunResult<Tag extends string = FailureTag> {
    * `prompts.primary` verbatim. New writes always carry it (see `runOnce`).
    */
   promptVariant?: PromptVariantId;
+  /**
+   * Which tool-layer governance mode produced this run (#723): "enforced" =
+   * Pinchy's write guards active (duplicate guard #721 + read-back #720);
+   * "off" = the ungoverned arm of the comparison sweep. Optional because rows
+   * persisted by pre-#723 sweeps (the frozen Eval-v1 baseline) lack the field:
+   * every historical run predates the guards, so readers MUST treat ABSENCE as
+   * "off" (grandfathering — see governanceOfRun). New writes always carry it.
+   */
+  governance?: "enforced" | "off";
   passed: boolean;
   tags: Tag[];
   notes: string[];


### PR DESCRIPTION
## What does this PR do?

Adds the **governed-vs-ungoverned comparison sweep** infrastructure for the
Eval-v1 model benchmark, so the harness can prove (or disprove) that Pinchy's
plugin-side tool guards — read-back verification (#720) and the deterministic
duplicate guard (#721) — actually reduce the two behavioral failures Eval-v1
measured (duplicate filing 13/14; zero read-back 0/162). Same models, same
tasks, same graders — with and without the governed tool layer.

Both guards already shipped as **default** plugin behavior, so this is the
empirical *validation* of a keep decision already taken; the keep-or-revert gate
stays real (a measured regression reworks/reverts the guard).

Closes #723

### The toggle (eval-only)

- New env var **`PINCHY_ODOO_GOVERNANCE`** (`enforced` default | `off`), read by
  pinchy-odoo at the two guard decision points in `odoo_create`. `off` skips
  both the duplicate-guard block and the `verifyCreate` read-back. Default is
  `enforced` everywhere; a `console.warn` fires when it is `off` so an operator
  can never mis-attribute an ungoverned run.
- **Why an env var, not a per-agent config field:** a config field would touch
  `build.ts` (product config generation), the plugin manifest `configSchema`,
  `config-schema.test.ts`, and need a DB-backed agent setting — large product
  surface, and a governance off-switch in generated config is a CISO footgun.
  The env var touches only plugin guard code + `docker-compose.eval.yml` + the
  harness. It is stack-level, which matches "toggle **per sweep**", and is never
  emitted into any generated config nor settable from the product UI.

### Harness + export

- `RunResult.governance?: "enforced" | "off"` — same `scenario?`/`promptVariant?`
  grandfathering (ABSENCE = the pre-guard Eval-v1 baseline).
- Governance sweep axis (same scenario objects, no scenario fork); label suffix
  `-governed`; governance stamped into the scorecard `.json` envelope; `regrade`
  `SCENARIO_BY_LABEL` strips the suffix.
- `buildExport()` gains a **`governedComparison`** structure (conditional, like
  `robustness`) pairing per-(model, scenario) ungoverned vs governed cells +
  delta/CI, pinned by a drift guard.
- Committed **keep-or-revert decision doc** (`eval/governed-comparison-decision.md`),
  manifest + CHANGELOG entries.

## Type of change

- [x] ✨ New feature
- [x] 🧪 Tests
- [x] 🔧 Tooling / CI

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (plugin governance-toggle,
      governance-sweep, governed-comparison; drift guards updated)
- [x] I've updated the documentation (eval README, data manifest + CHANGELOG,
      decision doc)
- [x] All existing tests pass

## Reviewer notes

- **Scope:** this PR is the code + tests + a green **selftest** (13/13 against a
  real Docker eval stack, validating stack boot + harness dispatch + grading
  with the toggle). Deliberately **out of scope**, as operator follow-ups: the
  full 14-model × 4-scenario × 12-run governed sweep (~12h watchdog, billed
  Ollama Cloud) that fills the decision doc's verdicts, and the "same model,
  with governed tools" rendering on the reliability site (separate
  heypinchy-website repo).
- **Expected drift-guard movement:** once real `governedComparison` data lands,
  `dataset-version.test.ts` (DATASET_FINGERPRINT + scenario counts) will move by
  design and forces a dataset version bump — that is the intended gate, not a
  regression.
- Gates run locally on Node 22: pinchy-odoo 452 · eval unit + drift guards 75 ·
  web typecheck (incl. tests) · `typecheck:plugins` (9 pkgs) · prettier.
