### PR TITLE
fix(usage): record context_tokens for system (cron/channel) sessions too

### DIFF
--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -53,7 +53,7 @@ Pinchy writes a usage record whenever an LLM call completes. **Agent chat turns 
 Pinchy multiplies those by the per-million-token prices configured for the model and stores the result in USD with six decimals. Cache tokens use Anthropic-style pricing ratios: cache reads at 10% of the input price, cache writes at 125%.
 
 :::note[Tuning the poll interval]
-Chat and system-session turns alike are recorded the moment they complete (chat via the "done" event, system sessions on the next sweep), and a background sweep (every 60 seconds by default) backstops anything missed. Set `PINCHY_USAGE_POLL_INTERVAL_MS` to override the sweep cadence (the value is in milliseconds, clamped to a 1000 ms floor so a misconfigured value can't hammer OpenClaw). Most deployments never need to set it.
+Chat turns are recorded the moment they complete (the OpenClaw "done" event); system-session turns (scheduled tasks, channel bots) are recorded on the next background sweep. That sweep (every 60 seconds by default) also backstops any chat turn its low-latency path missed. Set `PINCHY_USAGE_POLL_INTERVAL_MS` to override the sweep cadence (the value is in milliseconds, clamped to a 1000 ms floor so a misconfigured value can't hammer OpenClaw). Most deployments never need to set it.
 :::
 
 A few honest caveats:

--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -48,19 +48,19 @@ Both filters apply to every card and tab on the page.
 
 ## Where the numbers come from
 
-Pinchy writes a usage record whenever an LLM call completes. **Agent chat turns** are recorded individually and exactly — each turn's OpenClaw trajectory entry carries that turn's precise tokens, so Pinchy records one row per turn (deduplicated, so restarts and retries never double-count). **System usage** (scheduled tasks, channel bots) and **plugin-internal LLM calls** (e.g. a plugin transcoding a scanned PDF) are captured separately — the former sampled from OpenClaw's per-session counters, the latter reported directly by the plugin. Each record carries the input/output tokens the provider reported, plus cache read and write tokens when the provider supports prompt caching.
+Pinchy writes a usage record whenever an LLM call completes. **Agent chat turns and system usage** (scheduled tasks, channel bots) are both recorded individually and exactly — each turn's OpenClaw trajectory entry carries that turn's precise tokens, so Pinchy records one row per turn (deduplicated, so restarts and retries never double-count). **Plugin-internal LLM calls** (e.g. a plugin transcoding a scanned PDF) are captured separately, reported directly by the plugin. Each record carries the input/output tokens the provider reported, plus cache read and write tokens when the provider supports prompt caching.
 
 Pinchy multiplies those by the per-million-token prices configured for the model and stores the result in USD with six decimals. Cache tokens use Anthropic-style pricing ratios: cache reads at 10% of the input price, cache writes at 125%.
 
 :::note[Tuning the poll interval]
-Chat turns are recorded the moment they complete, and a background sweep (every 60 seconds by default) backstops anything missed and records system-session usage. Set `PINCHY_USAGE_POLL_INTERVAL_MS` to override the sweep cadence (the value is in milliseconds, clamped to a 1000 ms floor so a misconfigured value can't hammer OpenClaw). Most deployments never need to set it.
+Chat and system-session turns alike are recorded the moment they complete (chat via the "done" event, system sessions on the next sweep), and a background sweep (every 60 seconds by default) backstops anything missed. Set `PINCHY_USAGE_POLL_INTERVAL_MS` to override the sweep cadence (the value is in milliseconds, clamped to a 1000 ms floor so a misconfigured value can't hammer OpenClaw). Most deployments never need to set it.
 :::
 
 A few honest caveats:
 
 - **It's an estimate.** Provider invoices are the source of truth. Pinchy uses the prices baked into the OpenClaw model config, which can drift from a provider's current published rates.
 - **Cache pricing is approximate.** The 10%/125% ratios match Anthropic's published pricing. If your provider uses different cache pricing, the estimate will be off.
-- **Chat token counts are exact, per turn.** Each agent chat turn is recorded individually from its OpenClaw trajectory entry (the precise input/output/cache tokens that turn used), so nothing is dropped or double-counted even on busy sessions. System usage (scheduled tasks, channel bots) is still sampled from OpenClaw's per-session counters and can lag slightly.
+- **Token counts are exact, per turn — for chat and system usage alike.** Each turn (chat or system: scheduled tasks, channel bots) is recorded individually from its OpenClaw trajectory entry (the precise input/output/cache tokens that turn used), so nothing is dropped or double-counted even on busy sessions.
 - **Local Ollama shows "—" for cost.** Local models record token counts but have no pricing config. The dashboard shows a dash instead of $0.00 to make this clear.
 - **Tool execution time isn't tracked here.** Only the LLM tokens count. The Audit Trail at `/audit` is where you go for tool-use details.
 

--- a/packages/web/src/__tests__/integration/usage-per-turn.integration.test.ts
+++ b/packages/web/src/__tests__/integration/usage-per-turn.integration.test.ts
@@ -189,3 +189,168 @@ describe("per-turn usage accounting (#483) — real Postgres", () => {
     expect(await rowsForSession()).toHaveLength(3);
   });
 });
+
+// #767: system sessions (cron/channel/main/hook) were left on a separate
+// gauge-delta path under the belief that they have "no per-user trajectory to
+// scan" — verified false in production, so the poller now routes them through
+// the SAME recorder as chat sessions. Real Postgres proves the two things a
+// faked DB cannot for this migration: (1) a pre-existing gauge-poller row
+// (run_id/context_tokens NULL, written before this change shipped) is left
+// untouched — the unique index's NULLS DISTINCT means it never collides with
+// a real run_id; (2) the newly-scanned trajectory turn gets its own row with
+// run_id + context_tokens populated, without double-counting the old row.
+describe("per-turn usage accounting for SYSTEM sessions (#767) — real Postgres", () => {
+  const AGENT = "agent-pt-sys-1";
+  const SESSION_KEY = `agent:${AGENT}:cron:job-1`.toLowerCase();
+  const SESSION_ID = "sess-pt-sys-1";
+
+  let stateDir: string;
+
+  async function rowsForSession() {
+    return db.select().from(usageRecords).where(eq(usageRecords.sessionKey, SESSION_KEY));
+  }
+
+  function fakeOpenclawClient() {
+    return {
+      config: { get: async () => ({ config: { models: { providers: {} } } }) },
+    } as never;
+  }
+
+  beforeEach(async () => {
+    _resetPricingCacheForTest();
+    await db.delete(usageRecords).where(eq(usageRecords.sessionKey, SESSION_KEY));
+    stateDir = mkdtempSync(join(tmpdir(), "pinchy-pt-sys-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    rmSync(stateDir, { recursive: true, force: true });
+    await db.delete(usageRecords).where(eq(usageRecords.sessionKey, SESSION_KEY));
+  });
+
+  it("routes a system session through the trajectory recorder and gives it context_tokens", async () => {
+    const dir = join(stateDir, "agents", AGENT, "sessions");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "sessions.json"),
+      JSON.stringify({ [SESSION_KEY]: { sessionId: SESSION_ID } })
+    );
+    writeFileSync(
+      join(dir, `${SESSION_ID}.trajectory.jsonl`),
+      JSON.stringify({
+        type: "model.completed",
+        runId: "run-sys-1",
+        seq: 2,
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        data: {
+          usage: { input: 20, output: 40, total: 60 },
+          promptCache: { lastCallUsage: { input: 20, output: 40, cacheRead: 0, cacheWrite: 0 } },
+        },
+      })
+    );
+
+    const inserted = await recordSessionTurnsUsage({
+      openclawClient: fakeOpenclawClient(),
+      agentId: AGENT,
+      userId: "system",
+      agentName: "Cron Runner",
+      sessionKey: SESSION_KEY,
+    });
+    expect(inserted).toBe(1);
+
+    const rows = await rowsForSession();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].runId).toBe("run-sys-1");
+    expect(rows[0].userId).toBe("system");
+    expect(rows[0].contextTokens).toBe(20);
+  });
+
+  it("does not double-count or corrupt a pre-existing gauge row once the trajectory path scans the same system session (migration)", async () => {
+    // Simulate the PRE-EXISTING state: an old gauge-poller row for this
+    // system session, written with the shape recordUsage() always inserted —
+    // run_id/seq/context_tokens all NULL. This row predates #767 and must
+    // survive the switch untouched.
+    await db.insert(usageRecords).values({
+      userId: "system",
+      agentId: AGENT,
+      agentName: "Cron Runner",
+      sessionKey: SESSION_KEY,
+      model: "claude-sonnet-4-6",
+      inputTokens: 500,
+      outputTokens: 200,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      estimatedCostUsd: null,
+      // runId / seq / contextTokens intentionally omitted — NULL, the
+      // pre-#767 gauge shape.
+    });
+
+    const preExisting = await rowsForSession();
+    expect(preExisting).toHaveLength(1);
+    expect(preExisting[0].runId).toBeNull();
+    expect(preExisting[0].contextTokens).toBeNull();
+
+    // A NEW turn now completes and gets scanned by the (post-#767) trajectory
+    // path — a different turn from whatever the old gauge row summed.
+    const dir = join(stateDir, "agents", AGENT, "sessions");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "sessions.json"),
+      JSON.stringify({ [SESSION_KEY]: { sessionId: SESSION_ID } })
+    );
+    writeFileSync(
+      join(dir, `${SESSION_ID}.trajectory.jsonl`),
+      JSON.stringify({
+        type: "model.completed",
+        runId: "run-sys-new",
+        seq: 1,
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        data: {
+          usage: { input: 30, output: 15, total: 45 },
+          promptCache: { lastCallUsage: { input: 30, output: 15, cacheRead: 0, cacheWrite: 0 } },
+        },
+      })
+    );
+
+    const inserted = await recordSessionTurnsUsage({
+      openclawClient: fakeOpenclawClient(),
+      agentId: AGENT,
+      userId: "system",
+      agentName: "Cron Runner",
+      sessionKey: SESSION_KEY,
+    });
+    expect(inserted).toBe(1);
+
+    // Both rows coexist: the old NULL-run_id gauge row (untouched — the
+    // dedup index is NULLS DISTINCT, so it never collides with a real run_id)
+    // AND the new trajectory row with run_id + context_tokens populated.
+    const rows = await rowsForSession();
+    expect(rows).toHaveLength(2);
+    const oldRow = rows.find((r) => r.runId === null);
+    const newRow = rows.find((r) => r.runId === "run-sys-new");
+    expect(oldRow).toBeDefined();
+    expect(oldRow?.inputTokens).toBe(500);
+    expect(oldRow?.contextTokens).toBeNull();
+    expect(newRow).toBeDefined();
+    expect(newRow?.inputTokens).toBe(30);
+    expect(newRow?.contextTokens).toBe(30);
+
+    // Re-scanning is idempotent — no third row appears.
+    const again = await recordSessionTurnsUsage({
+      openclawClient: fakeOpenclawClient(),
+      agentId: AGENT,
+      userId: "system",
+      agentName: "Cron Runner",
+      sessionKey: SESSION_KEY,
+    });
+    expect(again).toBe(0);
+    expect(await rowsForSession()).toHaveLength(2);
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -265,17 +265,24 @@ describe("recordSessionTurnsUsage with no trajectory file", () => {
     consoleError.mockRestore();
   });
 
-  it("still logs an error for a real IO failure, so genuine breakage stays visible", async () => {
+  it("reports a real IO failure as null and logs it, so genuine breakage stays visible and retryable", async () => {
     // EACCES is the transient case `readFileResilient` already retries against
     // OpenClaw's chmod window — reaching the recorder means those retries are
     // exhausted, so this is real breakage and must NOT join the silent branch.
+    //
+    // It returns `null`, not `0`: the poller marks a session processed on a
+    // successful scan, and 0 is a perfectly successful scan ("no new turn").
+    // Reporting a failure as 0 made the poller skip the session until its
+    // 5-minute catch-up, and made the #261 retry it documents unreachable —
+    // the only tests that exercised it had to fake a rejection this function
+    // never produces.
     const ioError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
     mockReadTrajectoryJsonl.mockRejectedValue(ioError);
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const recorded = await recordSessionTurnsUsage(params());
 
-    expect(recorded).toBe(0);
+    expect(recorded).toBeNull();
     expect(consoleError).toHaveBeenCalledTimes(1);
     // The original error must reach the log, not a rewrapped stand-in — the
     // `code`/stack is what an operator diagnoses the volume mount from.

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -21,7 +21,8 @@ vi.mock("@/lib/usage", () => ({
   recordUsage: (...args: unknown[]) => mockRecordUsage(...args),
 }));
 
-// #483: chat sessions are recorded per-turn from the trajectory, not the gauge.
+// #483 (chat) / #767 (system): every session is recorded per-turn from the
+// trajectory, not the gauge.
 vi.mock("@/lib/usage-per-turn", () => ({
   recordSessionTurnsUsage: (...args: unknown[]) => mockRecordSessionTurns(...args),
 }));
@@ -186,26 +187,60 @@ describe("pollAllSessions", () => {
     expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
-  it("system sessions use the gauge delta path, not the per-turn recorder", async () => {
+  it("routes system sessions to the per-turn trajectory recorder too, not the gauge (#767)", async () => {
+    // Verified in production: cron/channel sessions DO have a
+    // <sessionId>.trajectory.jsonl with promptCache.lastCallUsage, and
+    // sessions.json maps every sessionKey (system included) to its
+    // sessionId, so resolveSessionId already works for system keys. Routing
+    // them through the trajectory recorder gives them context_tokens too —
+    // the exact observability gap behind the 2026-07-15 Piper incident.
     const client = makeOpenClawClient([
       { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50, model: "claude" },
     ]);
     await pollAllSessions(client);
-    expect(mockRecordSessionTurns).not.toHaveBeenCalled();
-    expect(mockRecordUsage).toHaveBeenCalledWith(
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+    expect(mockRecordSessionTurns).toHaveBeenCalledWith({
+      openclawClient: client,
+      agentId: "agent-1",
+      userId: "system",
+      agentName: "Smithers",
+      sessionKey: "agent:agent-1:cron:job-1",
+    });
+  });
+
+  it("routes a channel-style system session to the trajectory recorder too (#767)", async () => {
+    // main/cron/hook/channel all parse to type "system" (see parseSessionKey)
+    // and must all take the same trajectory path — not just cron.
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:telegram:chat-42", inputTokens: 40, outputTokens: 12, model: "claude" },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+    expect(mockRecordSessionTurns).toHaveBeenCalledWith(
       expect.objectContaining({
-        userId: "system",
         agentId: "agent-1",
-        sessionKey: "agent:agent-1:cron:job-1",
+        userId: "system",
+        sessionKey: "agent:agent-1:telegram:chat-42",
       })
     );
   });
 
-  it("maps OpenClaw's cacheRead/cacheWrite session fields into the gauge snapshot (system sessions)", async () => {
-    // The #482 cache-field-name fix: OpenClaw's session store names the
-    // counters `cacheRead`/`cacheWrite` (verified live, OC 2026.5.28), NOT the
-    // `*Tokens` spellings. Still applies to the gauge path (system sessions).
-    const client = makeOpenClawClient([
+  it("still resolves OpenClaw's cacheRead/cacheWrite spelling into the change-detection signature (system sessions)", async () => {
+    // The #482 cache-field-name fix (cacheRead/cacheWrite, not
+    // cacheReadTokens/cacheWriteTokens) used to feed the gauge snapshot; now
+    // that system sessions route through the trajectory recorder, it instead
+    // feeds gaugeSignature() so a cache-only change still triggers a rescan.
+    const first = makeOpenClawClient([
+      {
+        key: "agent:agent-1:cron:job-1",
+        inputTokens: 3,
+        outputTokens: 80,
+        cacheRead: 0,
+        cacheWrite: 0,
+        model: "claude-sonnet-4-6",
+      },
+    ]);
+    const second = makeOpenClawClient([
       {
         key: "agent:agent-1:cron:job-1",
         inputTokens: 3,
@@ -216,20 +251,25 @@ describe("pollAllSessions", () => {
       },
     ]);
 
-    await pollAllSessions(client);
+    await pollAllSessions(first);
+    await pollAllSessions(second);
 
-    expect(mockRecordUsage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionSnapshot: expect.objectContaining({
-          cacheReadTokens: 14404,
-          cacheWriteTokens: 21135,
-        }),
-      })
-    );
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
-  it("still accepts the cacheReadTokens/cacheWriteTokens spelling as fallback (gauge)", async () => {
-    const client = makeOpenClawClient([
+  it("still accepts the cacheReadTokens/cacheWriteTokens spelling as a fallback in the change-detection signature", async () => {
+    const first = makeOpenClawClient([
+      {
+        key: "agent:agent-1:cron:job-1",
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "claude-sonnet-4-6",
+      },
+    ]);
+    const second = makeOpenClawClient([
       {
         key: "agent:agent-1:cron:job-1",
         inputTokens: 10,
@@ -240,20 +280,17 @@ describe("pollAllSessions", () => {
       },
     ]);
 
-    await pollAllSessions(client);
+    await pollAllSessions(first);
+    await pollAllSessions(second);
 
-    expect(mockRecordUsage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionSnapshot: expect.objectContaining({
-          cacheReadTokens: 111,
-          cacheWriteTokens: 222,
-        }),
-      })
-    );
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
   });
 
-  it("does not skip a system session whose only activity is cache traffic (gauge)", async () => {
+  it("scans a system session whose only activity is cache traffic, same as a chat session (#767)", async () => {
     // Last-turn gauges can show input=0/output=0 while cache counters moved.
+    // System sessions are scanned exactly like chat sessions now — the
+    // trajectory recorder (not a gauge hasTokens gate) decides whether
+    // there's anything to record.
     const client = makeOpenClawClient([
       {
         key: "agent:agent-1:cron:job-1",
@@ -267,40 +304,16 @@ describe("pollAllSessions", () => {
 
     await pollAllSessions(client);
 
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
-  it("records gauge usage for a system session with the forwarded snapshot", async () => {
-    mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
-    const client = makeOpenClawClient([
-      { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50, model: "claude" },
-    ]);
-
-    await pollAllSessions(client);
-
-    // The poller MUST pass sessionSnapshot so recordUsage does not issue a
-    // second sessions.list() round-trip per session.
-    expect(mockRecordUsage).toHaveBeenCalledWith({
-      openclawClient: client,
-      userId: "system",
-      agentId: "agent-1",
-      agentName: "Smithers",
-      sessionKey: "agent:agent-1:cron:job-1",
-      sessionSnapshot: {
-        inputTokens: 100,
-        outputTokens: 50,
-        cacheReadTokens: undefined,
-        cacheWriteTokens: undefined,
-        model: "claude",
-      },
-    });
-  });
-
-  it("skips system sessions with zero tokens", async () => {
+  it("scans a system session with zero gauge tokens via the trajectory recorder — the trajectory decides, not the gauge (#767)", async () => {
     const client = makeOpenClawClient([
       { key: "agent:agent-1:main", inputTokens: 0, outputTokens: 0 },
     ]);
     await pollAllSessions(client);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
     expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
@@ -313,18 +326,19 @@ describe("pollAllSessions", () => {
     expect(mockRecordSessionTurns).not.toHaveBeenCalled();
   });
 
-  it("records system sessions with userId='system'", async () => {
+  it("routes system sessions to the trajectory recorder with userId='system'", async () => {
     const client = makeOpenClawClient([
       { key: "agent:agent-1:main", inputTokens: 100, outputTokens: 50 },
     ]);
     await pollAllSessions(client);
-    expect(mockRecordUsage).toHaveBeenCalledWith(
+    expect(mockRecordSessionTurns).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "system",
         agentId: "agent-1",
         sessionKey: "agent:agent-1:main",
       })
     );
+    expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
   it("falls back to agentId when agent name is not in DB (path-agnostic)", async () => {
@@ -389,29 +403,31 @@ describe("pollAllSessions", () => {
 
     await pollAllSessions(client);
 
-    expect(mockRecordUsage).toHaveBeenCalledWith(
+    expect(mockRecordSessionTurns).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "system",
       })
     );
   });
 
-  it("does not throw when a single gauge recordUsage call rejects", async () => {
+  it("does not throw when a single system-session recordSessionTurns call rejects", async () => {
     mockFrom._agentResult = [
       { id: "agent-1", name: "A1" },
       { id: "agent-2", name: "A2" },
     ];
-    mockRecordUsage.mockRejectedValueOnce(new Error("db error")).mockResolvedValueOnce(undefined);
+    mockRecordSessionTurns
+      .mockRejectedValueOnce(new Error("trajectory read error"))
+      .mockResolvedValueOnce(0);
 
-    // System sessions use the gauge path; a rejecting recordUsage must not
-    // abort the whole poll.
+    // System sessions now use the per-turn trajectory recorder; a rejecting
+    // call must not abort the whole poll.
     const client = makeOpenClawClient([
       { key: "agent:agent-1:cron:j1", inputTokens: 10, outputTokens: 5 },
       { key: "agent:agent-2:cron:j2", inputTokens: 20, outputTokens: 8 },
     ]);
 
     await expect(pollAllSessions(client)).resolves.toBeUndefined();
-    expect(mockRecordUsage).toHaveBeenCalled();
+    expect(mockRecordSessionTurns).toHaveBeenCalled();
   });
 });
 
@@ -436,7 +452,7 @@ describe("pollAllSessions adaptive backoff (#261)", () => {
     expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
   });
 
-  it("skips the gauge-delta recordUsage for a system session whose gauge is unchanged", async () => {
+  it("skips the per-turn scan for a system session whose gauge is unchanged since the last poll", async () => {
     const client = makeOpenClawClient([
       { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50 },
     ]);
@@ -444,7 +460,7 @@ describe("pollAllSessions adaptive backoff (#261)", () => {
     await pollAllSessions(client);
     await pollAllSessions(client); // identical gauge → idle → skip
 
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
   });
 
   it("re-processes when the gauge changes (a new turn happened)", async () => {
@@ -519,8 +535,8 @@ describe("pollAllSessions adaptive backoff (#261)", () => {
   // for up to IDLE_RESCAN_MS (5 min), even though the record never happened.
   // Pre-adaptive-backoff behavior retried every tick (60s); this restores
   // that retry behavior for failed record calls specifically.
-  it("retries a system session every tick after a transient recordUsage failure, instead of treating it as processed", async () => {
-    mockRecordUsage.mockRejectedValueOnce(new Error("db blip"));
+  it("retries a system session every tick after a transient recordSessionTurns failure, instead of treating it as processed", async () => {
+    mockRecordSessionTurns.mockRejectedValueOnce(new Error("db blip"));
     const client = makeOpenClawClient([
       { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50 },
     ]);
@@ -528,7 +544,7 @@ describe("pollAllSessions adaptive backoff (#261)", () => {
     await pollAllSessions(client); // fails — must not mark the session as processed
     await pollAllSessions(client); // identical gauge — should still retry, not skip
 
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
   });
 
   it("retries a chat session every tick after a transient recordSessionTurns failure, instead of treating it as processed", async () => {

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -558,6 +558,56 @@ describe("pollAllSessions adaptive backoff (#261)", () => {
 
     expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
   });
+
+  // The two tests above drive the failure by REJECTING — which neither
+  // recorder ever does. `recordSessionTurnsUsage` catches everything and
+  // returns; `recordUsage` ends its chain in `.catch(() => {})`. So the #261
+  // retry described right above has never once been reachable in production,
+  // on either path: both tests pass against a rejection the code cannot
+  // produce, which is a green check for an impossible path rather than proof
+  // the retry works. They are kept — a recorder that starts throwing must
+  // still not abort the poll — but the retry itself needs a signal that
+  // actually arrives. The recorder now reports a failed scan as `null`
+  // (distinct from `0` = "scan ran, nothing new"), and these three pin it.
+  it("retries a system session every tick when the recorder REPORTS a failure (null), the signal production really emits", async () => {
+    mockRecordSessionTurns.mockResolvedValueOnce(null);
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client); // reported failure — must not mark as processed
+    await pollAllSessions(client); // identical gauge — should still retry, not skip
+
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a chat session every tick when the recorder REPORTS a failure (null)", async () => {
+    mockRecordSessionTurns.mockResolvedValueOnce(null);
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client);
+    await pollAllSessions(client);
+
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a scan that found nothing to record (0) as processed, not as a failure", async () => {
+    // The distinction that makes `null` worth having: a system session whose
+    // trajectory has no new completed turn returns 0 every tick. Retrying THAT
+    // every 60s would defeat the whole backoff (#261) and re-read the
+    // trajectory file for every idle cron session forever.
+    mockRecordSessionTurns.mockResolvedValue(0);
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client);
+    await pollAllSessions(client); // identical gauge → idle → skip
+
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("getPollIntervalMs", () => {

--- a/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
+++ b/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
@@ -184,11 +184,19 @@ describe("polling timing scenarios", () => {
     _resetUsageWatermarksForTest();
   });
 
-  it("captures tokens added after 'done' event on next poll cycle", async () => {
+  it("captures tokens added after an initial recordUsage call on a later recordUsage call", async () => {
     // Scenario from the design doc: OpenClaw fires "done" when assistant
     // text streaming finishes, but background tool calls (e.g. vision API,
-    // subagent spawn) can add tokens afterwards. Those tokens would be
-    // lost without the poller — this test proves the poller captures them.
+    // subagent spawn) can add tokens afterwards. Those tokens would be lost
+    // without a later re-read — this test proves a later recordUsage call
+    // captures them.
+    //
+    // #767: this used to route the second call through `pollAllSessions`,
+    // which forwarded a fresh gauge snapshot to `recordUsage` for system
+    // sessions. The poller no longer calls `recordUsage` at all — system
+    // sessions now go through the per-turn trajectory recorder instead (see
+    // usage-poller.test.ts). `recordUsage`'s own watermark/delta logic is
+    // otherwise unchanged, so the second call is made directly here.
 
     const sessionRef = {
       current: {
@@ -200,7 +208,7 @@ describe("polling timing scenarios", () => {
     };
     const client = makeClient(sessionRef);
 
-    // Step 1: "done" event fires, recordUsage inserts the initial snapshot.
+    // Step 1: initial recordUsage call inserts the first snapshot.
     await recordUsage({ openclawClient: client, ...baseParams });
     expect(mockValues).toHaveBeenCalledTimes(1);
     expect(mockValues).toHaveBeenNthCalledWith(
@@ -210,16 +218,17 @@ describe("polling timing scenarios", () => {
     expect(dbState.inputSum).toBe(100);
     expect(dbState.outputSum).toBe(50);
 
-    // Step 2: Background work bumps session tokens in OpenClaw — no event
-    // fires, nothing gets recorded yet.
+    // Step 2: Background work bumps session tokens in OpenClaw — no call
+    // happens yet, nothing gets recorded.
     sessionRef.current = {
       ...sessionRef.current,
       inputTokens: 250,
       outputTokens: 80,
     };
 
-    // Step 3: Poller runs. It sees the grown session and inserts the delta.
-    await pollAllSessions(client);
+    // Step 3: A later recordUsage call sees the grown session and inserts
+    // the delta.
+    await recordUsage({ openclawClient: client, ...baseParams });
 
     expect(mockValues).toHaveBeenCalledTimes(2);
     expect(mockValues).toHaveBeenNthCalledWith(
@@ -231,9 +240,12 @@ describe("polling timing scenarios", () => {
     expect(dbState.outputSum).toBe(80);
   });
 
-  it("accumulates deltas correctly across multiple poll cycles", async () => {
-    // Simulate a long-running chat: tokens grow monotonically over 3 polls.
+  it("accumulates deltas correctly across multiple recordUsage calls", async () => {
+    // Simulate a long-running chat: tokens grow monotonically over 3 calls.
     // The sum of all recorded deltas must equal the final OpenClaw total.
+    //
+    // #767: repointed from `pollAllSessions` to direct `recordUsage` calls —
+    // see the comment on the previous test for why.
 
     const sessionRef = {
       current: {
@@ -245,22 +257,22 @@ describe("polling timing scenarios", () => {
     };
     const client = makeClient(sessionRef);
 
-    // Tick 1: 100 input tokens → delta 100
-    await pollAllSessions(client);
+    // Call 1: 100 input tokens → delta 100
+    await recordUsage({ openclawClient: client, ...baseParams });
     expect(mockValues).toHaveBeenLastCalledWith(
       expect.objectContaining({ inputTokens: 100, outputTokens: 0 })
     );
 
-    // Tick 2: 200 input tokens (delta 100)
+    // Call 2: 200 input tokens (delta 100)
     sessionRef.current = { ...sessionRef.current, inputTokens: 200 };
-    await pollAllSessions(client);
+    await recordUsage({ openclawClient: client, ...baseParams });
     expect(mockValues).toHaveBeenLastCalledWith(
       expect.objectContaining({ inputTokens: 100, outputTokens: 0 })
     );
 
-    // Tick 3: 350 input tokens (delta 150)
+    // Call 3: 350 input tokens (delta 150)
     sessionRef.current = { ...sessionRef.current, inputTokens: 350 };
-    await pollAllSessions(client);
+    await recordUsage({ openclawClient: client, ...baseParams });
     expect(mockValues).toHaveBeenLastCalledWith(
       expect.objectContaining({ inputTokens: 150, outputTokens: 0 })
     );
@@ -377,12 +389,17 @@ describe("polling timing scenarios", () => {
     expect(_getPendingSessionsCountForTest()).toBe(0);
   });
 
-  it("poller avoids duplicate sessions.list calls on recordUsage", async () => {
-    // The poller already fetches sessions.list() to discover which sessions
-    // have tokens to record. recordUsage should consume the snapshot passed
-    // by the poller instead of making a second round-trip — otherwise every
-    // poll tick doubles the OpenClaw sessions.list traffic (and per-session
-    // that cost scales linearly with the number of active chat sessions).
+  it("poller calls sessions.list() exactly once per tick, regardless of session routing", async () => {
+    // #767: the poller used to forward its already-fetched snapshot into
+    // `recordUsage` for system sessions, avoiding a second sessions.list()
+    // round-trip. `recordUsage` is no longer reachable from the poller at
+    // all — system sessions now route through the per-turn trajectory
+    // recorder (`recordSessionTurnsUsage`), which never calls
+    // `sessions.list()` in the first place (it reads the trajectory file
+    // instead). This guards the surviving invariant: exactly one
+    // sessions.list() round-trip per tick, however many sessions get
+    // scanned and however they're routed. The direct recordUsage
+    // snapshot-forwarding behavior itself is unit-tested in usage.test.ts.
     const sessionRef = {
       current: {
         key: SESSION_KEY,
@@ -397,8 +414,11 @@ describe("polling timing scenarios", () => {
 
     await pollAllSessions(client);
 
-    expect(mockValues).toHaveBeenCalledTimes(1);
     expect(listSpy).toHaveBeenCalledTimes(1);
+    // No trajectory file exists for this session in the test environment, so
+    // the trajectory recorder finds nothing to record (the correct, silent
+    // "no completed turn yet" case) — recordUsage is never reached.
+    expect(mockValues).not.toHaveBeenCalled();
   });
 
   it("recovers from OpenClaw counter reset (compaction)", async () => {

--- a/packages/web/src/__tests__/lib/usage.test.ts
+++ b/packages/web/src/__tests__/lib/usage.test.ts
@@ -202,6 +202,46 @@ describe("recordUsage", () => {
     );
   });
 
+  it("uses the caller-supplied sessionSnapshot instead of calling sessions.list() again", async () => {
+    // Relocated from usage-poller.test.ts (#767): the poller used to be the
+    // only caller that forwarded a pre-fetched snapshot (avoiding a second
+    // sessions.list() round-trip per session) — now that system sessions
+    // route through the per-turn trajectory recorder instead of recordUsage,
+    // that forwarding behavior lives here as a direct test of recordUsage
+    // itself. Uses both OC cache-field spellings' RESOLVED values (the
+    // cacheRead/cacheWrite vs. cacheReadTokens/cacheWriteTokens fallback
+    // itself is resolved by the caller — recordUsage just consumes the
+    // snapshot's cacheReadTokens/cacheWriteTokens directly).
+    const client = makeOpenClawClient(); // no sessions in sessions.list()
+
+    await recordUsage({
+      openclawClient: client,
+      ...baseParams,
+      sessionSnapshot: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 14404,
+        cacheWriteTokens: 21135,
+        model: "claude-sonnet-4-6",
+      },
+    });
+
+    expect(client.sessions.list).not.toHaveBeenCalled();
+    expect(mockInsert).toHaveBeenCalledWith(usageRecords);
+    expect(mockValues).toHaveBeenCalledWith({
+      userId: "user-1",
+      agentId: "agent-1",
+      agentName: "Smithers",
+      sessionKey: "agent:agent-1:user-user-1",
+      model: "claude-sonnet-4-6",
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 14404,
+      cacheWriteTokens: 21135,
+      estimatedCostUsd: null,
+    });
+  });
+
   it("does not throw when sessions.list() fails", async () => {
     const client = {
       sessions: {

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -762,8 +762,9 @@ export const usageRecords = pgTable(
     }),
     // Per-turn accounting (#483): the OpenClaw run id of the `model.completed`
     // turn this row records, plus the trajectory `seq` watermark. Both nullable
-    // so the gauge poller (system sessions) and the /api/internal/usage/record
-    // sink (plugin vision tokens) keep inserting without a run id.
+    // so the /api/internal/usage/record sink (plugin vision tokens) keeps
+    // inserting without a run id — and so the gauge-poller rows written before
+    // #767 moved system sessions onto the per-turn path stay readable.
     runId: text("run_id"),
     seq: integer("seq"),
     // How full the model's context window got on this turn — the size of the
@@ -776,9 +777,10 @@ export const usageRecords = pgTable(
     // which the usage payload shows to be disjoint — since all three are tokens
     // the model read, differing only in how they are billed.
     //
-    // Nullable: only the per-turn trajectory path can know it. The gauge poller
-    // and the /api/internal/usage/record sink leave it NULL, as do events with
-    // no usable promptCache — NULL means "unknown", never "empty".
+    // Nullable: only the per-turn trajectory path can know it. The
+    // /api/internal/usage/record sink leaves it NULL, as do events with no
+    // usable promptCache and every row the gauge poller wrote before #767 —
+    // NULL means "unknown", never "empty".
     //
     // This is the read-side of the 2026-07-15 "Piper" incident: the agent ran at
     // ~170k context with compaction never firing (its window was configured at
@@ -801,8 +803,9 @@ export const usageRecords = pgTable(
     index("idx_usage_agent_timestamp").on(table.agentId, table.timestamp),
     // Idempotent per-turn inserts: one row per (session, run). A plain unique
     // index suffices — Postgres treats NULLs as distinct (default NULLS
-    // DISTINCT), so per-turn rows (run_id NOT NULL) dedup while the gauge poller
-    // and the /api/internal/usage/record sink (run_id NULL) insert freely.
+    // DISTINCT), so per-turn rows (run_id NOT NULL) dedup while the
+    // /api/internal/usage/record sink (run_id NULL) inserts freely — and the
+    // pre-#767 gauge rows (also run_id NULL) never collide with a real run id.
     // onConflictDoNothing(target [sessionKey, runId]) relies on this index.
     uniqueIndex("uq_usage_session_run").on(table.sessionKey, table.runId),
   ]

--- a/packages/web/src/lib/usage-cost.ts
+++ b/packages/web/src/lib/usage-cost.ts
@@ -1,7 +1,7 @@
 /**
  * Pure USD cost estimate for a set of token classes — the single source of
- * truth shared by the gauge poller (system sessions) and the per-turn recorder
- * (#483 chat sessions). OpenClaw's model config carries only input/output
+ * truth for the per-turn recorder, which prices every session's turns (#483
+ * chat, #767 system). OpenClaw's model config carries only input/output
  * prices, so cache classes use Anthropic-style ratios: a cache READ is 10% of
  * the input price, a cache WRITE is 125%.
  */

--- a/packages/web/src/lib/usage-per-turn.ts
+++ b/packages/web/src/lib/usage-per-turn.ts
@@ -126,11 +126,25 @@ export interface RecordSessionTurnsParams {
 }
 
 /**
- * Scan one chat session's trajectory and record any not-yet-recorded turns.
- * Safe to call repeatedly (DB dedup) — from the interval poller and from the
- * chat `done` path. Returns the number of newly recorded turns.
+ * Scan one session's trajectory (chat or system) and record any
+ * not-yet-recorded turns. Safe to call repeatedly (DB dedup) — from the
+ * interval poller and from the chat `done` path.
+ *
+ * Returns the number of newly recorded turns, or `null` when the scan FAILED
+ * and should be retried. The two are deliberately distinct: `0` is a
+ * successful scan that found nothing new (the common idle case, and the one
+ * the poller's backoff must be allowed to skip), while `null` says nothing is
+ * known about this session's turns yet. Collapsing both into `0` let a
+ * transient DB/IO error read as "processed" and pushed the retry out to the
+ * poller's 5-minute catch-up scan — and left the retry the poller documents
+ * (#261) unreachable, since this function never rejects for the poller's
+ * `catch` to see.
+ *
+ * It still never THROWS — the chat `done` path calls it fire-and-forget.
  */
-export async function recordSessionTurnsUsage(params: RecordSessionTurnsParams): Promise<number> {
+export async function recordSessionTurnsUsage(
+  params: RecordSessionTurnsParams
+): Promise<number | null> {
   const { openclawClient, agentId, userId, agentName, sessionKey } = params;
   try {
     const sessionId = params.sessionId ?? (await resolveSessionId(agentId, sessionKey));
@@ -171,9 +185,10 @@ export async function recordSessionTurnsUsage(params: RecordSessionTurnsParams):
     // quiet; a trajectory that appears later is picked up by the next scan.
     if (error instanceof TrajectoryFileNotFoundError) return 0;
     // Everything else (unreadable file, DB hiccup) is real breakage worth
-    // surfacing — but still never thrown into the poller or chat path. The
-    // next scan retries; dedup keeps it safe.
+    // surfacing — but still never thrown into the poller or chat path. `null`
+    // (not 0) tells the poller the scan did not happen, so it retries on the
+    // next tick instead of riding the idle backoff; dedup keeps that safe.
     console.error("[usage-per-turn] Failed to record session turns:", error);
-    return 0;
+    return null;
   }
 }

--- a/packages/web/src/lib/usage-per-turn.ts
+++ b/packages/web/src/lib/usage-per-turn.ts
@@ -12,15 +12,22 @@ import { getModelPricing } from "@/lib/usage";
 import { estimateTurnCostUsd, type ModelPricing } from "@/lib/usage-cost";
 
 /**
- * Lossless per-turn token accounting (#483). OpenClaw overwrites its
- * per-session token counters every turn, so the gauge poller (which samples
- * those counters on an interval) silently drops turns that complete between
- * polls. Each completed turn instead writes a `model.completed` trajectory
- * event carrying that turn's EXACT token classes; this recorder reads them and
- * inserts one usage_records row per turn, deduped by (sessionKey, runId) at the
- * DB layer so re-scans / restarts / the low-latency chat-`done` trigger are all
- * idempotent. Chat sessions move to this path; the poller keeps system
- * sessions (cron/channel/main), which have no per-user trajectory we scan.
+ * Lossless per-turn token accounting (#483, extended to system sessions by
+ * #767). OpenClaw overwrites its per-session token counters every turn, so a
+ * gauge poller (which samples those counters on an interval) silently drops
+ * turns that complete between polls. Each completed turn instead writes a
+ * `model.completed` trajectory event carrying that turn's EXACT token
+ * classes; this recorder reads them and inserts one usage_records row per
+ * turn, deduped by (sessionKey, runId) at the DB layer so re-scans / restarts
+ * / the low-latency chat-`done` trigger are all idempotent. Chat sessions
+ * moved to this path under #483; the poller originally kept system sessions
+ * (cron/channel/main/hook) on a separate gauge-delta path under the belief
+ * that they had "no per-user trajectory to scan" — verified false in
+ * production (#767): cron/channel sessions DO have a per-session
+ * `<sessionId>.trajectory.jsonl`, so system sessions now go through this same
+ * recorder too. That gap meant the autonomous/cron/Telegram runs — exactly
+ * the shape of the 2026-07-15 Piper incident — never got a `context_tokens`
+ * reading; they do now.
  */
 
 export interface InsertableUsageRow {

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -1,6 +1,5 @@
 import type { OpenClawClient } from "openclaw-node";
 import { isNull } from "drizzle-orm";
-import { recordUsage } from "@/lib/usage";
 import { recordSessionTurnsUsage } from "@/lib/usage-per-turn";
 import { db } from "@/db";
 import { agents, users } from "@/db/schema";
@@ -79,15 +78,15 @@ interface SessionListEntry {
   model?: string;
 }
 
-// Adaptive backoff (#261 D): the per-turn trajectory scan (chat sessions) runs
-// on every tick regardless of the gauge, and the gauge-delta recordUsage
-// (system sessions) re-reads the DB watermark every tick. Both are no-ops when
-// nothing changed, so re-running them every 60 s for idle sessions is wasted
-// DB/CPU at scale (50 agents × 50 sessions ≈ 2 500 scans/min). We fingerprint
-// each session's gauge counters and skip the expensive processing while the
-// fingerprint is unchanged, with a periodic catch-up scan every IDLE_RESCAN_MS
-// as a backstop (covers the narrow case where two turns carry identical gauge
-// counts AND the lower-latency chat `done` path also missed one).
+// Adaptive backoff (#261 D): the per-turn trajectory scan runs on every tick
+// regardless of the gauge, for both chat AND system sessions (#767 moved
+// system sessions onto this same path). It's a no-op when nothing changed, so
+// re-running it every 60 s for idle sessions is wasted DB/CPU at scale (50
+// agents × 50 sessions ≈ 2 500 scans/min). We fingerprint each session's gauge
+// counters and skip the expensive processing while the fingerprint is
+// unchanged, with a periodic catch-up scan every IDLE_RESCAN_MS as a backstop
+// (covers the narrow case where two turns carry identical gauge counts AND
+// the lower-latency chat `done` path also missed one).
 const IDLE_RESCAN_MS = 5 * 60_000;
 
 interface SessionActivity {
@@ -104,8 +103,9 @@ export function _resetSessionActivity(): void {
 /**
  * Resolves a session's cache counters from either OC spelling
  * (`cacheRead`/`cacheWrite` vs. `cacheReadTokens`/`cacheWriteTokens` — see the
- * SessionListEntry comment). Left as `undefined`, not defaulted to 0, because
- * callers differ on how they need the "no cache data" case represented.
+ * SessionListEntry comment). Left as `undefined`, not defaulted to 0, so
+ * `gaugeSignature` (the only caller) can distinguish "no cache data" from a
+ * genuine zero when building its change-detection fingerprint.
  */
 function resolveCacheCounters(s: SessionListEntry): {
   cacheReadTokens: number | undefined;
@@ -129,10 +129,10 @@ function gaugeSignature(s: SessionListEntry): string {
 }
 
 /**
- * Polls all OpenClaw sessions once and records usage deltas for each
- * session that has tokens. Unknown agent IDs fall back to the ID itself
- * as the agent name. Failures are logged but never thrown — a failed poll
- * just means we try again next tick.
+ * Polls all OpenClaw sessions once and records per-turn usage for chat AND
+ * system sessions from each session's trajectory (#483, #767). Unknown agent
+ * IDs fall back to the ID itself as the agent name. Failures are logged but
+ * never thrown — a failed poll just means we try again next tick.
  */
 export async function pollAllSessions(openclawClient: OpenClawClient): Promise<void> {
   try {
@@ -183,59 +183,39 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
 
       const agentName = agentNameMap.get(parsed.agentId) ?? parsed.agentId;
 
-      if (parsed.type === "chat") {
-        // Lossless per-turn accounting (#483): chat usage is recorded from the
-        // trajectory's exact per-turn `model.completed` events, NOT the gauge
-        // counters (which OpenClaw overwrites each turn, so sampling drops
-        // turns). This poll is a backstop scan; the chat `done` path scans with
-        // lower latency. DB dedup by (sessionKey, runId) makes re-scans no-ops.
-        const userId = userIdMap.get(parsed.userId.toLowerCase()) ?? parsed.userId;
-        await recordSessionTurnsUsage({
-          openclawClient,
-          agentId: parsed.agentId,
-          userId,
-          agentName,
-          sessionKey: session.key,
-        });
-        // Mark as processed only after the record call succeeds — if it threw,
-        // the catch below aborts the loop, and the fingerprint must stay
-        // unset so the next tick retries this session instead of treating a
-        // failed record as done and skipping it until the catch-up rescan.
-        sessionActivity.set(session.key, { signature, lastProcessedAt: now });
-        continue;
-      }
-
-      // System sessions (main/cron/hook/channel) have no per-user trajectory we
-      // scan, so they stay on the gauge delta path.
-      const { cacheReadTokens, cacheWriteTokens } = resolveCacheCounters(session);
-      const hasTokens =
-        (session.inputTokens ?? 0) > 0 ||
-        (session.outputTokens ?? 0) > 0 ||
-        (cacheReadTokens ?? 0) > 0 ||
-        (cacheWriteTokens ?? 0) > 0;
-      if (!hasTokens) {
-        // Nothing to record — this isn't a failure, so it's safe to mark the
-        // session processed and let it ride the idle backoff.
-        sessionActivity.set(session.key, { signature, lastProcessedAt: now });
-        continue;
-      }
-
-      await recordUsage({
+      // Lossless per-turn accounting (#483 for chat, extended to system
+      // sessions by #767): usage is recorded from the trajectory's exact
+      // per-turn `model.completed` events, NOT the gauge counters (which
+      // OpenClaw overwrites each turn, so sampling drops turns). This used to
+      // gate on `parsed.type === "chat"` — the comment here claimed system
+      // sessions (main/cron/hook/channel) have "no per-user trajectory we
+      // scan", which was never re-verified after #483 shipped. Verified live
+      // in production: cron/channel sessions DO have a
+      // <sessionId>.trajectory.jsonl with promptCache.lastCallUsage, and
+      // sessions.json maps every sessionKey — system included — to its
+      // sessionId, so resolveSessionId() already works for system keys.
+      // Leaving system sessions on the gauge meant the autonomous/cron/
+      // Telegram runs (exactly the shape of the 2026-07-15 Piper incident)
+      // never got a context_tokens reading. A session with no trajectory yet
+      // just records nothing (recordSessionTurnsUsage returns 0) — correct,
+      // there's no completed turn to count. This poll is a backstop scan; the
+      // chat `done` path scans with lower latency. DB dedup by
+      // (sessionKey, runId) makes re-scans no-ops.
+      const userId =
+        parsed.type === "chat"
+          ? (userIdMap.get(parsed.userId.toLowerCase()) ?? parsed.userId)
+          : parsed.userId; // "system" — no per-user lookup needed
+      await recordSessionTurnsUsage({
         openclawClient,
-        userId: parsed.userId, // "system"
         agentId: parsed.agentId,
+        userId,
         agentName,
         sessionKey: session.key,
-        sessionSnapshot: {
-          inputTokens: session.inputTokens,
-          outputTokens: session.outputTokens,
-          cacheReadTokens,
-          cacheWriteTokens,
-          model: session.model,
-        },
       });
-      // Mark as processed only after the record call succeeds (see comment
-      // on the chat-session path above for why ordering matters here).
+      // Mark as processed only after the record call succeeds — if it threw,
+      // the catch below aborts the loop, and the fingerprint must stay unset
+      // so the next tick retries this session instead of treating a failed
+      // record as done and skipping it until the catch-up rescan.
       sessionActivity.set(session.key, { signature, lastProcessedAt: now });
     }
 

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -205,17 +205,20 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
         parsed.type === "chat"
           ? (userIdMap.get(parsed.userId.toLowerCase()) ?? parsed.userId)
           : parsed.userId; // "system" — no per-user lookup needed
-      await recordSessionTurnsUsage({
+      const recorded = await recordSessionTurnsUsage({
         openclawClient,
         agentId: parsed.agentId,
         userId,
         agentName,
         sessionKey: session.key,
       });
-      // Mark as processed only after the record call succeeds — if it threw,
-      // the catch below aborts the loop, and the fingerprint must stay unset
-      // so the next tick retries this session instead of treating a failed
-      // record as done and skipping it until the catch-up rescan.
+      // Mark as processed only after the scan actually succeeded, so a failed
+      // one is retried on the next tick rather than skipped until the 5-minute
+      // catch-up rescan. `null` is the recorder's failure report; `0` means the
+      // scan ran and found nothing new, which IS processed. The recorder never
+      // throws (the chat `done` path calls it fire-and-forget), so this
+      // explicit signal — not the catch below — is what keeps the retry real.
+      if (recorded === null) continue;
       sessionActivity.set(session.key, { signature, lastProcessedAt: now });
     }
 

--- a/packages/web/src/lib/usage.ts
+++ b/packages/web/src/lib/usage.ts
@@ -5,11 +5,11 @@ import { eq, sum } from "drizzle-orm";
 import type { OpenClawClient } from "openclaw-node";
 
 /**
- * OpenClaw session token snapshot passed from callers that already have
- * one in hand (notably the poller, which fetches sessions.list() once per
- * tick and fans out to recordUsage for each session). If omitted, the
- * implementation does its own sessions.list() round-trip — useful for
- * one-off callers like the "done" event path from the chat route.
+ * OpenClaw session token snapshot passed from callers that already have one in
+ * hand, so `recordUsage` skips its own sessions.list() round-trip. The usage
+ * poller used to be that caller; since #767 it records every session — chat
+ * and system alike — through the per-turn trajectory recorder, so `recordUsage`
+ * has no production caller left at all (see the note on `recordUsage` itself).
  */
 export interface SessionTokenSnapshot {
   inputTokens?: number;
@@ -120,6 +120,18 @@ export async function getModelPricing(
   return pricingMap.get(modelId) ?? null;
 }
 
+/**
+ * Gauge-delta usage recording: read OpenClaw's cumulative per-session counters,
+ * subtract the watermark, insert the difference.
+ *
+ * NO PRODUCTION CALLER since #767. Chat sessions moved to the per-turn
+ * trajectory recorder in #483 and system sessions followed in #767; the
+ * `/api/internal/usage/record` sink writes its own `db.insert` rather than
+ * going through here. Only tests reach it. It is kept for one release so the
+ * routing change can be reverted on its own, and is slated for removal — do
+ * not wire new callers to it: it drops turns that complete between polls,
+ * which is the whole reason both paths left it.
+ */
 export async function recordUsage(params: RecordUsageParams): Promise<void> {
   const { sessionKey } = params;
   // Normalize to lowercase to match OpenClaw's key format


### PR DESCRIPTION
## Why

#767 added `usage_records.context_tokens` — the per-turn context-window pressure that is the read-side of the 2026-07-15 **Piper incident** (agent ran to ~170K context with compaction never firing). But it only ever populated for **web-chat (`:direct:`) sessions**. `:cron:`, `:channel:` (Telegram), `main`, and `hook` sessions were left on the usage poller's **gauge-delta path** (`recordUsage`), which writes `context_tokens`, `run_id`, and `seq` as NULL.

So the observability landed everywhere **except** the autonomous / scheduled / Telegram-driven runs — which is exactly the shape of the incident it was built to observe. Verified live on production (2026-08-02): driving the Piper agent to a compaction over web-chat recorded `context_tokens` perfectly (12840 → 34623 → 57200 → 79121 → **39024** drop), but its cron session's rows stayed NULL.

The gating assumption — *"system sessions have no per-user trajectory we scan"* — was never re-checked after #483. It's **false**: cron/channel sessions DO have a `<sessionId>.trajectory.jsonl` with `promptCache.lastCallUsage`, and `sessions.json` maps every sessionKey (system included) to its sessionId, so `resolveSessionId()` already works for system keys.

## What

Route **system sessions through the same per-turn trajectory recorder as chat sessions** (`recordSessionTurnsUsage`) in `pollAllSessions`, instead of the gauge-delta `recordUsage`. This mirrors the #483 chat-session migration and gives cron/channel/main/hook runs their `context_tokens` (plus exact per-turn accounting — the gauge "silently drops turns", which is #483's whole rationale).

- **No gauge fallback** for trajectory-less system sessions: a session with no trajectory yet records nothing (correct — no completed turn to count). Adding a fallback would reintroduce the exact double-count race #483 eliminated (a just-completed turn shows in the gauge before its trajectory flushes → a NULL-run_id gauge row *and* later a real-run_id trajectory row for the same turn).
- Backoff fingerprint (`gaugeSignature`) is untouched — it still drives change-detection for both paths.

## Tests (TDD)

- Repurposed the poller's system-session gauge tests → assert routing to `recordSessionTurnsUsage` with `userId: "system"` (behavior flip, edited in place — **no test removed on net**, `check-test-deletions` green; +3 net).
- Relocated the gauge cache-spelling / snapshot assertions to direct `recordUsage` unit tests so that coverage isn't lost.
- **Migration test** (real Postgres, the "test migrations against pre-existing data" guard): a pre-existing gauge row (NULL `run_id`/`context_tokens`) survives untouched while a newly-scanned trajectory turn is inserted with `run_id` + `context_tokens` — no double-count (dedup by `(session_key, run_id)`, NULLS DISTINCT).

## Review follow-ups (applied on this branch)

- **The poller's #261 retry was decoration, and this change made it the only path.** The poller marks a session processed only after the record call "succeeds", so a transient failure retries next tick instead of waiting out the 5-minute rescan. Neither recorder can report a failure: `recordSessionTurnsUsage` catches everything and returns `0`, `recordUsage` ends in `.catch(() => {})`. Both retry tests drive a rejection that cannot happen. The recorder now returns `null` for a failed scan — distinct from `0` ("ran, nothing new", which the backoff must still skip) — and the poller retries on it. Three tests pin the reachable signal; the rejection tests stay as resilience coverage.
- **Five comments outlived the routing change.** `usage-cost.ts`, three in `schema.ts` (justifying the nullable `run_id`/`seq`/`context_tokens` and the NULLS DISTINCT dedup by a gauge poller that still inserts), and `SessionTokenSnapshot` describing the poller fanning out to `recordUsage`. Corrected — the nullable columns are still load-bearing, just for the internal sink and the pre-existing gauge rows.
- **`recordUsage` is unused in production.** The brief assumed `/api/internal/usage/record` calls it — it doesn't (raw `db.insert`). Zero production call sites after this change. Left in place for one release so the routing can be reverted on its own, now labelled as such in code; **follow-up removes it** (lock machinery + tests) under a tracked deletion.

## Known gap (deliberate, not fixed here)

**Nothing automated proves OpenClaw writes `model.completed` trajectories for system sessions.** That premise is the whole PR and it rests on one manual production check. The integration test fabricates the trajectory file, so it proves the recorder given a trajectory — not that OpenClaw produces one for `cron:`/`channel:`. The E2E suite only covers `direct:` sessions, and the only Telegram tests that drive a real LLM turn are `@llm`-tagged and CI-skipped. With the gauge fallback gone (rightly — it would reinstate the #483 double-count), a regression here is a silent drop to zero usage rows for autonomous runs. Worth its own issue + an E2E that drives a channel or cron turn through the fake-Ollama stack.

## Verification

`pnpm -C packages/web test:db` — **executed against real Postgres**, 62 files / 454 tests green, including the new system-session migration test. (An earlier revision of this description said Docker was unavailable and the suite unverified; it has since been run.)

Also green locally: full `pnpm test` (10796 passed), `pnpm -C packages/web typecheck`, `eslint` (0 errors), `pnpm format:check`, `pnpm test:scripts` (839), `check-test-deletions` (no net removal), and `pnpm build` via the pre-push gate.

