### PR TITLE
fix(dev): a guard asserting about the repo must not read untracked files

### DIFF
--- a/scripts/lib/dev-stack-port-isolation.test.mjs
+++ b/scripts/lib/dev-stack-port-isolation.test.mjs
@@ -31,6 +31,7 @@ import { fileURLToPath } from "node:url";
 
 import { unreservedBandConflicts } from "./worktree-ports.mjs";
 import { MANAGED_KEYS } from "./env-file.mjs";
+import { trackedRootFiles } from "./tracked-files.mjs";
 
 const ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const WEB = join(ROOT, "packages", "web");
@@ -38,7 +39,16 @@ const DEV_OVERLAY = "docker-compose.dev.yml";
 
 const read = (...parts) => readFileSync(join(ROOT, ...parts), "utf8");
 
-const composeFiles = readdirSync(ROOT).filter(
+// git, NOT readdir. An untracked `docker-compose.local.yml` is a developer's
+// own business: guard 2 below asserts about ports "hard-coded in the repo", and
+// a gitignored file is not in the repo. Reading it produced a red that could
+// only be cleared by committing one worktree's local port into the shared
+// RESERVED_PORTS list — and it was red locally while staying green in CI, where
+// the file does not exist. See lib/tracked-files.mjs.
+//
+// Falls back to the directory listing when git cannot answer: a guard may check
+// too much, never too little.
+const composeFiles = (trackedRootFiles(ROOT) ?? readdirSync(ROOT)).filter(
   (f) => f.startsWith("docker-compose") && f.endsWith(".yml"),
 );
 

--- a/scripts/lib/dev-stack-port-isolation.test.mjs
+++ b/scripts/lib/dev-stack-port-isolation.test.mjs
@@ -31,7 +31,7 @@ import { fileURLToPath } from "node:url";
 
 import { unreservedBandConflicts } from "./worktree-ports.mjs";
 import { MANAGED_KEYS } from "./env-file.mjs";
-import { trackedRootFiles } from "./tracked-files.mjs";
+import { trackedFilesIn } from "./tracked-files.mjs";
 
 const ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const WEB = join(ROOT, "packages", "web");
@@ -39,21 +39,23 @@ const DEV_OVERLAY = "docker-compose.dev.yml";
 
 const read = (...parts) => readFileSync(join(ROOT, ...parts), "utf8");
 
-// git, NOT readdir. An untracked `docker-compose.local.yml` is a developer's
-// own business: guard 2 below asserts about ports "hard-coded in the repo", and
-// a gitignored file is not in the repo. Reading it produced a red that could
-// only be cleared by committing one worktree's local port into the shared
-// RESERVED_PORTS list — and it was red locally while staying green in CI, where
-// the file does not exist. See lib/tracked-files.mjs.
+// git, NOT readdir — for BOTH corpora below. An untracked
+// `docker-compose.local.yml`, or a `playwright.local.config.ts` pointed at some
+// other stack, is a developer's own business: guard 2 asserts about ports
+// "hard-coded in the repo", and a file git does not track is not in the repo.
+// Reading one produced a red that could only be cleared by committing one
+// worktree's local port into the shared RESERVED_PORTS list — and it was red
+// locally while staying green in CI, where the file does not exist. See
+// lib/tracked-files.mjs.
 //
-// Falls back to the directory listing when git cannot answer: a guard may check
-// too much, never too little.
-const composeFiles = (trackedRootFiles(ROOT) ?? readdirSync(ROOT)).filter(
+// Both fall back to the directory listing when git cannot answer: a guard may
+// check too much, never too little.
+const composeFiles = (trackedFilesIn(ROOT) ?? readdirSync(ROOT)).filter(
   (f) => f.startsWith("docker-compose") && f.endsWith(".yml"),
 );
 
 const playwrightConfigs = [
-  ...readdirSync(WEB)
+  ...(trackedFilesIn(WEB) ?? readdirSync(WEB))
     .filter((f) => f.startsWith("playwright") && f.endsWith(".config.ts"))
     .map((f) => join("packages", "web", f)),
   join("packages", "web", "eval", "playwright.eval.config.ts"),

--- a/scripts/lib/tracked-files.mjs
+++ b/scripts/lib/tracked-files.mjs
@@ -1,0 +1,50 @@
+/**
+ * Enumerating a repo the way a guard should: by asking git, not readdir.
+ *
+ * A guard that asserts something about "the repo" and reads the working
+ * directory instead will eventually assert something about a developer's
+ * private files. `dev-stack-port-isolation`'s band check did exactly that — it
+ * globbed `docker-compose*.yml` out of readdirSync and failed on a gitignored
+ * `docker-compose.local.yml`, telling the developer to fix it by committing
+ * their local port into the shared RESERVED_PORTS list. An assertion nobody can
+ * discharge correctly is one people learn to look past, and it was red only
+ * locally — never in CI, where the file does not exist.
+ *
+ * Several guards here already enumerate this way (node-version-pin, docs-required,
+ * curl-origin-csrf, format-gate). This is that call in one place.
+ */
+
+import { execFileSync } from "node:child_process";
+
+const defaultRun = (root) =>
+  execFileSync("git", ["ls-files", "-z"], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+/**
+ * The files git tracks directly in `root`, excluding anything in a
+ * subdirectory. `git ls-files` lists recursively, so that filtering is ours.
+ *
+ * Returns `null` — never `[]` — when git cannot answer, so the caller can fall
+ * back to reading the directory. The direction is deliberate: a guard may check
+ * too much, never too little, and an empty corpus is the one failure that turns
+ * a check green forever without anyone noticing.
+ *
+ * @param {string} root absolute path to the repository (or worktree) root
+ * @param {(root: string) => string} [run] injected for testing
+ * @returns {string[] | null}
+ */
+export function trackedRootFiles(root, run = defaultRun) {
+  let output;
+  try {
+    output = run(root);
+  } catch {
+    return null;
+  }
+  return output
+    .split("\0")
+    .filter(Boolean)
+    .filter((file) => !file.includes("/"));
+}

--- a/scripts/lib/tracked-files.mjs
+++ b/scripts/lib/tracked-files.mjs
@@ -10,36 +10,51 @@
  * discharge correctly is one people learn to look past, and it was red only
  * locally — never in CI, where the file does not exist.
  *
- * Several guards here already enumerate this way (node-version-pin, docs-required,
- * curl-origin-csrf, format-gate). This is that call in one place.
+ * Four guards here already reach for git rather than readdir for the same
+ * reason: `node-version-pin.test.mjs`, `docs-required.test.mjs`,
+ * `curl-origin-csrf.test.mjs` and `format-gate.test.mjs`. They are deliberately
+ * NOT rewritten to call this — each wants a different slice (every Dockerfile
+ * at any depth, every shell script, the full path list), and this helper answers
+ * one narrow question. Sharing the `execFileSync` line would not have shared
+ * anything worth sharing.
  */
 
 import { execFileSync } from "node:child_process";
 
-const defaultRun = (root) =>
-  execFileSync("git", ["ls-files", "-z"], {
-    cwd: root,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+/**
+ * Node's default is 1 MB. The repo's own listing is already ~115 KB and grows,
+ * and overflowing it throws ENOBUFS, which this module turns into `null` — a
+ * silent fall back to the readdir behaviour the module exists to replace.
+ * `docs-required.test.mjs` sets an explicit ceiling for the same reason.
+ */
+const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
 
 /**
- * The files git tracks directly in `root`, excluding anything in a
- * subdirectory. `git ls-files` lists recursively, so that filtering is ours.
+ * The files git tracks directly in `dir`, excluding anything below it.
+ *
+ * "Tracked" means "in the index", which is what `git ls-files` reports: a new
+ * file counts once it is `git add`ed and not before. Paths come back relative
+ * to `dir`, so passing a subdirectory enumerates that subdirectory — and the
+ * recursion is filtered out here, since `git ls-files` itself lists every
+ * depth.
  *
  * Returns `null` — never `[]` — when git cannot answer, so the caller can fall
  * back to reading the directory. The direction is deliberate: a guard may check
  * too much, never too little, and an empty corpus is the one failure that turns
  * a check green forever without anyone noticing.
  *
- * @param {string} root absolute path to the repository (or worktree) root
- * @param {(root: string) => string} [run] injected for testing
+ * @param {string} dir absolute path to a repository, worktree, or subdirectory
  * @returns {string[] | null}
  */
-export function trackedRootFiles(root, run = defaultRun) {
+export function trackedFilesIn(dir) {
   let output;
   try {
-    output = run(root);
+    output = execFileSync("git", ["ls-files", "-z"], {
+      cwd: dir,
+      encoding: "utf8",
+      maxBuffer: MAX_OUTPUT_BYTES,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
   } catch {
     return null;
   }

--- a/scripts/lib/tracked-files.test.mjs
+++ b/scripts/lib/tracked-files.test.mjs
@@ -1,11 +1,11 @@
-import { test, describe } from "node:test";
+import { test, describe, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { trackedRootFiles } from "./tracked-files.mjs";
+import { trackedFilesIn } from "./tracked-files.mjs";
 
 /**
  * A guard that enumerates the repo with readdirSync also reads files git does
@@ -26,10 +26,24 @@ import { trackedRootFiles } from "./tracked-files.mjs";
  * The test's own name says "no hard-coded port IN THE REPO". A gitignored file
  * is not in the repo; git decides that question, not readdir.
  */
-describe("listing the root files git actually tracks", () => {
-  /** A throwaway repo, so the assertions are about git and not about ours. */
+describe("listing the files git actually tracks in a directory", () => {
+  const made = [];
+  after(() => {
+    for (const dir of made) rmSync(dir, { recursive: true, force: true });
+  });
+
+  /**
+   * A throwaway repo, so the assertions are about git and not about ours.
+   *
+   * No commit anywhere in this file, deliberately: `git ls-files` reads the
+   * INDEX, so `git add` is the whole of "tracked" as far as this helper is
+   * concerned, and a commit would test nothing while pulling in a user
+   * identity, a gpg setting, and whatever `core.hooksPath` the developer has
+   * set globally.
+   */
   function makeRepo() {
     const repo = mkdtempSync(join(tmpdir(), "pinchy-tracked-probe-"));
+    made.push(repo);
     execFileSync("git", [
       "-c",
       "init.defaultBranch=main",
@@ -37,23 +51,18 @@ describe("listing the root files git actually tracks", () => {
       "--quiet",
       repo,
     ]);
-    for (const [key, value] of [
-      ["user.email", "probe@example.com"],
-      ["user.name", "Probe"],
-      ["commit.gpgsign", "false"],
-    ]) {
-      execFileSync("git", ["config", key, value], { cwd: repo });
-    }
     return repo;
   }
+
+  /** Stage everything — the index is what `git ls-files` reports. */
+  const stage = (repo) => execFileSync("git", ["add", "-A"], { cwd: repo });
 
   test("includes a tracked file", () => {
     const repo = makeRepo();
     writeFileSync(join(repo, "docker-compose.yml"), "services: {}\n");
-    execFileSync("git", ["add", "-A"], { cwd: repo });
-    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+    stage(repo);
 
-    assert.deepEqual(trackedRootFiles(repo), ["docker-compose.yml"]);
+    assert.deepEqual(trackedFilesIn(repo), ["docker-compose.yml"]);
   });
 
   // The regression itself: the file exists on disk and readdir would return it.
@@ -61,11 +70,10 @@ describe("listing the root files git actually tracks", () => {
     const repo = makeRepo();
     writeFileSync(join(repo, ".gitignore"), "docker-compose.local.yml\n");
     writeFileSync(join(repo, "docker-compose.yml"), "services: {}\n");
-    execFileSync("git", ["add", "-A"], { cwd: repo });
-    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+    stage(repo);
     writeFileSync(join(repo, "docker-compose.local.yml"), "services: {}\n");
 
-    const files = trackedRootFiles(repo);
+    const files = trackedFilesIn(repo);
     assert.ok(files.includes("docker-compose.yml"));
     assert.ok(
       !files.includes("docker-compose.local.yml"),
@@ -78,11 +86,10 @@ describe("listing the root files git actually tracks", () => {
   test("excludes a file that is merely untracked", () => {
     const repo = makeRepo();
     writeFileSync(join(repo, "docker-compose.yml"), "services: {}\n");
-    execFileSync("git", ["add", "-A"], { cwd: repo });
-    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+    stage(repo);
     writeFileSync(join(repo, "docker-compose.scratch.yml"), "services: {}\n");
 
-    assert.deepEqual(trackedRootFiles(repo), ["docker-compose.yml"]);
+    assert.deepEqual(trackedFilesIn(repo), ["docker-compose.yml"]);
   });
 
   // Only the root. A guard that globs `docker-compose*` at the root must not
@@ -94,10 +101,59 @@ describe("listing the root files git actually tracks", () => {
     // Tracked, same name, one level down: `git ls-files` lists it recursively,
     // so the filtering is the helper's job and not git's.
     writeFileSync(join(repo, "sub", "docker-compose.yml"), "services: {}\n");
-    execFileSync("git", ["add", "-A"], { cwd: repo });
-    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+    stage(repo);
 
-    assert.deepEqual(trackedRootFiles(repo), ["docker-compose.yml"]);
+    assert.deepEqual(trackedFilesIn(repo), ["docker-compose.yml"]);
+  });
+
+  /**
+   * "Root" means the directory you pass, not the repository's top level. The
+   * port guard enumerates two of them — the repo root for compose files and
+   * `packages/web` for Playwright configs — and the second only works because
+   * `git ls-files` reports paths relative to its cwd rather than to the repo.
+   * Asserted rather than assumed: the alternative spelling (`--full-name`)
+   * would return `packages/web/playwright.config.ts`, which the root filter
+   * then drops, silently emptying the corpus.
+   */
+  test("enumerates a subdirectory relative to that subdirectory", () => {
+    const repo = makeRepo();
+    mkdirSync(join(repo, "web"));
+    writeFileSync(join(repo, "root-only.yml"), "services: {}\n");
+    writeFileSync(join(repo, "web", "playwright.config.ts"), "export {};\n");
+    mkdirSync(join(repo, "web", "e2e"));
+    writeFileSync(join(repo, "web", "e2e", "deep.config.ts"), "export {};\n");
+    stage(repo);
+
+    assert.deepEqual(trackedFilesIn(join(repo, "web")), [
+      "playwright.config.ts",
+    ]);
+  });
+
+  /**
+   * The failure this helper must not have. Node's default `maxBuffer` is 1 MB;
+   * `git ls-files -z` here is already 115 KB and grows with the repo. Past the
+   * limit execFileSync throws ENOBUFS, the catch below turns that into `null`,
+   * the caller falls back to readdirSync — and the very bug this helper exists
+   * to fix is back, silently, on the day the repo gets big enough.
+   *
+   * 6000 files is a fraction of a second and clears 1 MB; `docs-required`
+   * already sets an explicit maxBuffer for the same reason.
+   */
+  test("survives an output larger than the default 1 MB buffer", () => {
+    const repo = makeRepo();
+    const padding = "p".repeat(200);
+    for (let i = 0; i < 6000; i++) {
+      writeFileSync(join(repo, `${i}-${padding}.yml`), "x");
+    }
+    stage(repo);
+
+    const files = trackedFilesIn(repo);
+    assert.ok(
+      files !== null,
+      "git could not be read and the caller would fall back to readdirSync — " +
+        "raise maxBuffer instead of letting the corpus quietly change source",
+    );
+    assert.equal(files.length, 6000);
   });
 
   /**
@@ -109,6 +165,7 @@ describe("listing the root files git actually tracks", () => {
    */
   test("answers null when git cannot enumerate, never an empty list", () => {
     const notARepo = mkdtempSync(join(tmpdir(), "pinchy-tracked-norepo-"));
-    assert.equal(trackedRootFiles(notARepo), null);
+    made.push(notARepo);
+    assert.equal(trackedFilesIn(notARepo), null);
   });
 });

--- a/scripts/lib/tracked-files.test.mjs
+++ b/scripts/lib/tracked-files.test.mjs
@@ -1,0 +1,114 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { trackedRootFiles } from "./tracked-files.mjs";
+
+/**
+ * A guard that enumerates the repo with readdirSync also reads files git does
+ * not track — and then asserts things about a developer's private state.
+ *
+ * The concrete case: dev-stack-port-isolation's band check picked up a
+ * gitignored `docker-compose.local.yml` and failed on the host port it binds.
+ * Two things make that worse than a cosmetic false positive:
+ *
+ *   1. The remedy it prints is impossible. "Add it to RESERVED_PORTS in
+ *      worktree-ports.mjs" means committing one developer's local port choice
+ *      into the list every worktree allocates against. The assertion cannot be
+ *      discharged correctly, so the only way out is to ignore it.
+ *   2. It is red LOCALLY and green in CI, where the file does not exist. That
+ *      teaches "local red is normal, CI will tell me" — and a gate people
+ *      routinely look past has stopped being a gate.
+ *
+ * The test's own name says "no hard-coded port IN THE REPO". A gitignored file
+ * is not in the repo; git decides that question, not readdir.
+ */
+describe("listing the root files git actually tracks", () => {
+  /** A throwaway repo, so the assertions are about git and not about ours. */
+  function makeRepo() {
+    const repo = mkdtempSync(join(tmpdir(), "pinchy-tracked-probe-"));
+    execFileSync("git", [
+      "-c",
+      "init.defaultBranch=main",
+      "init",
+      "--quiet",
+      repo,
+    ]);
+    for (const [key, value] of [
+      ["user.email", "probe@example.com"],
+      ["user.name", "Probe"],
+      ["commit.gpgsign", "false"],
+    ]) {
+      execFileSync("git", ["config", key, value], { cwd: repo });
+    }
+    return repo;
+  }
+
+  test("includes a tracked file", () => {
+    const repo = makeRepo();
+    writeFileSync(join(repo, "docker-compose.yml"), "services: {}\n");
+    execFileSync("git", ["add", "-A"], { cwd: repo });
+    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+
+    assert.deepEqual(trackedRootFiles(repo), ["docker-compose.yml"]);
+  });
+
+  // The regression itself: the file exists on disk and readdir would return it.
+  test("excludes a gitignored file that is really on disk", () => {
+    const repo = makeRepo();
+    writeFileSync(join(repo, ".gitignore"), "docker-compose.local.yml\n");
+    writeFileSync(join(repo, "docker-compose.yml"), "services: {}\n");
+    execFileSync("git", ["add", "-A"], { cwd: repo });
+    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+    writeFileSync(join(repo, "docker-compose.local.yml"), "services: {}\n");
+
+    const files = trackedRootFiles(repo);
+    assert.ok(files.includes("docker-compose.yml"));
+    assert.ok(
+      !files.includes("docker-compose.local.yml"),
+      `a gitignored file is a developer's own business, not the repo's: ${files.join(", ")}`,
+    );
+  });
+
+  // An untracked-but-not-ignored file is the same case: it is not in the repo,
+  // so a guard asserting about "the repo" must not read it.
+  test("excludes a file that is merely untracked", () => {
+    const repo = makeRepo();
+    writeFileSync(join(repo, "docker-compose.yml"), "services: {}\n");
+    execFileSync("git", ["add", "-A"], { cwd: repo });
+    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+    writeFileSync(join(repo, "docker-compose.scratch.yml"), "services: {}\n");
+
+    assert.deepEqual(trackedRootFiles(repo), ["docker-compose.yml"]);
+  });
+
+  // Only the root. A guard that globs `docker-compose*` at the root must not
+  // silently start matching a nested file of the same name.
+  test("does not descend into subdirectories", () => {
+    const repo = makeRepo();
+    mkdirSync(join(repo, "sub"));
+    writeFileSync(join(repo, "docker-compose.yml"), "services: {}\n");
+    // Tracked, same name, one level down: `git ls-files` lists it recursively,
+    // so the filtering is the helper's job and not git's.
+    writeFileSync(join(repo, "sub", "docker-compose.yml"), "services: {}\n");
+    execFileSync("git", ["add", "-A"], { cwd: repo });
+    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repo });
+
+    assert.deepEqual(trackedRootFiles(repo), ["docker-compose.yml"]);
+  });
+
+  /**
+   * Fail OPEN, and the direction is deliberate: a guard may check too much,
+   * never too little. If git cannot answer, the caller falls back to reading
+   * the directory — which is the behaviour that shipped before this helper.
+   * Returning [] here would silently empty the corpus and turn the guard green
+   * forever, which is the failure this repo cares about most.
+   */
+  test("answers null when git cannot enumerate, never an empty list", () => {
+    const notARepo = mkdtempSync(join(tmpdir(), "pinchy-tracked-norepo-"));
+    assert.equal(trackedRootFiles(notARepo), null);
+  });
+});


### PR DESCRIPTION
## What

`scripts/lib/dev-stack-port-isolation.test.mjs` enumerated its corpora with `readdirSync`, so its band check also read a **gitignored** `docker-compose.local.yml` — the worktree-local override our own dev-stack docs tell you to write — and failed on the host port it binds:

```
✖ no hard-coded port in the repo sits inside an allocation band
  … 5451 (docker-compose.local.yml)
```

It now enumerates via `git ls-files`, for **both** corpora it feeds into that assertion (root compose files and `packages/web` Playwright configs). Four other guards here already reach for git for the same reason — `node-version-pin.test.mjs`, `docs-required.test.mjs`, `curl-origin-csrf.test.mjs`, `format-gate.test.mjs`. This one was the outlier.

## Why it is more than a cosmetic false positive

1. **The remedy it prints cannot be applied.** "Add it to `RESERVED_PORTS` in `worktree-ports.mjs`" means committing one developer's local port choice into the list every worktree allocates against. There is no correct way to discharge the assertion, so the only way out is to ignore it.
2. **Red locally, green in CI**, where the file does not exist. That is precisely the shape that teaches "local red is normal, CI will tell me". `pnpm test:scripts` had been 821/822 for weeks, and every session had to re-derive that the one red was "the known local one".

The test's own name already states the rule — *no hard-coded port **in the repo***. A file git does not track is not in the repo, and git decides that question, not readdir.

## Design notes

- `trackedFilesIn()` returns **`null`, never `[]`**, when git cannot answer, and the caller falls back to `readdirSync`. The direction is deliberate: a guard may check too much, never too little, and an empty corpus is the one failure that turns a check green forever without anyone noticing.
- **It sets an explicit `maxBuffer`**, because that fallback is silent. Node's default is 1 MB, this repo's listing is already 115 KB and grows, and past the limit `execFileSync` throws ENOBUFS — which the `catch` would turn into a quiet return to the readdir behaviour the helper exists to replace. Measured, not argued: 6000 padded filenames clear 1 MB and Node throws. `docs-required.test.mjs` sets one for the same reason.
- **"Tracked" means "in the index".** A brand-new compose file is covered as soon as it is `git add`ed, and not before; committed files — everything CI ever sees — always are. The tests state that by staging without committing.
- Tests build real throwaway repositories rather than stubbing git — a stub can agree with a wrong assumption forever. They cover tracked, gitignored-but-on-disk, merely-untracked, nested-same-name, subdirectory-relative enumeration, the >1 MB case, and the not-a-repo fallback.

## Verification

Canary rather than code-reading, per the repo's own rule.

| | |
|---|---|
| Guard with `docker-compose.local.yml` present | **4/4 green** |
| Band-conflicting port in a **tracked** compose file | **red**, naming the port |
| Untracked `playwright.canary.config.ts` on a band port | **green** — correctly ignored |
| …the same file staged | **red**, naming `7783` |
| After revert | **4/4 green**, empty diff |
| `pnpm test:scripts` | **829/829** (was 821/822) |
| `pnpm format:check` | green |

Docs-not-needed: internal test-guard enumeration, no user-facing surface