### PR TITLE
docs(upgrading): open the post-v0.9.0 section, and move what belongs in it

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -185,6 +185,67 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
+## Upgrading from v0.9.0 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+#### Knowledge Base agents need one reindex after upgrading
+
+The knowledge base no longer embeds through Ollama. The embedding model now runs inside Pinchy itself — the same offline `embeddinggemma` model that already powers agent memory — so there is nothing to pull, nothing to configure, and no Ollama endpoint involved. Indexing and search work on a fully offline install.
+
+The two models produce vectors that cannot be compared, and Postgres cannot change a vector column's width in place, so the old embeddings can be neither kept nor converted. Migration `0056` clears `kb_documents` and `kb_chunks` and recreates the index column at the new width. **Your documents are not touched** — those tables are derived entirely from the files on disk, and the files stay where they are.
+
+So after upgrading, a Knowledge Base agent finds nothing until you reindex it: open the agent's **Permissions** tab, and in the **Knowledge Base** section click **Reindex now**. The run reports its progress inline. If you never set up a Knowledge Base agent, there is nothing to do — the tables were already empty.
+
+The `ollama pull bge-m3` step from the v0.9.0 notes no longer applies. If nothing else on your machine uses that model, you can remove it.
+
+### Upgrade notes
+
+The standard flow applies:
+
+```bash
+cd /opt/pinchy
+sed -i 's/^PINCHY_VERSION=.*/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+docker compose pull && docker compose up -d && docker image prune -f
+```
+
+#### A provider key that can't reach the runtime now says so
+
+Pinchy and the agent runtime share one config volume under two different users, and each agent has a directory in it that both of them write to. If the runtime got there first, the directory came out owned by the wrong user and Pinchy could no longer store that agent's credentials — which stopped the whole config from reaching the runtime. The agent then simply stopped answering, with the real reason only in `docker compose logs pinchy`.
+
+The runtime now hands that directory back on start and on every tick, so the case should not arise. If it ever does, saving a provider key tells you plainly that it saved but couldn't be applied, and the affected agent says it has no API key instead of going quiet. Nothing to configure.
+
+#### Ollama Cloud catalog: one model removed, two gain vision
+
+Re-verified against the live API. `nemotron-3-nano:30b` is **no longer offered**: it now skips the tool call outright in most attempts, which for an agent looks like deciding not to act rather than failing. Any agent pinned to it needs a new model — the fast tier's general pick (`deepseek-v4-flash`) is the closest equivalent.
+
+`kimi-k2.7-code` and `qwen3.5:397b` can now **accept images**. Both previously could not — `qwen3.5:397b` was the model an [earlier release note](#ollama-cloud-model-catalog-refreshed-against-the-live-api) marked text-only for hallucinating image contents — and both read test images correctly now. They become selectable for image work; the default image model is unchanged, so nothing re-routes on its own.
+
+#### Documents in archive folders drop out of everyday answers
+
+A knowledge-base document now counts as archived if any **folder** on its path is called `old`, `archive`, `archived` or `archiv` — matched whole and case-insensitively, so `OLD/` counts and `Goldakte/` does not. The rule reads directories only: a file named `archive.pdf` is not archived. Archived documents are still fully indexed, and the agent can still reach them when a question asks it to; they are simply left out of an ordinary answer. Year and quarter folders (`2013/`, `Q3/`) are never archives. See [Current documents first](/guides/create-knowledge-base-agent/#current-documents-first). If you keep superseded files in a folder named something else, rename it to one of those four to get the same treatment.
+
+#### Agents can hand you a file in chat
+
+An agent with **Write files** permission can now turn tabular data it already holds into a CSV, XLSX or PDF and deliver it in the conversation, via the new `pinchy_generate_file` tool. It rides on the existing permission — no new grant to make, and agents without write access can't reach it. See [Generating files](/guides/file-uploads/#generating-files).
+
+#### Automations move into the agent
+
+Email workflows now have their own **Automations** tab in an agent's settings, where you can review, create, enable, disable and delete them. It is visible to admins on any agent, and to the owner of a personal agent. Existing workflows are listed as-is; nothing changes on upgrade until you edit one.
+
+### Database migrations
+
+Nine migrations (`0056`–`0064`) run automatically on startup — no manual steps. Only `0056` is destructive, and only for the Knowledge Base tables (see the breaking change above); the rest are additive.
+
+- `0056` — recreates `kb_chunks.embedding` at 768 dimensions for the bundled in-process `embeddinggemma` embedder and clears the two Knowledge Base tables.
+- `0057` — backfills `kb_documents.status` so documents ingested before the archive rule existed are classified by it too.
+- `0058` — `agent_delivered_files`, the record behind files an agent hands you in chat.
+- `0059` — the OpenAI-compatible provider table. A v0.9.0 database already has it (the release branch shipped the same change as its own `0056`), so this one applies `IF NOT EXISTS` and does nothing there.
+- `0060` — a partial index over failed audit-integrity checks, so the verification report stays fast as the log grows.
+- `0061`, `0062` — a Knowledge Base chunk is anchored by a **locator** (slide, sheet and row range, heading path) instead of a page number, since only PDFs have pages; `0062` drops the old `page` column once `0061` has carried every anchor across.
+- `0063` — byte-level progress on index jobs (`total_bytes`, `processed_bytes`) backing the reindex progress bar and its estimate.
+- `0064` — `run_started_at` and `show_banner` on `chat_session_errors`, so a run failure's banner can be dismissed and re-armed per run.
+
 ## Upgrading from v0.8.0 to v0.9.0
 
 ### Breaking changes
@@ -240,7 +301,7 @@ The compose file now caps each service (pinchy 1 GB, openclaw 2 GB, db 1 GB memo
 
 #### Knowledge Base agents (new, opt-in)
 
-Agents can now answer from your own documents with cited sources, backed by a search index in Pinchy's Postgres. Nothing is indexed until you set it up: mount document directories, create an agent from the new Knowledge Base template, and trigger indexing. The embedding model ships inside the image (the same offline `embeddinggemma` model that powers agent memory), so there is nothing to pull or configure and no Ollama endpoint is involved — indexing and search work fully offline. See [Create a Knowledge Base agent](/guides/create-knowledge-base-agent/). If you don't use it, nothing changes for you.
+Agents can now answer from your own documents with cited sources, backed by a search index in Pinchy's Postgres. Nothing is indexed until you set it up: mount document directories, pull the embedding model on your local Ollama (`ollama pull bge-m3`), create an agent from the new Knowledge Base template, and trigger indexing. See [Create a Knowledge Base agent](/guides/create-knowledge-base-agent/). If you don't use it, nothing changes for you.
 
 #### Agent memory recall now works offline
 
@@ -254,25 +315,13 @@ A shared agent's `MEMORY.md` — what it learned in one-to-one conversations —
 
 Inbound channel media (Telegram photos, documents) is now copied into the agent workspace on arrival, and the runtime's internal media cache is swept after 48 hours instead of growing forever. Attachments received **before** this upgrade were never copied, so ones older than 48 hours are removed by the first sweep and may no longer open from old conversations. Export anything you still need from pre-upgrade chats before upgrading.
 
-#### A provider key that can't reach the runtime now says so
-
-Pinchy and the agent runtime share one config volume under two different users, and each agent has a directory in it that both of them write to. If the runtime got there first, the directory came out owned by the wrong user and Pinchy could no longer store that agent's credentials — which stopped the whole config from reaching the runtime. The agent then simply stopped answering, with the real reason only in `docker compose logs pinchy`.
-
-The runtime now hands that directory back on every tick, so the case should not arise. If it ever does, saving a provider key tells you plainly that it saved but couldn't be applied, and the affected agent says it has no API key instead of going quiet. Nothing to do on upgrade.
-
 #### Workspace terminals stay disabled
 
 The OpenClaw runtime this release ships (2026.7.1) adds an interactive terminal into agent workspaces. Pinchy pins it off: a shell would bypass agent permission allow-lists and the audit trail. It will return as an RBAC-scoped, audited feature.
 
-#### Ollama Cloud catalog: one model removed, two gain vision
-
-Re-verified against the live API. `nemotron-3-nano:30b` is **no longer offered**: it now skips the tool call outright in most attempts, which for an agent looks like deciding not to act rather than failing. Any agent pinned to it needs a new model — the fast tier's general pick (`deepseek-v4-flash`) is the closest equivalent.
-
-`kimi-k2.7-code` and `qwen3.5:397b` can now **accept images**. Both previously could not — `qwen3.5:397b` was the model an [earlier release note](#ollama-cloud-model-catalog-refreshed-against-the-live-api) marked text-only for hallucinating image contents — and both read test images correctly now. They become selectable for image work; the default image model is unchanged, so nothing re-routes on its own.
-
 ### Database migrations
 
-Thirteen migrations (`0044`–`0056`) run automatically on startup — no manual steps. No existing data is dropped: every one is additive except `0056`, which recreates a Knowledge Base index column introduced earlier in this same release (see below), so the tables it rewrites are empty on upgrade.
+Twelve additive migrations (`0044`–`0055`) run automatically on startup — no manual steps. No data is dropped or destructively rewritten; existing rows already satisfy every new constraint.
 
 - `0044` — schema hardening: four timestamp columns to `NOT NULL`, foreign-key and hot-path composite indexes, `CHECK` constraints on the enum-like text columns (roles, agent visibility, invite/connection types and statuses), and the `invites.claimed_by_user_id` foreign key switched to `ON DELETE SET NULL`.
 - `0045` — per-agent starter prompts (`agents.starter_prompts`, defaults to empty).
@@ -283,7 +332,6 @@ Thirteen migrations (`0044`–`0056`) run automatically on startup — no manual
 - `0053` — per-turn context-window usage tracking (`usage_records.context_tokens`).
 - `0054` — Knowledge Base tables (`kb_documents`, `kb_chunks`) with the pgvector index; enables the `vector` extension (see the breaking change above).
 - `0055` — the Knowledge Base async index-job queue (`kb_index_jobs`) backing the background reindex.
-- `0056` — recreates `kb_chunks.embedding` at 768 dimensions for the bundled in-process `embeddinggemma` embedder (replacing the earlier plan to embed over Ollama) and clears the two KB tables. Both were introduced in `0054` above and are empty on any real upgrade, so nothing is lost — the first reindex populates them.
 
 ## Upgrading from v0.7.0 to v0.8.0
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -321,7 +321,7 @@ The OpenClaw runtime this release ships (2026.7.1) adds an interactive terminal 
 
 ### Database migrations
 
-Twelve additive migrations (`0044`–`0055`) run automatically on startup — no manual steps. No data is dropped or destructively rewritten; existing rows already satisfy every new constraint.
+Thirteen additive migrations (`0044`–`0056`) run automatically on startup — no manual steps. No data is dropped or destructively rewritten; existing rows already satisfy every new constraint.
 
 - `0044` — schema hardening: four timestamp columns to `NOT NULL`, foreign-key and hot-path composite indexes, `CHECK` constraints on the enum-like text columns (roles, agent visibility, invite/connection types and statuses), and the `invites.claimed_by_user_id` foreign key switched to `ON DELETE SET NULL`.
 - `0045` — per-agent starter prompts (`agents.starter_prompts`, defaults to empty).
@@ -332,6 +332,7 @@ Twelve additive migrations (`0044`–`0055`) run automatically on startup — no
 - `0053` — per-turn context-window usage tracking (`usage_records.context_tokens`).
 - `0054` — Knowledge Base tables (`kb_documents`, `kb_chunks`) with the pgvector index; enables the `vector` extension (see the breaking change above).
 - `0055` — the Knowledge Base async index-job queue (`kb_index_jobs`) backing the background reindex.
+- `0056` — the `openai_compatible_providers` table, behind connecting an OpenAI-compatible endpoint. This number belongs to the v0.9.x line only: the same table reaches later releases as `0059`, which is why that one creates it `IF NOT EXISTS`.
 
 ## Upgrading from v0.7.0 to v0.8.0
 

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -20,6 +20,19 @@ export function parseAndValidateVersion(input) {
 }
 
 /**
+ * Orders two versions (no leading 'v'). Negative / zero / positive, like a
+ * comparator: `compareVersions("0.9.0", "0.10.0") < 0`.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function compareVersions(a, b) {
+  const [x, y] = [a.split(".").map(Number), b.split(".").map(Number)];
+  for (let i = 0; i < 3; i++) if (x[i] !== y[i]) return x[i] - y[i];
+  return 0;
+}
+
+/**
  * Returns the contents of a package.json file with the version field updated.
  * Preserves formatting and trailing newline.
  * @param {string} content - raw file contents
@@ -263,11 +276,22 @@ export function finalizeUpgradeSection(mdx, prevVersion, targetVersion) {
  * Invariant enforced:
  *  - At most ONE `## Upgrading from vX to %%PINCHY_VERSION%%` section may exist
  *    (the current/in-progress one). Two means a prior release never froze.
- *  - If one exists, its `from` version must equal the latest released version
- *    (root package.json#version). A lagging `from` means the previous release
- *    forgot to freeze its notes.
+ *  - If one exists, its `from` version must equal the latest released version.
+ *    A lagging `from` means the previous release forgot to freeze its notes.
  *  - A frozen (concrete-headed `to vY`) section must not keep `%%PINCHY_VERSION%%`
  *    anywhere in its body.
+ *
+ * "Latest released version" is the NEWER of `latestReleasedVersion` (root
+ * package.json#version) and the newest frozen `to vY` heading in the file — NOT
+ * package.json alone. Since releases are cut on a `release/X.Y` branch, only
+ * that branch gets the version bump; `main` deliberately stays on the previous
+ * number until its own next cut. So after v0.9.0 shipped, main's package.json
+ * still said 0.8.0 while its newest frozen section already said v0.9.0, and
+ * reading package.json alone made the correct next section — `from v0.9.0` —
+ * impossible to open. That is not hypothetical: it is why nobody opened one,
+ * and why d7ea428d's upgrade note landed inside the frozen v0.9.0 section.
+ * Taking the newer of the two keeps the v0.5.8 miss caught (there the lagging
+ * side is the FILE, so package.json wins) and works on both branches.
  *
  * Scope: only `## Upgrading from vX to …` sections are inspected. The preamble
  * and the "Standard upgrade" section legitimately render `%%PINCHY_VERSION%%` as
@@ -278,7 +302,7 @@ export function finalizeUpgradeSection(mdx, prevVersion, targetVersion) {
  * @throws {Error} on a stale, lagging, or duplicated placeholder section
  */
 export function assertNoStaleUpgradeSections(mdx, latestReleasedVersion) {
-  const latest = parseAndValidateVersion(latestReleasedVersion);
+  const pkgLatest = parseAndValidateVersion(latestReleasedVersion);
   const headingRe =
     /^##\s+Upgrading\s+from\s+v(\d+\.\d+\.\d+)\s+to\s+(v\d+\.\d+\.\d+|%%PINCHY_VERSION%%)\s*$/gm;
 
@@ -292,6 +316,15 @@ export function assertNoStaleUpgradeSections(mdx, latestReleasedVersion) {
       headingLen: m[0].length,
     });
   }
+
+  // The newest version this file already records as released. On a branch that
+  // did not take the release bump, this is ahead of package.json.
+  const frozenTos = matches
+    .filter((s) => s.to !== "%%PINCHY_VERSION%%")
+    .map((s) => s.to.slice(1));
+  const latest = [pkgLatest, ...frozenTos].reduce((a, b) =>
+    compareVersions(a, b) >= 0 ? a : b,
+  );
 
   const placeholderSections = [];
   for (const s of matches) {
@@ -545,12 +578,7 @@ export function movingTagForRef(refName) {
  * @returns {string[]} skipped release tags, oldest first (empty = ok)
  */
 export function findSkippedReleases(prevVersion, targetVersion, allTags) {
-  const key = (v) => v.split(".").map(Number);
-  const cmp = (a, b) => {
-    const [x, y] = [key(a), key(b)];
-    for (let i = 0; i < 3; i++) if (x[i] !== y[i]) return x[i] - y[i];
-    return 0;
-  };
+  const cmp = compareVersions;
   return allTags
     .map((t) => t.trim())
     .filter((t) => /^v\d+\.\d+\.\d+$/.test(t))

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   parseAndValidateVersion,
+  compareVersions,
   bumpPackageJson,
   buildTagName,
   buildCommitMessage,
@@ -544,6 +545,14 @@ test("finalizeUpgradeSection is a no-op when no matching section exists", () => 
   assert.equal(finalizeUpgradeSection(mdx, "0.5.8", "0.6.0"), mdx);
 });
 
+test("compareVersions orders numerically, not lexically", () => {
+  // The trap this exists for: "0.10.0" < "0.9.0" as strings.
+  assert.ok(compareVersions("0.9.0", "0.10.0") < 0);
+  assert.ok(compareVersions("0.10.0", "0.9.0") > 0);
+  assert.equal(compareVersions("0.9.0", "0.9.0"), 0);
+  assert.ok(compareVersions("0.9.1", "0.9.0") > 0);
+});
+
 // assertNoStaleUpgradeSections — CI guard against unfrozen / drifted sections.
 
 test("assertNoStaleUpgradeSections passes when the single placeholder section matches latest", () => {
@@ -570,6 +579,40 @@ test("assertNoStaleUpgradeSections passes with zero placeholder sections (post-r
     "Older.",
   ].join("\n");
   assert.doesNotThrow(() => assertNoStaleUpgradeSections(mdx, "0.6.0"));
+});
+
+// The release-branch workflow: v0.9.0 was cut on release/0.9, so only that
+// branch took the version bump. main stays on 0.8.0 until its own next cut,
+// while its newest frozen section already reads v0.9.0. Reading package.json
+// alone made `from v0.9.0` unopenable on main — which is how d7ea428d's upgrade
+// note ended up inside the frozen v0.9.0 section.
+test("assertNoStaleUpgradeSections accepts a 'from' the file says is released but package.json has not caught up to", () => {
+  const mdx = [
+    "## Upgrading from v0.9.0 to %%PINCHY_VERSION%%",
+    "",
+    "Current, on main.",
+    "",
+    "## Upgrading from v0.8.0 to v0.9.0",
+    "",
+    "Frozen — cut on release/0.9, so main never bumped package.json.",
+  ].join("\n");
+  assert.doesNotThrow(() => assertNoStaleUpgradeSections(mdx, "0.8.0"));
+});
+
+test("assertNoStaleUpgradeSections still throws on a 'from' newer than anything released", () => {
+  const mdx = [
+    "## Upgrading from v1.0.0 to %%PINCHY_VERSION%%",
+    "",
+    "Invented a release that never happened.",
+    "",
+    "## Upgrading from v0.8.0 to v0.9.0",
+    "",
+    "Frozen.",
+  ].join("\n");
+  assert.throws(
+    () => assertNoStaleUpgradeSections(mdx, "0.8.0"),
+    /stale upgrade-notes section/i,
+  );
 });
 
 test("assertNoStaleUpgradeSections throws when the placeholder section's 'from' lags the latest tag (the v0.5.8 miss)", () => {


### PR DESCRIPTION
`main` has no `## Upgrading from v0.9.0 to %%PINCHY_VERSION%%` section, so every upgrade-affecting change since the tag appended to the last section that existed — the **frozen** `v0.8.0 → v0.9.0` one. A v0.9.0 upgrader is being told about behaviour that release does not have.

Same misplacement as [#1021](https://github.com/heypinchy/pinchy/pull/1021) on the release branch (`25676bdb`), whose wording this follows. That branch already had a 0.9.1 section; main has to create one.

## Why nobody opened the section

The freshness guard made it impossible. `assertNoStaleUpgradeSections` reads the latest released version from root `package.json` alone — true while releases were cut from `main`, false since `c8b4e5c5` moved them to a `release/X.Y` branch that takes the bump on its own. main sits at `0.8.0` while its newest frozen section reads `to v0.9.0`, so the correct heading was rejected:

```
Stale upgrade-notes section: "Upgrading from v0.9.0 to %%PINCHY_VERSION%%",
but the latest released version is v0.8.0.
```

Its advice — freeze to v0.8.0, open `from v0.8.0` — would have produced a second section for a release that already shipped. First commit fixes that: the latest released version is now the newer of `package.json#version` and the newest frozen `to vY` heading in the file. The v0.5.8 miss is still caught (there the *file* lags, so package.json wins), and a `from` newer than either is still rejected.

## Four notes were in the wrong release, not one

Three landed while the section was still open and were sealed in by `246d2688`'s forward-port; `d7ea428d` appended the fourth after the freeze.

| Note | Commit | Evidence it isn't in v0.9.0 |
| --- | --- | --- |
| Per-agent config-dir ownership | `d7ea428d` | not in the tag; #1021 moved it on the release branch |
| Ollama Cloud catalog | `beadd844` | `nemotron-3-nano:30b` is still in `git ls-tree v0.9.0` |
| KB note rewritten for bundled `embeddinggemma` | `8baa64cc` | v0.9.0 embeds over Ollama with `bge-m3`; the 768-dim switch is main's `0056_serious_expediter`, absent from the tag |
| Migration range widened to `0044`–`0056` | `8baa64cc` | v0.9.0 numbers its own `0056` differently (an OpenAI-compatible provider backport) |

The v0.9.0 section is restored to what that release ships, `ollama pull bge-m3` included. Its migration range now stops at `0055`, which **is** in the tag (`3826d4b5`) — so this reads one migration further than the release branch's "eleven / `0044`–`0054`", which undercounts. Worth correcting on `release/0.9` separately; that copy is the deployed one.

## What else had no note

Covered in the new section: the destructive KB re-embed (**breaking** — the index is cleared and needs one reindex), archive-folder gating, agent-generated files, the Automations tab, and migrations `0056`–`0064`.

Every claim was read against the code, not the commit message — the `Reindex now` control in `knowledge-reindex-section.tsx`, the four folder names in `archive-paths.ts`, `fast.general` in `model-resolver/providers/ollama-cloud.ts`, the `vision: true` flags, and that `pinchy_generate_file` rides on the `pinchy_write` grant and never appears in `allowedTools` itself.

This is not the full next-release changelog — feature-level notes are authored at the cut, per `cut-pinchy-release`. It is the upgrade-affecting subset that had no home.

## Gates

- `pnpm test:scripts` — 825 pass (was failing on the guard; see commit 1)
- `pnpm format:check` — clean
- `cd docs && pnpm build && pnpm check:anchors && pnpm check:rendered && pnpm test` — 69 pages, 42 tests, clean
- `upgrade-prune-step` / `openclaw-secrets-drift` / `migrate-smithers-soul` — 28 pass (they read the file from disk, so `test:related` cannot see them)