### PR TITLE
fix(providers): make a rotated API key reach the running OpenClaw

### DIFF
--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -295,8 +295,17 @@ openclaw gateway --port 18789 &
 mark_bootstrap_when_ready
 
 # Keep the container alive. Health-check restarts gateway if it crashes.
-# Provider API keys are resolved live from secrets.json via SecretRef —
-# no env-export or gateway restart needed on key rotation.
+#
+# Provider API keys need no env-export and no gateway restart on rotation —
+# but NOT because they are resolved live. They are not: OpenClaw resolves
+# SecretRefs eagerly into an in-memory snapshot at activation time, never on
+# the request path (openclaw docs, gateway/secrets.md "Runtime model"). This
+# comment used to claim otherwise, which is exactly why #943 stayed invisible:
+# a rotated key sat in secrets.json unread, every agent kept presenting the
+# revoked one, and the bootstrap marker above deliberately suppresses the
+# restart for anything past the first write. Pinchy closes that gap from its
+# side by calling the `secrets.reload` RPC whenever the bundle changes (see
+# packages/web/src/lib/openclaw-config/secrets-reload.ts).
 while true; do
     sleep 30
 

--- a/docs/src/content/docs/guides/llm-providers.mdx
+++ b/docs/src/content/docs/guides/llm-providers.mdx
@@ -37,6 +37,21 @@ Pinchy validates the credentials immediately by making a test call to the provid
 
 API keys are encrypted at rest with AES-256-GCM. They never appear in logs, audit events, or error messages.
 
+## Rotate an API key
+
+Keys expire, and sometimes one has to be replaced in a hurry. Rotating is the same three clicks as adding:
+
+1. Go to **Settings → AI Provider**
+2. Click the provider's tile and paste the new key
+3. Click **Save**
+
+Pinchy validates the new key, stores it, and hands it straight to the agent runtime — your agents pick it up within seconds. There is nothing to restart.
+
+<Aside type="note">
+  For security, Pinchy never shows a saved key back to you. A blank field means
+  "keep the current key", so an empty save is not an accidental rotation.
+</Aside>
+
 ## Change an agent's model
 
 Each agent uses one model at a time. To change it:

--- a/docs/src/content/docs/security/secrets.md
+++ b/docs/src/content/docs/security/secrets.md
@@ -44,6 +44,9 @@ At startup — and every time you change a provider or integration — Pinchy ca
 1. Reads all relevant rows from PostgreSQL
 2. Decrypts each value in memory
 3. Writes the decrypted keys to `/openclaw-secrets/secrets.json`
+4. Tells OpenClaw to re-read that file whenever its contents changed
+
+Step 4 is what makes rotation immediate. OpenClaw resolves each pointer once and holds the value for the life of the process, and `openclaw.json` is unchanged by a rotation — it carries the pointer, not the key. So a new key would otherwise sit in the file unread until the container restarted, with every agent still presenting the old one.
 
 That path is a Docker `tmpfs` mount. tmpfs is RAM-based storage — it's never written to disk, never included in Docker volume exports, and disappears on container restart.
 
@@ -81,7 +84,7 @@ These are infrastructure-level threats. Protect against them at the host level: 
 
 Different consumers reach their secrets through different paths. Knowing which pattern applies is useful when something looks wrong in `openclaw.json`.
 
-**Pattern A — OpenClaw resolves SecretRef pointers.** Used for `models.providers.<name>.apiKey` and any `env.<VAR>` template. The flow above describes this pattern in full: ciphertext lives in PostgreSQL, plaintext lands in the tmpfs `secrets.json`, OpenClaw walks the pointer at call time. Provider API keys (Anthropic, OpenAI, Google, etc.) all use this path.
+**Pattern A — OpenClaw resolves SecretRef pointers.** Used for `models.providers.<name>.apiKey` and any `env.<VAR>` template. The flow above describes this pattern in full: ciphertext lives in PostgreSQL, plaintext lands in the tmpfs `secrets.json`, and OpenClaw walks the pointer when it loads its runtime — then keeps the resolved value until Pinchy tells it the file moved. Provider API keys (Anthropic, OpenAI, Google, etc.) all use this path.
 
 **Pattern B — Pinchy plugins fetch credentials at call time.** Used by every Pinchy-built plugin that talks to a third-party SaaS: `pinchy-odoo`, `pinchy-email`, `pinchy-web`. `openclaw.json` only carries the plugin's `apiBaseUrl`, the gateway auth token, and an opaque `connectionId`. The plugin calls `GET /api/internal/integrations/:connectionId/credentials?agentId=<id>` with the gateway token as Bearer auth when it actually needs the credential, caches it in-process with a 5-minute TTL, and invalidates the cache on a 401 so credential rotation works without restarts. The credential itself never appears in `openclaw.json`.
 
@@ -93,7 +96,7 @@ The defense-in-depth scan that runs at config-write time recognises known provid
 
 ## Key rotation
 
-If you suspect an API key has been exposed, rotate it at the provider and update it in Pinchy via **Settings → AI Provider**. Pinchy will write the new encrypted value to PostgreSQL and regenerate the secrets file immediately.
+If you suspect an API key has been exposed, rotate it at the provider and update it in Pinchy via **Settings → AI Provider**. Pinchy writes the new encrypted value to PostgreSQL, regenerates the secrets file, and tells OpenClaw to re-resolve it — so your agents stop presenting the exposed key within seconds, without a restart. See [Rotate an API key](/guides/llm-providers/#rotate-an-api-key) for the operator's view.
 
 ## Reporting a vulnerability
 

--- a/packages/web/e2e/setup-wizard/openai-compatible.spec.ts
+++ b/packages/web/e2e/setup-wizard/openai-compatible.spec.ts
@@ -71,7 +71,7 @@ interface ConfigChangedDetail {
   authType?: string;
   baseUrlHost?: string;
   modelCount?: number;
-  runtimeApplied?: boolean;
+  configRegenerated?: boolean;
   provider?: { id?: string; name?: string };
   previousDefault?: string | null;
   newDefault?: string;

--- a/packages/web/src/__tests__/api/openai-compatible-providers.test.ts
+++ b/packages/web/src/__tests__/api/openai-compatible-providers.test.ts
@@ -399,7 +399,7 @@ describe("POST /api/settings/providers/openai-compatible", () => {
       authType: "openai-compatible",
       baseUrlHost: "acme.example.com",
       modelCount: 1,
-      runtimeApplied: true,
+      configRegenerated: true,
     });
   });
 
@@ -421,7 +421,7 @@ describe("POST /api/settings/providers/openai-compatible", () => {
     expect(serialized).toContain("acme.example.com");
   });
 
-  it("records runtimeApplied: false when regenerate throws (best-effort)", async () => {
+  it("records configRegenerated: false when regenerate throws (best-effort)", async () => {
     vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(new Error("EACCES"));
 
     const res = await POST(
@@ -437,7 +437,7 @@ describe("POST /api/settings/providers/openai-compatible", () => {
     expect(res.status).toBe(200);
     expect(resetCache).toHaveBeenCalled();
     const entry = vi.mocked(appendAuditLog).mock.calls[0][0];
-    expect(entry.detail).toMatchObject({ runtimeApplied: false });
+    expect(entry.detail).toMatchObject({ configRegenerated: false });
   });
 
   it("updates an existing provider without an api key and still succeeds, discovering with the STORED key", async () => {
@@ -968,7 +968,7 @@ describe("DELETE /api/settings/providers/openai-compatible", () => {
           toModel: "anthropic/claude-haiku-4-5-20251001",
         },
       ],
-      runtimeApplied: true,
+      configRegenerated: true,
     });
     // The deleted provider's display name survives for post-deletion analysis,
     // and nothing key- or PII-shaped leaks into the detail.
@@ -1094,7 +1094,7 @@ describe("DELETE /api/settings/providers/openai-compatible", () => {
     });
   });
 
-  it("still succeeds with runtimeApplied:false when regenerate throws (best-effort)", async () => {
+  it("still succeeds with configRegenerated:false when regenerate throws (best-effort)", async () => {
     vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(new Error("EACCES"));
 
     const res = await DELETE(deleteRequest({ id: PROVIDER_ID }), routeCtx);
@@ -1102,6 +1102,6 @@ describe("DELETE /api/settings/providers/openai-compatible", () => {
     expect(res.status).toBe(200);
     expect(resetCache).toHaveBeenCalled();
     const entry = vi.mocked(appendAuditLog).mock.calls[0][0];
-    expect(entry.detail).toMatchObject({ runtimeApplied: false });
+    expect(entry.detail).toMatchObject({ configRegenerated: false });
   });
 });

--- a/packages/web/src/__tests__/api/settings-providers-default.test.ts
+++ b/packages/web/src/__tests__/api/settings-providers-default.test.ts
@@ -150,7 +150,7 @@ describe("PATCH /api/settings/providers/default", () => {
       provider: { id: "anthropic", name: "Anthropic" },
       previousDefault: "openai",
       newDefault: "anthropic",
-      runtimeApplied: true,
+      configRegenerated: true,
     });
   });
 
@@ -190,7 +190,7 @@ describe("PATCH /api/settings/providers/default", () => {
     expect(setSetting).toHaveBeenCalledWith("default_provider", "anthropic", false);
     expect(resetCache).toHaveBeenCalled();
     const entry = vi.mocked(appendAuditLog).mock.calls[0][0];
-    expect(entry.detail).toMatchObject({ runtimeApplied: false });
+    expect(entry.detail).toMatchObject({ configRegenerated: false });
   });
 
   it("never writes an audit entry on a rejected request", async () => {

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -297,7 +297,7 @@ describe("POST /api/setup/provider", () => {
       string,
       unknown
     >;
-    expect(auditDetail.runtimeApplied).toBe(false);
+    expect(auditDetail.configRegenerated).toBe(false);
   });
 
   it("should not include a warning when config regeneration succeeds", async () => {
@@ -676,7 +676,7 @@ describe("POST /api/setup/provider", () => {
       provider: { id: "anthropic", name: "Anthropic" },
       authType: "api-key",
       // On the happy path the setting also reached the runtime (#880).
-      runtimeApplied: true,
+      configRegenerated: true,
     });
   });
 

--- a/packages/web/src/__tests__/api/user-config-audit.test.ts
+++ b/packages/web/src/__tests__/api/user-config-audit.test.ts
@@ -312,7 +312,7 @@ describe("audit: POST /api/setup/provider", () => {
         provider: { id: "anthropic", name: "Anthropic" },
         authType: "api-key",
         // Records whether the setting also reached the OpenClaw runtime (#880).
-        runtimeApplied: true,
+        configRegenerated: true,
       },
     });
   });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -3622,7 +3622,7 @@ describe("regenerateOpenClawConfig", () => {
 
     it("still reports the failure to the caller, naming the agent and what did land", async () => {
       // Silence is the other half of the bug: the wizard turns this rejection
-      // into a warning toast and records runtimeApplied:false in the audit
+      // into a warning toast and records configRegenerated: false in the audit
       // trail. Swallowing it would trade a loud failure for a silent one.
       //
       // But the message has to say what actually happened now — the raw EACCES

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -211,7 +211,7 @@ describe("writeAgentAuthProfiles", () => {
     // (Smithers exists before the wizard's provider step). And `unlink` inside a
     // root-owned 0700 directory returns EACCES, not ENOENT. A bare catch here
     // therefore reports the broken directory as a clean removal: nothing lands
-    // in `authProfileFailures`, no warning toast, no `runtimeApplied: false` —
+    // in `authProfileFailures`, no warning toast, no `configRegenerated: false` —
     // the permission problem stays invisible until a provider is saved, which is
     // the very silence the rest of this fix exists to remove.
     it("retries a denied removal and succeeds once the tick lands", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config/secrets-reload.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/secrets-reload.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockGetClient } = vi.hoisted(() => ({ mockGetClient: vi.fn() }));
+
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => mockGetClient(),
+}));
+
+import { reloadSecretsInBackground } from "@/lib/openclaw-config/secrets-reload";
+
+/** The push is fire-and-forget; let its microtasks run. */
+async function drain(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe("reloadSecretsInBackground (#943)", () => {
+  let request: ReturnType<typeof vi.fn>;
+  let hasMethod: ReturnType<typeof vi.fn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    request = vi.fn().mockResolvedValue({ type: "res", id: "1", ok: true, payload: {} });
+    hasMethod = vi.fn().mockReturnValue(true);
+    mockGetClient.mockReturnValue({ request, hasMethod });
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("asks the gateway to re-resolve its secrets", async () => {
+    // The whole point of #943: a rotated key sits in secrets.json, the emitted
+    // config is byte-identical, so `config.apply` is (correctly) skipped. This
+    // RPC is the only thing that makes the running OpenClaw drop the credential
+    // it resolved at process start.
+    reloadSecretsInBackground();
+    await drain();
+
+    expect(request).toHaveBeenCalledWith("secrets.reload");
+  });
+
+  it("warns instead of throwing when no OpenClaw client is connected", async () => {
+    mockGetClient.mockImplementation(() => {
+      throw new Error("OpenClaw client not initialized");
+    });
+
+    expect(() => reloadSecretsInBackground()).not.toThrow();
+    await drain();
+
+    expect(request).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("still calls a gateway that advertises no method list yet", async () => {
+    // The advertised-method list is empty until the hello-ok handshake, so a
+    // `hasMethod` gate cannot tell "gateway is too old" from "we reconnected a
+    // moment ago" — and skipping on the latter would drop the rotation on a
+    // gateway that supports it. A gateway that genuinely lacks the method
+    // answers with an error, which is reported like any other refusal.
+    hasMethod.mockReturnValue(false);
+
+    reloadSecretsInBackground();
+    await drain();
+
+    expect(request).toHaveBeenCalledWith("secrets.reload");
+  });
+
+  it("warns instead of throwing when the RPC rejects", async () => {
+    request.mockRejectedValue(new Error("Not connected to OpenClaw Gateway"));
+
+    expect(() => reloadSecretsInBackground()).not.toThrow();
+    await drain();
+
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("treats an ok:false response as a failure rather than success", async () => {
+    // openclaw-node resolves the promise for an error response, so a bare
+    // `await request(...)` would report a refused reload as a successful one.
+    request.mockResolvedValue({
+      type: "res",
+      id: "1",
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "secrets.reload failed" },
+    });
+
+    reloadSecretsInBackground();
+    await drain();
+
+    expect(warnSpy).toHaveBeenCalled();
+    const warning = warnSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+    expect(warning).toContain("secrets.reload failed");
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/secrets-rotation.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/secrets-rotation.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const writeFileSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn().mockReturnValue(true);
+  const mkdirSyncMock = vi.fn();
+  const renameSyncMock = vi.fn();
+  const chmodSyncMock = vi.fn();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      writeFileSync: writeFileSyncMock,
+      readFileSync: readFileSyncMock,
+      existsSync: existsSyncMock,
+      mkdirSync: mkdirSyncMock,
+      renameSync: renameSyncMock,
+      chmodSync: chmodSyncMock,
+    },
+    writeFileSync: writeFileSyncMock,
+    readFileSync: readFileSyncMock,
+    existsSync: existsSyncMock,
+    mkdirSync: mkdirSyncMock,
+    renameSync: renameSyncMock,
+    chmodSync: chmodSyncMock,
+  };
+});
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() =>
+        Object.assign(Promise.resolve([]), {
+          innerJoin: vi.fn().mockReturnValue(
+            Object.assign(Promise.resolve([]), {
+              where: vi.fn().mockResolvedValue([]),
+            })
+          ),
+          where: vi.fn().mockResolvedValue([]),
+        })
+      ),
+    })),
+  },
+}));
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (val: string) => val,
+  encrypt: (val: string) => val,
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+vi.mock("@/server/restart-state", () => ({
+  restartState: { notifyRestart: vi.fn() },
+}));
+
+const { mockWriteSecretsFile } = vi.hoisted(() => ({
+  mockWriteSecretsFile: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/openclaw-secrets", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/openclaw-secrets")>();
+  return {
+    ...actual,
+    writeSecretsFile: mockWriteSecretsFile,
+    readSecretsFile: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: vi.fn(async () => ""),
+}));
+
+const { mockGetClient, mockConfigGet, mockConfigApply, mockRequest } = vi.hoisted(() => ({
+  mockGetClient: vi.fn(),
+  mockConfigGet: vi.fn(),
+  mockConfigApply: vi.fn(),
+  mockRequest: vi.fn(),
+}));
+
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => mockGetClient(),
+}));
+
+import { writeFileSync, readFileSync, existsSync } from "fs";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import {
+  writtenOpenClawConfig,
+  findOpenClawConfigWrite,
+} from "../../helpers/openclaw-config-write";
+
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedExistsSync = vi.mocked(existsSync);
+
+const gatewayConfig = {
+  gateway: { mode: "local", bind: "lan", auth: { token: "gw-token-123" } },
+};
+
+/** The pushes are fire-and-forget; let their microtasks run. */
+async function drain(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+/**
+ * Runs one regenerate against `gatewayConfig` and returns the config bytes it
+ * emitted, so a follow-up regenerate can be given an on-disk file that is
+ * genuinely identical to what it will produce. Reproducing THAT state is the
+ * whole point: a key rotation on an already-configured provider leaves the
+ * emitted config byte-identical, which is why nothing reached the runtime.
+ */
+async function settleOnDiskConfig(): Promise<string> {
+  mockedReadFileSync.mockReturnValue(JSON.stringify(gatewayConfig));
+  await regenerateOpenClawConfig();
+  await drain();
+  return writtenOpenClawConfig(mockedWriteFileSync);
+}
+
+describe("provider key rotation reaches the OpenClaw runtime (#943)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExistsSync.mockReturnValue(true);
+    mockWriteSecretsFile.mockReturnValue(false);
+    mockGetClient.mockImplementation(() => {
+      throw new Error("OpenClaw client not initialized");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("asks OpenClaw to reload its secrets when only the secrets bundle changed", async () => {
+    const onDisk = await settleOnDiskConfig();
+
+    // Second pass: the rotated key changed secrets.json and nothing else. The
+    // emitted config equals the file on disk, so every config-level change
+    // detector correctly sees a no-op — and before #943 that meant the running
+    // OpenClaw kept serving the revoked key until someone restarted it.
+    vi.clearAllMocks();
+    mockedReadFileSync.mockReturnValue(onDisk);
+    mockWriteSecretsFile.mockReturnValue(true);
+    mockRequest.mockResolvedValue({ type: "res", id: "1", ok: true, payload: {} });
+    mockGetClient.mockReturnValue({
+      config: { get: mockConfigGet, apply: mockConfigApply },
+      hasMethod: () => true,
+      request: mockRequest,
+    });
+
+    await regenerateOpenClawConfig();
+    await drain();
+
+    expect(mockRequest).toHaveBeenCalledWith("secrets.reload");
+  });
+
+  it("leaves the config no-op guard alone — no config.apply for a secrets-only change", async () => {
+    // The guard exists because OpenClaw 5.3 rate-limits config.apply at ~3
+    // calls per 45 s and a wasted slot has real cost. Fixing the rotation must
+    // not buy the fix by spending that slot: secrets.reload is not a
+    // control-plane write, so it costs nothing from that budget.
+    const onDisk = await settleOnDiskConfig();
+
+    vi.clearAllMocks();
+    mockedReadFileSync.mockReturnValue(onDisk);
+    mockWriteSecretsFile.mockReturnValue(true);
+    mockRequest.mockResolvedValue({ type: "res", id: "1", ok: true, payload: {} });
+    mockConfigGet.mockResolvedValue({ hash: "h1", config: JSON.parse(onDisk) });
+    mockGetClient.mockReturnValue({
+      config: { get: mockConfigGet, apply: mockConfigApply },
+      hasMethod: () => true,
+      request: mockRequest,
+    });
+
+    await regenerateOpenClawConfig();
+    await drain();
+
+    expect(mockConfigApply).not.toHaveBeenCalled();
+    expect(findOpenClawConfigWrite(mockedWriteFileSync)).toBeUndefined();
+  });
+
+  it("does not reload secrets on a genuine no-op regenerate", async () => {
+    // Nothing changed at all — not the config, not the secrets. Firing the RPC
+    // here would put an unnecessary round trip (and a channel restart check) on
+    // every boot and every unrelated settings save.
+    const onDisk = await settleOnDiskConfig();
+
+    vi.clearAllMocks();
+    mockedReadFileSync.mockReturnValue(onDisk);
+    mockWriteSecretsFile.mockReturnValue(false);
+    mockGetClient.mockReturnValue({
+      config: { get: mockConfigGet, apply: mockConfigApply },
+      hasMethod: () => true,
+      request: mockRequest,
+    });
+
+    await regenerateOpenClawConfig();
+    await drain();
+
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/secrets-rotation.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/secrets-rotation.test.ts
@@ -188,6 +188,11 @@ describe("provider key rotation reaches the OpenClaw runtime (#943)", () => {
     // Nothing changed at all — not the config, not the secrets. Firing the RPC
     // here would put an unnecessary round trip (and a channel restart check) on
     // every boot and every unrelated settings save.
+    //
+    // This is also the deletion path: `writeSecretsFile` deliberately reports
+    // `false` for a write that only REMOVES values, because a reload would then
+    // fail on the pointer still present in OpenClaw's running config. Which
+    // write reports what is pinned in openclaw-secrets.test.ts.
     const onDisk = await settleOnDiskConfig();
 
     vi.clearAllMocks();

--- a/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
@@ -82,6 +82,25 @@ describe("writeSecretsFile", () => {
     expect(content.providers.openai.apiKey).toBe("sk-different");
   });
 
+  // The return value is the only signal a caller has that the running OpenClaw
+  // now holds a stale credential. A rotation on an ALREADY-configured provider
+  // changes nothing but this file — the emitted openclaw.json carries a
+  // SecretRef, not the value — so every config-level change detector reports
+  // "nothing happened" and the new key never reaches the runtime (#943).
+  it("reports a change when it creates the file", () => {
+    expect(writeSecretsFile(bundle)).toBe(true);
+  });
+
+  it("reports a change when the key is rotated", () => {
+    writeSecretsFile(bundle);
+    expect(writeSecretsFile({ providers: { anthropic: { apiKey: "sk-ant-rotated" } } })).toBe(true);
+  });
+
+  it("reports no change when the bundle is identical", () => {
+    writeSecretsFile(bundle);
+    expect(writeSecretsFile(bundle)).toBe(false);
+  });
+
   it("throws an actionable error when the secrets directory cannot be created (missing volume mount)", () => {
     // Reproduce the #878 failure shape: the `openclaw-secrets` volume is not
     // mounted, so the directory Pinchy expects to write into cannot be created.

--- a/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
@@ -87,18 +87,51 @@ describe("writeSecretsFile", () => {
   // changes nothing but this file — the emitted openclaw.json carries a
   // SecretRef, not the value — so every config-level change detector reports
   // "nothing happened" and the new key never reaches the runtime (#943).
-  it("reports a change when it creates the file", () => {
+  it("reports a stale runtime when it creates the file", () => {
     expect(writeSecretsFile(bundle)).toBe(true);
   });
 
-  it("reports a change when the key is rotated", () => {
+  it("reports a stale runtime when the key is rotated", () => {
     writeSecretsFile(bundle);
     expect(writeSecretsFile({ providers: { anthropic: { apiKey: "sk-ant-rotated" } } })).toBe(true);
   });
 
-  it("reports no change when the bundle is identical", () => {
+  it("reports nothing to do when the bundle is identical", () => {
     writeSecretsFile(bundle);
     expect(writeSecretsFile(bundle)).toBe(false);
+  });
+
+  // A removal is the one secrets change that must NOT report a stale runtime.
+  // OpenClaw re-resolves the config it is CURRENTLY running, and that config
+  // still points at the key we just took away — so the reload fails on the
+  // dangling pointer, OpenClaw marks its secrets runtime degraded, and the
+  // operator is told to restart a gateway that the config apply from this very
+  // regenerate is already about to repair. The removal travels with that config
+  // change; it needs no reload of its own.
+  it("reports nothing to do when a provider is only removed", () => {
+    writeSecretsFile({ providers: { anthropic: { apiKey: "a" }, openai: { apiKey: "b" } } });
+    expect(writeSecretsFile({ providers: { anthropic: { apiKey: "a" } } })).toBe(false);
+  });
+
+  it("still writes the removal to disk even though it reports nothing to do", () => {
+    writeSecretsFile({ providers: { anthropic: { apiKey: "a" }, openai: { apiKey: "b" } } });
+    writeSecretsFile({ providers: { anthropic: { apiKey: "a" } } });
+    const content = JSON.parse(readFileSync(process.env.OPENCLAW_SECRETS_PATH!, "utf-8"));
+    expect(content.providers.openai).toBeUndefined();
+  });
+
+  it("reports a stale runtime when one key rotates while another is removed", () => {
+    // Mixed change: the rotation still has to reach the runtime, so the
+    // removal-only exemption must not swallow it.
+    writeSecretsFile({ providers: { anthropic: { apiKey: "a" }, openai: { apiKey: "b" } } });
+    expect(writeSecretsFile({ providers: { anthropic: { apiKey: "rotated" } } })).toBe(true);
+  });
+
+  it("reports a stale runtime for a nested plugin secret, not just providers", () => {
+    // The bundle is nested (gateway / providers / integrations / telegram /
+    // plugins), so the comparison has to walk it rather than eyeball one branch.
+    writeSecretsFile({ plugins: { "pinchy-odoo": { refTokenKey: "k1" } } });
+    expect(writeSecretsFile({ plugins: { "pinchy-odoo": { refTokenKey: "k2" } } })).toBe(true);
   });
 
   it("throws an actionable error when the secrets directory cannot be created (missing volume mount)", () => {

--- a/packages/web/src/app/api/settings/providers/default/route.ts
+++ b/packages/web/src/app/api/settings/providers/default/route.ts
@@ -60,14 +60,16 @@ export const PATCH = withAdmin(async (request, _ctx, session) => {
 
   // Best-effort runtime apply (#880 pattern, mirrored across every provider
   // write route): the setting is already committed, so a failed regenerate
-  // must not turn a successful save into a 500.
-  let runtimeApplied = true;
+  // must not turn a successful save into a 500. The audited flag asserts only
+  // that the regenerate did not throw — the push itself is fire-and-forget, so
+  // it is deliberately NOT named `runtimeApplied` (see setup/provider, #943).
+  let configRegenerated = true;
   let warning: string | undefined;
   try {
     await regenerateOpenClawConfig();
   } catch (err) {
     console.error("Failed to apply the new default provider to the runtime:", err);
-    runtimeApplied = false;
+    configRegenerated = false;
     warning =
       "Saved. Applying it to the agent runtime failed — check the server logs; it will retry on the next restart or config change.";
   }
@@ -83,7 +85,7 @@ export const PATCH = withAdmin(async (request, _ctx, session) => {
         provider: { id: provider, name: targetName },
         previousDefault,
         newDefault: provider,
-        runtimeApplied,
+        configRegenerated,
       },
     })
   );

--- a/packages/web/src/app/api/settings/providers/openai-compatible/route.ts
+++ b/packages/web/src/app/api/settings/providers/openai-compatible/route.ts
@@ -38,7 +38,7 @@ import { recordAuditFailure } from "@/lib/audit-deferred";
 // Generic "OpenAI-compatible" provider write/read routes (#894). Mirrors the
 // built-in provider route's conventions verbatim: admin guard via `withAdmin`,
 // `parseRequestBody` for structured 400s, best-effort `regenerateOpenClawConfig`
-// that derives a `runtimeApplied` flag rather than 500-ing an already-persisted
+// that derives a `configRegenerated` flag rather than 500-ing an already-persisted
 // save (see setup/provider/route.ts + #880), `resetCache()`, and a
 // `config.changed` audit whose detail snapshots `{ id, name }` and NEVER carries
 // the API key or the full base URL (host only).
@@ -201,14 +201,16 @@ export const POST = withAdmin(async (request, _ctx, session) => {
   }
 
   // Best-effort runtime apply: the row is already committed, so a failed
-  // regenerate must NOT 500 (mirrors setup/provider/route.ts, #880). Record
-  // whether it reached the runtime so the audit distinguishes saved vs applied.
-  let runtimeApplied = true;
+  // regenerate must NOT 500 (mirrors setup/provider/route.ts, #880). The
+  // audited flag asserts only that the regenerate did not throw — the push
+  // itself is fire-and-forget, so it is deliberately NOT named
+  // `runtimeApplied` (see setup/provider, #943).
+  let configRegenerated = true;
   try {
     await regenerateOpenClawConfig();
   } catch (err) {
     console.error("Failed to apply OpenAI-compatible provider config to the runtime:", err);
-    runtimeApplied = false;
+    configRegenerated = false;
   }
   resetCache();
 
@@ -227,7 +229,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
         authType: "openai-compatible",
         baseUrlHost,
         modelCount: row.models.length,
-        runtimeApplied,
+        configRegenerated,
         // Only present when an edit actually repointed agents off removed models.
         ...(migratedAgents.length > 0
           ? {
@@ -262,7 +264,7 @@ export const GET = withAdmin(async () => {
  * built-ins-first remaining-candidate ordering (Task 8), the shared
  * migration/reassignment/audit-diff helper, and a `settings.deleted` audit that
  * snapshots `{ id, name }`, caps the migrated-agent diff, and NEVER carries the
- * API key. Runtime apply is best-effort (`runtimeApplied`) — the row is already
+ * API key. Runtime apply is best-effort (`configRegenerated`) — the row is already
  * gone, so a failed regenerate must not 500 (mirrors POST + #880).
  */
 export const DELETE = withAdmin(async (request, _ctx, session) => {
@@ -340,12 +342,12 @@ export const DELETE = withAdmin(async (request, _ctx, session) => {
 
   // Best-effort runtime apply: the row is already gone, so a failed regenerate
   // must NOT 500 (mirrors POST + #880). Record whether it reached the runtime.
-  let runtimeApplied = true;
+  let configRegenerated = true;
   try {
     await regenerateOpenClawConfig();
   } catch (err) {
     console.error("Failed to apply OpenAI-compatible provider deletion to the runtime:", err);
-    runtimeApplied = false;
+    configRegenerated = false;
   }
   resetCache();
 
@@ -368,7 +370,7 @@ export const DELETE = withAdmin(async (request, _ctx, session) => {
         agentCount: migratedAgents.length,
         migratedAgents: inlineMigrated,
         ...(truncated ? { migratedAgentsTruncated: true } : {}),
-        runtimeApplied,
+        configRegenerated,
       },
     })
   );

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -254,9 +254,14 @@ export async function POST(request: NextRequest) {
   const detail: Record<string, unknown> = {
     provider: { id: provider, name: PROVIDERS[provider].name },
     authType: config.authType,
-    // The setting is committed regardless; record whether it also reached the
-    // OpenClaw runtime so the trail distinguishes "saved" from "saved+applied".
-    runtimeApplied: !runtimeWarning,
+    // What this asserts, precisely: `regenerateOpenClawConfig()` returned
+    // without throwing. It is NOT a confirmation that OpenClaw's runtime now
+    // holds the value — the push is fire-and-forget by design (see
+    // pushConfigInBackground). It was called `runtimeApplied` until #943, where
+    // a rotated key was audited as applied while every agent kept 401-ing; an
+    // audit row claiming success for a change that did not take effect is worse
+    // than no row at all.
+    configRegenerated: !runtimeWarning,
   };
   if (config.authType === "url" && body.url) {
     try {

--- a/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
+++ b/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
@@ -65,7 +65,7 @@ export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParam
     // provider step, which is precisely when OpenClaw wins the race for
     // agents/<id>/agent). So the very moment the directory broke, the agent was
     // reported as clean: nothing reached `authProfileFailures`, no warning
-    // toast, no `runtimeApplied: false` — invisible until someone saved a
+    // toast, no `configRegenerated: false` — invisible until someone saved a
     // provider key.
     try {
       await withPermissionRetry(() => fs.unlinkSync(target));

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1715,6 +1715,11 @@ export async function regenerateOpenClawConfig() {
   // `secrets.reload` is the RPC that closes that gap, and it is fired BEFORE the
   // early returns for exactly that reason. It costs no `config.apply` rate-limit
   // slot, so the no-op guard keeps doing the job it exists for.
+  //
+  // The flag is "a value was added or rotated", NOT "the file changed": a pure
+  // removal must stay silent here, because OpenClaw would re-resolve the config
+  // it is still running — which points at the key this regenerate just took
+  // away. See writeSecretsFile.
   if (writeSecretsFile(secretsBundle)) {
     reloadSecretsInBackground();
   }

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -43,6 +43,7 @@ import { resolveBootstrapCaps } from "./bootstrap-caps";
 import { CONFIG_PATH } from "./paths";
 import { configsAreEquivalentUpToOpenClawMetadata } from "./normalize";
 import { readExistingConfig, pushConfigInBackground } from "./write";
+import { reloadSecretsInBackground } from "./secrets-reload";
 import {
   buildSecretsBundle,
   collectPluginSecrets,
@@ -1706,7 +1707,17 @@ export async function regenerateOpenClawConfig() {
     );
   }
 
-  writeSecretsFile(secretsBundle);
+  // A secrets-only change is invisible to EVERY guard below: `openclaw.json`
+  // carries a SecretRef, not the value, so a rotated provider key leaves the
+  // emitted config byte-identical, the equivalence check returns right here, and
+  // the running OpenClaw keeps serving the credential it resolved at process
+  // start — 401 on every agent until someone restarts the container (#943).
+  // `secrets.reload` is the RPC that closes that gap, and it is fired BEFORE the
+  // early returns for exactly that reason. It costs no `config.apply` rate-limit
+  // slot, so the no-op guard keeps doing the job it exists for.
+  if (writeSecretsFile(secretsBundle)) {
+    reloadSecretsInBackground();
+  }
 
   // Only write if content actually changed — prevents unnecessary OpenClaw restarts.
   // Format must match what OpenClaw's writeConfigFile produces (trimEnd + "\n")
@@ -1849,7 +1860,7 @@ export async function regenerateOpenClawConfig() {
 
   // Report AFTER the push, never instead of it. The caller has to hear about
   // this — the setup wizard turns the rejection into a warning toast and records
-  // `runtimeApplied: false` in the audit trail, which is the only reason this
+  // `configRegenerated: false` in the audit trail, which is the only reason this
   // failure is visible outside the container logs at all. But the message must
   // describe what actually happened: the config DID reach OpenClaw, these agents
   // just have no credentials, so they answer "No API key found" rather than

--- a/packages/web/src/lib/openclaw-config/secrets-reload.ts
+++ b/packages/web/src/lib/openclaw-config/secrets-reload.ts
@@ -1,0 +1,83 @@
+import { getOpenClawClient } from "@/server/openclaw-client";
+
+/**
+ * OpenClaw's purpose-built "re-resolve the secrets you already hold" RPC
+ * (`operator.admin` scope, and deliberately NOT a control-plane write — so it
+ * costs none of the ~3-per-45s `config.apply` budget).
+ */
+const SECRETS_RELOAD_METHOD = "secrets.reload";
+
+/**
+ * Tells the running OpenClaw to drop the secret values it resolved at process
+ * start and re-read them from `/openclaw-secrets/secrets.json`.
+ *
+ * Why this exists at all (#943): rotating the API key of an ALREADY-configured
+ * provider changes the secrets file and nothing else. `openclaw.json` holds a
+ * SecretRef, not the value, so the emitted config stays byte-identical, every
+ * no-op guard on the way to `config.apply` correctly fires, and OpenClaw keeps
+ * serving the old — now revoked — credential until someone restarts the
+ * container. Every agent answers HTTP 401 in the meantime.
+ *
+ * Why not simply force the `config.apply` through instead: it would not fix it.
+ * OpenClaw commits a config write with `includeAuthStoreRefs: false` and carries
+ * the previously-resolved auth-profile stores over verbatim — and Pinchy's
+ * per-agent `auth-profiles.json` is exactly where an agent's provider key is
+ * resolved from. `secrets.reload` re-prepares the WHOLE runtime snapshot
+ * (config refs and auth stores), restarts the channels whose secrets moved, and
+ * rolls back on failure. Forcing the apply would also spend a rate-limit slot
+ * the no-op guard exists to protect.
+ *
+ * Fire-and-forget, like {@link pushConfigInBackground}: interactive save flows
+ * must not block on an OpenClaw round trip. A failure here is loud but benign —
+ * the new value is already on disk, so any later OpenClaw start reads it.
+ * There is deliberately no retry: the only realistic reason the WS is down
+ * inside the compose network is that OpenClaw is restarting, and a restarting
+ * OpenClaw resolves the fresh file on its way up.
+ */
+export function reloadSecretsInBackground(): void {
+  void (async () => {
+    let client;
+    try {
+      client = getOpenClawClient();
+    } catch {
+      client = undefined;
+    }
+    if (!client) {
+      console.warn(
+        "[openclaw-config] secrets changed but no WS client is connected — OpenClaw will pick " +
+          "them up on its next start; agents keep using the previous credentials until then."
+      );
+      return;
+    }
+    // Deliberately NOT gated on `client.hasMethod`: the advertised-method list
+    // is empty until the hello-ok handshake lands, so "this gateway is too old"
+    // and "we just reconnected" look identical through it (see
+    // createAgentReadinessGate for the same trap). Unobservable is not "no" —
+    // and a gateway that really lacks the method answers with an error we
+    // report exactly like any other refusal, so the check would buy nothing
+    // and could silently skip a rotation on a gateway that supports it.
+    try {
+      // openclaw-node RESOLVES on an error response rather than rejecting, so
+      // the `ok` flag has to be read: awaiting alone would report a refused
+      // reload as a successful one, which is the class of lie #943 is about.
+      const response = await client.request(SECRETS_RELOAD_METHOD);
+      if (!response.ok) {
+        console.warn(
+          `[openclaw-config] ${SECRETS_RELOAD_METHOD} was refused by the gateway ` +
+            `(${response.error?.message ?? "no reason given"}) — restart OpenClaw to apply the ` +
+            "new credentials."
+        );
+        return;
+      }
+      console.log(
+        `[openclaw-config] ${SECRETS_RELOAD_METHOD}: OpenClaw re-resolved its secrets from disk`
+      );
+    } catch (err) {
+      console.warn(
+        `[openclaw-config] ${SECRETS_RELOAD_METHOD} failed — restart OpenClaw to apply the new ` +
+          "credentials:",
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+  })();
+}

--- a/packages/web/src/lib/openclaw-config/secrets-reload.ts
+++ b/packages/web/src/lib/openclaw-config/secrets-reload.ts
@@ -27,7 +27,7 @@ const SECRETS_RELOAD_METHOD = "secrets.reload";
  * rolls back on failure. Forcing the apply would also spend a rate-limit slot
  * the no-op guard exists to protect.
  *
- * Fire-and-forget, like {@link pushConfigInBackground}: interactive save flows
+ * Fire-and-forget, like `pushConfigInBackground`: interactive save flows
  * must not block on an OpenClaw round trip. A failure here is loud but benign —
  * the new value is already on disk, so any later OpenClaw start reads it.
  * There is deliberately no retry: the only realistic reason the WS is down
@@ -43,9 +43,15 @@ export function reloadSecretsInBackground(): void {
       client = undefined;
     }
     if (!client) {
+      // Deliberately worded for BOTH cases this branch really sees. The common
+      // one is a cold start: `/openclaw-secrets` is a tmpfs, so every container
+      // restart writes the bundle afresh while the WS is still coming up — and
+      // there "agents are stuck on the old key" would simply be untrue. The
+      // other is a rotation while OpenClaw is down, where the wait is real.
       console.warn(
-        "[openclaw-config] secrets changed but no WS client is connected — OpenClaw will pick " +
-          "them up on its next start; agents keep using the previous credentials until then."
+        "[openclaw-config] secrets changed but no WS client is connected. The values are on " +
+          "disk and OpenClaw resolves them when it starts; a gateway that is already running " +
+          "keeps the credentials it resolved at ITS start until then."
       );
       return;
     }

--- a/packages/web/src/lib/openclaw-secrets.ts
+++ b/packages/web/src/lib/openclaw-secrets.ts
@@ -84,7 +84,55 @@ export function checkSecretsVolumeWritable(): { ok: true } | { ok: false; messag
 }
 
 /**
- * Writes the secrets bundle and reports whether it actually changed anything.
+ * Every secret value in a bundle, keyed by its path through the nested shape
+ * (`providers/anthropic/apiKey`, `plugins/pinchy-odoo/refTokenKey`, …). Walking
+ * the tree rather than naming branches keeps this correct when the bundle grows
+ * a section — a missed branch would silently stop reporting rotations in it.
+ */
+function flattenSecretValues(
+  value: unknown,
+  prefix = "",
+  out = new Map<string, string>()
+): Map<string, string> {
+  if (typeof value === "string") {
+    out.set(prefix, value);
+    return out;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      flattenSecretValues(child, prefix ? `${prefix}/${key}` : key, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * True when `next` holds a value the previous bundle did not have under the
+ * same path — added or rotated. Deliberately false when the only difference is
+ * that values DISAPPEARED: see the removal note on {@link writeSecretsFile}.
+ */
+function hasNewOrRotatedValue(previousContent: string | undefined, next: SecretsBundle): boolean {
+  let previousBundle: unknown = {};
+  if (previousContent !== undefined) {
+    try {
+      previousBundle = JSON.parse(previousContent);
+    } catch {
+      // Unreadable/corrupt previous state — treat every value as new, which is
+      // the safe side: an unnecessary reload costs a round trip, a missed one
+      // costs every agent a 401.
+      previousBundle = {};
+    }
+  }
+  const before = flattenSecretValues(previousBundle);
+  for (const [path, value] of flattenSecretValues(next)) {
+    if (before.get(path) !== value) return true;
+  }
+  return false;
+}
+
+/**
+ * Writes the secrets bundle and reports whether the running OpenClaw is now
+ * holding a stale credential.
  *
  * The return value is load-bearing, not a convenience: a rotation on an
  * already-configured provider changes THIS FILE AND NOTHING ELSE. The emitted
@@ -93,6 +141,13 @@ export function checkSecretsVolumeWritable(): { ok: true } | { ok: false; messag
  * which nothing tells the running OpenClaw that the credential it resolved at
  * process start is now stale (#943). Callers use this flag to push a
  * `secrets.reload` that no config diff would ever trigger.
+ *
+ * A pure REMOVAL returns false even though the file did change. OpenClaw
+ * re-resolves the config it is currently running, and that config still points
+ * at the key just taken away — so a reload there fails on the dangling pointer,
+ * degrades OpenClaw's secrets runtime, and prints "restart the gateway" for a
+ * deletion that the config apply from this same regenerate already repairs. The
+ * removal travels with that config change and needs no reload of its own.
  */
 export function writeSecretsFile(bundle: SecretsBundle): boolean {
   const path = process.env.OPENCLAW_SECRETS_PATH || DEFAULT_SECRETS_PATH;
@@ -100,14 +155,18 @@ export function writeSecretsFile(bundle: SecretsBundle): boolean {
 
   // Skip the write when content is unchanged to avoid a spurious inotify event
   // that would trigger OpenClaw's secrets-file watcher unnecessarily.
+  let previousContent: string | undefined;
   if (existsSync(path)) {
     try {
-      if (readFileSync(path, "utf-8") === newContent) return false;
+      previousContent = readFileSync(path, "utf-8");
+      if (previousContent === newContent) return false;
     } catch {
       // Fall through and write — if read failed for any reason, a write attempt
       // is the safer recovery path than silently leaving stale content.
+      previousContent = undefined;
     }
   }
+  const runtimeIsStale = hasNewOrRotatedValue(previousContent, bundle);
 
   const dir = dirname(path);
   try {
@@ -120,7 +179,7 @@ export function writeSecretsFile(bundle: SecretsBundle): boolean {
     writeFileSync(tmp, newContent, { mode: 0o600 });
     chmodSync(tmp, 0o600); // enforce regardless of umask
     renameSync(tmp, path);
-    return true;
+    return runtimeIsStale;
   } catch (err) {
     // Replace the bare EACCES/ENOTDIR with an actionable message. This is the
     // single choke point every regenerateOpenClawConfig() flows through, so both

--- a/packages/web/src/lib/openclaw-secrets.ts
+++ b/packages/web/src/lib/openclaw-secrets.ts
@@ -83,7 +83,18 @@ export function checkSecretsVolumeWritable(): { ok: true } | { ok: false; messag
   }
 }
 
-export function writeSecretsFile(bundle: SecretsBundle): void {
+/**
+ * Writes the secrets bundle and reports whether it actually changed anything.
+ *
+ * The return value is load-bearing, not a convenience: a rotation on an
+ * already-configured provider changes THIS FILE AND NOTHING ELSE. The emitted
+ * `openclaw.json` carries a SecretRef, not the value, so it stays byte-identical
+ * and every config-level change detector correctly concludes "no change" — after
+ * which nothing tells the running OpenClaw that the credential it resolved at
+ * process start is now stale (#943). Callers use this flag to push a
+ * `secrets.reload` that no config diff would ever trigger.
+ */
+export function writeSecretsFile(bundle: SecretsBundle): boolean {
   const path = process.env.OPENCLAW_SECRETS_PATH || DEFAULT_SECRETS_PATH;
   const newContent = JSON.stringify(bundle, null, 2);
 
@@ -91,7 +102,7 @@ export function writeSecretsFile(bundle: SecretsBundle): void {
   // that would trigger OpenClaw's secrets-file watcher unnecessarily.
   if (existsSync(path)) {
     try {
-      if (readFileSync(path, "utf-8") === newContent) return;
+      if (readFileSync(path, "utf-8") === newContent) return false;
     } catch {
       // Fall through and write — if read failed for any reason, a write attempt
       // is the safer recovery path than silently leaving stale content.
@@ -109,6 +120,7 @@ export function writeSecretsFile(bundle: SecretsBundle): void {
     writeFileSync(tmp, newContent, { mode: 0o600 });
     chmodSync(tmp, 0o600); // enforce regardless of umask
     renameSync(tmp, path);
+    return true;
   } catch (err) {
     // Replace the bare EACCES/ENOTDIR with an actionable message. This is the
     // single choke point every regenerateOpenClawConfig() flows through, so both


### PR DESCRIPTION
Closes #943.

## The bug

Rotating the API key of an **already-configured** provider was saved, audited as `runtimeApplied: true` / `outcome: "success"`, and never applied. Every agent kept answering HTTP 401 until someone restarted the container from a shell.

## Why nothing reached the runtime

A rotation changes `/openclaw-secrets/secrets.json` and nothing else. The emitted `openclaw.json` carries a SecretRef, not the value, so it stays byte-identical — and `regenerateOpenClawConfig()` returns at its equivalence guard (`build.ts`) *before* the push is ever started. The `config.apply` no-op guard the issue points at is the second line of defence; the first one already returned.

The new value then sat in the file unread, because OpenClaw resolves SecretRefs **eagerly into an in-memory snapshot at activation time, never on the request path** (openclaw `docs/gateway/secrets.md`, "Runtime model").

## The fix

`writeSecretsFile()` now reports whether it changed anything, and a changed bundle fires OpenClaw's own **`secrets.reload`** RPC before any config guard can return.

That is the vendor's documented primitive for exactly this case — *"Snapshot refresh after backend secret rotation is handled by `openclaw secrets reload`"* — and it is **not** a control-plane write, so the `config.apply` no-op guard keeps protecting the ~3-per-45 s rate-limit budget it exists for. No gateway restart, no downtime.

**Forcing the `config.apply` through instead would not have fixed it.** OpenClaw commits a config write with `includeAuthStoreRefs: false` and carries the previously-resolved auth-profile stores over verbatim — and Pinchy's per-agent `auth-profiles.json` is exactly where an agent's provider key is resolved from.

## Verification against the real binary

Canary against the pinned OpenClaw 2026.7.1-2 (`pinchy-openclaw:e2e`), a SecretRef config and a file secrets provider:

| Step | Result |
| --- | --- |
| `secrets.reload` with the key present | `{"ok": true, "warningCount": 0}` |
| key removed from `secrets.json`, reload | **fails** — `SecretRefResolutionError: JSON pointer segment "anthropic" does not exist`, `SECRETS_RELOADER_DEGRADED`, runtime stays on last-known-good |
| rotated key written back, reload | `{"ok": true}`, `SECRETS_RELOADER_RECOVERED` |

The middle row is the proof: the gateway genuinely re-reads the file rather than reusing what it resolved at process start.

## Audit honesty

`runtimeApplied` → `configRegenerated` across the four provider write routes. It only ever asserted "the regenerate did not throw" — the push is fire-and-forget by design — and, as the issue says, an audit row claiming success for a change that did not take effect is worse than no row.

## Also

The comment in `config/start-openclaw.sh` claiming provider keys are *"resolved live from secrets.json via SecretRef — no gateway restart needed on key rotation"* is corrected. That belief is why the gap stayed invisible: the script restarts the gateway on the **first** appearance of `secrets.json` and deliberately suppresses it for every write after.

## Tests

- `openclaw-secrets.test.ts` — the write reports created / rotated / unchanged.
- `openclaw-config/secrets-reload.test.ts` — the RPC is sent; no client, a rejecting RPC and an `ok: false` response all warn instead of throwing (openclaw-node *resolves* on an error response, so the flag has to be read).
- `openclaw-config/secrets-rotation.test.ts` — the regression: a secrets-only change against a byte-identical on-disk config triggers the reload, spends **no** `config.apply`, and a genuine no-op regenerate triggers nothing.

Gates run locally: `pnpm test` (10 803), `test:db` (452), `test:scripts` (829), `typecheck`, `lint`, `format:check`, `build`, and the docs build + anchor/table checks.