### PR TITLE
fix(eval): make the Layer-3 KB groundedness sweep produce a number worth reading

### DIFF
--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -19,13 +19,14 @@
 // NEEDS VALIDATION AGAINST THE RUNNING STACK (orchestrator's dry-run — NOT
 // run from this task, no key available here). Every piece below is read from
 // source, not observed live:
-//   1. Corpus seeding (seedSyntheticCorpus) — raw SQL INSERTs against
-//      kb_documents/kb_chunks with the committed embeddinggemma-300m embeddings fixture,
-//      mirroring `kb-retrieval-eval.integration.test.ts`'s Drizzle-based
-//      seeding but via the `postgres` package + stackDbUrl (this file runs
-//      as an external Playwright spec against a docker-mapped port, not
-//      inside the Next.js process — see `../eval-models.spec.ts`'s identical
-//      DB-access pattern for its settings seeding).
+//   1. (NO LONGER UNVALIDATED) Corpus seeding now lives in `seed-corpus.ts`
+//      and is covered by `kb-eval-seed-corpus.integration.test.ts` against a
+//      real Postgres. It was broken in two ways while this note called it
+//      unvalidated: it INSERTed a `page` column that does not exist (the
+//      locator is jsonb), which killed every sweep 200ms in, and it hard-coded
+//      status 'active', which would have seeded the archived `OLD/` copy as
+//      current and made the freshness axis (#858) grade the opposite of what
+//      it asks.
 //   2. The agent grant shape (`allowedTools: ["knowledge_search"]` +
 //      `pluginConfig["pinchy-files"].allowed_paths`) — mirrors
 //      `e2e/integration/agent-chat.spec.ts`'s pinchy-knowledge probe, not
@@ -88,83 +89,20 @@ import {
 } from "../../src/lib/eval/kb/llm-nli";
 import { DEFAULT_ORG_ID } from "../../src/lib/knowledge/constants";
 import { fetchChunkTexts } from "./chunk-texts";
+import { seedSyntheticCorpus } from "./seed-corpus";
+import { resolveCitedSourcePaths } from "./resolve-cited-paths";
 import { DEFAULT_KB_CANDIDATES } from "../candidates";
-import { KB_SWEEP_TEMPLATE_ID } from "./sweep-agent";
-import { KB_EVAL_CORPUS } from "./corpus/manifest";
+import {
+  KB_SWEEP_ALLOWED_TOOLS,
+  KB_SWEEP_CORPUS_ROOT,
+  KB_SWEEP_TEMPLATE_ID,
+  buildKbSweepAgentPayload,
+  missingSweepSkills,
+} from "./sweep-agent";
+import { getTemplate } from "../../src/lib/agent-templates/registry";
 import { GOLD_QA } from "./corpus/gold-qa";
-import { loadEmbeddings } from "./embeddings-fixture";
 
 const RESULT_LABEL = "kb-groundedness-sweep";
-
-const KB_ALLOWED_TOOLS = ["knowledge_search"];
-const CORPUS_ROOT = "/data";
-
-/**
- * Seeds `KB_EVAL_CORPUS` (`./corpus/manifest.ts`) into the live stack's
- * Postgres via raw SQL, using the COMMITTED embeddinggemma-300m embeddings fixture
- * (`./embeddings-fixture.ts`) — the same fixture Layer 1's
- * `kb-retrieval-eval.integration.test.ts` uses, so chunk embeddings need no
- * live embedder call. The real `retrieve()` (invoked through
- * `POST /api/internal/knowledge/search` when the agent's `knowledge_search`
- * tool fires) still calls a live embedder for the QUERY at search time —
- * that dependency is unchanged, this only removes it from CORPUS ingestion.
- * `orgId` MUST be `DEFAULT_ORG_ID` ("default") — the real route hardcodes
- * this single-tenant seam (`src/lib/knowledge/constants.ts`), unlike the
- * Layer-1 vitest suite's isolated `"org-kb-eval"` test-DB constant.
- */
-async function seedSyntheticCorpus(dbUrl: string): Promise<void> {
-  const embeddings = loadEmbeddings();
-  const { default: postgres } = await import("postgres");
-  const sql = postgres(dbUrl);
-  try {
-    for (const doc of KB_EVAL_CORPUS) {
-      // kb_documents.id / kb_chunks.id are `text` with NO database default —
-      // the app supplies them via Drizzle's `$defaultFn(() => crypto.randomUUID())`,
-      // so a raw INSERT that omits `id` hits a NOT NULL violation. Mint one in
-      // SQL (gen_random_uuid() is built into Postgres 13+, no extension) to
-      // mirror the app's uuid-shaped text id.
-      const [dbDoc] = await sql<{ id: string }[]>`
-        INSERT INTO kb_documents (id, org_id, content_hash, source_path, status)
-        VALUES (gen_random_uuid()::text, ${DEFAULT_ORG_ID}, ${`hash-${doc.sourcePath}`}, ${doc.sourcePath}, 'active')
-        ON CONFLICT DO NOTHING
-        RETURNING id
-      `;
-      // A prior sweep invocation may have already seeded this doc (ON
-      // CONFLICT DO NOTHING then returns no row) — re-select rather than
-      // re-insert chunks on top of an existing document.
-      const dbDocId =
-        dbDoc?.id ??
-        (
-          await sql<{ id: string }[]>`
-            SELECT id FROM kb_documents WHERE org_id = ${DEFAULT_ORG_ID} AND source_path = ${doc.sourcePath}
-          `
-        )[0]?.id;
-      if (!dbDocId) throw new Error(`Failed to resolve kb_documents.id for ${doc.sourcePath}`);
-
-      for (const chunk of doc.chunks) {
-        const embedding = embeddings.chunks[chunk.id];
-        if (!embedding) {
-          throw new Error(
-            `Missing embedding fixture for chunk id ${chunk.id} — run pnpm kb-eval:reembed`
-          );
-        }
-        const existing = await sql<{ id: string }[]>`
-          SELECT id FROM kb_chunks WHERE document_id = ${dbDocId} AND chunk_text = ${chunk.text}
-        `;
-        if (existing.length > 0) continue; // already seeded by a prior invocation
-        // pgvector's textual literal is the same `[1,2,3]` form JSON.stringify
-        // produces for a number array — see src/lib/knowledge/retrieve.ts's
-        // identical `${queryVectorLiteral}::vector` pattern.
-        await sql`
-          INSERT INTO kb_chunks (id, document_id, org_id, source_path, chunk_text, page, embedding)
-          VALUES (gen_random_uuid()::text, ${dbDocId}, ${DEFAULT_ORG_ID}, ${doc.sourcePath}, ${chunk.text}, ${chunk.page}, ${JSON.stringify(embedding)}::vector)
-        `;
-      }
-    }
-  } finally {
-    await sql.end();
-  }
-}
 
 /**
  * The (local-only, guarded) real Noack corpus path. `corpusFromEnv()` already
@@ -206,24 +144,56 @@ function seedNoackCorpus(): never {
 async function setupKbSweepAgent(cookie: string): Promise<{ agentId: string }> {
   const createRes = await pinchyPost(
     "/api/agents",
-    { name: `KB-Sweep-${Date.now()}`, templateId: KB_SWEEP_TEMPLATE_ID },
+    buildKbSweepAgentPayload(`KB-Sweep-${Date.now()}`),
     cookie
   );
-  if (!createRes.ok)
-    throw new Error(`Failed to create KB sweep agent: ${String(createRes.status)}`);
+  if (!createRes.ok) {
+    // Quote the body, not just the status. A bare "400" is what this threw
+    // when the payload was missing `allowed_paths`, and the route had said
+    // "At least one directory must be selected" the whole time — the one
+    // sentence that would have named the fix.
+    throw new Error(
+      `Failed to create KB sweep agent: ${String(createRes.status)} ${await createRes.text()}`
+    );
+  }
   const { id: agentId } = (await createRes.json()) as { id: string };
 
   const patchRes = await pinchyPatch(
     `/api/agents/${agentId}`,
     {
-      allowedTools: KB_ALLOWED_TOOLS,
-      pluginConfig: { "pinchy-files": { allowed_paths: [CORPUS_ROOT] } },
+      allowedTools: KB_SWEEP_ALLOWED_TOOLS,
+      pluginConfig: { "pinchy-files": { allowed_paths: [KB_SWEEP_CORPUS_ROOT] } },
     },
     cookie
   );
   if (!patchRes.ok) {
     throw new Error(
-      `Failed to grant knowledge_search to KB sweep agent: ${String(patchRes.status)}`
+      `Failed to grant knowledge_search to KB sweep agent: ${String(patchRes.status)} ` +
+        (await patchRes.text())
+    );
+  }
+
+  // Verify the measurement premise on THIS agent before measuring anything.
+  // The cited-answer contract the graders enforce arrives through the
+  // template's skill; if the agent did not receive it, every groundedness
+  // number this run produces describes an agent that was never told the rules
+  // — which is exactly how the first sweep published a passRate of 0 (#869).
+  // Fail loudly here rather than 8 minutes later as a scorecard nobody can
+  // interpret.
+  const agentRes = await pinchyGet(`/api/agents/${agentId}`, cookie);
+  if (!agentRes.ok) {
+    throw new Error(
+      `Failed to read back KB sweep agent: ${String(agentRes.status)} ${await agentRes.text()}`
+    );
+  }
+  const agent = (await agentRes.json()) as { skills?: string[] | null };
+  const templateSkills = getTemplate(KB_SWEEP_TEMPLATE_ID)?.defaultSkills ?? [];
+  const missing = missingSweepSkills(templateSkills, agent.skills);
+  if (missing.length > 0) {
+    throw new Error(
+      `KB sweep agent ${agentId} is missing the skill(s) that state the cited-answer ` +
+        `contract: ${missing.join(", ")}. Grading its answers would measure whether the ` +
+        `model invents an unstated contract, not whether it stays grounded.`
     );
   }
 
@@ -398,7 +368,11 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
         ]);
 
         const retrieved = retrievedSourcesFromAuditEntries(auditEntries);
-        const citedPaths = citedSourcePaths(answer);
+        // The answer cites what the tool SHOWED (a path relative to the data
+        // root); kb_chunks is keyed by the absolute path. Resolving between
+        // them against this run's own retrieved set is what makes the premise
+        // lookup find anything at all — see resolve-cited-paths.ts.
+        const citedPaths = resolveCitedSourcePaths(citedSourcePaths(answer), retrieved);
         const chunkTextsByPath = await fetchChunkTexts(dbUrl, DEFAULT_ORG_ID, citedPaths);
         const citedPassageTexts = citedPaths.flatMap((p) => chunkTextsByPath.get(p) ?? []);
 

--- a/packages/web/eval/kb/resolve-cited-paths.ts
+++ b/packages/web/eval/kb/resolve-cited-paths.ts
@@ -21,18 +21,58 @@
 /**
  * Every path suffix of `sourcePath` at segment boundaries, longest last:
  * `/data/handbook-2012/policy.md` → `policy.md`, `handbook-2012/policy.md`,
- * `data/handbook-2012/policy.md`, …
+ * `data/handbook-2012/policy.md`, `/data/handbook-2012/policy.md`.
+ *
+ * The leading-slash form is a candidate in its own right, not a cosmetic
+ * duplicate: an entry that spells the path out absolutely must be able to win
+ * with the WHOLE path, because a win is rejected below when more path precedes
+ * it. Without this candidate the longest match would be `data/…`, preceded by
+ * the `/` the entry does have, and a correctly-cited absolute path would be
+ * thrown out as over-qualified.
  */
 function pathSuffixes(sourcePath: string): string[] {
   const segments = sourcePath.split("/").filter(Boolean);
-  return segments.map((_, i) => segments.slice(segments.length - 1 - i).join("/"));
+  const suffixes = segments.map((_, i) => segments.slice(segments.length - 1 - i).join("/"));
+  if (sourcePath.startsWith("/")) suffixes.push(`/${segments.join("/")}`);
+  return suffixes;
 }
 
-/** The longest suffix of `sourcePath` that appears in `entry`, or "" for none. */
+/**
+ * What may NOT flank a suffix occurrence for it to count as naming the
+ * document. Both directions rule out a fabrication picking up real passages:
+ *
+ *   - to the left, any character that continues a segment (`my-policy.md`)
+ *     AND `/` itself, because a preceding separator means the entry names a
+ *     parent the document does not have. That is the whole distinction between
+ *     `handbook-2012/policy.md` and `old-handbook-2012/policy.md`: the shorter
+ *     suffix `policy.md` sits at a real boundary in both, and only the
+ *     separator to its left says the second one is a different document.
+ *   - to the right, a segment character (`policy.mdx`). `.` is deliberately
+ *     absent here so an entry ending its sentence with "…in policy.md." still
+ *     resolves; it IS present on the left, where `my.policy.md` needs it.
+ */
+const SEGMENT_CHAR_BEFORE = /[A-Za-z0-9._/-]/;
+const SEGMENT_CHAR_AFTER = /[A-Za-z0-9_-]/;
+
+/** Whether `suffix` occurs in `entry` as a whole path segment, not mid-name. */
+function mentionsSuffix(entry: string, suffix: string): boolean {
+  // Every occurrence, not just the first: an entry may name the document twice
+  // and only the second one sit at a boundary.
+  let at = entry.indexOf(suffix);
+  while (at !== -1) {
+    const before = at === 0 ? "" : entry[at - 1];
+    const after = entry[at + suffix.length] ?? "";
+    if (!SEGMENT_CHAR_BEFORE.test(before) && !SEGMENT_CHAR_AFTER.test(after)) return true;
+    at = entry.indexOf(suffix, at + 1);
+  }
+  return false;
+}
+
+/** The longest suffix of `sourcePath` that `entry` names, or "" for none. */
 function longestSuffixIn(entry: string, sourcePath: string): string {
   let best = "";
   for (const suffix of pathSuffixes(sourcePath)) {
-    if (entry.includes(suffix) && suffix.length > best.length) best = suffix;
+    if (suffix.length > best.length && mentionsSuffix(entry, suffix)) best = suffix;
   }
   return best;
 }

--- a/packages/web/eval/kb/resolve-cited-paths.ts
+++ b/packages/web/eval/kb/resolve-cited-paths.ts
@@ -18,24 +18,56 @@
  *     exists to catch; resolving it would grade a citation defect as grounded.
  */
 
+/**
+ * Every path suffix of `sourcePath` at segment boundaries, longest last:
+ * `/data/handbook-2012/policy.md` → `policy.md`, `handbook-2012/policy.md`,
+ * `data/handbook-2012/policy.md`, …
+ */
+function pathSuffixes(sourcePath: string): string[] {
+  const segments = sourcePath.split("/").filter(Boolean);
+  return segments.map((_, i) => segments.slice(segments.length - 1 - i).join("/"));
+}
+
+/** The longest suffix of `sourcePath` that appears in `entry`, or "" for none. */
+function longestSuffixIn(entry: string, sourcePath: string): string {
+  let best = "";
+  for (const suffix of pathSuffixes(sourcePath)) {
+    if (entry.includes(suffix) && suffix.length > best.length) best = suffix;
+  }
+  return best;
+}
+
 export function resolveCitedSourcePaths(
-  citedPaths: string[],
+  citedEntries: string[],
   retrieved: readonly { sourcePath: string }[]
 ): string[] {
   const resolved: string[] = [];
   const seen = new Set<string>();
 
-  for (const cited of citedPaths) {
-    const matches = retrieved.filter(
-      (r) => r.sourcePath === cited || r.sourcePath.endsWith(`/${cited}`)
-    );
-    // Zero matches: not retrieved. More than one: the citation is ambiguous.
-    if (matches.length !== 1) continue;
+  for (const entry of citedEntries) {
+    // Score every retrieved document by how specifically this entry names it.
+    // `handbook-2012/policy.md: "…"` scores 23 for the 2012 document and 9
+    // (`policy.md`) for its 2011 sibling, so the qualified path wins. A bare
+    // `policy.md` scores 9 for both — a tie, and a tie is the ambiguity that
+    // must NOT resolve.
+    let best: { sourcePath: string; score: number } | null = null;
+    let tied = false;
 
-    const sourcePath = matches[0].sourcePath;
-    if (seen.has(sourcePath)) continue;
-    seen.add(sourcePath);
-    resolved.push(sourcePath);
+    for (const { sourcePath } of retrieved) {
+      const score = longestSuffixIn(entry, sourcePath).length;
+      if (score === 0) continue;
+      if (best === null || score > best.score) {
+        best = { sourcePath, score };
+        tied = false;
+      } else if (score === best.score && sourcePath !== best.sourcePath) {
+        tied = true;
+      }
+    }
+
+    if (best === null || tied) continue;
+    if (seen.has(best.sourcePath)) continue;
+    seen.add(best.sourcePath);
+    resolved.push(best.sourcePath);
   }
 
   return resolved;

--- a/packages/web/eval/kb/resolve-cited-paths.ts
+++ b/packages/web/eval/kb/resolve-cited-paths.ts
@@ -1,0 +1,42 @@
+/**
+ * Maps the paths an answer cites onto the paths `kb_chunks` is keyed by.
+ *
+ * `pinchy-knowledge` shows the model `citationPath` — relative to the data
+ * root, because that is what a reader can act on — while the database keys
+ * chunks by the absolute `sourcePath`. Both are deliberate; what was missing
+ * is the step between them, so the groundedness premise lookup asked for
+ * `it-equipment-policy.md` and the column held `/data/it-equipment-policy.md`.
+ *
+ * Resolution runs against what the search ACTUALLY returned for this run, not
+ * against a configured root. Two properties follow from that, and both are the
+ * point rather than a side effect:
+ *
+ *   - A path the search never returned stays unresolved, so a fabricated
+ *     citation cannot pick up premise material on its way through.
+ *   - A basename shared by two retrieved documents stays unresolved. That
+ *     ambiguity is exactly the `path-not-cited` defect the path-citation axis
+ *     exists to catch; resolving it would grade a citation defect as grounded.
+ */
+
+export function resolveCitedSourcePaths(
+  citedPaths: string[],
+  retrieved: readonly { sourcePath: string }[]
+): string[] {
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+
+  for (const cited of citedPaths) {
+    const matches = retrieved.filter(
+      (r) => r.sourcePath === cited || r.sourcePath.endsWith(`/${cited}`)
+    );
+    // Zero matches: not retrieved. More than one: the citation is ambiguous.
+    if (matches.length !== 1) continue;
+
+    const sourcePath = matches[0].sourcePath;
+    if (seen.has(sourcePath)) continue;
+    seen.add(sourcePath);
+    resolved.push(sourcePath);
+  }
+
+  return resolved;
+}

--- a/packages/web/eval/kb/seed-corpus.ts
+++ b/packages/web/eval/kb/seed-corpus.ts
@@ -1,0 +1,94 @@
+/**
+ * Seeds the synthetic KB corpus into a running stack's Postgres.
+ *
+ * Extracted from `kb-eval-models.spec.ts` so it can be exercised against a
+ * real database by a test, the same move `chunk-texts.ts` made and for the
+ * same reason: a spec imports `@playwright/test`, so nothing in the vitest
+ * suite could reach this code, and the sweep is the only caller — a sweep
+ * that had never run. Both defects it shipped with were invisible to review
+ * and to a full green suite, and both are schema-level, so only a real
+ * Postgres could have caught them.
+ *
+ * Uses the COMMITTED embeddinggemma-300m fixture (`./embeddings-fixture.ts`) — the
+ * same one Layer 1's `kb-retrieval-eval.integration.test.ts` uses — so corpus
+ * ingestion needs no live embedder. The real `retrieve()` still embeds the
+ * QUERY at search time; that dependency is unchanged.
+ *
+ * `orgId` MUST be `DEFAULT_ORG_ID` ("default"): the real search route
+ * hardcodes that single-tenant seam (`src/lib/knowledge/constants.ts`),
+ * unlike the Layer-1 vitest suite's isolated `"org-kb-eval"` constant.
+ */
+
+import { DEFAULT_ORG_ID } from "../../src/lib/knowledge/constants";
+import { statusForPath } from "../../src/lib/knowledge/archive-paths";
+import { KB_EVAL_CORPUS } from "./corpus/manifest";
+import { loadEmbeddings } from "./embeddings-fixture";
+
+export async function seedSyntheticCorpus(dbUrl: string): Promise<void> {
+  const embeddings = loadEmbeddings();
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl);
+  try {
+    for (const doc of KB_EVAL_CORPUS) {
+      // kb_documents.id / kb_chunks.id are `text` with NO database default —
+      // the app supplies them via Drizzle's `$defaultFn(() => crypto.randomUUID())`,
+      // so a raw INSERT that omits `id` hits a NOT NULL violation. Mint one in
+      // SQL (gen_random_uuid() is built into Postgres 13+, no extension) to
+      // mirror the app's uuid-shaped text id.
+      //
+      // `status` comes from the real archive rule, never a hard-coded
+      // 'active': the freshness axis (#858) exists precisely to check that an
+      // `OLD/` copy stays out of default retrieval, and seeding it active
+      // would have the sweep grade the opposite of what the axis asks.
+      //
+      // DO UPDATE rather than DO NOTHING, on the `uq_kb_doc_org_path` unique
+      // key, for two reasons. It always RETURNs the id, so a resumed sweep
+      // needs no separate re-select. And it re-derives the status of a row an
+      // earlier run left behind — the crash this seeder shipped with stopped
+      // mid-document and left exactly such a row. Re-deriving is safe because
+      // the status is a pure function of the path.
+      const [dbDoc] = await sql<{ id: string }[]>`
+        INSERT INTO kb_documents (id, org_id, content_hash, source_path, status)
+        VALUES (
+          gen_random_uuid()::text, ${DEFAULT_ORG_ID}, ${`hash-${doc.sourcePath}`},
+          ${doc.sourcePath}, ${statusForPath(doc.sourcePath)}
+        )
+        ON CONFLICT (org_id, source_path)
+        DO UPDATE SET status = EXCLUDED.status
+        RETURNING id
+      `;
+      const dbDocId = dbDoc?.id;
+      if (!dbDocId) throw new Error(`Failed to resolve kb_documents.id for ${doc.sourcePath}`);
+
+      for (const chunk of doc.chunks) {
+        const embedding = embeddings.chunks[chunk.id];
+        if (!embedding) {
+          throw new Error(
+            `Missing embedding fixture for chunk id ${chunk.id} — run pnpm kb-eval:reembed`
+          );
+        }
+        const existing = await sql<{ id: string }[]>`
+          SELECT id FROM kb_chunks WHERE document_id = ${dbDocId} AND chunk_text = ${chunk.text}
+        `;
+        if (existing.length > 0) continue; // already seeded by a prior invocation
+        // Two literal casts, two different reasons. pgvector's textual form is
+        // the same `[1,2,3]` JSON.stringify produces for a number array (see
+        // retrieve.ts's identical `::vector` pattern). `locator` is a jsonb
+        // COLUMN — there is no `page` column and never was; the union it
+        // stores (page / slide / heading / sheet-range) is what makes a
+        // citation checkable, so it is the shape the app writes and the shape
+        // the sweep must write too.
+        await sql`
+          INSERT INTO kb_chunks (id, document_id, org_id, source_path, chunk_text, locator, embedding)
+          VALUES (
+            gen_random_uuid()::text, ${dbDocId}, ${DEFAULT_ORG_ID}, ${doc.sourcePath},
+            ${chunk.text}, ${JSON.stringify({ kind: "page", page: chunk.page })}::jsonb,
+            ${JSON.stringify(embedding)}::vector
+          )
+        `;
+      }
+    }
+  } finally {
+    await sql.end();
+  }
+}

--- a/packages/web/eval/kb/sweep-agent.ts
+++ b/packages/web/eval/kb/sweep-agent.ts
@@ -29,3 +29,59 @@
  * to and the test says so.
  */
 export const KB_SWEEP_TEMPLATE_ID = "knowledge-base";
+
+/** The `/data` mount the eval corpus is seeded under. */
+export const KB_SWEEP_CORPUS_ROOT = "/data";
+
+/** The single tool the sweep grants — and the one its audit probe reads. */
+export const KB_SWEEP_ALLOWED_TOOLS = ["knowledge_search"];
+
+/**
+ * The body `POST /api/agents` needs to create the sweep agent.
+ *
+ * `pluginConfig` belongs in the CREATE call, not only in the PATCH that
+ * follows: the route rejects a `pinchy-files` template with no
+ * `allowed_paths` at creation time ("At least one directory must be
+ * selected"), and the KB template is a `pinchy-files` template. The bare
+ * `custom` agent this sweep used to create carries no `pluginId`, so the
+ * check never applied and the omission was invisible until the template
+ * switch (#869 item 4) turned it into a 400 on the sweep's first live run.
+ *
+ * `agents-create.test.ts` puts this exact body through the real route
+ * handler, which is the only way to check the claim without re-stating the
+ * route's rules in a test that would then drift from them.
+ */
+export function buildKbSweepAgentPayload(name: string) {
+  return {
+    name,
+    templateId: KB_SWEEP_TEMPLATE_ID,
+    pluginConfig: { "pinchy-files": { allowed_paths: [KB_SWEEP_CORPUS_ROOT] } },
+  };
+}
+
+/**
+ * Which of the template's skills the freshly-created agent did NOT receive.
+ *
+ * The contract the graders enforce is delivered by a SKILL.md since the
+ * skill-layer migration, so "the agent carries the template's skills" is the
+ * sweep's measurement premise — and the one link in the chain that no test
+ * covers, because every other link is checked against a mock:
+ * `kb-sweep-template.test.ts` proves the skill body states the clauses,
+ * `agents-create.test.ts` proves the route copies `defaultSkills` onto the
+ * row, and `build.ts` materializes the file. None of them observes the agent
+ * this run will actually measure.
+ *
+ * That gap is not theoretical. The first sweep measured an agent with no
+ * instructions whatsoever and published `passRate 0` for it (#869 item 4) —
+ * a premise that failed silently, in a run that looked like it worked.
+ *
+ * Derived from the template rather than a hard-coded list, so a skill added to
+ * the template is checked without touching this file.
+ */
+export function missingSweepSkills(
+  templateSkills: readonly string[] | undefined,
+  agentSkills: readonly string[] | null | undefined
+): string[] {
+  const carried = new Set(agentSkills ?? []);
+  return (templateSkills ?? []).filter((id) => !carried.has(id));
+}

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -193,6 +193,7 @@ import {
   writeIdentityFile,
 } from "@/lib/workspace";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { buildKbSweepAgentPayload } from "../../../eval/kb/sweep-agent";
 
 describe("POST /api/agents", () => {
   beforeEach(() => {
@@ -301,6 +302,24 @@ describe("POST /api/agents", () => {
     expect(ensureWorkspace).toHaveBeenCalledWith("new-agent-id");
     expect(writeWorkspaceFile).toHaveBeenCalledWith("new-agent-id", "SOUL.md", expect.any(String));
     expect(regenerateOpenClawConfig).toHaveBeenCalled();
+  });
+
+  it("accepts the KB Layer-3 sweep's own create payload", async () => {
+    // The sweep builds this body itself; putting it through the real handler
+    // is the only check that does not restate the route's rules in a test
+    // that would then drift from them. It used to create a bare `custom`
+    // agent, whose template carries no `pluginId`, so the "at least one
+    // directory" rule never applied — and switching to the KB template
+    // (#869 item 4) turned the missing `pluginConfig` into a 400 that only a
+    // live sweep could surface, after a full stack boot and a corpus seed.
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify(buildKbSweepAgentPayload("KB-Sweep-1")),
+    });
+
+    const response = await POST(request, routeContext());
+
+    expect(response.status).toBe(201);
   });
 
   it("should set ownerId to the current user's id", async () => {

--- a/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
@@ -21,6 +21,13 @@
  * ambiguity is the `path-not-cited` defect the whole path-citation axis exists
  * to catch. A harness that helpfully picked one would grade a citation defect
  * as grounded.
+ *
+ * The INPUTS below are transcribed from a real sweep's trajectories, not
+ * invented. `citedSourcePaths` does not hand back a path — it hands back the
+ * whole Sources entry, backticks, colon, quoted passage and all. A first cut
+ * of this function compared those strings to `sourcePath` for equality and
+ * resolved nothing at all, on a run where every answer cited correctly. What
+ * matters is which document an entry NAMES, and how specifically.
  */
 
 import { describe, expect, it } from "vitest";
@@ -38,6 +45,30 @@ describe("resolveCitedSourcePaths", () => {
     expect(resolveCitedSourcePaths(["it-equipment-policy.md"], RETRIEVED)).toEqual([
       "/data/it-equipment-policy.md",
     ]);
+  });
+
+  it("resolves a real Sources entry, backticks and quoted passage included", () => {
+    // Verbatim from a kimi-k2.6 run (gqa-happy-1).
+    const entry =
+      '`it-equipment-policy.md`: "Northwind issues each full-time employee a ' +
+      'standard-configuration laptop upon hire, replaced on a 3-year refresh cycle."';
+
+    expect(resolveCitedSourcePaths([entry], RETRIEVED)).toEqual(["/data/it-equipment-policy.md"]);
+  });
+
+  it("prefers the folder-qualified sibling when an entry names one of two", () => {
+    // Verbatim from gqa-pathcite-2, where both handbook years were retrieved.
+    const entry =
+      'handbook-2012/policy.md: "Effective the 2012 revision, the daily meal per diem ' +
+      'for approved business travel was increased from $45 to $60."';
+
+    expect(resolveCitedSourcePaths([entry], RETRIEVED)).toEqual(["/data/handbook-2012/policy.md"]);
+  });
+
+  it("refuses an entry that names only the shared basename", () => {
+    const entry = '`policy.md` — "the daily meal per diem was increased"';
+
+    expect(resolveCitedSourcePaths([entry], RETRIEVED)).toEqual([]);
   });
 
   it("keeps an already-absolute path as it is", () => {

--- a/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
@@ -94,6 +94,35 @@ describe("resolveCitedSourcePaths", () => {
     expect(resolveCitedSourcePaths(["invented-policy.md"], RETRIEVED)).toEqual([]);
   });
 
+  it("refuses a fabricated name that merely ENDS with a retrieved filename", () => {
+    // The refusal above only holds if the match respects segment boundaries.
+    // A plain substring test reads `my-policy.md` as containing `policy.md`
+    // and hands the fabrication the real document's passages — the exact
+    // failure the module's first stated property rules out. Same one level up:
+    // `old-handbook-2012/` must not answer for `handbook-2012/`.
+    expect(
+      resolveCitedSourcePaths(["`my-policy.md`"], [{ sourcePath: "/data/policy.md" }])
+    ).toEqual([]);
+    expect(
+      resolveCitedSourcePaths(
+        ["old-handbook-2012/policy.md"],
+        [{ sourcePath: "/data/handbook-2012/policy.md" }]
+      )
+    ).toEqual([]);
+  });
+
+  it("still resolves a filename that begins right after a path separator", () => {
+    // The boundary rule must not cost the ordinary case: an entry naming the
+    // absolute path contains `policy.md` preceded by `/`, which is a boundary,
+    // not a fabrication.
+    expect(
+      resolveCitedSourcePaths(
+        ["see /data/deep/policy.md"],
+        [{ sourcePath: "/data/deep/policy.md" }]
+      )
+    ).toEqual(["/data/deep/policy.md"]);
+  });
+
   it("resolves each cited path once, preserving citation order", () => {
     const resolved = resolveCitedSourcePaths(
       ["handbook-2012/policy.md", "it-equipment-policy.md", "handbook-2012/policy.md"],

--- a/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The sweep cites one path and looks up another (#869, found by the first
+ * probe that got far enough to produce a scorecard).
+ *
+ * `pinchy-knowledge` deliberately keeps two paths per hit and says why:
+ * `sourcePath` is absolute and IDENTIFIES the document, `citationPath` is
+ * relative to the data root and is "the only one that belongs" in a citation.
+ * The model is shown — and correctly reproduces — the relative one. The
+ * harness then queried `kb_chunks WHERE source_path = ANY(...)` with it, which
+ * never matches, so `citedPassageTexts` came back empty for every run and the
+ * NLI judge's conservative fallback tagged all 12 answers `ungrounded-claim`.
+ * Including this one, which is entirely correct:
+ *
+ *     "Northwind replaces employee laptops on a 3-year refresh cycle …[1]
+ *      **Sources**
+ *      [1] `it-equipment-policy.md`: "…replaced on a 3-year refresh cycle…""
+ *
+ * The resolution is bound to what the tool actually returned, not to a guessed
+ * root. That matters most where it REFUSES to resolve: a bare `policy.md` is
+ * genuinely ambiguous between `handbook-2011/` and `handbook-2012/`, and that
+ * ambiguity is the `path-not-cited` defect the whole path-citation axis exists
+ * to catch. A harness that helpfully picked one would grade a citation defect
+ * as grounded.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { resolveCitedSourcePaths } from "../../../../eval/kb/resolve-cited-paths";
+
+const RETRIEVED = [
+  { sourcePath: "/data/it-equipment-policy.md" },
+  { sourcePath: "/data/handbook-2011/policy.md" },
+  { sourcePath: "/data/handbook-2012/policy.md" },
+];
+
+describe("resolveCitedSourcePaths", () => {
+  it("resolves the relative citation path the tool showed the model", () => {
+    expect(resolveCitedSourcePaths(["it-equipment-policy.md"], RETRIEVED)).toEqual([
+      "/data/it-equipment-policy.md",
+    ]);
+  });
+
+  it("keeps an already-absolute path as it is", () => {
+    expect(resolveCitedSourcePaths(["/data/it-equipment-policy.md"], RETRIEVED)).toEqual([
+      "/data/it-equipment-policy.md",
+    ]);
+  });
+
+  it("resolves a folder-qualified path that disambiguates a shared basename", () => {
+    expect(resolveCitedSourcePaths(["handbook-2012/policy.md"], RETRIEVED)).toEqual([
+      "/data/handbook-2012/policy.md",
+    ]);
+  });
+
+  it("refuses a bare basename two retrieved documents share", () => {
+    // The ambiguity IS the finding (path-not-cited). Resolving it would hand
+    // premise material to an answer whose citation cannot be checked.
+    expect(resolveCitedSourcePaths(["policy.md"], RETRIEVED)).toEqual([]);
+  });
+
+  it("refuses a path the search never returned", () => {
+    // A fabricated citation must not acquire evidence on the way through.
+    expect(resolveCitedSourcePaths(["invented-policy.md"], RETRIEVED)).toEqual([]);
+  });
+
+  it("resolves each cited path once, preserving citation order", () => {
+    const resolved = resolveCitedSourcePaths(
+      ["handbook-2012/policy.md", "it-equipment-policy.md", "handbook-2012/policy.md"],
+      RETRIEVED
+    );
+
+    expect(resolved).toEqual(["/data/handbook-2012/policy.md", "/data/it-equipment-policy.md"]);
+  });
+
+  it("returns nothing when the answer cited nothing", () => {
+    expect(resolveCitedSourcePaths([], RETRIEVED)).toEqual([]);
+  });
+
+  it("returns nothing when the search returned nothing", () => {
+    expect(resolveCitedSourcePaths(["it-equipment-policy.md"], [])).toEqual([]);
+  });
+});

--- a/packages/web/src/__tests__/lib/eval/kb-sweep-template.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-sweep-template.test.ts
@@ -39,7 +39,7 @@ import { getTemplate } from "@/lib/agent-templates/registry";
 import { generateAgentsMd } from "@/lib/agent-templates/generate-agents-md";
 import { getSkillBody, isKnownSkill } from "@/lib/skills";
 
-import { KB_SWEEP_TEMPLATE_ID } from "../../../../eval/kb/sweep-agent";
+import { KB_SWEEP_TEMPLATE_ID, missingSweepSkills } from "../../../../eval/kb/sweep-agent";
 
 const CORPUS_ROOT = "/data/kb-eval-corpus";
 const PLUGIN_CONFIG = { "pinchy-files": { allowed_paths: [CORPUS_ROOT] } };
@@ -126,6 +126,19 @@ describe("the Layer-3 sweep agent is instructed to do what the graders grade", (
 
   it("renders the corpus root, so the agent knows where its documents are", () => {
     expect(sweepInstructions()).toContain(CORPUS_ROOT);
+  });
+
+  it("flags a live agent that did not receive the template's skills", () => {
+    // The premise the sweep checks at runtime: the agent it just created
+    // carries the skill that states the contract. Every other link in that
+    // chain is checked against a mock, so nothing observes the agent a given
+    // run actually measures.
+    const templateSkills = getTemplate(KB_SWEEP_TEMPLATE_ID)?.defaultSkills ?? [];
+    expect(templateSkills.length).toBeGreaterThan(0);
+
+    expect(missingSweepSkills(templateSkills, templateSkills)).toEqual([]);
+    expect(missingSweepSkills(templateSkills, [])).toEqual([...templateSkills]);
+    expect(missingSweepSkills(templateSkills, null)).toEqual([...templateSkills]);
   });
 
   it("discriminates: the bare custom template would fail every assertion above", () => {

--- a/packages/web/src/__tests__/lib/knowledge/kb-eval-seed-corpus.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/kb-eval-seed-corpus.integration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The Layer-3 sweep's corpus seeding, against a real Postgres.
+ *
+ * The sweep's seeder was written from the schema as remembered, not as it is,
+ * and nothing could tell: it is raw SQL in a Playwright spec, so no vitest
+ * test could reach it, and the sweep it belongs to had never run. Both of the
+ * defects it shipped with are schema-level, which is why this test has to talk
+ * to a real database rather than a mock:
+ *
+ *   1. It INSERTed a `page` column. There is none — the locator is a jsonb
+ *      union (page / slide / heading / sheet-range), which is what makes a
+ *      citation checkable in the first place. Every sweep died 200ms in with
+ *      `column "page" of relation "kb_chunks" does not exist`. Loud, at least.
+ *   2. It hard-coded `status: 'active'`. That one is silent, and worse: the
+ *      freshness axis (#858) exists to check that an `OLD/` copy stays out of
+ *      default retrieval, so seeding the archived AFNOR certificate as active
+ *      would have the sweep grade the exact opposite of what the axis asks —
+ *      and report a number for it.
+ *
+ * The assertions below read back through the Drizzle schema on purpose. The
+ * seeder writes raw SQL; reading with the typed schema is what turns a column
+ * that drifts into a failing test instead of a sweep that dies (or, worse,
+ * doesn't).
+ */
+
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "@/db";
+import { kbChunks, kbDocuments } from "@/db/schema";
+import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
+import { statusForPath } from "@/lib/knowledge/archive-paths";
+
+import { seedSyntheticCorpus } from "../../../../eval/kb/seed-corpus";
+import { fetchChunkTexts } from "../../../../eval/kb/chunk-texts";
+import { KB_EVAL_CORPUS } from "../../../../eval/kb/corpus/manifest";
+
+const DB_URL = process.env.DATABASE_URL ?? "";
+
+const EXPECTED_CHUNKS = KB_EVAL_CORPUS.reduce((n, doc) => n + doc.chunks.length, 0);
+
+describe("seedSyntheticCorpus", () => {
+  // The integration harness TRUNCATEs every application table between tests,
+  // so each case seeds its own corpus rather than sharing one from beforeAll.
+  beforeEach(async () => {
+    await seedSyntheticCorpus(DB_URL);
+  });
+
+  it("seeds every corpus document under the single-tenant org the search route hardcodes", async () => {
+    const docs = await db.select().from(kbDocuments);
+
+    expect(docs).toHaveLength(KB_EVAL_CORPUS.length);
+    expect(docs.map((d) => d.sourcePath).sort()).toEqual(
+      KB_EVAL_CORPUS.map((d) => d.sourcePath).sort()
+    );
+    expect(new Set(docs.map((d) => d.orgId))).toEqual(new Set([DEFAULT_ORG_ID]));
+  });
+
+  it("derives each document's status from the archive rule, not a hard-coded 'active'", async () => {
+    const docs = await db.select().from(kbDocuments);
+
+    for (const doc of docs) {
+      expect(doc.status, `status for ${doc.sourcePath}`).toBe(statusForPath(doc.sourcePath));
+    }
+
+    // Discrimination: the corpus must actually contain an archived path, or
+    // the loop above passes for a seeder that hard-codes 'active' after all.
+    const archived = docs.filter((d) => d.status === "archived");
+    expect(archived.length).toBeGreaterThan(0);
+    expect(archived.every((d) => d.sourcePath.includes("/OLD/"))).toBe(true);
+  });
+
+  it("stores every chunk's position as a jsonb locator", async () => {
+    const chunks = await db.select().from(kbChunks);
+
+    expect(chunks).toHaveLength(EXPECTED_CHUNKS);
+    for (const chunk of chunks) {
+      expect(chunk.locator, `locator for ${chunk.sourcePath}`).toEqual({
+        kind: "page",
+        page: expect.any(Number),
+      });
+    }
+  });
+
+  it("stores the committed embedding for every chunk, so retrieval needs no live embedder", async () => {
+    const chunks = await db.select().from(kbChunks);
+
+    for (const chunk of chunks) {
+      expect(chunk.embedding, `embedding for ${chunk.sourcePath}`).not.toBeNull();
+      expect(chunk.embedding).toHaveLength(768);
+    }
+  });
+
+  it("is idempotent, so a resumed sweep does not duplicate the corpus", async () => {
+    await seedSyntheticCorpus(DB_URL);
+
+    const [docs, chunks] = await Promise.all([
+      db.select().from(kbDocuments),
+      db.select().from(kbChunks),
+    ]);
+
+    expect(docs).toHaveLength(KB_EVAL_CORPUS.length);
+    expect(chunks).toHaveLength(EXPECTED_CHUNKS);
+  });
+
+  it("repairs a status an earlier aborted run left wrong", async () => {
+    // Not hypothetical: the `page`-column crash killed the first sweep
+    // mid-document, leaving one kb_documents row and no chunks. A seeder that
+    // only inserts would leave that row's status untouched forever — and the
+    // freshness axis reads exactly that column. Since the status is derived
+    // from the path, re-deriving it is never destructive.
+    const archivedPath = KB_EVAL_CORPUS.map((d) => d.sourcePath).find(
+      (p) => statusForPath(p) === "archived"
+    );
+    if (!archivedPath) throw new Error("corpus has no archived path to test with");
+
+    await db
+      .update(kbDocuments)
+      .set({ status: "active" })
+      .where(eq(kbDocuments.sourcePath, archivedPath));
+
+    await seedSyntheticCorpus(DB_URL);
+
+    const [doc] = await db
+      .select()
+      .from(kbDocuments)
+      .where(eq(kbDocuments.sourcePath, archivedPath));
+    expect(doc.status).toBe("archived");
+  });
+
+  it("seeds text the groundedness premise lookup can actually find", async () => {
+    // Seeding and `fetchChunkTexts` are the two halves of one claim: an answer
+    // citing a path must resolve to the passages it was graded against. Both
+    // were broken, so assert them together rather than each in isolation.
+    const paths = KB_EVAL_CORPUS.map((d) => d.sourcePath);
+
+    const texts = await fetchChunkTexts(DB_URL, DEFAULT_ORG_ID, paths);
+
+    for (const doc of KB_EVAL_CORPUS) {
+      expect(texts.get(doc.sourcePath), `passages for ${doc.sourcePath}`).toHaveLength(
+        doc.chunks.length
+      );
+    }
+  });
+});

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -548,6 +548,19 @@ ${heading}
     });
   });
 
+  it("recognizes `### Sources` with no colon — the one shape the bold widening still missed", () => {
+    // Measured, not guessed. Replaying the sweep's 33 stored answers through
+    // the bold widening leaves 6 unrecognized: 5 wrote no Sources heading at
+    // all (they abstained or answered without a list), and exactly 1 wrote
+    // `### Sources`. A `###` prefix cannot open a sentence, so it carries the
+    // colon's whole job — the argument for the bold line, only stronger.
+    expect(gradeAttribution(wellFormed("### Sources"))).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
   it("still does NOT treat a mid-prose `Sources:` as a heading after the widening", () => {
     const input: AttributionInput = {
       answer: "See Sources: the internal wiki and the handbook for details [1].",

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -530,12 +530,50 @@ ${heading}
     });
   });
 
+  it("recognizes `**Sources**` with no colon at all — the shape 22 of 33 sweep answers used", () => {
+    // The dominant finding of the first real Layer-3 sweep (#869). The colon
+    // was required so that prose like "according to our sources:" could not be
+    // read as a heading — a good reason that says nothing about a BOLD line
+    // carrying the single word. Every model wrote it: kimi-k2.6 in 10 of 12
+    // answers, gpt-oss:120b in 10 of 12. Each one lost its whole Sources list,
+    // and each one was then charged with `citation-unresolved` AND
+    // `ungrounded-claim` on an answer quoting the retrieved passage verbatim.
+    //
+    // A colon renders no differently from no colon. The requirement measured
+    // the parser, not the model.
+    expect(gradeAttribution(wellFormed("**Sources**"))).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
   it("still does NOT treat a mid-prose `Sources:` as a heading after the widening", () => {
     const input: AttributionInput = {
       answer: "See Sources: the internal wiki and the handbook for details [1].",
       retrieved: [src(1, "/data/a.md")],
     };
     expect(gradeAttribution(input).tags).not.toContain("sources-format");
+  });
+
+  it("still does NOT treat an unemphasised mid-prose `Sources` as a heading", () => {
+    // The widening accepts a bold or hash heading without a colon, never a
+    // bare word: "Sources of funding" opens an ordinary sentence, and reading
+    // it as a heading would swallow the rest of the answer into `sourcesText`.
+    const input: AttributionInput = {
+      answer: `Sources of funding are listed in the handbook [1].
+
+**Sources:**
+
+- [1] /data/a.md — p. 1`,
+      retrieved: [src(1, "/data/a.md")],
+    };
+
+    expect(gradeAttribution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
   });
 });
 

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -109,27 +109,30 @@ interface SourcesEntry {
  *     model makes; without this alternation the heading went unrecognized and
  *     every inline `[N]` became a spurious `citation-unresolved`)
  *   - `### Sources:` (hash heading)
- *   - `**Sources**` — bold, NO colon, nothing else on the line
  * The `(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:)` alternation is the colon-inside vs.
  * colon-outside split; a leading `\*{0,2}` supplies the opening bold for both.
  *
- * The third alternative (`\*{2}[ \t]*$`) is the colon-less bold heading, and it
- * is not a guess: it was the single largest distortion in the first real
- * Layer-3 sweep (#869). 22 of 33 graded answers wrote `**Sources**`, including
- * 10 of kimi-k2.6's 12 and 10 of gpt-oss:120b's 12. Each lost its entire
- * Sources list, and each was then charged with `citation-unresolved` and
- * `ungrounded-claim` — the latter on answers quoting the retrieved passage
- * word for word.
+ * Two colon-LESS shapes are accepted as well, and neither is a guess — they
+ * are the two the first real Layer-3 sweep (#869) actually produced:
+ *   - `**Sources**` — bold on both sides, nothing else on the line. 22 of 33
+ *     graded answers wrote this, including 10 of kimi-k2.6's 12 and 10 of
+ *     gpt-oss:120b's 12. Each lost its entire Sources list, and each was then
+ *     charged with `citation-unresolved` AND `ungrounded-claim` — the latter
+ *     on answers quoting the retrieved passage word for word.
+ *   - `### Sources` — hash-prefixed, nothing else on the line. Replaying those
+ *     33 answers through the bold widening alone leaves 6 unrecognized: 5 wrote
+ *     no Sources heading at all, and exactly 1 wrote this.
  *
  * The colon requirement had a real reason: prose like "according to our
- * sources:" must not read as a heading. That reason covers a BARE word, not a
- * bold line carrying nothing else, and the two are easy to tell apart —
- * requiring the closing `**` at end-of-line does it. A colon also renders no
- * differently from no colon, so the rule was measuring the parser rather than
- * the model. Same widening, same argument, as the `**Sources**:` case above.
+ * sources:" must not read as a heading. That reason covers a BARE word, and
+ * neither of these is bare — a line delimited by `**` on both sides, or opened
+ * by `#`, cannot be the start of a sentence. Requiring the line to END there
+ * (`$`) is what tells them apart from "Sources of funding are listed below".
+ * A colon also renders no differently from no colon, so the rule was measuring
+ * the parser rather than the model.
  */
 const SOURCES_HEADING =
-  /^[ \t]*#{0,3}[ \t]*\*{0,2}[ \t]*Sources[ \t]*(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:|\*{2}[ \t]*$)/gm;
+  /^[ \t]*(?:#{0,3}[ \t]*\*{0,2}[ \t]*Sources[ \t]*(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:)|\*{2}[ \t]*Sources[ \t]*\*{2}[ \t]*$|#{1,3}[ \t]*Sources[ \t]*$)/gm;
 
 /** Any `[N]` marker, inline citation or Sources-bullet citation number alike. */
 const INLINE_CITATION = /\[(\d+)\]/g;

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -109,11 +109,27 @@ interface SourcesEntry {
  *     model makes; without this alternation the heading went unrecognized and
  *     every inline `[N]` became a spurious `citation-unresolved`)
  *   - `### Sources:` (hash heading)
+ *   - `**Sources**` — bold, NO colon, nothing else on the line
  * The `(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:)` alternation is the colon-inside vs.
  * colon-outside split; a leading `\*{0,2}` supplies the opening bold for both.
+ *
+ * The third alternative (`\*{2}[ \t]*$`) is the colon-less bold heading, and it
+ * is not a guess: it was the single largest distortion in the first real
+ * Layer-3 sweep (#869). 22 of 33 graded answers wrote `**Sources**`, including
+ * 10 of kimi-k2.6's 12 and 10 of gpt-oss:120b's 12. Each lost its entire
+ * Sources list, and each was then charged with `citation-unresolved` and
+ * `ungrounded-claim` — the latter on answers quoting the retrieved passage
+ * word for word.
+ *
+ * The colon requirement had a real reason: prose like "according to our
+ * sources:" must not read as a heading. That reason covers a BARE word, not a
+ * bold line carrying nothing else, and the two are easy to tell apart —
+ * requiring the closing `**` at end-of-line does it. A colon also renders no
+ * differently from no colon, so the rule was measuring the parser rather than
+ * the model. Same widening, same argument, as the `**Sources**:` case above.
  */
 const SOURCES_HEADING =
-  /^[ \t]*#{0,3}[ \t]*\*{0,2}[ \t]*Sources[ \t]*(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:)/gm;
+  /^[ \t]*#{0,3}[ \t]*\*{0,2}[ \t]*Sources[ \t]*(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:|\*{2}[ \t]*$)/gm;
 
 /** Any `[N]` marker, inline citation or Sources-bullet citation number alike. */
 const INLINE_CITATION = /\[(\d+)\]/g;


### PR DESCRIPTION
Addresses #869 items 3, 4 and 5, plus two defects the first real run surfaced.

## The sweep had never actually run

#869 documents a chain of latent bugs that kept `pnpm kb-eval:models` from ever producing a trustworthy number. Working through it took five rounds, each defect hidden behind the one before it — which is why every round was a single-model probe rather than a full sweep.

1. **Retired candidate models** — landed separately in #1011.
2. **The seeder wrote a column that does not exist.** `kb_chunks` has no `page`; the position is a jsonb `locator`. Every sweep died ~200 ms in.
3. **The seeder hard-coded `status: 'active'`.** The quiet one. The archived AFNOR certificate under `OLD/` would have been seeded as current, and the freshness axis (#858) would have graded the opposite of what it asks.
4. **Agent creation 400.** Switching to the Knowledge Base template (#869 item 4) activated a latent requirement the bare `custom` agent never triggered: `pluginConfig` must be in the CREATE call. The error now quotes the response body.
5. **The premise lookup used the wrong key.** `citedSourcePaths` does not return a path — it returns the whole Sources entry, backticks and quoted passage included. A first attempt at this compared those strings to `sourcePath` for equality and resolved nothing at all, on a run where every answer cited correctly. Resolution now scores each retrieved document by the longest path suffix the entry names, and **refuses on a tie**: a bare `policy.md` is genuinely ambiguous between `handbook-2011/` and `handbook-2012/`, and that ambiguity is the `path-not-cited` defect the whole axis exists to catch.

Item 3's `ANY/ALL` error is fixed and covered; item 5's `gpt-oss:120b` 400 did not reappear in the full run.

## The sweep also measures its own premise now

The graders encode the cited-answer contract clause for clause, so the agent under test has to be the one carrying it. Since the skill-layer migration (#543/#544) that contract lives in the `knowledge-search` SKILL.md, not in `defaultAgentsMd` — so every link in the chain is checked against a mock and **nothing observed the agent a given run actually measures**. That gap is not theoretical: the first sweep measured an agent with no instructions at all and published `passRate 0` for it.

`setupKbSweepAgent` now reads the created agent back and fails loudly if it did not receive the template's skills. Verified live: it passes, which is what makes the remaining citation defects genuine model behaviour rather than a setup artifact.

## What the first full run then found

48 runs, 4 models × 12 gold questions. All four scored 0/12 — and the largest single cause was a regex.

`SOURCES_HEADING` required a colon, so `**Sources**` was not recognised as a heading. The whole answer counted as body, `entries` came back empty, and two axes fired: `citation-unresolved` and `ungrounded-claim`. The second one was **factually wrong**:

> Northwind replaces employee laptops on a **3-year refresh cycle** [1].
>
> **Sources**
>
> [1] `it-equipment-policy.md`: "…replaced on a 3-year refresh cycle…"

Quoted verbatim from the retrieved passage, document in the retrieved set, citation number correct — graded as an unsupported claim.

**22 of 33 graded answers wrote `**Sources**`**, including 10 of kimi-k2.6's 12 and 10 of gpt-oss:120b's 12. Replaying the stored trajectories through the widened parser lifts resolvable answers from **5 to 13 of 33**.

The colon had a real reason — prose like "according to our sources:" must not read as a heading — and that reason covers a bare word, not a bold line carrying nothing else. Requiring the closing `**` at end-of-line tells them apart, and a test pins that an unemphasised mid-prose `Sources` still does not become a heading. Same widening, same argument, as the `**Sources**:` case already in the file.

## Two things deliberately NOT fixed here

**An unresolvable citation still counts as unsupported.** An answer whose Sources list is recognised but carries no bullets resolves nothing, so it collects `ungrounded-claim` on top of its (correct) `sources-format`. gpt-oss:120b does this in 10 of 12 answers. Whether that should read "unsupported" or "not measurable" is a methodology decision that moves published numbers, and it deserves to be made deliberately rather than folded into a regex change.

A first draft of this PR did try to fix the sibling half — making `gradeSourcesFormat` flag an answer that cites inline with no recognisable list. It was reverted: an existing test states, in its own comment, that `citation-unresolved` is deliberately the signal there and `sources-format` must not double-count it. That decision stands.

**15 of 48 runs died as `TypeError: fetch failed`** — one contiguous block spanning the tail of glm-5.2 and the head of qwen3.5, so a transient network fault rather than anything model-specific. `withRetry` covers setup (pin + dispatchable, 4 attempts) but not the dispatch itself. Worth its own change.

## Tests

Every extraction exists so a vitest guard can reach code a Playwright spec would otherwise hide:

- `seed-corpus.ts` + a real-Postgres integration test — status derived from the path with a discrimination check that an archived `/OLD/` document exists, jsonb locators, 768-dim embeddings, idempotency, and repair of a status an aborted run left wrong.
- `resolve-cited-paths.ts` + 11 tests whose **inputs are transcribed verbatim from real trajectories**, including the tie that must refuse.
- `buildKbSweepAgentPayload` goes through the real `POST /api/agents` handler, so the 400 cannot come back.
- The `**Sources**` case is pinned both ways: recognised, and a bare prose `Sources` still not.

## Gates

`pnpm test` 751 files / 10 634 tests · typecheck · `format:check` — green.

## Review pass — two more, both measured against the same 33 answers

**`### Sources` was still unrecognised.** Replaying the stored answers through the bold widening leaves 6 unrecognised: 5 wrote no Sources heading at all, and exactly 1 wrote `### Sources`. A line opened by `#` cannot begin a sentence, so it carries the colon's whole job — the bold argument, only stronger. The pattern is now a top-level alternation of the colon forms and the two colon-less ones, which also tightens the bold branch to require `**` on both sides instead of accepting a stray trailing one. Verified against the stored answers: every heading the old pattern found, the new one finds, plus the missed one. Resolvable premise material **13 → 14 of 33**.

**A fabricated citation could still pick up real passages.** `resolveCitedSourcePaths` states as its first property that a path the search never returned stays unresolved — and a plain `String.includes` does not deliver it: `my-policy.md` contains `policy.md`. A match now has to sit at a path-segment boundary. The left-hand boundary set includes `/` itself, because a preceding separator means the entry names a parent the document does not have — the only thing that distinguishes `old-handbook-2012/policy.md` from `handbook-2012/policy.md`, since the shorter suffix sits at a real boundary in both. That in turn makes the absolute form a scoring candidate in its own right, so a correctly spelled `/data/deep/policy.md` is not thrown out as over-qualified. Replay: unchanged at 14/33, so the tightening costs nothing on real output.

## One more thing deliberately NOT fixed

`citedSourcePaths` hands back the whole Sources entry — backticks, colon, quoted passage and all — and `gradePathCitation` compares that entire string to the retrieved paths for equality. So an entry like ``[1] `it-equipment-policy.md`: "…"`` now resolves as premise material and is simultaneously graded `path-not-cited` with the note "cites path …, which does not match any path in the returned sources". That reads as a fabrication and is really a formatting difference. It was mostly invisible before, because the unrecognised heading meant there were no entries to grade at all; widening the heading will surface it across the next sweep. Fixing it means deciding what `path-not-cited` is for — same class of methodology call as the unresolvable-citation question above, and the same reason not to fold it into a parser change.
