### PR TITLE
feat(triage): sweep the issue backlog by evidence, verify before closing

### DIFF
--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -34,6 +34,13 @@ the count, and is why Step 2 exists in the shape it does:
 | `subsumed`      | 6          | **0**            |
 | `no-discussion` | 40         | 34               |
 
+**The sweep's worst wrong answer came from what it did not look at.** It read
+merged pull requests only, so it closed #128, #333 and #829 as "nobody is going
+to build this" while an **open** PR sat against each one. An open PR has
+already answered the question the 37signals rule asks. There is now an
+`in-flight` bucket, ranked above everything else, and it can only be got wrong
+in the safe direction — see the asymmetry note in Step 2.
+
 **A merge cross-reference is weak evidence — it was right 30% of the time.**
 Three that would have been closed by anything that trusts the link: #164
 (pairing race) pointed at a Brave-Search PR; #602 (build a governed browser
@@ -121,6 +128,15 @@ check settles it:
 Watch for the **inverted** PR — one that _restricts_ what the issue asked to
 build. #603 denied access to the browser tool #602 wanted governed. A title
 match on the topic is not a match on the direction.
+
+**`in-flight` is exempt from all of this, and that asymmetry is deliberate.**
+It carries the same weakness as `closed-by-pr` — GitHub records a
+cross-reference for a mere mention, so a PR that merely quotes an issue number
+lands it in the bucket (this skill's own PR did that to #465, #543 and #669).
+The difference is which way a wrong answer falls. A false `closed-by-pr`
+deletes live work; a false `in-flight` costs one extra look next sweep. So do
+not verify this bucket down — leave every entry alone, and let the PR merging
+or closing move it on its own.
 
 Three verdicts, and **"partly" is a real one** — 5 of 54 were, and #755 is the
 instructive one: the workspace-retrofit half shipped while the reported core

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -37,9 +37,19 @@ the count, and is why Step 2 exists in the shape it does:
 **The sweep's worst wrong answer came from what it did not look at.** It read
 merged pull requests only, so it closed #128, #333 and #829 as "nobody is going
 to build this" while an **open** PR sat against each one. An open PR has
-already answered the question the 37signals rule asks. There is now an
-`in-flight` bucket, ranked above everything else, and it can only be got wrong
-in the safe direction — see the asymmetry note in Step 2.
+already answered the question the 37signals rule asks.
+
+Two things came out of that, and **you need both — the bucket alone would have
+caught two of the three**:
+
+1. An `in-flight` bucket, ranked above everything else. It can only be got
+   wrong in the safe direction (see Step 2).
+2. **The open-PR roster at the top of the report, which you must read against
+   your close list.** #128's implementation, PR #163, names no issue number
+   anywhere — so GitHub records no cross-reference and #128's timeline is
+   genuinely empty. No bucket can see it. It was found by recognising "OpenAI
+   ChatGPT subscription (Device Code Flow)" as "Provider OAuth auth (OpenAI
+   first)", which is a semantic match only a reader makes.
 
 **A merge cross-reference is weak evidence — it was right 30% of the time.**
 Three that would have been closed by anything that trusts the link: #164
@@ -172,6 +182,14 @@ moved. The flag exists so the question gets asked once, in the pass that is
 already looking.
 
 ## Step 3 — Act, by evidence class
+
+**Before you propose a single closure, read the open-PR roster at the top of
+the report against your close list, by topic.** Not by issue number — the case
+this exists for is precisely the PR that names no number. Fifteen titles, once,
+and it is the only thing standing between a block-close and deleting work
+somebody currently has in review. If the report says `roster not fetched`, run
+`gh pr list --state open` yourself and do it anyway; a missing roster is not an
+empty one.
 
 Approval is **per class, never per issue** — 148 individual confirmations is
 not a review, it is a rubber stamp. Present the user with grouped decisions:

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: triage-issues
+description: Use when triaging the GitHub issue backlog — the weekly pass over new issues, or a full sweep to clear out issues that are already done, already covered, or were never real. Also when the user says "triage the issues", "clean up the backlog", "welche Issues können wir zumachen", or asks how many open issues are actually still open. Verifies against the code before closing anything.
+---
+
+# Triage the issue backlog
+
+## Why this exists
+
+Issues here arrive faster than they close, and the backlog does not decay in
+the way the usual tooling assumes. Measured on 2026-08-01 against 148 open
+issues:
+
+| Signal                                   | Count |
+| ---------------------------------------- | ----- |
+| a merged PR already references the issue | 54    |
+| never categorised by anyone              | 28    |
+| an `enhancement` with zero comments      | 40    |
+| untouched for more than 90 days          | 16    |
+
+**The last row is why there is no stale-bot here.** Close-after-90-days would
+find 16 of 148 and be wrong about most of them. The backlog is not abandoned,
+it is unresolved — the real mass is work that is _done_ but still open, because
+a PR titled `… (#796)` does not close anything without `Closes #796`.
+
+## The two modes
+
+Same method, different scope. The full sweep establishes the state the weekly
+pass depends on.
+
+|           | Full sweep                   | Weekly pass            |
+| --------- | ---------------------------- | ---------------------- |
+| Scope     | everything                   | the `untriaged` bucket |
+| Expect    | dozens of closures           | 5–15 issues            |
+| Ends with | every open issue categorised | same                   |
+
+The weekly filter only works while the invariant below holds. Until the first
+full sweep has run, run the full sweep.
+
+## Step 1 — Sweep
+
+```bash
+node scripts/triage-sweep.mjs > docs/plans/triage-$(date +%F).md
+```
+
+One GraphQL pass, a few seconds, no writes to GitHub. It sorts every open issue
+into a bucket by evidence and prints markdown. It borrows credentials from
+`gh`, so `gh auth login` must have happened.
+
+**Write it to a file and keep the verdicts there as you go.** A full sweep is
+54 candidates times three checks; that outlives a context window, and
+re-verifying from scratch after a compaction is the difference between a pass
+that finishes and one that gets abandoned half-done. `docs/plans/` is
+gitignored, so the working file never lands in a commit.
+
+**The sweep never reaches a verdict.** It reports that #465 has a merged PR in
+its timeline; it does not report that #465 is done. Of the 54 in
+`closed-by-pr`, some are tracking issues that legitimately accumulate merged
+PRs for months — #543 and #669 both look exactly like a zombie and both are
+alive. Treat the bucket as a candidate list.
+
+## Step 2 — Verify, per candidate
+
+This is the actual work, and it is the reason this is a skill and not a cron
+job. For each `closed-by-pr` candidate, three checks — in this order, stopping
+as soon as one settles it:
+
+1. **Read the PR.** `gh pr view <n>` — does it claim to do what the issue asks,
+   or does it merely mention the number in passing?
+2. **Grep `main` for the thing the issue names.** The symbol, the file, the
+   flag. `git grep -n <symbol> origin/main -- <path>`. An issue asking for a
+   function that now exists is done; an issue asking for behaviour is not
+   settled by a grep, and needs the PR read.
+3. **Check for unlanded work.** `git branch -a` and `git worktree list`, by
+   issue number _and_ by keyword. Finished-but-never-pushed branches sit
+   around here regularly. That is not "done", it is "started".
+
+Three verdicts, and **"partly" is a real one** — #799 was exactly that, half
+shipped and half open. A partly-done issue gets rewritten to the remainder,
+not closed.
+
+For `subsumed` candidates: open the tracking issue and confirm it genuinely
+covers this one. If it does, close with a pointer; if it merely mentions it,
+it is not subsumed.
+
+For `no-discussion` — the 40 enhancements nobody ever commented on — read each
+one briefly and ask **the only question that matters: is anyone going to build
+this?** The house rule is 37signals: no standing backlog of someday-ideas,
+because what matters comes back on its own when it hurts. So default to
+closing, and lift out the few that carry real substance — a concrete defect, a
+decision already made, a contract that needs the number. Do not deep-verify
+this bucket; that is the expensive mistake. Skim, lift out the keepers, close
+the rest as a block.
+
+## Step 3 — Act, by evidence class
+
+Approval is **per class, never per issue** — 148 individual confirmations is
+not a review, it is a rubber stamp. Present the user with grouped decisions:
+
+> "38 verified done (merged PR + symbol present in main) — close?"
+> "6 partly done — rewrite to the remainder?"
+> "34 of 40 enhancements with no substance — close as out of scope?"
+
+Show the lifted-out keepers by name and let the user veto individually there,
+because that list is short.
+
+Closing comments name the evidence: the PR that did it, or the tracking issue
+that covers it. A closure nobody can audit later is a deletion.
+
+## The one prohibition
+
+`unanswered-sweep` in `.github/workflows/issue-triage.yml` goes red while an
+outside report sits unanswered, and **only a maintainer comment clears it** —
+no label, no assignee, no snooze. A triage pass that posts a friendly comment
+under the user's account would silence that alarm without anyone having
+answered.
+
+So: **never comment on an issue the sweep flags `⚠ external, unanswered`.**
+Closing it with a reason is allowed — the policy names that as the honest
+alternative — and needs explicit approval each time.
+
+## The invariant that makes next week cheap
+
+**When the pass ends, every open issue carries a category label and no
+`triage`.** That is what makes `untriaged` a trustworthy filter next week: no
+state file, no date marker, no database — the labels are the state.
+
+Label from the existing set (`gh label list`); do not invent new ones. Note
+that `triage` and `external` are process markers, not categories — the sweep
+already treats them as "nobody looked yet", which is why an incoming report
+cannot hide behind a label its own arrival created.
+
+## What this skill does not do
+
+- **No staleness rule.** Measured, found useless here. See the table above.
+- **No auto-close.** Every closure is approved, by class.
+- **No new issues.** Triage removes; if something surfaces that deserves an
+  issue, apply the usual bar — real intent to build, a silent correctness
+  defect, or a process contract that needs the number.
+- **No label invention.** The sweep reads existing labels; a new label is a
+  decision for the user, not a side effect of triage.
+
+## Changing the rules
+
+Bucket logic lives in `scripts/lib/triage-sweep.mjs` and is covered by
+`scripts/lib/triage-sweep.test.mjs` (`pnpm test:scripts`). Add a rule with a
+test — the failure mode of every one of these classifiers is a silently
+shorter list, which reads as a clean tracker.

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -40,8 +40,11 @@ full sweep has run, run the full sweep.
 ## Step 1 — Sweep
 
 ```bash
-node scripts/triage-sweep.mjs > docs/plans/triage-$(date +%F).md
+mkdir -p docs/plans && node scripts/triage-sweep.mjs > docs/plans/triage-$(date +%F).md
 ```
+
+`docs/plans/` is gitignored, so it does not exist in a fresh checkout and the
+redirect alone would fail before the sweep ever ran.
 
 One GraphQL pass, a few seconds, no writes to GitHub. It sorts every open issue
 into a bucket by evidence and prints markdown. It borrows credentials from
@@ -50,8 +53,8 @@ into a bucket by evidence and prints markdown. It borrows credentials from
 **Write it to a file and keep the verdicts there as you go.** A full sweep is
 54 candidates times three checks; that outlives a context window, and
 re-verifying from scratch after a compaction is the difference between a pass
-that finishes and one that gets abandoned half-done. `docs/plans/` is
-gitignored, so the working file never lands in a commit.
+that finishes and one that gets abandoned half-done. The working file never
+lands in a commit.
 
 **The sweep never reaches a verdict.** It reports that #465 has a merged PR in
 its timeline; it does not report that #465 is done. Of the 54 in

--- a/.claude/skills/triage-issues/SKILL.md
+++ b/.claude/skills/triage-issues/SKILL.md
@@ -23,6 +23,25 @@ find 16 of 148 and be wrong about most of them. The backlog is not abandoned,
 it is unresolved — the real mass is work that is _done_ but still open, because
 a PR titled `… (#796)` does not close anything without `Closes #796`.
 
+The first full sweep ran on 2026-08-01 and took the backlog from **148 to 97**:
+18 closed against verified evidence, 32 closed as out-of-scope, 5 rewritten to
+their remainder. What it measured about its own heuristics matters more than
+the count, and is why Step 2 exists in the shape it does:
+
+| Bucket          | Candidates | Actually settled |
+| --------------- | ---------- | ---------------- |
+| `closed-by-pr`  | 54         | **16**           |
+| `subsumed`      | 6          | **0**            |
+| `no-discussion` | 40         | 34               |
+
+**A merge cross-reference is weak evidence — it was right 30% of the time.**
+Three that would have been closed by anything that trusts the link: #164
+(pairing race) pointed at a Brave-Search PR; #602 (build a governed browser
+tool) pointed at PR #603, _"**deny** OpenClaw group:ui so the native browser
+tool isn't silently reachable"_ — the opposite act; and #849, an outside bug
+report, pointed at _"Never let an outside bug report wait unseen"_, the process
+fix that report caused rather than the fix it asked for.
+
 ## The two modes
 
 Same method, different scope. The full sweep establishes the state the weekly
@@ -50,6 +69,14 @@ One GraphQL pass, a few seconds, no writes to GitHub. It sorts every open issue
 into a bucket by evidence and prints markdown. It borrows credentials from
 `gh`, so `gh auth login` must have happened.
 
+Each line can carry two flags in brackets, and both cut across the buckets
+rather than replacing them:
+
+- `⚠ external, unanswered` — an outside reporter is owed a reply. See the
+  prohibition below; this one governs what you may not do.
+- `never discussed` — nobody has ever commented. Not a verdict either, but it
+  is the question the pass must ask before labelling anything.
+
 **Write it to a file and keep the verdicts there as you go.** A full sweep is
 54 candidates times three checks; that outlives a context window, and
 re-verifying from scratch after a compaction is the difference between a pass
@@ -65,11 +92,24 @@ alive. Treat the bucket as a candidate list.
 ## Step 2 — Verify, per candidate
 
 This is the actual work, and it is the reason this is a skill and not a cron
-job. For each `closed-by-pr` candidate, three checks — in this order, stopping
-as soon as one settles it:
+job.
 
-1. **Read the PR.** `gh pr view <n>` — does it claim to do what the issue asks,
-   or does it merely mention the number in passing?
+**Gather in bulk first, then judge.** 54 candidates checked one at a time will
+not survive a context window. Two loops — issue titles/bodies/labels, then the
+titles of every referenced PR — turn the whole bucket into two files you can
+read straight through. Do that before opening anything individually.
+
+Then, per `closed-by-pr` candidate, in this order, stopping as soon as one
+check settles it:
+
+1. **Read the PR's title.** The cheapest decisive signal by a wide margin, and
+   you already have all of them from the bulk pass. Two shapes settle
+   immediately:
+   - **A title carrying the issue's own number** is strong evidence _for_
+     completion — "strip MEMORY.md from group-session bootstrap (#369)" and
+     "make the Layer-3 groundedness sweep actually run (#869)" were both real.
+   - **A title about something else entirely** is the passing mention, and it
+     is the common case. Move on; do not open the diff.
 2. **Grep `main` for the thing the issue names.** The symbol, the file, the
    flag. `git grep -n <symbol> origin/main -- <path>`. An issue asking for a
    function that now exists is done; an issue asking for behaviour is not
@@ -78,22 +118,42 @@ as soon as one settles it:
    issue number _and_ by keyword. Finished-but-never-pushed branches sit
    around here regularly. That is not "done", it is "started".
 
-Three verdicts, and **"partly" is a real one** — #799 was exactly that, half
-shipped and half open. A partly-done issue gets rewritten to the remainder,
-not closed.
+Watch for the **inverted** PR — one that _restricts_ what the issue asked to
+build. #603 denied access to the browser tool #602 wanted governed. A title
+match on the topic is not a match on the direction.
+
+Three verdicts, and **"partly" is a real one** — 5 of 54 were, and #755 is the
+instructive one: the workspace-retrofit half shipped while the reported core
+(memory gated on a grant no template hands out) stood untouched. A partly-done
+issue gets rewritten to the remainder, not closed.
 
 For `subsumed` candidates: open the tracking issue and confirm it genuinely
-covers this one. If it does, close with a pointer; if it merely mentions it,
-it is not subsumed.
+covers this one. **All 6 failed this test on the first sweep, so expect to
+close none of them.** The distinction that matters: #556 says outright _"this
+is the umbrella so the individual findings stay connected — pick work off the
+table below."_ An umbrella that **indexes** work does not **replace** it, and
+closing its rows deletes the only place the work is written down. Subsumption
+means the tracking issue's own body carries the scope — as #543's title does,
+naming exactly which three RFCs it consolidated.
 
-For `no-discussion` — the 40 enhancements nobody ever commented on — read each
-one briefly and ask **the only question that matters: is anyone going to build
+For `no-discussion` — enhancements nobody ever commented on — read each one
+briefly and ask **the only question that matters: is anyone going to build
 this?** The house rule is 37signals: no standing backlog of someday-ideas,
 because what matters comes back on its own when it hurts. So default to
 closing, and lift out the few that carry real substance — a concrete defect, a
 decision already made, a contract that needs the number. Do not deep-verify
 this bucket; that is the expensive mistake. Skim, lift out the keepers, close
 the rest as a block.
+
+**Ask that same question of every `[never discussed]` entry, in whatever bucket
+it appears — not just this one.** The buckets are exclusive and `untriaged`
+outranks `no-discussion`, so an unlabeled enhancement nobody commented on shows
+up only as untriaged. Label it to satisfy the invariant below and it silently
+becomes a `no-discussion` entry — which next week's report offers up as a
+fresh default-close candidate that nobody has actually read. The first sweep
+did this to 19 issues in an afternoon, and only noticed because the counts
+moved. The flag exists so the question gets asked once, in the pass that is
+already looking.
 
 ## Step 3 — Act, by evidence class
 
@@ -109,6 +169,12 @@ because that list is short.
 
 Closing comments name the evidence: the PR that did it, or the tracking issue
 that covers it. A closure nobody can audit later is a deletion.
+
+**Comment on the keepers too, saying why.** Same reason, one level up: an issue
+kept against the 37signals default has had a decision made about it, and a
+decision with no trace gets re-litigated from scratch next sweep — or worse,
+goes the other way. The comment is also what moves it out of the comment-less
+set, so the record and the classifier agree instead of drifting.
 
 ## The one prohibition
 

--- a/scripts/lib/triage-sweep.mjs
+++ b/scripts/lib/triage-sweep.mjs
@@ -1,0 +1,293 @@
+/**
+ * Sorts every open issue into one bucket of evidence, so a triage pass reads
+ * the tracker once instead of opening 149 tabs.
+ *
+ * The split that matters is between this file and the skill that drives it:
+ * **this file collects facts, it never reaches a verdict.** It will say that
+ * #465 has a merged pull request in its timeline; it will not say that #465 is
+ * done. That distinction is not pedantry — a sweep on 2026-08-01 found 39 of
+ * the 100 oldest issues carrying a merged cross-reference, and #543 and #669
+ * were among them while being perfectly legitimate open tracking issues. The
+ * heuristic produces candidates. Deciding costs a human-or-agent read of the
+ * PR and a grep against `origin/main`, and that lives in the skill.
+ *
+ * Staleness is deliberately absent. The obvious design — close what nobody
+ * touched in 90 days — was measured against this tracker and found 16 issues
+ * out of 149. The backlog here is not abandoned, it is unresolved, and a
+ * signal that weak would spend the trust the sweep needs.
+ */
+
+import { isExternalIssue, hasMaintainerReply } from "./issue-triage.mjs";
+
+/**
+ * Buckets in priority order: an issue lands in the first one it matches.
+ *
+ * Ordering is what keeps the strongest evidence visible. An issue is very
+ * often unlabeled AND solved by a merged PR, and reporting it as merely
+ * unlabeled would bury the one fact that decides its fate.
+ */
+export const BUCKET_ORDER = [
+  "closed-by-pr",
+  "subsumed",
+  "untriaged",
+  "no-discussion",
+  "active",
+];
+
+export const BUCKET_DESCRIPTIONS = {
+  "closed-by-pr": "a merged PR references this issue — verify, then close",
+  subsumed: "an open tracking issue covers this — verify, then fold in",
+  untriaged: "nobody has categorised this yet",
+  "no-discussion": "an enhancement nobody has ever commented on",
+  active: "categorised, discussed, no merge evidence — leave alone",
+};
+
+/**
+ * Labels that record a process state rather than a human's judgement.
+ *
+ * `issue-triage.yml` stamps both onto an external report the moment it lands,
+ * before anyone has read a word of it. Counting them as "categorised" would
+ * make every incoming report look triaged by its own arrival — and the weekly
+ * pass filters on exactly this, so the bug would be invisible: a clean queue
+ * that quietly excludes the issues that most need a look.
+ */
+const PROCESS_LABELS = new Set(["triage", "external"]);
+
+/**
+ * Titles that mark an issue as an umbrella rather than a peer.
+ *
+ * Narrow on purpose. Issues cross-reference each other constantly ("related to
+ * #x"), so treating every reference as subsumption would sweep the whole
+ * tracker into one bucket and say nothing. These three words are how the
+ * umbrellas in this repo actually name themselves — #543 is
+ * "RFC/Tracking: Pinchy Skill Layer (consolidates #354/#126/#37…)".
+ */
+const TRACKING_TITLE = /\btracking\b|\brfc\b|consolidat/i;
+
+function bucketFor(issue) {
+  const categoryLabels = issue.labels.filter((l) => !PROCESS_LABELS.has(l));
+
+  if (issue.mergedPrs.length > 0) return "closed-by-pr";
+  if (issue.trackedBy.length > 0) return "subsumed";
+  if (categoryLabels.length === 0) return "untriaged";
+  if (categoryLabels.includes("enhancement") && issue.comments.length === 0) {
+    return "no-discussion";
+  }
+  return "active";
+}
+
+/**
+ * Classifies one issue into a bucket plus an orthogonal `externalWaiting` flag.
+ *
+ * The flag is not a bucket, and that is the load-bearing choice here. Making
+ * it exclusive would hide the merge evidence on precisely the issues where an
+ * outside reporter is owed an answer. `unanswered-sweep` goes red until a
+ * maintainer comments, and only a maintainer comment clears it — so the
+ * triage pass must be able to see "this is solved" and "do not comment here"
+ * at the same time. See the skill for what the flag forbids.
+ */
+export function classifyIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    url: issue.url,
+    bucket: bucketFor(issue),
+    externalWaiting: isExternalIssue(issue) && !hasMaintainerReply(issue),
+    evidence: {
+      mergedPrs: issue.mergedPrs,
+      trackedBy: issue.trackedBy,
+      labels: issue.labels,
+      comments: issue.comments.length,
+    },
+  };
+}
+
+/** Classifies every issue, strongest evidence first. */
+export function classifyIssues(issues) {
+  return issues
+    .map(classifyIssue)
+    .sort(
+      (a, b) =>
+        BUCKET_ORDER.indexOf(a.bucket) - BUCKET_ORDER.indexOf(b.bucket) ||
+        a.number - b.number,
+    );
+}
+
+/**
+ * Decodes the GraphQL payload into the flat shape above.
+ *
+ * It throws on anything it cannot read, for the same reason
+ * parseIssuesResponse does: decoding a broken payload to an empty list would
+ * report a clean tracker, and "nothing to triage" is exactly the silent green
+ * a triage tool must never produce. An expired token is the likely cause and
+ * it must stop the pass, not shorten it.
+ */
+function requireComplete(issueNumber, what, connection) {
+  const fetched = connection?.nodes?.length ?? 0;
+  const total = connection?.totalCount;
+  if (typeof total === "number" && fetched < total) {
+    throw new Error(
+      `issue #${issueNumber}: read ${fetched} of ${total} ${what} — raise the page size in SWEEP_QUERY, ` +
+        `a truncated list would classify this issue on partial evidence`,
+    );
+  }
+}
+
+export function parseSweepResponse(response) {
+  if (response?.errors?.length) {
+    throw new Error(
+      `GitHub API returned errors: ${response.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+
+  const nodes = response?.data?.repository?.issues?.nodes;
+  if (!Array.isArray(nodes)) {
+    throw new Error(
+      "unexpected GitHub API response: data.repository.issues.nodes is not an array",
+    );
+  }
+
+  // Same reasoning as parsePageInfo in issue-triage.mjs: this tracker holds
+  // more issues than one page, so a query that quietly drops the cursor would
+  // read part of the backlog and present it as all of it.
+  if (!response.data.repository.issues.pageInfo) {
+    throw new Error(
+      "unexpected GitHub API response: issues.pageInfo is missing — the query must select it",
+    );
+  }
+
+  return nodes.map((node) => {
+    // A clipped nested list is this parser's subtlest wrong answer, and it
+    // never looks like an error: 51 comments with the maintainer's reply at
+    // #51 turns an answered report into "external, unanswered", and a clipped
+    // timeline drops the merge evidence that decides the whole closed-by-pr
+    // bucket. Both are one number in SWEEP_QUERY, so failing loudly costs a
+    // one-word edit and buying silence costs a wrong triage pass.
+    requireComplete(node.number, "comments", node.comments);
+    requireComplete(node.number, "cross-references", node.timelineItems);
+
+    const sources = (node.timelineItems?.nodes ?? [])
+      .map((item) => item.source)
+      .filter(Boolean);
+
+    return {
+      number: node.number,
+      title: node.title,
+      url: node.url,
+      createdAt: node.createdAt,
+      authorLogin: node.author?.login ?? null,
+      authorAssociation: node.authorAssociation,
+      labels: (node.labels?.nodes ?? []).map((label) => label.name),
+      comments: (node.comments?.nodes ?? []).map((comment) => ({
+        authorLogin: comment.author?.login ?? null,
+        authorAssociation: comment.authorAssociation,
+      })),
+      // `merged` rather than "there was a PR": a pull request closed without
+      // merging is evidence of nothing, and counting it would recommend
+      // closing an issue whose fix was abandoned.
+      mergedPrs: sources
+        .filter((s) => s.__typename === "PullRequest" && s.merged === true)
+        .map((s) => s.number),
+      trackedBy: sources
+        .filter(
+          (s) =>
+            s.__typename === "Issue" &&
+            s.state === "OPEN" &&
+            TRACKING_TITLE.test(s.title ?? ""),
+        )
+        .map((s) => s.number),
+    };
+  });
+}
+
+/**
+ * The GraphQL query the sweep runs.
+ *
+ * Exported because every other test in this file runs against a fixture, so
+ * all of them stay green if this query stops selecting a field the parser
+ * reads — and the resulting empty bucket looks exactly like a clean tracker.
+ * `the query selects every field the parser reads` is what makes that edit
+ * fail instead of pass.
+ */
+export const SWEEP_QUERY = `
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(states: OPEN, first: 50, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number title url createdAt authorAssociation
+        author { login }
+        labels(first: 20) { nodes { name } }
+        comments(first: 100) { totalCount nodes { authorAssociation author { login } } }
+        timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
+          totalCount
+          nodes {
+            ... on CrossReferencedEvent {
+              source {
+                __typename
+                ... on PullRequest { number merged }
+                ... on Issue { number title state }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+function line(entry) {
+  const facts = [];
+  if (entry.evidence.mergedPrs.length) {
+    facts.push(
+      `merged: ${entry.evidence.mergedPrs.map((n) => `#${n}`).join(", ")}`,
+    );
+  }
+  if (entry.evidence.trackedBy.length) {
+    facts.push(
+      `tracked by ${entry.evidence.trackedBy.map((n) => `#${n}`).join(", ")}`,
+    );
+  }
+  const flag = entry.externalWaiting ? " ⚠ external, unanswered" : "";
+  const detail = facts.length ? ` — ${facts.join("; ")}` : "";
+  return `- #${entry.number} ${entry.title}${detail}${flag}`;
+}
+
+/**
+ * Renders the sweep as markdown for the skill to read.
+ *
+ * Protected issues get their own section at the top rather than only an inline
+ * marker: the rule they carry is a prohibition, and a prohibition buried on
+ * line 90 of a 149-line report is one nobody applies.
+ */
+export function formatSweepReport(entries) {
+  const out = [`# Triage sweep — ${entries.length} open issues`, ""];
+
+  const protectedEntries = entries.filter((e) => e.externalWaiting);
+  if (protectedEntries.length) {
+    out.push(
+      `## ⚠ Protected: ${protectedEntries.length} external report(s) awaiting a maintainer reply`,
+      "",
+      "Do NOT comment on these. Only a maintainer comment clears the",
+      "`unanswered-sweep` alarm, so an automated reply would silence it without",
+      "anyone having answered. Closing with a reason is the honest alternative,",
+      "and needs explicit approval.",
+      "",
+      ...protectedEntries.map(line),
+      "",
+    );
+  }
+
+  for (const bucket of BUCKET_ORDER) {
+    const inBucket = entries.filter((e) => e.bucket === bucket);
+    if (!inBucket.length) continue;
+    out.push(
+      `## ${bucket} (${inBucket.length}) — ${BUCKET_DESCRIPTIONS[bucket]}`,
+      "",
+      ...inBucket.map(line),
+      "",
+    );
+  }
+
+  return out.join("\n");
+}

--- a/scripts/lib/triage-sweep.mjs
+++ b/scripts/lib/triage-sweep.mjs
@@ -327,13 +327,55 @@ function line(entry) {
 }
 
 /**
+ * Renders the open pull requests as a roster the reader checks by eye.
+ *
+ * This exists because the `in-flight` bucket has a hole it cannot close from
+ * the issue side. PR #163 implements #128 and names no issue number anywhere,
+ * so GitHub records no cross-referenced event and #128's timeline is genuinely
+ * empty — the first sweep closed it as "nobody is going to build this" while
+ * the implementation sat in review. Nothing read off the issue finds that.
+ * Recognising "OpenAI ChatGPT subscription (Device Code Flow)" as "Provider
+ * OAuth auth (OpenAI first)" does, and only a reader does that.
+ *
+ * A title-similarity heuristic was the obvious alternative and is deliberately
+ * not here: it would have to fire on a pair sharing one word ("OAuth") to
+ * catch this, which buries the roster in noise. Fourteen titles read once,
+ * against a close-list, is cheaper and does not pretend to be a rule.
+ */
+function rosterSection(openPrs) {
+  if (!openPrs) {
+    // Never silently omit it. An absent roster and an empty one look identical
+    // in the output, and "no open PRs" is exactly the wrong thing to conclude
+    // right before block-closing 32 issues.
+    return [
+      "## Open PRs — roster not fetched",
+      "",
+      "Could not read the open pull requests. **Do not block-close anything**",
+      "until you have run `gh pr list --state open` and checked your close list",
+      "against it by topic — see the skill.",
+      "",
+    ];
+  }
+
+  return [
+    `## Open PRs (${openPrs.length}) — check every close candidate against this`,
+    "",
+    "An open PR need not mention its issue, and when it does not, no bucket",
+    "here can see it. Read these titles against anything you plan to close.",
+    "",
+    ...openPrs.map((pr) => `- #${pr.number} ${oneLine(pr.title)}`),
+    "",
+  ];
+}
+
+/**
  * Renders the sweep as markdown for the skill to read.
  *
  * Protected issues get their own section at the top rather than only an inline
  * marker: the rule they carry is a prohibition, and a prohibition buried on
  * line 90 of a 149-line report is one nobody applies.
  */
-export function formatSweepReport(entries) {
+export function formatSweepReport(entries, { openPrs } = {}) {
   const out = [`# Triage sweep — ${entries.length} open issues`, ""];
 
   const protectedEntries = entries.filter((e) => e.externalWaiting);
@@ -350,6 +392,8 @@ export function formatSweepReport(entries) {
       "",
     );
   }
+
+  out.push(...rosterSection(openPrs));
 
   for (const bucket of BUCKET_ORDER) {
     const inBucket = entries.filter((e) => e.bucket === bucket);

--- a/scripts/lib/triage-sweep.mjs
+++ b/scripts/lib/triage-sweep.mjs
@@ -1,19 +1,19 @@
 /**
  * Sorts every open issue into one bucket of evidence, so a triage pass reads
- * the tracker once instead of opening 149 tabs.
+ * the tracker once instead of opening 148 tabs.
  *
  * The split that matters is between this file and the skill that drives it:
  * **this file collects facts, it never reaches a verdict.** It will say that
  * #465 has a merged pull request in its timeline; it will not say that #465 is
- * done. That distinction is not pedantry — a sweep on 2026-08-01 found 39 of
- * the 100 oldest issues carrying a merged cross-reference, and #543 and #669
- * were among them while being perfectly legitimate open tracking issues. The
+ * done. That distinction is not pedantry — a sweep on 2026-08-01 found 54 of
+ * 148 open issues carrying a merged cross-reference, and #543 and #669 were
+ * among them while being perfectly legitimate open tracking issues. The
  * heuristic produces candidates. Deciding costs a human-or-agent read of the
  * PR and a grep against `origin/main`, and that lives in the skill.
  *
  * Staleness is deliberately absent. The obvious design — close what nobody
  * touched in 90 days — was measured against this tracker and found 16 issues
- * out of 149. The backlog here is not abandoned, it is unresolved, and a
+ * out of 148. The backlog here is not abandoned, it is unresolved, and a
  * signal that weak would spend the trust the sweep needs.
  */
 
@@ -125,7 +125,21 @@ export function classifyIssues(issues) {
 function requireComplete(issueNumber, what, connection) {
   const fetched = connection?.nodes?.length ?? 0;
   const total = connection?.totalCount;
-  if (typeof total === "number" && fetched < total) {
+
+  // The guard's own silent-green path, and the reason this is a hard
+  // requirement rather than a `typeof total === "number" &&` guard: without
+  // the count, `fetched < undefined` is false for every issue, so a query that
+  // stopped selecting `totalCount` for one connection would switch that list's
+  // truncation check off and change nothing visible. Requiring it fails on the
+  // first real sweep, one line into the output.
+  if (typeof total !== "number") {
+    throw new Error(
+      `issue #${issueNumber}: the query must select totalCount for ${what} — ` +
+        `without it a truncated list is indistinguishable from a complete one`,
+    );
+  }
+
+  if (fetched < total) {
     throw new Error(
       `issue #${issueNumber}: read ${fetched} of ${total} ${what} — raise the page size in SWEEP_QUERY, ` +
         `a truncated list would classify this issue on partial evidence`,
@@ -159,10 +173,13 @@ export function parseSweepResponse(response) {
   return nodes.map((node) => {
     // A clipped nested list is this parser's subtlest wrong answer, and it
     // never looks like an error: 51 comments with the maintainer's reply at
-    // #51 turns an answered report into "external, unanswered", and a clipped
+    // #51 turns an answered report into "external, unanswered", a clipped
     // timeline drops the merge evidence that decides the whole closed-by-pr
-    // bucket. Both are one number in SWEEP_QUERY, so failing loudly costs a
-    // one-word edit and buying silence costs a wrong triage pass.
+    // bucket, and a clipped label list drops the `enhancement` that separates
+    // an untriaged issue from a triaged one. All three are one number in
+    // SWEEP_QUERY, so failing loudly costs a one-word edit and buying silence
+    // costs a wrong triage pass.
+    requireComplete(node.number, "labels", node.labels);
     requireComplete(node.number, "comments", node.comments);
     requireComplete(node.number, "cross-references", node.timelineItems);
 
@@ -217,7 +234,7 @@ query($owner: String!, $name: String!, $cursor: String) {
       nodes {
         number title url createdAt authorAssociation
         author { login }
-        labels(first: 20) { nodes { name } }
+        labels(first: 20) { totalCount nodes { name } }
         comments(first: 100) { totalCount nodes { authorAssociation author { login } } }
         timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
           totalCount
@@ -236,6 +253,20 @@ query($owner: String!, $name: String!, $cursor: String) {
   }
 }`;
 
+/**
+ * Flattens a title onto one line.
+ *
+ * Titles are text somebody outside the team wrote, and this report is read by
+ * an agent that then closes issues on its say-so. A newline would forge report
+ * structure — an extra list item, or a whole fake bucket heading — so the
+ * title has to stay inside the line it was given. `escapeCell` in
+ * issue-triage.mjs guards the same data for the same reason; it escapes `|`
+ * because it builds a table, which a list item does not need.
+ */
+function oneLine(text) {
+  return String(text).replace(/\s+/g, " ").trim();
+}
+
 function line(entry) {
   const facts = [];
   if (entry.evidence.mergedPrs.length) {
@@ -250,7 +281,7 @@ function line(entry) {
   }
   const flag = entry.externalWaiting ? " ⚠ external, unanswered" : "";
   const detail = facts.length ? ` — ${facts.join("; ")}` : "";
-  return `- #${entry.number} ${entry.title}${detail}${flag}`;
+  return `- #${entry.number} ${oneLine(entry.title)}${detail}${flag}`;
 }
 
 /**

--- a/scripts/lib/triage-sweep.mjs
+++ b/scripts/lib/triage-sweep.mjs
@@ -27,6 +27,7 @@ import { isExternalIssue, hasMaintainerReply } from "./issue-triage.mjs";
  * unlabeled would bury the one fact that decides its fate.
  */
 export const BUCKET_ORDER = [
+  "in-flight",
   "closed-by-pr",
   "subsumed",
   "untriaged",
@@ -35,6 +36,7 @@ export const BUCKET_ORDER = [
 ];
 
 export const BUCKET_DESCRIPTIONS = {
+  "in-flight": "an OPEN PR is against this issue — somebody is building it now",
   "closed-by-pr": "a merged PR references this issue — verify, then close",
   subsumed: "an open tracking issue covers this — verify, then fold in",
   untriaged: "nobody has categorised this yet",
@@ -67,6 +69,13 @@ const TRACKING_TITLE = /\btracking\b|\brfc\b|consolidat/i;
 function bucketFor(issue) {
   const categoryLabels = issue.labels.filter((l) => !PROCESS_LABELS.has(l));
 
+  // Ranked above merge evidence, and that ordering was paid for. The first
+  // full sweep closed #128, #333 and #829 under the no-standing-backlog rule
+  // while an open PR sat against each one — invisible, because the sweep read
+  // merged pull requests only. An open PR is the strongest possible answer to
+  // "is anyone going to build this", and an issue that has BOTH a merged and
+  // an open PR is a live follow-up, not a completed one.
+  if (issue.openPrs.length > 0) return "in-flight";
   if (issue.mergedPrs.length > 0) return "closed-by-pr";
   if (issue.trackedBy.length > 0) return "subsumed";
   if (categoryLabels.length === 0) return "untriaged";
@@ -106,6 +115,7 @@ export function classifyIssue(issue) {
     externalWaiting: isExternalIssue(issue) && !hasMaintainerReply(issue),
     neverDiscussed: issue.comments.length === 0,
     evidence: {
+      openPrs: issue.openPrs,
       mergedPrs: issue.mergedPrs,
       trackedBy: issue.trackedBy,
       labels: issue.labels,
@@ -211,6 +221,13 @@ export function parseSweepResponse(response) {
         authorLogin: comment.author?.login ?? null,
         authorAssociation: comment.authorAssociation,
       })),
+      // Work in flight. `state === "OPEN"` rather than `!merged`: a pull
+      // request CLOSED without merging is abandoned, and reading it as
+      // in-flight would keep an issue alive on the strength of work somebody
+      // already gave up on — the mirror of the merged-vs-closed mistake below.
+      openPrs: sources
+        .filter((s) => s.__typename === "PullRequest" && s.state === "OPEN")
+        .map((s) => s.number),
       // `merged` rather than "there was a PR": a pull request closed without
       // merging is evidence of nothing, and counting it would recommend
       // closing an issue whose fix was abandoned.
@@ -254,7 +271,7 @@ query($owner: String!, $name: String!, $cursor: String) {
             ... on CrossReferencedEvent {
               source {
                 __typename
-                ... on PullRequest { number merged }
+                ... on PullRequest { number merged state }
                 ... on Issue { number title state }
               }
             }
@@ -281,6 +298,11 @@ function oneLine(text) {
 
 function line(entry) {
   const facts = [];
+  if (entry.evidence.openPrs.length) {
+    facts.push(
+      `open PR ${entry.evidence.openPrs.map((n) => `#${n}`).join(", ")}`,
+    );
+  }
   if (entry.evidence.mergedPrs.length) {
     facts.push(
       `merged: ${entry.evidence.mergedPrs.map((n) => `#${n}`).join(", ")}`,

--- a/scripts/lib/triage-sweep.mjs
+++ b/scripts/lib/triage-sweep.mjs
@@ -77,14 +77,25 @@ function bucketFor(issue) {
 }
 
 /**
- * Classifies one issue into a bucket plus an orthogonal `externalWaiting` flag.
+ * Classifies one issue into a bucket plus two orthogonal flags.
  *
- * The flag is not a bucket, and that is the load-bearing choice here. Making
- * it exclusive would hide the merge evidence on precisely the issues where an
- * outside reporter is owed an answer. `unanswered-sweep` goes red until a
- * maintainer comments, and only a maintainer comment clears it — so the
- * triage pass must be able to see "this is solved" and "do not comment here"
- * at the same time. See the skill for what the flag forbids.
+ * Neither is a bucket, and that is the load-bearing choice here.
+ *
+ * `externalWaiting`: making it exclusive would hide the merge evidence on
+ * precisely the issues where an outside reporter is owed an answer.
+ * `unanswered-sweep` goes red until a maintainer comments, and only a
+ * maintainer comment clears it — so the triage pass must be able to see "this
+ * is solved" and "do not comment here" at the same time.
+ *
+ * `neverDiscussed`: the buckets are exclusive, and `untriaged` outranks
+ * `no-discussion`, so an unlabeled enhancement nobody ever commented on is
+ * only ever reported as untriaged. Labelling it — which is exactly what a pass
+ * does to satisfy the invariant — moves it into `no-discussion`, where the
+ * next report offers it up as a fresh default-close candidate. The first full
+ * sweep did that to 19 issues in one afternoon. The flag makes the fact
+ * visible in the bucket where it can still be acted on.
+ *
+ * See the skill for what these two mean for the pass.
  */
 export function classifyIssue(issue) {
   return {
@@ -93,6 +104,7 @@ export function classifyIssue(issue) {
     url: issue.url,
     bucket: bucketFor(issue),
     externalWaiting: isExternalIssue(issue) && !hasMaintainerReply(issue),
+    neverDiscussed: issue.comments.length === 0,
     evidence: {
       mergedPrs: issue.mergedPrs,
       trackedBy: issue.trackedBy,
@@ -279,8 +291,16 @@ function line(entry) {
       `tracked by ${entry.evidence.trackedBy.map((n) => `#${n}`).join(", ")}`,
     );
   }
-  const flag = entry.externalWaiting ? " ⚠ external, unanswered" : "";
+  const flags = [];
+  if (entry.externalWaiting) flags.push("⚠ external, unanswered");
+  // Only worth printing where the bucket does not already say it: the whole
+  // no-discussion bucket is comment-less by definition, and repeating it on
+  // every line there would train the reader to skip the marker.
+  if (entry.neverDiscussed && entry.bucket !== "no-discussion") {
+    flags.push("never discussed");
+  }
   const detail = facts.length ? ` — ${facts.join("; ")}` : "";
+  const flag = flags.length ? ` [${flags.join("; ")}]` : "";
   return `- #${entry.number} ${oneLine(entry.title)}${detail}${flag}`;
 }
 

--- a/scripts/lib/triage-sweep.test.mjs
+++ b/scripts/lib/triage-sweep.test.mjs
@@ -119,6 +119,36 @@ test("an outside report a maintainer already answered is not waiting", () => {
   assert.equal(entry.externalWaiting, false);
 });
 
+// Found by running the first full sweep, not by reading the code — the same way
+// the process-label bug was found.
+//
+// `untriaged` outranks `no-discussion`, so an unlabeled enhancement nobody ever
+// commented on shows up in exactly one bucket: untriaged. Labelling it — which
+// is what the pass does to satisfy the invariant — silently moves it into
+// no-discussion, where the NEXT report presents it as a fresh default-close
+// candidate. The 2026-08-01 sweep did this to 19 issues in one afternoon.
+//
+// Same remedy as externalWaiting: an orthogonal flag, so the bucket keeps the
+// strongest signal while the fact stays visible on the issues it applies to.
+test("a comment-less issue is flagged whatever bucket it lands in", () => {
+  const untriaged = classifyIssue(issue({ labels: [], comments: [] }));
+
+  assert.equal(untriaged.bucket, "untriaged");
+  assert.equal(untriaged.neverDiscussed, true);
+
+  const discussed = classifyIssue(issue({ labels: [] }));
+  assert.equal(discussed.bucket, "untriaged");
+  assert.equal(discussed.neverDiscussed, false);
+});
+
+test("the report marks comment-less issues so a pass can ask about them", () => {
+  const report = formatSweepReport(
+    classifyIssues([issue({ number: 61, labels: [], comments: [] })]),
+  );
+
+  assert.match(report, /#61.*never discussed/i);
+});
+
 test("classifyIssues returns entries ordered by bucket priority", () => {
   const entries = classifyIssues([
     issue({ number: 3, labels: ["bug"] }),

--- a/scripts/lib/triage-sweep.test.mjs
+++ b/scripts/lib/triage-sweep.test.mjs
@@ -1,0 +1,326 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BUCKET_ORDER,
+  SWEEP_QUERY,
+  classifyIssue,
+  classifyIssues,
+  parseSweepResponse,
+  formatSweepReport,
+} from "./triage-sweep.mjs";
+
+function issue(overrides = {}) {
+  return {
+    number: 1,
+    title: "Something",
+    url: "https://github.com/heypinchy/pinchy/issues/1",
+    createdAt: "2026-01-01T00:00:00Z",
+    authorLogin: "clemenshelm",
+    authorAssociation: "OWNER",
+    labels: ["enhancement"],
+    comments: [{ authorLogin: "clemenshelm", authorAssociation: "OWNER" }],
+    mergedPrs: [],
+    trackedBy: [],
+    ...overrides,
+  };
+}
+
+test("an issue with a merged cross-referenced PR is a closed-by-pr candidate", () => {
+  const entry = classifyIssue(issue({ mergedPrs: [872, 979] }));
+
+  assert.equal(entry.bucket, "closed-by-pr");
+  assert.deepEqual(entry.evidence.mergedPrs, [872, 979]);
+});
+
+test("an issue referenced by an open tracking issue is subsumed", () => {
+  const entry = classifyIssue(issue({ trackedBy: [543] }));
+
+  assert.equal(entry.bucket, "subsumed");
+  assert.deepEqual(entry.evidence.trackedBy, [543]);
+});
+
+test("an issue carrying no labels at all is untriaged", () => {
+  const entry = classifyIssue(issue({ labels: [] }));
+
+  assert.equal(entry.bucket, "untriaged");
+});
+
+// The weekly pass filters on "nobody has looked at this yet". `triage` and
+// `external` are set by the issue-triage workflow the moment a report lands,
+// so treating them as evidence of a look would hide every incoming report
+// behind a label the reporter's own arrival created.
+test("process labels are not evidence that anyone looked", () => {
+  const entry = classifyIssue(issue({ labels: ["triage", "external"] }));
+
+  assert.equal(entry.bucket, "untriaged");
+});
+
+test("any category label means the issue was triaged", () => {
+  for (const label of ["bug", "enhancement", "priority:P1", "wontfix"]) {
+    const entry = classifyIssue(
+      issue({
+        labels: [label, "triage"],
+        comments: [{ authorLogin: "x", authorAssociation: "OWNER" }],
+      }),
+    );
+    assert.notEqual(entry.bucket, "untriaged", `${label} should count`);
+  }
+});
+
+test("an enhancement nobody ever commented on is no-discussion", () => {
+  const entry = classifyIssue(issue({ labels: ["enhancement"], comments: [] }));
+
+  assert.equal(entry.bucket, "no-discussion");
+});
+
+test("a labelled, discussed issue with no merge evidence is active", () => {
+  assert.equal(classifyIssue(issue({ labels: ["bug"] })).bucket, "active");
+});
+
+// The whole point of the sweep is that the strongest evidence wins. An issue
+// can easily be unlabeled AND solved by a merged PR — reporting it as merely
+// unlabeled would bury the one fact that decides its fate.
+test("merge evidence outranks every weaker signal", () => {
+  const entry = classifyIssue(
+    issue({ labels: [], comments: [], mergedPrs: [42], trackedBy: [543] }),
+  );
+
+  assert.equal(entry.bucket, "closed-by-pr");
+});
+
+// external-waiting is a flag, not a bucket, and that is deliberate. Making it
+// exclusive would hide the merge evidence on exactly the issues where an
+// outside reporter is owed an answer — the ones we most need to get right.
+test("an unanswered outside report is flagged without losing its bucket", () => {
+  const entry = classifyIssue(
+    issue({
+      authorLogin: "stranger",
+      authorAssociation: "NONE",
+      comments: [],
+      labels: ["bug"],
+      mergedPrs: [900],
+    }),
+  );
+
+  assert.equal(entry.externalWaiting, true);
+  assert.equal(entry.bucket, "closed-by-pr");
+});
+
+test("an outside report a maintainer already answered is not waiting", () => {
+  const entry = classifyIssue(
+    issue({
+      authorLogin: "stranger",
+      authorAssociation: "NONE",
+      comments: [{ authorLogin: "clemenshelm", authorAssociation: "OWNER" }],
+    }),
+  );
+
+  assert.equal(entry.externalWaiting, false);
+});
+
+test("classifyIssues returns entries ordered by bucket priority", () => {
+  const entries = classifyIssues([
+    issue({ number: 3, labels: ["bug"] }),
+    issue({ number: 1, mergedPrs: [10] }),
+    issue({ number: 2, labels: [] }),
+  ]);
+
+  const buckets = entries.map((e) => e.bucket);
+  const positions = buckets.map((b) => BUCKET_ORDER.indexOf(b));
+  assert.deepEqual(
+    positions,
+    [...positions].sort((a, b) => a - b),
+  );
+  assert.equal(entries[0].number, 1);
+});
+
+test("parseSweepResponse flattens the GraphQL payload", () => {
+  const issues = parseSweepResponse({
+    data: {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              number: 7,
+              title: "Wire it up",
+              url: "https://example.invalid/7",
+              createdAt: "2026-01-01T00:00:00Z",
+              author: { login: "stranger" },
+              authorAssociation: "NONE",
+              labels: { nodes: [{ name: "bug" }] },
+              comments: {
+                nodes: [
+                  { author: { login: "bot[bot]" }, authorAssociation: "NONE" },
+                ],
+              },
+              timelineItems: {
+                nodes: [
+                  {
+                    source: {
+                      __typename: "PullRequest",
+                      number: 8,
+                      merged: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  assert.equal(issues.length, 1);
+  assert.deepEqual(issues[0].labels, ["bug"]);
+  assert.deepEqual(issues[0].mergedPrs, [8]);
+  assert.equal(issues[0].authorLogin, "stranger");
+  assert.equal(issues[0].comments.length, 1);
+});
+
+// The dangerous decode error. A PR that was closed without ever merging is
+// evidence of nothing, and counting it would recommend closing an issue whose
+// fix was abandoned.
+test("only merged pull requests count as merge evidence", () => {
+  const issues = parseSweepResponse(
+    responseWithTimeline([
+      { __typename: "PullRequest", number: 8, merged: false },
+      { __typename: "PullRequest", number: 9, merged: true },
+    ]),
+  );
+
+  assert.deepEqual(issues[0].mergedPrs, [9]);
+});
+
+test("only OPEN tracking issues subsume another issue", () => {
+  const issues = parseSweepResponse(
+    responseWithTimeline([
+      {
+        __typename: "Issue",
+        number: 543,
+        title: "Tracking: Skill Layer",
+        state: "OPEN",
+      },
+      {
+        __typename: "Issue",
+        number: 100,
+        title: "Tracking: done long ago",
+        state: "CLOSED",
+      },
+      {
+        __typename: "Issue",
+        number: 200,
+        title: "Some ordinary issue",
+        state: "OPEN",
+      },
+    ]),
+  );
+
+  assert.deepEqual(issues[0].trackedBy, [543]);
+});
+
+// Same discipline as parseIssuesResponse: a decode failure must be loud.
+// Returning [] here would report an empty tracker, which reads as "nothing to
+// triage" — the silent green this sweep exists to prevent.
+test("parseSweepResponse throws on a payload it cannot read", () => {
+  assert.throws(
+    () => parseSweepResponse({ data: { repository: {} } }),
+    /nodes/,
+  );
+  assert.throws(
+    () => parseSweepResponse({ errors: [{ message: "Bad credentials" }] }),
+    /Bad credentials/,
+  );
+});
+
+test("parseSweepResponse throws when the query drops pageInfo", () => {
+  const response = responseWithTimeline([]);
+  delete response.data.repository.issues.pageInfo;
+
+  assert.throws(() => parseSweepResponse(response), /pageInfo/);
+});
+
+test("the report names the protected issues explicitly", () => {
+  const report = formatSweepReport(
+    classifyIssues([
+      issue({
+        number: 42,
+        authorLogin: "stranger",
+        authorAssociation: "NONE",
+        comments: [],
+        labels: ["bug"],
+      }),
+    ]),
+  );
+
+  assert.match(report, /#42/);
+  assert.match(report, /external/i);
+});
+
+// Every test above runs against a fixture, so all of them stay green if the
+// real query stops selecting a field the parser reads. That is not a
+// hypothetical: drop `merged` and mergedPrs is empty for every issue, the
+// closed-by-pr bucket reads as zero, and an empty bucket looks exactly like a
+// clean tracker. These two tests are the only thing standing between a
+// one-word edit and a sweep that silently finds nothing.
+test("the query selects every field the parser reads", () => {
+  for (const field of [
+    "merged", // → mergedPrs, the whole closed-by-pr bucket
+    "state", // → trackedBy, open-tracking-issue check
+    "__typename", // → tells a PR source from an Issue source
+    "authorAssociation", // → externalWaiting
+    "pageInfo", // → pagination; without it the sweep reads one page
+    "totalCount", // → the truncation check below
+  ]) {
+    assert.match(
+      SWEEP_QUERY,
+      new RegExp(`\\b${field}\\b`),
+      `SWEEP_QUERY must select ${field}`,
+    );
+  }
+});
+
+// A page-size cap is a silent lie of the same family: 51 comments and the
+// maintainer reply sitting at #51 makes an answered report look unanswered,
+// while a clipped timeline hides merge evidence. Loud beats subtly wrong —
+// the fix is one number in the query, and the message says so.
+test("parseSweepResponse throws when a nested list was truncated", () => {
+  const clipped = responseWithTimeline([]);
+  clipped.data.repository.issues.nodes[0].comments.totalCount = 80;
+
+  assert.throws(() => parseSweepResponse(clipped), /#7.*80 comments/s);
+
+  const clippedTimeline = responseWithTimeline([]);
+  clippedTimeline.data.repository.issues.nodes[0].timelineItems.totalCount = 60;
+
+  assert.throws(() => parseSweepResponse(clippedTimeline), /#7.*cross-ref/s);
+});
+
+function responseWithTimeline(timelineNodes) {
+  return {
+    data: {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              number: 7,
+              title: "Wire it up",
+              url: "https://example.invalid/7",
+              createdAt: "2026-01-01T00:00:00Z",
+              author: { login: "clemenshelm" },
+              authorAssociation: "OWNER",
+              labels: { nodes: [] },
+              comments: { nodes: [], totalCount: 0 },
+              timelineItems: {
+                nodes: timelineNodes.map((source) => ({ source })),
+                totalCount: timelineNodes.length,
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}

--- a/scripts/lib/triage-sweep.test.mjs
+++ b/scripts/lib/triage-sweep.test.mjs
@@ -134,6 +134,33 @@ test("the report names the open PR that keeps an issue alive", () => {
   assert.match(report, /#77.*open PR #959/);
 });
 
+// The half the in-flight bucket structurally cannot cover. PR #163 implements
+// #128 and mentions no issue number at all, so GitHub records no
+// cross-referenced event and the issue's timeline is genuinely empty. Nothing
+// read off that issue can find it; only recognising "OpenAI OAuth Device Code
+// Flow" as "Provider OAuth auth (OpenAI first)" does — a semantic match no
+// query makes. So the report carries the open-PR roster and the reader makes
+// it, in the one place where they are already deciding what to close.
+test("the report carries the open-PR roster for the matches no query makes", () => {
+  const report = formatSweepReport(classifyIssues([issue({ number: 5 })]), {
+    openPrs: [
+      { number: 163, title: "feat(oauth): OpenAI ChatGPT subscription" },
+      { number: 959, title: "docs: codify the NFC rule" },
+    ],
+  });
+
+  assert.match(report, /#163 feat\(oauth\): OpenAI ChatGPT subscription/);
+  assert.match(report, /#959 docs: codify the NFC rule/);
+});
+
+// A missing roster must not read as "no open PRs" — that is the same silent
+// green as an empty bucket looking like a clean tracker.
+test("an unavailable roster says so rather than showing nothing", () => {
+  const report = formatSweepReport(classifyIssues([issue({ number: 5 })]));
+
+  assert.match(report, /roster (was )?not (fetched|available)/i);
+});
+
 // external-waiting is a flag, not a bucket, and that is deliberate. Making it
 // exclusive would hide the merge evidence on exactly the issues where an
 // outside reporter is owed an answer — the ones we most need to get right.

--- a/scripts/lib/triage-sweep.test.mjs
+++ b/scripts/lib/triage-sweep.test.mjs
@@ -20,6 +20,7 @@ function issue(overrides = {}) {
     authorAssociation: "OWNER",
     labels: ["enhancement"],
     comments: [{ authorLogin: "clemenshelm", authorAssociation: "OWNER" }],
+    openPrs: [],
     mergedPrs: [],
     trackedBy: [],
     ...overrides,
@@ -87,6 +88,50 @@ test("merge evidence outranks every weaker signal", () => {
   );
 
   assert.equal(entry.bucket, "closed-by-pr");
+});
+
+// The sweep's worst wrong answer, found by making it: the first full pass
+// closed #128, #333 and #829 as "nobody is going to build this" while an open
+// PR sat against each one. It read merged PRs only, so work in flight was
+// invisible — and an open PR has already answered the question the 37signals
+// rule asks. This outranks even merge evidence: a merged PR plus an open one
+// means the follow-up is live, which is the opposite of a closable issue.
+test("an open pull request outranks every other signal", () => {
+  const entry = classifyIssue(
+    issue({
+      labels: [],
+      comments: [],
+      openPrs: [399],
+      mergedPrs: [42],
+      trackedBy: [543],
+    }),
+  );
+
+  assert.equal(entry.bucket, "in-flight");
+  assert.deepEqual(entry.evidence.openPrs, [399]);
+});
+
+test("parseSweepResponse tells an open pull request from a merged one", () => {
+  const issues = parseSweepResponse(
+    responseWithTimeline([
+      { __typename: "PullRequest", number: 8, merged: false, state: "OPEN" },
+      { __typename: "PullRequest", number: 9, merged: true, state: "MERGED" },
+      { __typename: "PullRequest", number: 10, merged: false, state: "CLOSED" },
+    ]),
+  );
+
+  // A PR closed without merging is evidence of nothing, and must not be
+  // mistaken for work in flight any more than for a completed fix.
+  assert.deepEqual(issues[0].openPrs, [8]);
+  assert.deepEqual(issues[0].mergedPrs, [9]);
+});
+
+test("the report names the open PR that keeps an issue alive", () => {
+  const report = formatSweepReport(
+    classifyIssues([issue({ number: 77, openPrs: [959] })]),
+  );
+
+  assert.match(report, /#77.*open PR #959/);
 });
 
 // external-waiting is a flag, not a bucket, and that is deliberate. Making it

--- a/scripts/lib/triage-sweep.test.mjs
+++ b/scripts/lib/triage-sweep.test.mjs
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   BUCKET_ORDER,
+  BUCKET_DESCRIPTIONS,
   SWEEP_QUERY,
   classifyIssue,
   classifyIssues,
@@ -148,13 +149,15 @@ test("parseSweepResponse flattens the GraphQL payload", () => {
               createdAt: "2026-01-01T00:00:00Z",
               author: { login: "stranger" },
               authorAssociation: "NONE",
-              labels: { nodes: [{ name: "bug" }] },
+              labels: { totalCount: 1, nodes: [{ name: "bug" }] },
               comments: {
+                totalCount: 1,
                 nodes: [
                   { author: { login: "bot[bot]" }, authorAssociation: "NONE" },
                 ],
               },
               timelineItems: {
+                totalCount: 1,
                 nodes: [
                   {
                     source: {
@@ -297,6 +300,55 @@ test("parseSweepResponse throws when a nested list was truncated", () => {
   assert.throws(() => parseSweepResponse(clippedTimeline), /#7.*cross-ref/s);
 });
 
+// Labels decide the bucket directly — drop `enhancement` and the issue reads
+// as untriaged — so the truncation guard has to cover them too, not just the
+// two lists it was originally written for.
+test("parseSweepResponse throws when the label list was truncated", () => {
+  const clipped = responseWithTimeline([]);
+  clipped.data.repository.issues.nodes[0].labels.totalCount = 25;
+
+  assert.throws(() => parseSweepResponse(clipped), /#7.*25 labels/s);
+});
+
+// The truncation guard's own silent-green path: `totalCount` absent means
+// `fetched < total` compares against undefined, which is false for every
+// issue. Dropping the field from one connection in the query would disable
+// that list's guard alone, while the whole-query field check below still
+// matches the two `totalCount`s that remain.
+test("parseSweepResponse throws when the query drops totalCount", () => {
+  const response = responseWithTimeline([]);
+  delete response.data.repository.issues.nodes[0].comments.totalCount;
+
+  assert.throws(
+    () => parseSweepResponse(response),
+    /#7.*totalCount.*comments/s,
+  );
+});
+
+// Issue titles are text somebody outside the team wrote, and this report is
+// read by an agent that then closes issues on its say-so. A newline in a title
+// would forge report structure — an extra list item, or a whole fake bucket
+// heading. Same reasoning as escapeCell in issue-triage.mjs, minus the pipe
+// escaping: a list item does not need `|` escaped, it needs to stay one line.
+test("a title cannot break out of its report line", () => {
+  const report = formatSweepReport(
+    classifyIssues([issue({ number: 5, title: "Real\n- #999 forged entry" })]),
+  );
+
+  const entries = report.split("\n").filter((l) => l.startsWith("- #"));
+  assert.equal(entries.length, 1);
+  assert.match(entries[0], /#5 Real - #999 forged entry/);
+});
+
+// BUCKET_ORDER drives the sort, BUCKET_DESCRIPTIONS the heading. They drift in
+// silence: a bucket added to one alone prints `## newbucket (3) — undefined`.
+test("every bucket has a description and every description a bucket", () => {
+  assert.deepEqual(
+    [...BUCKET_ORDER].sort(),
+    Object.keys(BUCKET_DESCRIPTIONS).sort(),
+  );
+});
+
 function responseWithTimeline(timelineNodes) {
   return {
     data: {
@@ -311,7 +363,7 @@ function responseWithTimeline(timelineNodes) {
               createdAt: "2026-01-01T00:00:00Z",
               author: { login: "clemenshelm" },
               authorAssociation: "OWNER",
-              labels: { nodes: [] },
+              labels: { nodes: [], totalCount: 0 },
               comments: { nodes: [], totalCount: 0 },
               timelineItems: {
                 nodes: timelineNodes.map((source) => ({ source })),

--- a/scripts/triage-sweep.mjs
+++ b/scripts/triage-sweep.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Reads every open issue and prints the triage sweep as markdown.
+ *
+ * Thin on purpose: paginate, decode, print. Every rule lives in
+ * scripts/lib/triage-sweep.mjs where `pnpm test:scripts` can reach it.
+ *
+ * Usage:  node scripts/triage-sweep.mjs [--limit N]
+ *
+ * Unlike the other triage scripts this one runs on a laptop, not in Actions,
+ * so GITHUB_TOKEN and GITHUB_REPOSITORY are not in the environment. It borrows
+ * both from an authenticated `gh` rather than asking anyone to export a
+ * personal token — the CLI is already signed in, and a token that never lands
+ * in a shell history is one that cannot leak from one.
+ */
+
+import { execFileSync } from "node:child_process";
+import { graphql, currentRepo } from "./lib/github-api.mjs";
+import {
+  SWEEP_QUERY,
+  parseSweepResponse,
+  classifyIssues,
+  formatSweepReport,
+} from "./lib/triage-sweep.mjs";
+
+function fromGh(args) {
+  try {
+    return execFileSync("gh", args, { encoding: "utf8" }).trim();
+  } catch (error) {
+    throw new Error(
+      `Could not read this from the gh CLI (\`gh ${args.join(" ")}\`). ` +
+        `Run \`gh auth login\` first.\n${error.message}`,
+    );
+  }
+}
+
+if (!process.env.GITHUB_TOKEN) {
+  process.env.GITHUB_TOKEN = fromGh(["auth", "token"]);
+}
+if (!process.env.GITHUB_REPOSITORY) {
+  process.env.GITHUB_REPOSITORY = fromGh([
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "-q",
+    ".nameWithOwner",
+  ]);
+}
+
+const limitFlag = process.argv.indexOf("--limit");
+const limit =
+  limitFlag === -1 ? Infinity : Number(process.argv[limitFlag + 1] ?? NaN);
+if (!(limit > 0)) {
+  // NaN fails this comparison too, which is the point: `--limit abc` must stop
+  // rather than silently sweep zero issues and report a clean tracker.
+  throw new Error(
+    `--limit needs a positive number, got ${process.argv[limitFlag + 1]}`,
+  );
+}
+
+const { owner, name } = currentRepo();
+const issues = [];
+let cursor = null;
+
+do {
+  const response = await graphql(SWEEP_QUERY, { owner, name, cursor });
+  issues.push(...parseSweepResponse(response));
+  const { hasNextPage, endCursor } = response.data.repository.issues.pageInfo;
+  cursor = hasNextPage ? endCursor : null;
+} while (cursor && issues.length < limit);
+
+process.stdout.write(formatSweepReport(classifyIssues(issues.slice(0, limit))));
+process.stdout.write("\n");

--- a/scripts/triage-sweep.mjs
+++ b/scripts/triage-sweep.mjs
@@ -70,5 +70,40 @@ do {
   cursor = hasNextPage ? endCursor : null;
 } while (cursor && issues.length < limit);
 
-process.stdout.write(formatSweepReport(classifyIssues(issues.slice(0, limit))));
+/**
+ * The open pull requests, for the roster the report prints above the buckets.
+ *
+ * Read through `gh` rather than the GraphQL client on purpose: the roster is a
+ * reading aid, and a token that can list issues but chokes here must not take
+ * the whole sweep down with it. `undefined` makes the report say the roster is
+ * missing — which is the honest output, and louder than an empty list.
+ */
+function openPullRequests() {
+  try {
+    return JSON.parse(
+      execFileSync(
+        "gh",
+        [
+          "pr",
+          "list",
+          "--state",
+          "open",
+          "--limit",
+          "100",
+          "--json",
+          "number,title",
+        ],
+        { encoding: "utf8" },
+      ),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+process.stdout.write(
+  formatSweepReport(classifyIssues(issues.slice(0, limit)), {
+    openPrs: openPullRequests(),
+  }),
+);
 process.stdout.write("\n");


### PR DESCRIPTION
## What does this PR do?

Adds a `triage-issues` skill plus the sweep it runs on, for working down the
open-issue backlog — the weekly pass over new arrivals, and the full sweep we
have not done yet.

The starting point was measuring the backlog rather than assuming its shape:

| Signal | Count |
| --- | --- |
| a merged PR already references the issue | 54 |
| never categorised by anyone | 28 |
| an `enhancement` with zero comments | 40 |
| untouched for more than 90 days | **16** |

**The last row is why there is no stale-bot here.** Close-after-90-days would
find 16 of 148 and be wrong about most of them. This backlog is not abandoned,
it is unresolved: a PR titled `… (#796)` closes nothing without a literal
`Closes #796`, so the real mass is work that is *done* but still open.

### The split that matters

`scripts/triage-sweep.mjs` sorts every open issue into one bucket by evidence
in a single GraphQL pass, and **never reaches a verdict**. It reports that
\#465 has a merged PR in its timeline; it does not report that #465 is done —
\#543 and #669 both look exactly like zombies and are both legitimately open.
Deciding costs a read of the PR and a grep against `origin/main`, and that
lives in the skill.

### Two rules a reviewer should check

- **An external report awaiting a maintainer reply is flagged, never commented
  on.** Only a maintainer comment clears the `unanswered-sweep` alarm in
  `issue-triage.yml`, so an automated reply would silence it without anyone
  having answered. `externalWaiting` is a flag rather than a bucket precisely
  so it cannot hide the merge evidence on those issues.
- **`triage` and `external` do not count as categorisation.** The workflow
  stamps both on arrival, so counting them would hide every incoming report
  behind a label its own arrival created — and the weekly pass filters on
  exactly this, so the bug would have been invisible.

### On the tests

Every classification test runs against a fixture, which means all of them stay
green if the real query stops selecting a field the parser reads — and the
resulting empty bucket looks exactly like a clean tracker. `the query selects
every field the parser reads` is what makes that edit fail instead of pass.
**Verified with a canary, not by reading:** removing `merged` from
`SWEEP_QUERY` turns it red, restoring it turns it green.

`parseSweepResponse` also throws on a truncated nested list. No issue is near
the cap today (max 40 comments / cross-refs, measured), but a clipped comment
list turns an answered report into "unanswered", and a clipped timeline drops
the evidence that decides the largest bucket.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [x] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated the documentation (if applicable) — n/a, and the commit
      carries a `Docs-not-needed:` trailer: `docs/` describes the product, and
      this is internal maintainer tooling with no user-facing surface
- [x] All existing tests pass (`pnpm test:scripts` → 841 pass, `format:check` clean)
