### PR TITLE
feat(automations): edit-in-place form — change email workflows after creation (#139)

### DIFF
--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -174,7 +174,7 @@ Click **New automation** and fill in:
 A new automation is always created **disabled**. Pinchy proposes the workflow; it never activates one on its own. This is deliberate — an agent (or a form) should never grant itself standing autonomous authority. Nothing runs until a person reviews the workflow and switches it on.
 :::
 
-### Review, enable, and remove
+### Review, edit, enable, and remove
 
 The tab lists every workflow on the agent with its trigger (in plain words, not raw filters), its instruction, the mailboxes it watches, and its status:
 
@@ -187,9 +187,11 @@ The tab lists every workflow on the agent with its trigger (in plain words, not 
 
 Pinchy names the workflow and the reason in the server log the first time a workflow lands in this state. After that the badge is the record, so if you missed the line, the three causes above are what to check.
 
-An errored workflow stays switched on and keeps being retried, so there's nothing to re-enable. Repair the connection's credentials and the next pass moves the workflow back to **Active** by itself. The other two causes can't be edited on an existing workflow: a workflow's mailboxes and its recipient are fixed when you create it, so delete it and create it again — pointed at the reconnected mailbox, and by the person who should receive the results.
+An errored workflow stays switched on and keeps being retried, so there's nothing to re-enable. Repair the connection's credentials and the next pass moves the workflow back to **Active** by itself. A workflow watching the wrong mailbox is fixed with **Edit** (below). Only the recipient is fixed at creation, so a workflow reporting to the wrong person has to be deleted and created again by the person who should receive the results.
 
 Use **Enable** / **Disable** to turn a workflow on or off, and **Delete** to remove one for good. Enabling is the human-gated step that turns a proposal into a live automation; disabling pauses it without deleting it.
+
+**Edit** reopens the same form, pre-filled, so you can change a workflow's name, instruction, trigger, mailboxes, or look-back window in place. Two things stay put on purpose: editing **never** changes whether the workflow is enabled — activation is only ever the Enable/Disable toggle's job — and a mailbox you keep across an edit keeps its place in the mail stream, so no message is re-processed or skipped over the change. A mailbox you add starts watching from now on, never retroactively.
 
 For a walkthrough from a connected mailbox to a running workflow — including how to scope a trigger and what to check afterwards — see [Set Up Email Automations](/guides/email-automations/).
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -586,7 +586,7 @@ Standing email workflows an agent runs on its own — see [the Automations tab](
 
 The endpoints keyed by **`agentId`** ask two questions in order, and answer differently depending on which one you fail. Can you **see** the agent at all? If not — someone else's personal agent, or a restricted one outside your groups — you get a plain `404`, identical to an ID that was never issued, because any other answer would confirm the agent exists. If you can see it but may not **manage** its automations — the everyday case of a shared agent you chat with daily — you get `403`, which tells you nothing you did not already know and points you at an admin instead of at a typo.
 
-`PATCH` and `DELETE` are keyed by **workflow** id instead, and there a scope refusal is `404` too. The middle case has no equivalent: `GET /api/automations` asks this same scope question _and_ the visibility one in front of it, so anyone refused here could never have listed the workflow in the first place. `403` would be the only way to learn that a workflow id is real.
+`PUT`, `PATCH` and `DELETE` are keyed by **workflow** id instead, and there a scope refusal is `404` too. The middle case has no equivalent: `GET /api/automations` asks this same scope question _and_ the visibility one in front of it, so anyone refused here could never have listed the workflow in the first place. `403` would be the only way to learn that a workflow id is real.
 
 Being keyed by workflow id also gives these two a reach the `agentId` endpoints deliberately lack: an admin who already holds a workflow's id — from the [audit trail](/concepts/audit-trail/), which is where a runaway automation surfaces — can disable or delete it even on someone's personal agent. Standing autonomous authority has to stay stoppable. It grants no way to **find** such a workflow, only to act on one already known.
 
@@ -642,6 +642,24 @@ Toggling to the state it already has is a no-op: still `200`, no audit entry —
 - `400` — the body has no boolean `enabled`
 - `401` — not authenticated
 - `404` — no workflow has that id, **or** its agent is outside your scope. This endpoint addresses a workflow, not an agent, so a malformed id lands here as well: it definitionally matches nothing
+
+### `PUT /api/automations/:id`
+
+Change an existing workflow in place — its name, instruction, trigger, mailboxes, or look-back window. Same body as `POST /api/automations` minus `agentId`, which a workflow cannot move between agents.
+
+**Request body:** `{ "name": "...", "filter": { … }, "action": "...", "connectionIds": ["..."], "sweepWindowDays": 7 }`
+
+**Response:** `{ "id": "..." }`
+
+Two things this endpoint deliberately does **not** do. It never changes `enabled` — activation stays with `PATCH`, so an edit cannot quietly switch a workflow on. And it reconciles mailboxes as a **diff**, not a rewrite: a mailbox you keep holds its position in the mail stream, a mailbox you add starts watching from now, and a removed one is dropped. Rewriting the set would make an enabled workflow re-process or skip mail across the edit.
+
+An edit that changes nothing is still `200` and writes no audit entry.
+
+**Errors:**
+
+- `400` — the body fails validation, or the agent has no read access to a requested connection (the message names the ids)
+- `401` — not authenticated
+- `404` — no workflow has that id, **or** its agent is outside your scope (as with `PATCH`, a malformed id matches nothing)
 
 ### `DELETE /api/automations/:id`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -588,7 +588,9 @@ The endpoints keyed by **`agentId`** ask two questions in order, and answer diff
 
 `PUT`, `PATCH` and `DELETE` are keyed by **workflow** id instead, and there a scope refusal is `404` too. The middle case has no equivalent: `GET /api/automations` asks this same scope question _and_ the visibility one in front of it, so anyone refused here could never have listed the workflow in the first place. `403` would be the only way to learn that a workflow id is real.
 
-Being keyed by workflow id also gives these two a reach the `agentId` endpoints deliberately lack: an admin who already holds a workflow's id — from the [audit trail](/concepts/audit-trail/), which is where a runaway automation surfaces — can disable or delete it even on someone's personal agent. Standing autonomous authority has to stay stoppable. It grants no way to **find** such a workflow, only to act on one already known.
+Being keyed by workflow id also gives **`PATCH` and `DELETE`** a reach the `agentId` endpoints deliberately lack: an admin who already holds a workflow's id — from the [audit trail](/concepts/audit-trail/), which is where a runaway automation surfaces — can disable or delete it even on someone's personal agent. Standing autonomous authority has to stay stoppable. It grants no way to **find** such a workflow, only to act on one already known.
+
+`PUT` is pointedly not in that company, though it is keyed the same way. That reach is warranted by _stopping_ a runaway automation, and editing one is not stopping: rewriting an instruction on an agent you cannot see would change what somebody's private agent does with their private mail. So `PUT` asks the visibility question as well, and answers `404` when it fails — the same `404`, byte for byte, that an id matching nothing gets.
 
 ### `GET /api/automations?agentId=<agentId>`
 
@@ -659,7 +661,7 @@ An edit that changes nothing is still `200` and writes no audit entry.
 
 - `400` — the body fails validation, or the agent has no read access to a requested connection (the message names the ids)
 - `401` — not authenticated
-- `404` — no workflow has that id, **or** its agent is outside your scope (as with `PATCH`, a malformed id matches nothing)
+- `404` — no workflow has that id, **or** its agent is one you cannot see, **or** its agent is outside your scope. All three answer identically, on purpose (a malformed id matches nothing either). Unlike `PATCH` and `DELETE`, this includes an admin on someone else's personal agent: editing carries no emergency-stop warrant
 
 ### `DELETE /api/automations/:id`
 

--- a/packages/web/src/__tests__/api/automations-edit.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-edit.integration.test.ts
@@ -1,0 +1,337 @@
+// Real-DB integration tests for PUT /api/automations/[id] — the edit-in-place
+// path that closes the last gap in the Automations lifecycle: create → review →
+// enable/disable → **edit** → delete. Until this, changing a workflow's fields
+// meant delete + recreate, which always re-births it pending+disabled and (worse)
+// resets every connection watermark, so an enabled reconciler silently either
+// re-processed or skipped mail. PUT edits in place.
+//
+// Real DB (not mocked chains) for the same reasons the create/manage routes are:
+// the load-bearing behavior is scope-based RBAC over agent ownership, the SAME
+// email-read connection gate the create route enforces, and — the subtle one —
+// connection reconciliation that must PRESERVE the watermark of a kept mailbox
+// while stamping a newly-added one at `now`. Only a real query proves those.
+// @/lib/auth and @/lib/audit-deferred are mocked to drive the scope branches and
+// capture audit payloads.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+  agents,
+  users,
+  emailWorkflows,
+  emailWorkflowConnections,
+  integrationConnections,
+  agentConnectionPermissions,
+} from "@/db/schema";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
+
+const { getSessionMock, deferAuditLogMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  deferAuditLogMock: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+  auth: { api: { getSession: getSessionMock } },
+}));
+vi.mock("@/lib/audit-deferred", () => ({
+  deferAuditLog: (...args: unknown[]) => deferAuditLogMock(...args),
+}));
+
+const { PUT } = await import("@/app/api/automations/[id]/route");
+
+const OWNER = "user-owner";
+const ADMIN = "user-admin";
+
+function asMember(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "member" } });
+}
+function asAdmin(id: string) {
+  getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "admin" } });
+}
+
+async function seedUser(id: string, role: "member" | "admin" = "member") {
+  await db.insert(users).values({ id, name: id, email: `${id}@test.com`, role });
+}
+async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) {
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Smithers",
+      model: "ollama-cloud/gemini-3-flash",
+      greetingMessage: "Hi",
+      isPersonal: opts.isPersonal,
+      ownerId: opts.ownerId,
+    })
+    .returning();
+  return row;
+}
+async function seedConnection(id: string, name = "Mailbox") {
+  await db
+    .insert(integrationConnections)
+    .values({ id, type: "imap", name, credentials: "enc:placeholder" });
+}
+async function grantEmailRead(agentId: string, connectionId: string) {
+  await db
+    .insert(agentConnectionPermissions)
+    .values({ agentId, connectionId, model: "email", operation: "read" });
+}
+async function seedWorkflow(
+  agentId: string,
+  opts: {
+    enabled?: boolean;
+    name?: string;
+    filter?: unknown;
+    action?: string;
+    sweepWindowDays?: number;
+    createdBy?: string;
+  } = {}
+) {
+  const [wf] = await db
+    .insert(emailWorkflows)
+    .values({
+      agentId,
+      name: opts.name ?? "File supplier invoices",
+      filter: opts.filter ?? { hasAttachment: true },
+      action: opts.action ?? "Draft a supplier bill.",
+      sweepWindowDays: opts.sweepWindowDays ?? 14,
+      enabled: opts.enabled ?? false,
+      createdBy: opts.createdBy ?? null,
+    })
+    .returning();
+  return wf;
+}
+async function linkConnection(workflowId: string, connectionId: string, sinceTs: Date) {
+  await db.insert(emailWorkflowConnections).values({ workflowId, connectionId, sinceTs });
+}
+
+function put(id: string, body: unknown) {
+  return makeNextRequest(`http://localhost/api/automations/${id}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function loadWorkflow(id: string) {
+  const [row] = await db.select().from(emailWorkflows).where(eq(emailWorkflows.id, id));
+  return row;
+}
+async function loadConnections(workflowId: string) {
+  return db
+    .select()
+    .from(emailWorkflowConnections)
+    .where(eq(emailWorkflowConnections.workflowId, workflowId));
+}
+
+/** A full, valid edit payload — override per test. */
+function editBody(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "File supplier invoices",
+    filter: { hasAttachment: true },
+    action: "Draft a supplier bill.",
+    connectionIds: ["conn-a"],
+    sweepWindowDays: 14,
+    ...overrides,
+  };
+}
+
+describe("PUT /api/automations/[id]", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await seedUser(OWNER);
+    await seedUser(ADMIN, "admin");
+  });
+
+  it("updates name, filter, action and sweep window on an owner's personal-agent workflow", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-a");
+    await grantEmailRead(agent.id, "conn-a");
+    const wf = await seedWorkflow(agent.id, { createdBy: OWNER });
+    await linkConnection(wf.id, "conn-a", new Date("2020-01-01T00:00:00Z"));
+
+    const res = await PUT(
+      put(
+        wf.id,
+        editBody({
+          name: "File and pay invoices",
+          filter: { from: ["ap@acme.com"], subjectContains: ["invoice"] },
+          action: "Draft AND schedule payment for the supplier bill.",
+          sweepWindowDays: 30,
+        })
+      ),
+      routeContext({ id: wf.id })
+    );
+    expect(res.status).toBe(200);
+
+    const row = await loadWorkflow(wf.id);
+    expect(row.name).toBe("File and pay invoices");
+    expect(row.filter).toEqual({ from: ["ap@acme.com"], subjectContains: ["invoice"] });
+    expect(row.action).toBe("Draft AND schedule payment for the supplier bill.");
+    expect(row.sweepWindowDays).toBe(30);
+    // Edit never flips activation — enabled/status stay under the toggle's sole
+    // control (propose, don't self-activate; the editor is the same authority as
+    // the enabler, but activation stays an explicit, separate human act).
+    expect(row.enabled).toBe(false);
+    expect(row.status).toBe("pending");
+
+    expect(deferAuditLogMock).toHaveBeenCalledTimes(1);
+    const entry = deferAuditLogMock.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      eventType: "email_workflow.updated",
+      actorType: "user",
+      actorId: OWNER,
+      resource: `email_workflow:${wf.id}`,
+      outcome: "success",
+    });
+    // changedFields is the complete, PII-safe list of what moved; changes carries
+    // before/after only for the safe fields (name scrubbed, sweep window).
+    // action/filter are named but never dumped (they can carry addresses).
+    expect([...entry.detail.changedFields].sort()).toEqual([
+      "action",
+      "filter",
+      "name",
+      "sweepWindowDays",
+    ]);
+    expect(entry.detail.changes).toEqual({
+      name: { from: "File supplier invoices", to: "File and pay invoices" },
+      sweepWindowDays: { from: 14, to: 30 },
+    });
+    // Connections untouched → no connections diff.
+    expect(entry.detail.connections).toBeUndefined();
+  });
+
+  it("reconciles connections: preserves a kept mailbox's watermark, stamps a new one at now, drops the removed", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-keep");
+    await seedConnection("conn-drop");
+    await seedConnection("conn-add");
+    await grantEmailRead(agent.id, "conn-keep");
+    await grantEmailRead(agent.id, "conn-drop");
+    await grantEmailRead(agent.id, "conn-add");
+    const wf = await seedWorkflow(agent.id, { createdBy: OWNER });
+    const keptWatermark = new Date("2020-06-15T12:00:00Z");
+    await linkConnection(wf.id, "conn-keep", keptWatermark);
+    await linkConnection(wf.id, "conn-drop", new Date("2020-06-15T12:00:00Z"));
+
+    const before = Date.now();
+    const res = await PUT(
+      put(wf.id, editBody({ connectionIds: ["conn-keep", "conn-add"] })),
+      routeContext({ id: wf.id })
+    );
+    expect(res.status).toBe(200);
+
+    const conns = await loadConnections(wf.id);
+    const byId = new Map(conns.map((c) => [c.connectionId, c]));
+    expect([...byId.keys()].sort()).toEqual(["conn-add", "conn-keep"]);
+    // Kept mailbox: its watermark is UNTOUCHED — resetting it would make an
+    // enabled reconciler re-list (or skip) mail across the gap.
+    expect(byId.get("conn-keep")!.sinceTs.getTime()).toBe(keptWatermark.getTime());
+    // Newly added mailbox: stamped at ~now, so it never retroactively sweeps
+    // history (design §8, same rule as create).
+    expect(byId.get("conn-add")!.sinceTs.getTime()).toBeGreaterThanOrEqual(before - 1000);
+    // Removed mailbox: gone.
+    expect(byId.has("conn-drop")).toBe(false);
+
+    const entry = deferAuditLogMock.mock.calls[0][0];
+    expect(entry.detail.changedFields).toContain("connections");
+    expect(entry.detail.connections).toEqual({ added: ["conn-add"], removed: ["conn-drop"] });
+  });
+
+  it("rejects a connection the agent may not read — the same gate the create route enforces", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-a");
+    await grantEmailRead(agent.id, "conn-a");
+    await seedConnection("conn-forbidden");
+    // conn-forbidden exists but the agent has no email-read grant on it.
+    const wf = await seedWorkflow(agent.id, { createdBy: OWNER });
+    await linkConnection(wf.id, "conn-a", new Date("2020-01-01T00:00:00Z"));
+
+    const res = await PUT(
+      put(wf.id, editBody({ connectionIds: ["conn-a", "conn-forbidden"] })),
+      routeContext({ id: wf.id })
+    );
+    expect(res.status).toBe(400);
+    // Nothing was written — the workflow still points only at conn-a.
+    const conns = await loadConnections(wf.id);
+    expect(conns.map((c) => c.connectionId)).toEqual(["conn-a"]);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("forbids a member from editing a shared agent's workflow", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    await seedConnection("conn-a");
+    await grantEmailRead(agent.id, "conn-a");
+    const wf = await seedWorkflow(agent.id, { name: "Untouched" });
+    await linkConnection(wf.id, "conn-a", new Date("2020-01-01T00:00:00Z"));
+
+    const res = await PUT(put(wf.id, editBody({ name: "Hijacked" })), routeContext({ id: wf.id }));
+    expect(res.status).toBe(403);
+    expect((await loadWorkflow(wf.id)).name).toBe("Untouched");
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("lets an admin edit a shared agent's workflow", async () => {
+    asAdmin(ADMIN);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    await seedConnection("conn-a");
+    await grantEmailRead(agent.id, "conn-a");
+    const wf = await seedWorkflow(agent.id, { name: "Before" });
+    await linkConnection(wf.id, "conn-a", new Date("2020-01-01T00:00:00Z"));
+
+    const res = await PUT(put(wf.id, editBody({ name: "After" })), routeContext({ id: wf.id }));
+    expect(res.status).toBe(200);
+    expect((await loadWorkflow(wf.id)).name).toBe("After");
+  });
+
+  it("returns 404 for an unknown workflow", async () => {
+    asMember(OWNER);
+    const res = await PUT(
+      put("11111111-1111-4111-8111-111111111111", editBody()),
+      routeContext({ id: "11111111-1111-4111-8111-111111111111" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("does not audit a no-op edit (identical fields and connections)", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-a");
+    await grantEmailRead(agent.id, "conn-a");
+    const wf = await seedWorkflow(agent.id, {
+      name: "Steady",
+      filter: { hasAttachment: true },
+      action: "Draft a supplier bill.",
+      sweepWindowDays: 14,
+      createdBy: OWNER,
+    });
+    await linkConnection(wf.id, "conn-a", new Date("2020-01-01T00:00:00Z"));
+
+    const res = await PUT(
+      put(
+        wf.id,
+        editBody({
+          name: "Steady",
+          filter: { hasAttachment: true },
+          action: "Draft a supplier bill.",
+          connectionIds: ["conn-a"],
+          sweepWindowDays: 14,
+        })
+      ),
+      routeContext({ id: wf.id })
+    );
+    expect(res.status).toBe(200);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+    // The kept connection's watermark is left alone on a no-op too.
+    const conns = await loadConnections(wf.id);
+    expect(conns[0].sinceTs.getTime()).toBe(new Date("2020-01-01T00:00:00Z").getTime());
+  });
+});

--- a/packages/web/src/__tests__/api/automations-edit.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-edit.integration.test.ts
@@ -26,9 +26,10 @@ import {
 } from "@/db/schema";
 import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
-const { getSessionMock, deferAuditLogMock } = vi.hoisted(() => ({
+const { getSessionMock, deferAuditLogMock, licenseStateMock } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   deferAuditLogMock: vi.fn(),
+  licenseStateMock: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({
@@ -42,10 +43,22 @@ vi.mock("@/lib/audit-deferred", () => ({
   deferAuditLog: (...args: unknown[]) => deferAuditLogMock(...args),
 }));
 
+// Only the license STATE is replaced; the visibility half of the access gate
+// stays live. It only bites on a LICENSED instance — a community instance maps
+// "restricted" to "all" (agent-access.effectiveVisibility) — so a suite that
+// inherited the state could not tell a visibility denial from a scope one, and
+// would stay green whichever the route produced. Same reasoning as
+// automations-manage.integration.test.ts.
+vi.mock("@/lib/enterprise", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/enterprise")>()),
+  getLicenseState: licenseStateMock,
+}));
+
 const { PUT } = await import("@/app/api/automations/[id]/route");
 
 const OWNER = "user-owner";
 const ADMIN = "user-admin";
+const OTHER = "user-other";
 
 function asMember(id: string) {
   getSessionMock.mockResolvedValue({ user: { id, email: `${id}@test.com`, role: "member" } });
@@ -143,8 +156,45 @@ function editBody(overrides: Record<string, unknown> = {}) {
 describe("PUT /api/automations/[id]", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    licenseStateMock.mockResolvedValue("paid");
     await seedUser(OWNER);
     await seedUser(ADMIN, "admin");
+    await seedUser(OTHER);
+  });
+
+  // The #880 verdict, applied to the write path. `canManageAgentWorkflows`
+  // returns true for ANY admin on ANY agent, while the visibility gate holds a
+  // personal agent private to its owner — admins included. PATCH and DELETE are
+  // deliberately exempt from the read gate, and the exemption is written down
+  // narrowly: an admin holding a workflow id from the audit trail must be able
+  // to STOP standing autonomous authority. Stopping is the whole warrant.
+  //
+  // Editing is not stopping. Rewriting the instruction of a workflow on an agent
+  // an admin cannot even see changes what somebody's private agent does with
+  // their private mail — a reach no other agent-scoped surface grants. So PUT
+  // runs the read gate, and its refusal is byte-identical to the one an unknown
+  // id gets: a distinguishable body would itself confirm the workflow is real.
+  it("hides a colleague's personal-agent workflow from an admin, and changes nothing", async () => {
+    asAdmin(ADMIN);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OTHER });
+    await seedConnection("conn-a");
+    await grantEmailRead(agent.id, "conn-a");
+    const wf = await seedWorkflow(agent.id, { name: "Private" });
+    await linkConnection(wf.id, "conn-a", new Date("2020-01-01T00:00:00Z"));
+
+    const denied = await PUT(
+      put(wf.id, editBody({ name: "Hijacked" })),
+      routeContext({ id: wf.id })
+    );
+    const missingId = "11111111-1111-4111-8111-111111111111";
+    const absent = await PUT(put(missingId, editBody()), routeContext({ id: missingId }));
+
+    expect(denied.status).toBe(absent.status);
+    expect(await denied.json()).toEqual(await absent.json());
+    expect(denied.status).toBe(404);
+
+    expect((await loadWorkflow(wf.id)).name).toBe("Private");
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
   });
 
   it("updates name, filter, action and sweep window on an owner's personal-agent workflow", async () => {

--- a/packages/web/src/__tests__/api/automations-edit.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-edit.integration.test.ts
@@ -265,7 +265,17 @@ describe("PUT /api/automations/[id]", () => {
     expect(deferAuditLogMock).not.toHaveBeenCalled();
   });
 
-  it("forbids a member from editing a shared agent's workflow", async () => {
+  // This asserted 403 when it was written. #880 later settled the verdict for
+  // the workflow-keyed routes the other way — see `workflowNotFound` — because
+  // read and manage coincide here: a caller who fails this gate cannot list the
+  // workflow anywhere, so a distinguishable refusal is the only way they could
+  // learn the id is real. PATCH and DELETE already answer 404; PUT arrived
+  // after that decision was made and has to give the same answer.
+  //
+  // Asserting the status alone would not pin what matters. The property is that
+  // this refusal is INDISTINGUISHABLE from the one an id matching nothing gets,
+  // so the two are compared against each other rather than against a constant.
+  it("hides a shared agent's workflow from a member rather than refusing visibly", async () => {
     asMember(OWNER);
     const agent = await seedAgent({ isPersonal: false, ownerId: null });
     await seedConnection("conn-a");
@@ -273,8 +283,17 @@ describe("PUT /api/automations/[id]", () => {
     const wf = await seedWorkflow(agent.id, { name: "Untouched" });
     await linkConnection(wf.id, "conn-a", new Date("2020-01-01T00:00:00Z"));
 
-    const res = await PUT(put(wf.id, editBody({ name: "Hijacked" })), routeContext({ id: wf.id }));
-    expect(res.status).toBe(403);
+    const denied = await PUT(
+      put(wf.id, editBody({ name: "Hijacked" })),
+      routeContext({ id: wf.id })
+    );
+    const missingId = "11111111-1111-4111-8111-111111111111";
+    const absent = await PUT(put(missingId, editBody()), routeContext({ id: missingId }));
+
+    expect(denied.status).toBe(absent.status);
+    expect(await denied.json()).toEqual(await absent.json());
+    expect(denied.status).toBe(404);
+
     expect((await loadWorkflow(wf.id)).name).toBe("Untouched");
     expect(deferAuditLogMock).not.toHaveBeenCalled();
   });

--- a/packages/web/src/__tests__/components/agent-settings-automation-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automation-dialog.test.tsx
@@ -1,19 +1,20 @@
 // @vitest-environment jsdom
-// Component tests for the Automations create dialog — the form that finally
-// gives a human a way to author an email workflow in the UI (#139). Until this,
-// the only create path was the raw POST API; the tab could review/enable/delete
-// but never create. Both this form and the conversational tool (#705) write the
-// SAME object through POST /api/automations ("same object, one system").
+// Component tests for the Automations create/edit dialog — the one form a human
+// uses to author OR change an email workflow in the UI (#139). With no workflow
+// it POSTs a CreateAutomationInput to /api/automations; given a workflow it
+// pre-fills and PUTs an EditAutomationInput to /api/automations/[id]. Both write
+// the SAME structured object ("same object, one system"; the conversational tool
+// #705 will too).
 //
-// The dialog GETs the agent's email-readable mailboxes (the picker options) and
-// POSTs a CreateAutomationInput. We mock global.fetch (the api-client helpers
-// read the body via text()+JSON.parse), so each Response exposes json() + text().
+// The dialog GETs the agent's email-readable mailboxes (the picker options). We
+// mock global.fetch (the api-client helpers read the body via text()+JSON.parse),
+// so each Response exposes json() + text().
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { toast } from "sonner";
-import { AgentSettingsAutomationCreateDialog } from "@/components/agent-settings-automation-create-dialog";
+import { AgentSettingsAutomationDialog } from "@/components/agent-settings-automation-dialog";
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
@@ -23,7 +24,7 @@ const CONNECTIONS = [
   { id: "conn-b", name: "Newsletters" },
 ];
 
-describe("AgentSettingsAutomationCreateDialog", () => {
+describe("AgentSettingsAutomationDialog", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -68,14 +69,50 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     );
   }
 
+  function findPut(url: string) {
+    return fetchSpy.mock.calls.find(
+      (c: unknown[]) => String(c[0]) === url && (c[1] as RequestInit)?.method === "PUT"
+    );
+  }
+
+  /** An existing workflow to seed the dialog's edit mode. Its connection is one
+   *  of CONNECTIONS so the picker can pre-check it. */
+  const EXISTING_WORKFLOW = {
+    id: "wf-7",
+    name: "File supplier invoices",
+    filter: { from: ["ap@acme.com"], subjectContains: ["invoice"], hasAttachment: true },
+    action: "Draft a supplier bill in Odoo.",
+    enabled: false,
+    status: "pending" as const,
+    sweepWindowDays: 30,
+    createdBy: "user-1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    connectionIds: ["conn-a"],
+  };
+
+  /** GET connections → options; PUT edit → 200. */
+  function mockEditHappyPath(connections: unknown[] = CONNECTIONS) {
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith("/api/automations/connections")) return jsonResponse(connections);
+      if (
+        url === `/api/automations/${EXISTING_WORKFLOW.id}` &&
+        (init as RequestInit)?.method === "PUT"
+      ) {
+        return jsonResponse({ id: EXISTING_WORKFLOW.id, name: "x" });
+      }
+      return jsonResponse({});
+    });
+  }
+
   it("loads the agent's mailboxes scoped to the agent and offers them as options", async () => {
     mockHappyPath();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
+        onSaved={vi.fn()}
       />
     );
 
@@ -90,15 +127,15 @@ describe("AgentSettingsAutomationCreateDialog", () => {
 
   it("POSTs a well-formed create payload and then reports success", async () => {
     mockHappyPath();
-    const onCreated = vi.fn();
+    const onSaved = vi.fn();
     const onOpenChange = vi.fn();
     const user = userEvent.setup();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={onOpenChange}
-        onCreated={onCreated}
+        onSaved={onSaved}
       />
     );
 
@@ -130,7 +167,7 @@ describe("AgentSettingsAutomationCreateDialog", () => {
       sweepWindowDays: 14,
     });
 
-    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(toast.success).toHaveBeenCalled();
   });
@@ -139,11 +176,11 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     mockHappyPath();
     const user = userEvent.setup();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
+        onSaved={vi.fn()}
       />
     );
     await waitFor(() =>
@@ -165,11 +202,11 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     mockHappyPath();
     const user = userEvent.setup();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
+        onSaved={vi.fn()}
       />
     );
     await waitFor(() =>
@@ -198,15 +235,15 @@ describe("AgentSettingsAutomationCreateDialog", () => {
       }
       return jsonResponse({});
     });
-    const onCreated = vi.fn();
+    const onSaved = vi.fn();
     const onOpenChange = vi.fn();
     const user = userEvent.setup();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={onOpenChange}
-        onCreated={onCreated}
+        onSaved={onSaved}
       />
     );
     await waitFor(() =>
@@ -219,7 +256,7 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     await user.click(screen.getByRole("button", { name: /create automation/i }));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("The agent has no email access"));
-    expect(onCreated).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
     // The dialog is never asked to close on failure — the user can fix and retry.
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
@@ -228,11 +265,11 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     mockHappyPath();
     const user = userEvent.setup();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
+        onSaved={vi.fn()}
       />
     );
     await waitFor(() =>
@@ -264,11 +301,11 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     mockHappyPath();
     const user = userEvent.setup();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
+        onSaved={vi.fn()}
       />
     );
     await waitFor(() =>
@@ -301,11 +338,11 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     });
     const user = userEvent.setup();
     render(
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={AGENT_ID}
         open={true}
         onOpenChange={vi.fn()}
-        onCreated={vi.fn()}
+        onSaved={vi.fn()}
       />
     );
 
@@ -332,15 +369,15 @@ describe("AgentSettingsAutomationCreateDialog", () => {
       }
       return jsonResponse({});
     });
-    const props = { agentId: AGENT_ID, onOpenChange: vi.fn(), onCreated: vi.fn() };
-    const { rerender } = render(<AgentSettingsAutomationCreateDialog {...props} open={true} />);
+    const props = { agentId: AGENT_ID, onOpenChange: vi.fn(), onSaved: vi.fn() };
+    const { rerender } = render(<AgentSettingsAutomationDialog {...props} open={true} />);
     // Make sure the first open's request is actually in flight before closing —
     // the load is deferred to a microtask, so closing too early would cancel it.
     await waitFor(() => expect(connectionCalls).toBe(1));
 
     // Close and reopen while the first request is still in flight.
-    rerender(<AgentSettingsAutomationCreateDialog {...props} open={false} />);
-    rerender(<AgentSettingsAutomationCreateDialog {...props} open={true} />);
+    rerender(<AgentSettingsAutomationDialog {...props} open={false} />);
+    rerender(<AgentSettingsAutomationDialog {...props} open={true} />);
     await waitFor(() =>
       expect(screen.getByRole("checkbox", { name: /Fresh mailbox/i })).toBeInTheDocument()
     );
@@ -350,5 +387,121 @@ describe("AgentSettingsAutomationCreateDialog", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(screen.queryByText(/Stale mailbox/i)).not.toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: /Fresh mailbox/i })).toBeInTheDocument();
+  });
+
+  // --- Edit mode: the SAME dialog, seeded with an existing workflow, PUTs the
+  //     edited representation instead of POSTing a new one. Same object, one form.
+  describe("edit mode", () => {
+    it("prefills the form from the workflow and checks its current mailbox", async () => {
+      mockEditHappyPath();
+      render(
+        <AgentSettingsAutomationDialog
+          agentId={AGENT_ID}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSaved={vi.fn()}
+          workflow={EXISTING_WORKFLOW}
+        />
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+      );
+      // Scalar + list filter fields come back pre-filled from the stored workflow.
+      expect(screen.getByLabelText(/^Name/i)).toHaveValue("File supplier invoices");
+      expect(screen.getByLabelText(/Instruction/i)).toHaveValue("Draft a supplier bill in Odoo.");
+      expect(screen.getByLabelText(/^From/i)).toHaveValue("ap@acme.com");
+      expect(screen.getByLabelText(/Subject contains/i)).toHaveValue("invoice");
+      expect(screen.getByRole("checkbox", { name: /has an attachment/i })).toBeChecked();
+      expect(screen.getByLabelText(/Look back/i)).toHaveValue(30);
+      // The workflow's own mailbox is pre-selected; the other is not.
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeChecked();
+      expect(screen.getByRole("checkbox", { name: /Newsletters/i })).not.toBeChecked();
+      // Edit affordances, not create ones.
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /create automation/i })).not.toBeInTheDocument();
+    });
+
+    it("PUTs the edited representation to /api/automations/[id] and reports success", async () => {
+      mockEditHappyPath();
+      const onSaved = vi.fn();
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <AgentSettingsAutomationDialog
+          agentId={AGENT_ID}
+          open={true}
+          onOpenChange={onOpenChange}
+          onSaved={onSaved}
+          workflow={EXISTING_WORKFLOW}
+        />
+      );
+      await waitFor(() =>
+        expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+      );
+
+      // Rename, and add the second mailbox to the set.
+      const nameInput = screen.getByLabelText(/^Name/i);
+      await user.clear(nameInput);
+      await user.type(nameInput, "File and pay invoices");
+      await user.click(screen.getByRole("checkbox", { name: /Newsletters/i }));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      const url = `/api/automations/${EXISTING_WORKFLOW.id}`;
+      await waitFor(() => expect(findPut(url)).toBeTruthy());
+      const body = JSON.parse((findPut(url)![1] as RequestInit).body as string);
+      // No agentId in the edit payload — a workflow never changes agents.
+      expect(body).toEqual({
+        name: "File and pay invoices",
+        action: "Draft a supplier bill in Odoo.",
+        filter: { from: ["ap@acme.com"], subjectContains: ["invoice"], hasAttachment: true },
+        connectionIds: ["conn-a", "conn-b"],
+        sweepWindowDays: 30,
+      });
+
+      await waitFor(() => expect(onSaved).toHaveBeenCalled());
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    it("surfaces the API error and stays open when the edit fails", async () => {
+      vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url.startsWith("/api/automations/connections")) return jsonResponse(CONNECTIONS);
+        if (
+          url === `/api/automations/${EXISTING_WORKFLOW.id}` &&
+          (init as RequestInit)?.method === "PUT"
+        ) {
+          return jsonResponse(
+            { error: "The agent has no email access" },
+            { ok: false, status: 400 }
+          );
+        }
+        return jsonResponse({});
+      });
+      const onSaved = vi.fn();
+      const onOpenChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <AgentSettingsAutomationDialog
+          agentId={AGENT_ID}
+          open={true}
+          onOpenChange={onOpenChange}
+          onSaved={onSaved}
+          workflow={EXISTING_WORKFLOW}
+        />
+      );
+      await waitFor(() =>
+        expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+      );
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("The agent has no email access")
+      );
+      expect(onSaved).not.toHaveBeenCalled();
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/packages/web/src/__tests__/components/agent-settings-automation-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automation-dialog.test.tsx
@@ -503,5 +503,51 @@ describe("AgentSettingsAutomationDialog", () => {
       expect(onSaved).not.toHaveBeenCalled();
       expect(onOpenChange).not.toHaveBeenCalledWith(false);
     });
+
+    // A workflow can outlive its mailbox's read grant: the connections GET is
+    // email-read gated, so a mailbox the agent lost access to after creation is
+    // simply absent from the options. Its id would otherwise sit invisibly in
+    // the selection (no checkbox renders for a non-option) and ride along on the
+    // PUT, only to be rejected 400 by the server for a mailbox the user never
+    // saw. The dialog drops it up front and says so, so a plain rename saves.
+    it("drops a no-longer-readable mailbox, tells the user, and keeps it out of the PUT", async () => {
+      const WF = { ...EXISTING_WORKFLOW, connectionIds: ["conn-a", "conn-gone"] };
+      vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+        const url = String(input);
+        // Options no longer include conn-gone — the agent can't read it anymore.
+        if (url.startsWith("/api/automations/connections")) return jsonResponse(CONNECTIONS);
+        if (url === `/api/automations/${WF.id}` && (init as RequestInit)?.method === "PUT") {
+          return jsonResponse({ id: WF.id, name: "x" });
+        }
+        return jsonResponse({});
+      });
+      const user = userEvent.setup();
+      render(
+        <AgentSettingsAutomationDialog
+          agentId={AGENT_ID}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSaved={vi.fn()}
+          workflow={WF}
+        />
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeInTheDocument()
+      );
+      // The still-readable mailbox stays checked; the gone one has no checkbox.
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeChecked();
+      // The user is told one previously-watched mailbox is no longer accessible.
+      expect(screen.getByText(/no longer readable/i)).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      const url = `/api/automations/${WF.id}`;
+      await waitFor(() => expect(findPut(url)).toBeTruthy());
+      const body = JSON.parse((findPut(url)![1] as RequestInit).body as string);
+      // The unreadable id was pruned — it never reaches the server, so the save
+      // succeeds instead of 400-ing on a mailbox the user could not see.
+      expect(body.connectionIds).toEqual(["conn-a"]);
+    });
   });
 });

--- a/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-automations.test.tsx
@@ -255,4 +255,55 @@ describe("AgentSettingsAutomations", () => {
     // onCreated → load(): the list is re-fetched after a successful create.
     await waitFor(() => expect(listCalls).toBeGreaterThan(listCallsAfterLoad));
   });
+
+  it("opens the edit dialog prefilled from the row and reloads the list after saving", async () => {
+    let listCalls = 0;
+    vi.mocked(global.fetch).mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = (init as RequestInit)?.method ?? "GET";
+      if (url.startsWith("/api/automations/connections")) {
+        return jsonResponse([{ id: "conn-a", name: "Invoices mailbox" }]);
+      }
+      if (url.startsWith("/api/automations?")) {
+        listCalls++;
+        return jsonResponse(mockAutomations);
+      }
+      if (url === "/api/automations/wf-1" && method === "PUT") {
+        return jsonResponse({ id: "wf-1", name: "Renamed" });
+      }
+      return jsonResponse({ ok: true });
+    });
+
+    const user = userEvent.setup();
+    render(<AgentSettingsAutomations agentId={AGENT_ID} />);
+    await waitFor(() => expect(screen.getByText("File supplier invoices")).toBeInTheDocument());
+    const listCallsAfterLoad = listCalls;
+
+    const row1 = screen.getByRole("row", { name: /File supplier invoices/ });
+    await user.click(within(row1).getByRole("button", { name: /edit/i }));
+
+    // Dialog opens in edit mode, prefilled from the row it was opened on.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save changes/i })).toBeInTheDocument()
+    );
+    expect(screen.getByLabelText(/^Name/i)).toHaveValue("File supplier invoices");
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox", { name: /Invoices mailbox/i })).toBeChecked()
+    );
+
+    const nameInput = screen.getByLabelText(/^Name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Renamed");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      const put = fetchSpy.mock.calls.find(
+        (c: unknown[]) =>
+          String(c[0]) === "/api/automations/wf-1" && (c[1] as RequestInit)?.method === "PUT"
+      );
+      expect(put).toBeTruthy();
+    });
+    // onSaved → load(): the list is re-fetched after a successful edit.
+    await waitFor(() => expect(listCalls).toBeGreaterThan(listCallsAfterLoad));
+  });
 });

--- a/packages/web/src/app/api/automations/[id]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/route.ts
@@ -170,15 +170,16 @@ export const PUT = withAuth<RouteContext>(async (request, { params }, session) =
   if ("error" in parsed) return parsed.error;
   const { name, filter, action, connectionIds, sweepWindowDays } = parsed.data;
 
+  // Same refusal as PATCH and DELETE — see `workflowNotFound`. This route was
+  // written before #880 settled that verdict and originally answered 403 here,
+  // which is the existence oracle that decision closed: read and manage
+  // coincide for a workflow, so a caller who fails this gate cannot enumerate
+  // the workflow anywhere, and a distinguishable refusal is the only way they
+  // could learn the id is real.
   const workflow = await loadWorkflowWithAgent(id);
-  if (!workflow) {
-    return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
-  }
+  if (!workflow) return workflowNotFound();
   if (!canManageAgentWorkflows(workflow, { id: session.user.id!, role: session.user.role })) {
-    return NextResponse.json(
-      { error: "You do not have permission to change this workflow" },
-      { status: 403 }
-    );
+    return workflowNotFound();
   }
 
   const requestedConnectionIds = [...new Set(connectionIds)];

--- a/packages/web/src/app/api/automations/[id]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/route.ts
@@ -9,6 +9,7 @@ import { updateAutomationSchema, editAutomationSchema } from "@/lib/schemas/auto
 import { scrubEmails } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+import { getAgentWithAccess } from "@/lib/agent-access";
 import { findUnreadableConnectionIds } from "@/lib/email-workflows/connection-access";
 
 type RouteContext = { params: Promise<{ id: string }> };
@@ -178,6 +179,32 @@ export const PUT = withAuth<RouteContext>(async (request, { params }, session) =
   // could learn the id is real.
   const workflow = await loadWorkflowWithAgent(id);
   if (!workflow) return workflowNotFound();
+
+  // Unlike its two neighbours, this handler runs the VISIBILITY gate as well —
+  // it is deliberately NOT in `UNGATED_CALLERS` (see
+  // `__tests__/security/workflow-scope-gate-callers.test.ts`).
+  //
+  // The exemption PATCH and DELETE hold is written narrowly on purpose: an admin
+  // holding a workflow id from the audit trail must be able to STOP standing
+  // autonomous authority even on an agent they cannot see, and a read gate would
+  // remove that emergency stop. Stopping is the entire warrant.
+  //
+  // Editing is not stopping. `canManageAgentWorkflows` admits ANY admin on ANY
+  // agent, so without this gate an admin could rewrite the instruction of a
+  // workflow on a colleague's personal agent — changing what somebody's private
+  // agent does with their private mail, on an agent every other surface withholds
+  // from them. That is the #880 reach, arriving through a new door.
+  //
+  // Its refusal is collapsed into ours rather than returned: `getAgentWithAccess`
+  // answers `{error: "Agent not found"}`, and a body that differs from the one an
+  // unknown workflow id gets would itself confirm the id is real.
+  const agentOrError = await getAgentWithAccess(
+    workflow.agentId,
+    session.user.id!,
+    session.user.role
+  );
+  if (agentOrError instanceof NextResponse) return workflowNotFound();
+
   if (!canManageAgentWorkflows(workflow, { id: session.user.id!, role: session.user.role })) {
     return workflowNotFound();
   }

--- a/packages/web/src/app/api/automations/[id]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/route.ts
@@ -249,7 +249,12 @@ export const PUT = withAuth<RouteContext>(async (request, { params }, session) =
     if (toAdd.length) {
       await tx
         .insert(emailWorkflowConnections)
-        .values(toAdd.map((connectionId) => ({ workflowId: id, connectionId, sinceTs: now })));
+        .values(toAdd.map((connectionId) => ({ workflowId: id, connectionId, sinceTs: now })))
+        // (workflow_id, connection_id) is the composite PK. A concurrent edit that
+        // linked the same mailbox first would otherwise make this insert throw a
+        // duplicate-key 500. The add is idempotent — the row already exists with
+        // its own watermark, which we must not stomp — so skip the conflicting one.
+        .onConflictDoNothing();
     }
     // Kept connections are intentionally left untouched → watermark preserved.
   });

--- a/packages/web/src/app/api/automations/[id]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/route.ts
@@ -1,16 +1,35 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
-import { agents, emailWorkflows } from "@/db/schema";
+import { agents, emailWorkflows, emailWorkflowConnections } from "@/db/schema";
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
-import { updateAutomationSchema } from "@/lib/schemas/automations";
+import { updateAutomationSchema, editAutomationSchema } from "@/lib/schemas/automations";
 import { scrubEmails } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+import { findUnreadableConnectionIds } from "@/lib/email-workflows/connection-access";
 
 type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * Order-independent JSON serialization for comparing two filter objects: the
+ * stored filter (jsonb, key order set by Postgres) against the freshly parsed
+ * one (key order set by the request). Sorting keys makes "did the filter change"
+ * a value comparison, not an accident of key order. Arrays keep their order —
+ * reordering `from`/`subjectContains` is a real, intended change.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  // Object.entries (not keys + obj[k]) so there is no computed member access to
+  // flag as an injection sink — every value comes straight from the pair.
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`)
+    .join(",")}}`;
+}
 
 // email_workflows.id is a uuid column: a non-uuid path param (a typo, a probe)
 // would make the query throw a cast error (500) instead of resolving to
@@ -65,6 +84,11 @@ async function loadWorkflowWithAgent(id: string) {
       id: emailWorkflows.id,
       name: emailWorkflows.name,
       enabled: emailWorkflows.enabled,
+      // Editable fields — the before-image the PUT diff and audit snapshot read.
+      // PATCH/DELETE ignore them; carrying them costs nothing on the same row.
+      filter: emailWorkflows.filter,
+      action: emailWorkflows.action,
+      sweepWindowDays: emailWorkflows.sweepWindowDays,
       agentId: emailWorkflows.agentId,
       agentName: agents.name,
       isPersonal: agents.isPersonal,
@@ -121,6 +145,130 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   });
 
   return NextResponse.json({ id, enabled });
+});
+
+/**
+ * PUT /api/automations/[id] — edit a workflow's editable representation in place
+ * (the Automations edit form). Replaces name / filter / action / sweepWindowDays
+ * and reconciles the mailbox set. Same scope gate and same email-read connection
+ * gate as create (a workflow must never point at a mailbox its agent can't read),
+ * so the two write paths accept exactly the same shapes.
+ *
+ * Activation is deliberately untouched: `enabled`/`status` are not fields here.
+ * Editing substance never implicitly flips a workflow on or off — that stays the
+ * PATCH toggle's explicit, human-gated job.
+ *
+ * Connection reconciliation is a DIFF, not a rewrite: a mailbox kept across the
+ * edit keeps its `sinceTs` watermark (rewriting it would make an enabled
+ * reconciler re-list or skip mail across the gap), a newly added mailbox is
+ * stamped at `now` (never retroactively sweeps history, same rule as create),
+ * and a removed one is dropped.
+ */
+export const PUT = withAuth<RouteContext>(async (request, { params }, session) => {
+  const { id } = await params;
+  const parsed = await parseRequestBody(editAutomationSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { name, filter, action, connectionIds, sweepWindowDays } = parsed.data;
+
+  const workflow = await loadWorkflowWithAgent(id);
+  if (!workflow) {
+    return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+  }
+  if (!canManageAgentWorkflows(workflow, { id: session.user.id!, role: session.user.role })) {
+    return NextResponse.json(
+      { error: "You do not have permission to change this workflow" },
+      { status: 403 }
+    );
+  }
+
+  const requestedConnectionIds = [...new Set(connectionIds)];
+  const missing = await findUnreadableConnectionIds(workflow.agentId, requestedConnectionIds);
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { error: `The agent has no email access to connection(s): ${missing.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  const currentConnRows = await db
+    .select({ connectionId: emailWorkflowConnections.connectionId })
+    .from(emailWorkflowConnections)
+    .where(eq(emailWorkflowConnections.workflowId, id));
+  const currentConnIds = currentConnRows.map((r) => r.connectionId);
+  const afterSet = new Set(requestedConnectionIds);
+  const beforeSet = new Set(currentConnIds);
+  const toAdd = requestedConnectionIds.filter((c) => !beforeSet.has(c));
+  const toRemove = currentConnIds.filter((c) => !afterSet.has(c));
+
+  // Field-level diff so a reviewer sees WHAT changed, not merely that it did
+  // (AGENTS.md). `changedFields` is the complete, PII-safe list of what moved;
+  // `changes` carries the before/after only for the fields that are safe to
+  // print — the name (scrubbed) and the sweep window. `action` and `filter` can
+  // carry email addresses, so they are named in `changedFields` but never dumped
+  // into the append-only, HMAC-signed log. Connection membership is logged as an
+  // added/removed id diff (AGENTS.md: log the diff, not the final count).
+  const changedFields: string[] = [];
+  const changes: Record<string, { from: unknown; to: unknown }> = {};
+  if (workflow.name !== name) {
+    changedFields.push("name");
+    changes.name = { from: scrubEmails(workflow.name), to: scrubEmails(name) };
+  }
+  if (workflow.action !== action) changedFields.push("action");
+  if (stableStringify(workflow.filter) !== stableStringify(filter)) changedFields.push("filter");
+  if (workflow.sweepWindowDays !== sweepWindowDays) {
+    changedFields.push("sweepWindowDays");
+    changes.sweepWindowDays = { from: workflow.sweepWindowDays, to: sweepWindowDays };
+  }
+  const connectionsChanged = toAdd.length > 0 || toRemove.length > 0;
+  if (connectionsChanged) changedFields.push("connections");
+
+  // No-op edit: nothing actually differs, so nothing to write or record. Return
+  // 200 (idempotent) without touching the row — mirrors the PATCH no-op, and
+  // leaves every kept watermark exactly where it was.
+  if (changedFields.length === 0) {
+    return NextResponse.json({ id, name });
+  }
+
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    await tx
+      .update(emailWorkflows)
+      .set({ name, filter, action, sweepWindowDays, updatedAt: now })
+      .where(eq(emailWorkflows.id, id));
+    if (toRemove.length) {
+      await tx
+        .delete(emailWorkflowConnections)
+        .where(
+          and(
+            eq(emailWorkflowConnections.workflowId, id),
+            inArray(emailWorkflowConnections.connectionId, toRemove)
+          )
+        );
+    }
+    if (toAdd.length) {
+      await tx
+        .insert(emailWorkflowConnections)
+        .values(toAdd.map((connectionId) => ({ workflowId: id, connectionId, sinceTs: now })));
+    }
+    // Kept connections are intentionally left untouched → watermark preserved.
+  });
+
+  deferAuditLog({
+    actorType: "user",
+    actorId: session.user.id!,
+    eventType: "email_workflow.updated",
+    resource: `email_workflow:${id}`,
+    outcome: "success",
+    detail: {
+      workflow: { id, name: scrubEmails(name) },
+      agent: { id: workflow.agentId, name: workflow.agentName },
+      changedFields,
+      changes,
+      ...(connectionsChanged ? { connections: { added: toAdd, removed: toRemove } } : {}),
+    },
+  });
+
+  return NextResponse.json({ id, name });
 });
 
 /**

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from "next/server";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { desc, eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
-import { emailWorkflows, emailWorkflowConnections, agentConnectionPermissions } from "@/db/schema";
+import { emailWorkflows, emailWorkflowConnections } from "@/db/schema";
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
 import { createAutomationSchema } from "@/lib/schemas/automations";
 import { scrubEmails } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
-import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
+import { findUnreadableConnectionIds } from "@/lib/email-workflows/connection-access";
 import {
   resolveWorkflowAgent,
   resolveWorkflowAgentFromQuery,
@@ -102,25 +102,12 @@ export const POST = withAuth(async (request, _ctx, session) => {
 
   // Every requested mailbox must be one the agent is allowed to READ — a
   // workflow's trigger lists and reads mail, so a draft/send-only grant is not
-  // enough. EMAIL_READ_OPERATIONS includes the legacy "search"/"list" aliases
-  // the runtime already treats as read (tool-registry). An unknown connection
-  // id has no permission row either, so this single check rejects "no read
-  // access" and "no such connection" alike — a workflow must never point at a
-  // mailbox its agent can't open.
+  // enough. The rule (and why an unknown connection id is rejected by the same
+  // check) lives in `findUnreadableConnectionIds`, which PATCH shares: the edit
+  // path has to enforce the identical rule, and two copies of it would be one
+  // copy away from a workflow pointing at a mailbox its agent cannot open.
   const requestedConnectionIds = [...new Set(connectionIds)];
-  const permittedRows = await db
-    .selectDistinct({ connectionId: agentConnectionPermissions.connectionId })
-    .from(agentConnectionPermissions)
-    .where(
-      and(
-        eq(agentConnectionPermissions.agentId, agentId),
-        eq(agentConnectionPermissions.model, "email"),
-        inArray(agentConnectionPermissions.operation, [...EMAIL_READ_OPERATIONS]),
-        inArray(agentConnectionPermissions.connectionId, requestedConnectionIds)
-      )
-    );
-  const permitted = new Set(permittedRows.map((r) => r.connectionId));
-  const missing = requestedConnectionIds.filter((id) => !permitted.has(id));
+  const missing = await findUnreadableConnectionIds(agentId, requestedConnectionIds);
   if (missing.length > 0) {
     return NextResponse.json(
       { error: `The agent has no email access to connection(s): ${missing.join(", ")}` },

--- a/packages/web/src/components/agent-settings-automation-dialog.tsx
+++ b/packages/web/src/components/agent-settings-automation-dialog.tsx
@@ -3,9 +3,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { apiGet, apiPost, errorMessage } from "@/lib/api-client";
+import { apiGet, apiPost, apiPut, errorMessage } from "@/lib/api-client";
 import { AUTOMATION_MAX_SWEEP_WINDOW_DAYS } from "@/lib/schemas/automations";
-import type { AutomationConnectionOption, CreateAutomationInput } from "@/lib/schemas/automations";
+import type {
+  AutomationConnectionOption,
+  AutomationListItem,
+  CreateAutomationInput,
+  EditAutomationInput,
+} from "@/lib/schemas/automations";
 import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -35,30 +40,60 @@ function parseList(value: string): string[] {
 }
 
 /**
- * The create dialog for an Inbox Agent email workflow (#139) — the first UI path
- * to author one. It resolves the same object POST /api/automations writes, so it
- * shares the {@link CreateAutomationInput} contract with the route and the future
- * conversational tool (#705).
+ * The form's field state seeded from an existing workflow (edit mode) or blank
+ * (create mode). List filters become comma-joined strings — the inverse of
+ * {@link parseList} — so what the form parses on submit round-trips what it
+ * rendered. One function feeds both the initial state and the reset-on-reopen.
+ */
+function fieldsFromWorkflow(workflow?: AutomationListItem) {
+  const filter = workflow?.filter ?? {};
+  return {
+    name: workflow?.name ?? "",
+    action: workflow?.action ?? "",
+    from: (filter.from ?? []).join(", "),
+    toDomain: (filter.toDomain ?? []).join(", "),
+    subjectContains: (filter.subjectContains ?? []).join(", "),
+    hasAttachment: filter.hasAttachment ?? false,
+    attachmentType: filter.attachmentType ?? "",
+    folder: filter.folder ?? "",
+    sweepWindowDays: String(workflow?.sweepWindowDays ?? DEFAULT_SWEEP_WINDOW_DAYS),
+    selectedConnectionIds: workflow?.connectionIds ?? [],
+  };
+}
+
+/**
+ * The create/edit dialog for an Inbox Agent email workflow (#139). With no
+ * `workflow` it authors a new one (POST /api/automations); given a `workflow` it
+ * edits that one in place (PUT /api/automations/[id]). One form, because both
+ * write the identical structured object — the edit path just starts pre-filled.
+ * It shares the {@link CreateAutomationInput}/{@link EditAutomationInput}
+ * contracts with the routes and the future conversational tool (#705).
  *
  * The mailbox picker is populated from GET /api/automations/connections, which
- * resolves choices through the same email-read permission gate the create route
- * enforces — so the form can only offer mailboxes the server will accept.
+ * resolves choices through the same email-read permission gate the write routes
+ * enforce — so the form can only offer mailboxes the server will accept.
  *
- * Propose, don't self-activate: the route always writes the workflow
- * pending + disabled, so there is no "enable now" control here — activation is
- * the reviewer's separate step in the tab.
+ * Propose, don't self-activate: neither path touches `enabled`/`status`. A new
+ * workflow is written pending + disabled; an edit leaves activation exactly as it
+ * was. There is no "enable now" control here — activation is the reviewer's
+ * separate toggle in the tab.
  */
-export function AgentSettingsAutomationCreateDialog({
+export function AgentSettingsAutomationDialog({
   agentId,
   open,
   onOpenChange,
-  onCreated,
+  onSaved,
+  workflow,
 }: {
   agentId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated: () => void;
+  onSaved: () => void;
+  /** When set, the dialog edits this workflow instead of creating a new one. */
+  workflow?: AutomationListItem;
 }) {
+  const isEdit = workflow != null;
+
   const [connections, setConnections] = useState<AutomationConnectionOption[]>([]);
   const [loadingConnections, setLoadingConnections] = useState(true);
   const [connectionsError, setConnectionsError] = useState<string | null>(null);
@@ -68,34 +103,43 @@ export function AgentSettingsAutomationCreateDialog({
   // never clobber the picker a reopen just refreshed.
   const loadSeqRef = useRef(0);
 
-  const [name, setName] = useState("");
-  const [action, setAction] = useState("");
-  const [from, setFrom] = useState("");
-  const [toDomain, setToDomain] = useState("");
-  const [subjectContains, setSubjectContains] = useState("");
-  const [hasAttachment, setHasAttachment] = useState(false);
-  const [attachmentType, setAttachmentType] = useState("");
-  const [folder, setFolder] = useState("");
-  const [sweepWindowDays, setSweepWindowDays] = useState(String(DEFAULT_SWEEP_WINDOW_DAYS));
-  const [selectedConnectionIds, setSelectedConnectionIds] = useState<string[]>([]);
+  // Seed initial state from the workflow (edit) or blanks (create). Lazy so it
+  // reads the workflow once, on mount — the mount-open case (open=true from the
+  // first render) never fires the reset-on-open branch below, so the initial
+  // state is what pre-fills an edit dialog opened directly.
+  const [initial] = useState(() => fieldsFromWorkflow(workflow));
+  const [name, setName] = useState(initial.name);
+  const [action, setAction] = useState(initial.action);
+  const [from, setFrom] = useState(initial.from);
+  const [toDomain, setToDomain] = useState(initial.toDomain);
+  const [subjectContains, setSubjectContains] = useState(initial.subjectContains);
+  const [hasAttachment, setHasAttachment] = useState(initial.hasAttachment);
+  const [attachmentType, setAttachmentType] = useState(initial.attachmentType);
+  const [folder, setFolder] = useState(initial.folder);
+  const [sweepWindowDays, setSweepWindowDays] = useState(initial.sweepWindowDays);
+  const [selectedConnectionIds, setSelectedConnectionIds] = useState<string[]>(
+    initial.selectedConnectionIds
+  );
 
   // Fresh form on each open (React-recommended "adjust state during render"
-  // instead of an effect). Also clears the picker and re-arms the loading state
-  // so a reopen re-fetches rather than showing a stale mailbox list.
+  // instead of an effect) — re-seeded from the current workflow so a reopened
+  // edit dialog shows the stored values again. Also clears the picker and
+  // re-arms loading so a reopen re-fetches rather than showing a stale list.
   const [prevOpen, setPrevOpen] = useState(open);
   if (prevOpen !== open) {
     setPrevOpen(open);
     if (open) {
-      setName("");
-      setAction("");
-      setFrom("");
-      setToDomain("");
-      setSubjectContains("");
-      setHasAttachment(false);
-      setAttachmentType("");
-      setFolder("");
-      setSweepWindowDays(String(DEFAULT_SWEEP_WINDOW_DAYS));
-      setSelectedConnectionIds([]);
+      const seed = fieldsFromWorkflow(workflow);
+      setName(seed.name);
+      setAction(seed.action);
+      setFrom(seed.from);
+      setToDomain(seed.toDomain);
+      setSubjectContains(seed.subjectContains);
+      setHasAttachment(seed.hasAttachment);
+      setAttachmentType(seed.attachmentType);
+      setFolder(seed.folder);
+      setSweepWindowDays(seed.sweepWindowDays);
+      setSelectedConnectionIds(seed.selectedConnectionIds);
       setConnections([]);
       setConnectionsError(null);
       setLoadingConnections(true);
@@ -176,22 +220,39 @@ export function AgentSettingsAutomationCreateDialog({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!canSubmit) return;
-    const payload: CreateAutomationInput = {
-      agentId,
-      name: name.trim(),
-      action: action.trim(),
-      filter: buildFilter(),
-      connectionIds: selectedConnectionIds,
-      sweepWindowDays: parsedSweepDays,
-    };
     setSubmitting(true);
     try {
-      await apiPost("/api/automations", payload);
-      toast.success("Automation created — review and enable it below.");
-      onCreated();
+      if (workflow) {
+        // Edit: replace the workflow's editable representation. No agentId — a
+        // workflow never changes agents; no enabled — activation stays the tab's
+        // toggle.
+        const payload: EditAutomationInput = {
+          name: name.trim(),
+          action: action.trim(),
+          filter: buildFilter(),
+          connectionIds: selectedConnectionIds,
+          sweepWindowDays: parsedSweepDays,
+        };
+        await apiPut(`/api/automations/${workflow.id}`, payload);
+        toast.success("Automation updated.");
+      } else {
+        const payload: CreateAutomationInput = {
+          agentId,
+          name: name.trim(),
+          action: action.trim(),
+          filter: buildFilter(),
+          connectionIds: selectedConnectionIds,
+          sweepWindowDays: parsedSweepDays,
+        };
+        await apiPost("/api/automations", payload);
+        toast.success("Automation created — review and enable it below.");
+      }
+      onSaved();
       onOpenChange(false);
     } catch (e) {
-      toast.error(errorMessage(e, "Failed to create automation"));
+      toast.error(
+        errorMessage(e, isEdit ? "Failed to update automation" : "Failed to create automation")
+      );
     } finally {
       setSubmitting(false);
     }
@@ -201,10 +262,11 @@ export function AgentSettingsAutomationCreateDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>New automation</DialogTitle>
+          <DialogTitle>{isEdit ? "Edit automation" : "New automation"}</DialogTitle>
           <DialogDescription>
-            Describe which mail this agent should act on and what to do. It&apos;s created paused —
-            you review and enable it afterwards.
+            {isEdit
+              ? "Change which mail this agent acts on and what it does. Saving doesn't change whether it's enabled — use the toggle in the list for that."
+              : "Describe which mail this agent should act on and what to do. It's created paused — you review and enable it afterwards."}
           </DialogDescription>
         </DialogHeader>
 
@@ -364,7 +426,7 @@ export function AgentSettingsAutomationCreateDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={!canSubmit}>
-              Create automation
+              {isEdit ? "Save changes" : "Create automation"}
             </Button>
           </DialogFooter>
         </form>

--- a/packages/web/src/components/agent-settings-automation-dialog.tsx
+++ b/packages/web/src/components/agent-settings-automation-dialog.tsx
@@ -97,6 +97,11 @@ export function AgentSettingsAutomationDialog({
   const [connections, setConnections] = useState<AutomationConnectionOption[]>([]);
   const [loadingConnections, setLoadingConnections] = useState(true);
   const [connectionsError, setConnectionsError] = useState<string | null>(null);
+  // How many mailboxes this workflow watched are no longer email-readable by the
+  // agent (grant revoked after creation), so the picker can't offer them. We drop
+  // them from the selection and tell the user, rather than let an invisible id
+  // ride along on the PUT and come back a 400 for a mailbox they never saw.
+  const [unavailableCount, setUnavailableCount] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   // Monotonic sequence for connection loads: a response only lands if it still
   // belongs to the latest load, so a slow response from a previous open can
@@ -142,6 +147,7 @@ export function AgentSettingsAutomationDialog({
       setSelectedConnectionIds(seed.selectedConnectionIds);
       setConnections([]);
       setConnectionsError(null);
+      setUnavailableCount(0);
       setLoadingConnections(true);
     }
   }
@@ -155,7 +161,18 @@ export function AgentSettingsAutomationDialog({
         `/api/automations/connections?agentId=${encodeURIComponent(agentId)}`
       );
       if (seq !== loadSeqRef.current) return;
-      setConnections(Array.isArray(data) ? data : []);
+      const options = Array.isArray(data) ? data : [];
+      setConnections(options);
+      // Any mailbox this workflow watched that the options don't offer is one the
+      // agent can no longer read. Prune those ids from the selection so they
+      // never reach the PUT (which would 400 on them), and surface the count.
+      const optionIds = new Set(options.map((c) => c.id));
+      const unavailable = (workflow?.connectionIds ?? []).filter((id) => !optionIds.has(id));
+      setUnavailableCount(unavailable.length);
+      if (unavailable.length > 0) {
+        const gone = new Set(unavailable);
+        setSelectedConnectionIds((prev) => prev.filter((id) => !gone.has(id)));
+      }
     } catch (e) {
       if (seq !== loadSeqRef.current) return;
       setConnections([]);
@@ -165,7 +182,7 @@ export function AgentSettingsAutomationDialog({
     } finally {
       if (seq === loadSeqRef.current) setLoadingConnections(false);
     }
-  }, [agentId]);
+  }, [agentId, workflow]);
 
   useEffect(() => {
     if (!open) return;
@@ -365,6 +382,13 @@ export function AgentSettingsAutomationDialog({
               Which connected mailboxes this automation watches. Only mailboxes this agent may read
               are listed.
             </p>
+            {!loadingConnections && !connectionsError && unavailableCount > 0 && (
+              <p className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
+                {unavailableCount === 1
+                  ? "1 mailbox this automation watched is no longer readable by this agent and has been removed from the selection. Saving will stop watching it."
+                  : `${unavailableCount} mailboxes this automation watched are no longer readable by this agent and have been removed from the selection. Saving will stop watching them.`}
+              </p>
+            )}
             {loadingConnections ? (
               <div className="space-y-2">
                 <Skeleton className="h-6 w-full" />

--- a/packages/web/src/components/agent-settings-automations.tsx
+++ b/packages/web/src/components/agent-settings-automations.tsx
@@ -7,7 +7,7 @@ import { apiGet, apiPatch, apiDelete, errorMessage } from "@/lib/api-client";
 import type { AutomationListItem } from "@/lib/schemas/automations";
 import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
 import type { EmailWorkflowStatus } from "@/db/enums";
-import { AgentSettingsAutomationCreateDialog } from "@/components/agent-settings-automation-create-dialog";
+import { AgentSettingsAutomationDialog } from "@/components/agent-settings-automation-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -77,6 +77,7 @@ export function AgentSettingsAutomations({ agentId }: { agentId: string }) {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<AutomationListItem | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<AutomationListItem | null>(null);
 
   // No synchronous setState here: `loading` starts true and the `finally`
   // clears it, so the effect that calls this never sets state before its first
@@ -154,12 +155,26 @@ export function AgentSettingsAutomations({ agentId }: { agentId: string }) {
         </Button>
       </div>
 
-      <AgentSettingsAutomationCreateDialog
+      <AgentSettingsAutomationDialog
         agentId={agentId}
         open={createOpen}
         onOpenChange={setCreateOpen}
-        onCreated={load}
+        onSaved={load}
       />
+
+      {/* Edit reuses the same dialog, seeded with the row's workflow. Mounted
+          only while editing so each open re-seeds cleanly from the target. */}
+      {editTarget && (
+        <AgentSettingsAutomationDialog
+          agentId={agentId}
+          open={true}
+          onOpenChange={(o) => {
+            if (!o) setEditTarget(null);
+          }}
+          onSaved={load}
+          workflow={editTarget}
+        />
+      )}
 
       {loading ? (
         <div className="space-y-2">
@@ -221,6 +236,15 @@ export function AgentSettingsAutomations({ agentId }: { agentId: string }) {
                         onClick={() => handleToggle(item)}
                       >
                         {item.enabled ? "Disable" : "Enable"}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="ml-2"
+                        disabled={busyId === item.id}
+                        onClick={() => setEditTarget(item)}
+                      >
+                        Edit
                       </Button>
                       <Button
                         size="sm"

--- a/packages/web/src/lib/email-workflows/connection-access.ts
+++ b/packages/web/src/lib/email-workflows/connection-access.ts
@@ -1,0 +1,40 @@
+import { and, eq, inArray } from "drizzle-orm";
+
+import { db } from "@/db";
+import { agentConnectionPermissions } from "@/db/schema";
+import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
+
+/**
+ * Of the requested connection ids, return those the agent may NOT read.
+ *
+ * A workflow's trigger lists and reads mail, so a draft/send-only grant is not
+ * enough — only an email-READ permission qualifies. `EMAIL_READ_OPERATIONS`
+ * includes the legacy "search"/"list" aliases the runtime already treats as
+ * read. An unknown connection id has no permission row either, so this single
+ * check rejects "no read access" and "no such connection" alike.
+ *
+ * Shared by BOTH write paths — create (POST) and edit (PUT) — deliberately: a
+ * workflow must never point at a mailbox its agent can't open, and if the two
+ * paths validated this separately they could drift into a hole where one accepts
+ * what the other (and the runtime) forbids. One function, one boundary.
+ */
+export async function findUnreadableConnectionIds(
+  agentId: string,
+  requestedConnectionIds: string[]
+): Promise<string[]> {
+  const requested = [...new Set(requestedConnectionIds)];
+  if (requested.length === 0) return [];
+  const permittedRows = await db
+    .selectDistinct({ connectionId: agentConnectionPermissions.connectionId })
+    .from(agentConnectionPermissions)
+    .where(
+      and(
+        eq(agentConnectionPermissions.agentId, agentId),
+        eq(agentConnectionPermissions.model, "email"),
+        inArray(agentConnectionPermissions.operation, [...EMAIL_READ_OPERATIONS]),
+        inArray(agentConnectionPermissions.connectionId, requested)
+      )
+    );
+  const permitted = new Set(permittedRows.map((r) => r.connectionId));
+  return requested.filter((id) => !permitted.has(id));
+}

--- a/packages/web/src/lib/schemas/automations.ts
+++ b/packages/web/src/lib/schemas/automations.ts
@@ -90,6 +90,24 @@ export const updateAutomationSchema = z.object({
 export type UpdateAutomationInput = z.infer<typeof updateAutomationSchema>;
 
 /**
+ * Request schema for PUT /api/automations/[id] — edit a workflow's editable
+ * representation in place (the Automations edit form). Derived from
+ * {@link createAutomationSchema} by dropping `agentId` (a workflow never changes
+ * agents), so the two write paths validate every shared field identically and
+ * can't drift. Notably absent: `enabled`/`status`. Activation stays the PATCH
+ * toggle's sole concern — editing a workflow's substance never implicitly flips
+ * it on or off (propose, don't self-activate; the editor holds the same
+ * manage-scope as the enabler, but activation remains a separate, explicit act).
+ *
+ * A PUT (not PATCH): the edit form always submits the FULL current field set
+ * pre-filled from the row, so it replaces the editable representation rather than
+ * patching a subset — the narrow `enabled`-only PATCH keeps its distinct job.
+ */
+export const editAutomationSchema = createAutomationSchema.omit({ agentId: true });
+
+export type EditAutomationInput = z.infer<typeof editAutomationSchema>;
+
+/**
  * Client-side contract for one row of GET /api/automations?agentId — the shape
  * the Automations tab (#139) renders. `createdAt` is a string here (JSON has no
  * Date), whereas the route works with a `Date` before serialization; that is the


### PR DESCRIPTION
## Why

Closes the last gap in the Inbox Agent Automations lifecycle:

`create → review → enable/disable → **edit** → delete`

Until now the only way to change a workflow's fields was **delete + recreate** — which re-births it `pending`+`disabled` and, worse, **resets every connection watermark**, so an enabled reconciler would silently re-process or skip mail. This adds true in-place editing.

## What

- **`PUT /api/automations/[id]`** — edits `name / filter / action / sweepWindowDays` and reconciles the mailbox set, through the **same scope gate** and the **same email-read connection gate** as create. The two write paths now share `findUnreadableConnectionIds()` (new `lib/email-workflows/connection-access.ts`), so they can't drift into a hole where one accepts a mailbox the other (and the runtime) forbids. POST was refactored onto the shared helper too.
- **Connection reconciliation is a diff, not a rewrite** — the subtle correctness point:
  - a mailbox **kept** across the edit keeps its `sinceTs` watermark (rewriting it would make an enabled reconciler re-list or skip mail across the gap),
  - a **new** mailbox is stamped at `now` (never retroactively sweeps history — same rule as create),
  - a **removed** one is dropped.
- **The create dialog is generalized** into one create/edit dialog (renamed `AgentSettingsAutomationDialog`): given a `workflow` it pre-fills and PUTs; without one it POSTs as before. The tab gains a per-row **Edit** button.
- **Audit** `email_workflow.updated` carries `changedFields` (complete, PII-safe list) + before/after for the safe scalar fields (name scrubbed, sweep window) + a connection **added/removed id diff**. `action`/`filter` are named but never dumped (they can carry addresses).

## One product decision (default — tell me to flip it)

**Editing never changes `enabled`/`status`.** Activation stays the toggle's sole, explicit job (propose, don't self-activate). Rationale: whoever edits holds the same manage-scope as whoever enables, so the edit is itself an authorized human act — but activation remains a separate, deliberate step. (Alternative would be "a substantive edit re-enters review / disables.")

## Tests (TDD throughout, RED→GREEN)

- **Integration** (`automations-edit.integration.test.ts`, real DB): field update; **watermark-preserving reconciliation** (kept keeps `sinceTs`, added stamped at now, removed dropped); rejects an unreadable connection (400, mirrors create); member-on-shared 403; admin-on-shared ok; 404; **no-op edit → no audit**.
- **Component**: edit-mode prefill (fields + checked mailbox, "Save changes"); PUT payload (no `agentId`) + success; API-error toast + stays open. Create behavior unchanged.
- **Wiring**: tab Edit button opens the dialog prefilled from the row and reloads the list after saving.

## Gates

typecheck ✓ · eslint 0/0 ✓ · prettier (incl. docs) ✓ · automations integration 40/40 ✓ · full web unit suite **10778 passed / 0 failed** ✓

## Docs

`concepts/agent-settings.mdx` → the Automations "Review, **edit**, enable, and remove" section documents the edit flow, that it doesn't change enabled state, and the watermark behavior in user terms.

## Notes

- `#705` (conversational create) stays blocked on `#517`/#865 (confirmation gate); this brick is fully independent and needs no dependency.
- Field-editing was deliberately out of scope for #902 (the create form) because it needed the `updateAutomationSchema` → `editAutomationSchema` split this PR introduces.