### PR TITLE
fix(eval): survive an offline stretch instead of booking it as a result

### DIFF
--- a/packages/web/eval/error-detail.test.ts
+++ b/packages/web/eval/error-detail.test.ts
@@ -123,6 +123,38 @@ describe("isTransportError", () => {
     expect(isTransportError(new Error("socket hang up"))).toBe(true);
   });
 
+  // Three of the four calls in the retried dispatch block go through
+  // Playwright, not node fetch: loginViaUI and dispatchAndScrape navigate
+  // (`page.goto`), and getRawAssistantMessage reads the diagnostics export
+  // through `page.request`. Playwright puts EVERYTHING in the message —
+  // measured against @playwright/test, the thrown error's own keys are
+  // ["log", "name"], `code` is undefined and there is no `cause` at all. A
+  // check that reads only `err.code` therefore calls the local stack going
+  // away "the measurement" and never retries it.
+  it.each([
+    "apiRequestContext.get: connect ECONNREFUSED 127.0.0.1:7781",
+    "apiRequestContext.post: getaddrinfo ENOTFOUND ollama.com",
+    "apiRequestContext.get: connect ETIMEDOUT 10.0.0.5:443",
+    "page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:7781/chat/a/b",
+    "page.goto: net::ERR_NAME_NOT_RESOLVED at http://localhost:7781/",
+    "page.goto: net::ERR_INTERNET_DISCONNECTED at http://localhost:7781/",
+  ])("recognizes a code-less Playwright transport fault: %s", (message) => {
+    expect(isTransportError(new Error(message))).toBe(true);
+  });
+
+  it.each([
+    // How this repo's X-Frame-Options defect presents (AGENTS.md) — a product
+    // bug, and retrying it four times is exactly how one disappears behind a
+    // note blaming the uplink.
+    "page.goto: net::ERR_BLOCKED_BY_RESPONSE at http://localhost:7781/api/files/x.pdf",
+    // A navigation the page itself cancelled, not a connection that failed.
+    "page.goto: net::ERR_ABORTED at http://localhost:7781/chat/a/b",
+    // Configuration, not weather: a retry cannot fix a certificate.
+    "page.goto: net::ERR_CERT_AUTHORITY_INVALID at https://localhost:7781/",
+  ])("does NOT treat %s as a transport fault", (message) => {
+    expect(isTransportError(new Error(message))).toBe(false);
+  });
+
   it("does NOT claim an assertion failure is a network problem", () => {
     // The dividing line this whole module exists to draw. Retrying a real
     // defect four times turns one wrong answer into four, and hides it behind

--- a/packages/web/eval/error-detail.test.ts
+++ b/packages/web/eval/error-detail.test.ts
@@ -1,0 +1,144 @@
+/**
+ * A sweep that dies on the network must say WHICH call died (#869).
+ *
+ * The first real Layer-3 sweep lost 15 of 48 runs, every one of them recorded
+ * as the six words `TypeError: fetch failed`. That is `String(err)` on a node
+ * fetch rejection, and it is the least informative form the failure has: node
+ * puts the actual fault — `ECONNREFUSED`, `ENOTFOUND`, a TLS error, the
+ * address — in `err.cause`, which `String()` discards.
+ *
+ * The cost is not cosmetic. The KB sweep talks to two very different places
+ * inside one try-block: the local stack on `localhost:7781`, and Ollama Cloud
+ * for the NLI judge. Those two failures mean opposite things — a dead stack is
+ * ours to restart, a dead uplink is the café's wifi — and after the fact the
+ * record could not tell them apart. This laptop travels, so an offline stretch
+ * is an expected operating condition rather than an incident, and "we could
+ * not measure" has to stay distinguishable from "the model failed".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { describeError, isTransportError } from "./error-detail";
+
+/** How node's fetch actually rejects: a bare TypeError carrying the real fault. */
+function fetchFailure(cause: unknown): TypeError {
+  const err = new TypeError("fetch failed");
+  (err as TypeError & { cause?: unknown }).cause = cause;
+  return err;
+}
+
+function sysError(code: string, message: string): Error {
+  const err = new Error(message);
+  (err as Error & { code?: string }).code = code;
+  return err;
+}
+
+describe("describeError", () => {
+  it("keeps the plain message of an ordinary error", () => {
+    expect(describeError(new Error("boom"))).toBe("Error: boom");
+  });
+
+  it("stringifies a non-Error throw without throwing itself", () => {
+    expect(describeError("plain string failure")).toBe("plain string failure");
+    expect(describeError(undefined)).toBe("undefined");
+  });
+
+  it("names the endpoint a fetch failure was really about", () => {
+    // The whole point: `String(err)` yields "TypeError: fetch failed" for BOTH
+    // of the lines below, and they are the two different incidents the sweep
+    // has to be able to tell apart afterwards.
+    const localStack = describeError(
+      fetchFailure(sysError("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:7781"))
+    );
+    const uplink = describeError(
+      fetchFailure(sysError("ENOTFOUND", "getaddrinfo ENOTFOUND ollama.com"))
+    );
+
+    expect(localStack).toContain("127.0.0.1:7781");
+    expect(localStack).toContain("ECONNREFUSED");
+    expect(uplink).toContain("ollama.com");
+    expect(uplink).not.toContain("7781");
+  });
+
+  it("walks a nested cause chain", () => {
+    const inner = sysError("EAI_AGAIN", "getaddrinfo EAI_AGAIN ollama.com");
+    const middle = new Error("upstream request failed");
+    (middle as Error & { cause?: unknown }).cause = inner;
+
+    const described = describeError(fetchFailure(middle));
+
+    expect(described).toContain("fetch failed");
+    expect(described).toContain("upstream request failed");
+    expect(described).toContain("EAI_AGAIN");
+  });
+
+  it("includes an AggregateError's individual failures", () => {
+    // Node raises this when every resolved address fails — happens on a dual
+    // stack host the moment the uplink drops, and the per-address codes are
+    // the only thing that says whether DNS or the route was the problem.
+    const aggregate = new AggregateError(
+      [
+        sysError("ECONNREFUSED", "connect ECONNREFUSED ::1:7781"),
+        sysError("EHOSTUNREACH", "connect EHOSTUNREACH 10.0.0.5:443"),
+      ],
+      "all attempts failed"
+    );
+
+    const described = describeError(fetchFailure(aggregate));
+
+    expect(described).toContain("ECONNREFUSED");
+    expect(described).toContain("EHOSTUNREACH");
+  });
+
+  it("terminates on a cause that points back at itself", () => {
+    // Never worth debugging at 2am inside a sweep: a self-referential cause
+    // must not hang the harness that exists to report the failure.
+    const err = new Error("looping");
+    (err as Error & { cause?: unknown }).cause = err;
+
+    expect(describeError(err)).toContain("looping");
+  });
+});
+
+describe("isTransportError", () => {
+  it("recognizes a node fetch rejection", () => {
+    expect(isTransportError(fetchFailure(sysError("ECONNRESET", "read ECONNRESET")))).toBe(true);
+    expect(isTransportError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it.each([
+    "ECONNREFUSED",
+    "ECONNRESET",
+    "ENOTFOUND",
+    "EAI_AGAIN",
+    "ETIMEDOUT",
+    "EHOSTUNREACH",
+    "ENETUNREACH",
+    "EPIPE",
+  ])("recognizes %s anywhere in the cause chain", (code) => {
+    expect(isTransportError(fetchFailure(sysError(code, `failed with ${code}`)))).toBe(true);
+  });
+
+  it("recognizes a socket hang up, which carries no code", () => {
+    expect(isTransportError(new Error("socket hang up"))).toBe(true);
+  });
+
+  it("does NOT claim an assertion failure is a network problem", () => {
+    // The dividing line this whole module exists to draw. Retrying a real
+    // defect four times turns one wrong answer into four, and hides it behind
+    // a note that says the network was at fault.
+    expect(isTransportError(new Error("expected 3 to equal 4"))).toBe(false);
+  });
+
+  it("does NOT treat a run timeout as a transport fault", () => {
+    // A model that never stops talking is model behaviour and belongs in the
+    // scorecard as such. Only the harness's OWN plumbing is retryable here.
+    expect(isTransportError(new Error("Timeout 120000ms exceeded waiting for idle"))).toBe(false);
+    expect(isTransportError(new Error("locator.click: Timeout 30000ms exceeded"))).toBe(false);
+  });
+
+  it("does not blow up on a non-Error throw", () => {
+    expect(isTransportError("fetch failed")).toBe(false);
+    expect(isTransportError(null)).toBe(false);
+  });
+});

--- a/packages/web/eval/error-detail.ts
+++ b/packages/web/eval/error-detail.ts
@@ -1,0 +1,114 @@
+/**
+ * Says what a failed eval run actually failed at.
+ *
+ * `String(err)` on a node fetch rejection is the six words `TypeError: fetch
+ * failed`, and node puts the real fault — the code, the address, the TLS
+ * error — in `err.cause`, which `String()` throws away. The first real
+ * Layer-3 KB sweep recorded 15 of 48 runs with exactly those six words, and
+ * afterwards nothing in the record could say whether the local stack or the
+ * Ollama Cloud uplink had gone: both are called from inside one try-block, and
+ * they mean opposite things.
+ *
+ * `isTransportError` is the other half. A network fault is worth retrying and
+ * must never be booked as a model result; an assertion failure or a run
+ * timeout is the measurement and must never be retried away. The dividing line
+ * is deliberately narrow — plumbing only.
+ */
+
+/** Fields node attaches to a system-level failure. */
+interface ErrorLike {
+  name?: unknown;
+  message?: unknown;
+  code?: unknown;
+  cause?: unknown;
+  errors?: unknown;
+}
+
+/** OS/undici codes that mean "the connection did not happen", never "the answer was wrong". */
+const TRANSPORT_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EPIPE",
+  "EPROTO",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
+/**
+ * Message fragments that identify a transport fault carrying no `code`.
+ * Kept to shapes that cannot also describe a product failure: "timeout" alone
+ * is excluded on purpose, because a Playwright wait and an unstoppable model
+ * both produce one and neither is the network.
+ */
+const TRANSPORT_MESSAGES = ["fetch failed", "socket hang up", "network error", "other side closed"];
+
+function isErrorLike(value: unknown): value is ErrorLike {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * The error and everything it blames, breadth-first, each node visited once.
+ * A `cause` that points back at its own error is not hypothetical enough to
+ * ignore — the harness that exists to report a failure must not hang on one.
+ */
+function errorChain(err: unknown): ErrorLike[] {
+  const chain: ErrorLike[] = [];
+  const seen = new Set<unknown>();
+  const queue: unknown[] = [err];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!isErrorLike(current) || seen.has(current)) continue;
+    seen.add(current);
+    chain.push(current);
+
+    if (current.cause !== undefined) queue.push(current.cause);
+    if (Array.isArray(current.errors)) queue.push(...current.errors);
+  }
+
+  return chain;
+}
+
+function describeOne(err: ErrorLike): string {
+  const name = typeof err.name === "string" ? err.name : "Error";
+  const message = typeof err.message === "string" ? err.message : "";
+  const code = typeof err.code === "string" && !message.includes(err.code) ? ` [${err.code}]` : "";
+  return `${name}: ${message}${code}`;
+}
+
+/**
+ * A one-line description that names the endpoint and the OS-level code, not
+ * just the fact that something threw.
+ */
+export function describeError(err: unknown): string {
+  const chain = errorChain(err);
+  if (chain.length === 0) return String(err);
+
+  const [head, ...causes] = chain;
+  if (causes.length === 0) return describeOne(head);
+  return `${describeOne(head)} (cause: ${causes.map(describeOne).join(" ← ")})`;
+}
+
+/**
+ * Whether this failure is the network rather than the measurement.
+ *
+ * True means "retry it, and if it keeps failing, record an invalid trial".
+ * False means "this IS the result" — so the check errs towards false: a defect
+ * mis-read as a network blip is retried four times and then filed under a note
+ * blaming the uplink, which is how a real bug disappears from a scorecard.
+ */
+export function isTransportError(err: unknown): boolean {
+  return errorChain(err).some((link) => {
+    if (typeof link.code === "string" && TRANSPORT_CODES.has(link.code)) return true;
+    const message = typeof link.message === "string" ? link.message.toLowerCase() : "";
+    return TRANSPORT_MESSAGES.some((fragment) => message.includes(fragment));
+  });
+}

--- a/packages/web/eval/error-detail.ts
+++ b/packages/web/eval/error-detail.ts
@@ -43,12 +43,67 @@ const TRANSPORT_CODES = new Set([
 ]);
 
 /**
+ * Chromium's network-layer error names, as Playwright surfaces them:
+ * `page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:7781/…`.
+ *
+ * Curated, never a blanket `net::ERR_` prefix match. `ERR_BLOCKED_BY_RESPONSE`
+ * is how this repo's X-Frame-Options defect presents (see AGENTS.md),
+ * `ERR_ABORTED` is a navigation the page itself cancelled, and `ERR_CERT_*` is
+ * a configuration fault a retry cannot fix. Retrying any of those is exactly
+ * how a product bug disappears behind a note blaming the uplink.
+ */
+const CHROMIUM_NETWORK_ERRORS = [
+  "ERR_CONNECTION_REFUSED",
+  "ERR_CONNECTION_RESET",
+  "ERR_CONNECTION_CLOSED",
+  "ERR_CONNECTION_FAILED",
+  "ERR_CONNECTION_TIMED_OUT",
+  "ERR_NAME_NOT_RESOLVED",
+  "ERR_NAME_RESOLUTION_FAILED",
+  "ERR_INTERNET_DISCONNECTED",
+  "ERR_NETWORK_CHANGED",
+  "ERR_ADDRESS_UNREACHABLE",
+  "ERR_SOCKET_NOT_CONNECTED",
+  "ERR_PROXY_CONNECTION_FAILED",
+  "ERR_EMPTY_RESPONSE",
+  "ERR_TIMED_OUT",
+];
+
+/**
+ * Every code that may also arrive as bare message text rather than as `code`.
+ *
+ * Playwright is the reason this exists. Three of the four calls in the KB
+ * sweep's retried dispatch block go through it — `loginViaUI` and
+ * `dispatchAndScrape` navigate, `getRawAssistantMessage` reads the diagnostics
+ * export via `page.request` — and a Playwright error carries the whole fault in
+ * its message: measured against @playwright/test, its own keys are
+ * ["log", "name"], `code` is `undefined` and there is no `cause`. A check that
+ * reads only `err.code` sees node fetch and nothing else, so the local stack
+ * going away would be classified as the measurement and never retried.
+ */
+const TRANSPORT_TOKENS = new Set([...TRANSPORT_CODES, ...CHROMIUM_NETWORK_ERRORS]);
+
+/**
  * Message fragments that identify a transport fault carrying no `code`.
  * Kept to shapes that cannot also describe a product failure: "timeout" alone
  * is excluded on purpose, because a Playwright wait and an unstoppable model
  * both produce one and neither is the network.
  */
 const TRANSPORT_MESSAGES = ["fetch failed", "socket hang up", "network error", "other side closed"];
+
+/**
+ * Whether the message names a transport code as a WHOLE token.
+ *
+ * Tokenising rather than substring-matching is what keeps `ETIMEDOUT` from
+ * firing on Playwright's `Timeout 30000ms exceeded`, which is a wait and not
+ * the network — the one distinction this module cannot afford to lose.
+ */
+function hasTransportToken(message: string): boolean {
+  for (const token of message.split(/[^A-Za-z0-9_]+/)) {
+    if (TRANSPORT_TOKENS.has(token)) return true;
+  }
+  return false;
+}
 
 function isErrorLike(value: unknown): value is ErrorLike {
   return typeof value === "object" && value !== null;
@@ -108,7 +163,9 @@ export function describeError(err: unknown): string {
 export function isTransportError(err: unknown): boolean {
   return errorChain(err).some((link) => {
     if (typeof link.code === "string" && TRANSPORT_CODES.has(link.code)) return true;
-    const message = typeof link.message === "string" ? link.message.toLowerCase() : "";
+    if (typeof link.message !== "string") return false;
+    if (hasTransportToken(link.message)) return true;
+    const message = link.message.toLowerCase();
     return TRANSPORT_MESSAGES.some((fragment) => message.includes(fragment));
   });
 }

--- a/packages/web/eval/eval-models.spec.ts
+++ b/packages/web/eval/eval-models.spec.ts
@@ -59,6 +59,7 @@ import {
   governedScorecardLabel,
 } from "./run-eval";
 import { DEFAULT_INVOICE_CANDIDATES } from "./candidates";
+import { describeError } from "./error-detail";
 import { captureRunFingerprint } from "./fingerprint";
 import { makeTokenCollector } from "./token-usage";
 import { setupHetznerAgent } from "./eval-shared";
@@ -332,13 +333,13 @@ test.describe("Eval-v1: model sweep (real Ollama Cloud)", () => {
                 // run-timeout failure and keep going.
                 const latencyMs = Date.now() - runStart;
                 console.warn(
-                  `[eval] run ${String(i + 1)}/${String(target)} [${variant}] for ${model} / ${label} recorded as run-timeout: ${String(err)}`
+                  `[eval] run ${String(i + 1)}/${String(target)} [${variant}] for ${model} / ${label} recorded as run-timeout: ${describeError(err)}`
                 );
                 const timeoutResult: RunResult = {
                   model,
                   passed: false,
                   tags: ["run-timeout"],
-                  notes: [String(err)],
+                  notes: [describeError(err)],
                   latencyMs,
                   scenario: label,
                   // Stamp the DISPATCHED variant so a timed-out variant run

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -75,6 +75,7 @@ import {
   noackCorpusDir,
   retrievedSourcesFromAuditEntries,
   infraErrorRun,
+  sweepShouldAbort,
 } from "./run-kb-eval";
 import type { KnowledgeSearchAuditEntry } from "./run-kb-eval";
 import { getRawAssistantMessage } from "./getRawAssistantMessage";
@@ -92,6 +93,7 @@ import { fetchChunkTexts } from "./chunk-texts";
 import { seedSyntheticCorpus } from "./seed-corpus";
 import { resolveCitedSourcePaths } from "./resolve-cited-paths";
 import { withTransportRetry } from "../transport-retry";
+import { describeError } from "../error-detail";
 import { DEFAULT_KB_CANDIDATES } from "../candidates";
 import {
   KB_SWEEP_ALLOWED_TOOLS,
@@ -319,6 +321,13 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
     const allRuns: KbRunResult[] = [...existingRuns];
 
     let pinnedModel: string | null = null;
+    // A dead endpoint is not 48 bad runs, it is one bad endpoint. Now that a
+    // transport fault is retried, each pair costs the full ~9-minute backoff
+    // before it gives up — roughly seven hours across a whole sweep, and every
+    // pair comes out with an infra-error row that `pendingPairs` counts as
+    // done, so a later resume never revisits it. Stopping leaves the rest
+    // UNSTARTED, which resume handles perfectly. Reset on any completed run.
+    let consecutiveInfraErrors = 0;
     for (const { model, goldId } of pendingPairs(existingRuns, candidates, goldIds, n)) {
       const gold = GOLD_QA.find((g) => g.id === goldId);
       if (!gold) throw new Error(`Unknown gold id in pendingPairs: ${goldId}`);
@@ -346,11 +355,13 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
           // infra-error row per pair (each pair re-enters this block, since
           // `pinnedModel` was never advanced to it).
           console.warn(
-            `[kb-eval] setup failed for ${model}/${goldId} after retries, recording run-infra-error: ${String(err)}`
+            `[kb-eval] setup failed for ${model}/${goldId} after retries, recording run-infra-error: ${describeError(err)}`
           );
           const setupErrorRun = infraErrorRun(model, goldId, err, Date.now() - setupStart);
           allRuns.push(setupErrorRun);
           await appendRunResult(RESULT_LABEL, setupErrorRun);
+          consecutiveInfraErrors++;
+          if (sweepShouldAbort(consecutiveInfraErrors)) break;
           continue;
         }
       }
@@ -366,8 +377,18 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
         // judge retries on its own. `isTransportError` keeps a real defect —
         // no assistant text, a grader disagreement — out of the retry entirely
         // (#869: 15 of 48 runs lost to one offline stretch).
-        const { answer, auditEntries } = await withTransportRetry(
+        const { answer, auditEntries, attemptStart } = await withTransportRetry(
           async () => {
+            // Stamped INSIDE the attempt, not at `runStart` above. The
+            // trajectory's latency is a model measurement, and a start taken
+            // outside this call would charge the model for every failed
+            // attempt plus the whole backoff — up to nine minutes of waiting
+            // out a dead uplink, landing in `medianLatencyMs`. At the sweep's
+            // default of one run per model, that single number IS the cell:
+            // the network would be booked as a model result, which is the one
+            // thing this retry exists to prevent. `runStart` still bounds the
+            // infra-error row below, where the whole ordeal IS the story.
+            const attemptStart = Date.now();
             await loginViaUI(page, getAdminEmail(), getAdminPassword());
             const chatId = randomUUID();
             const since = new Date().toISOString();
@@ -376,7 +397,7 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
               getRawAssistantMessage(page, agentId, chatId),
               collectKnowledgeSearchAuditEntries(cookie, agentId, since),
             ]);
-            return { answer, auditEntries };
+            return { answer, auditEntries, attemptStart };
           },
           { what: `dispatch ${model}/${goldId}` }
         );
@@ -396,7 +417,7 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
           answer,
           retrieved,
           citedPassageTexts,
-          latencyMs: Date.now() - runStart,
+          latencyMs: Date.now() - attemptStart,
         };
 
         // The judge is an Ollama Cloud call, so it fails exactly when the
@@ -409,6 +430,9 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
         const stampedResult: KbRunResult = { ...result, scenario: goldId };
         allRuns.push(stampedResult);
         await appendRunResult(RESULT_LABEL, stampedResult);
+        // A completed run — graded pass OR fail — proves the endpoints are
+        // reachable, so the breaker's streak starts over.
+        consecutiveInfraErrors = 0;
         await appendTrajectory(RESULT_LABEL, goldId, trajectory, result.passed, result.tags).catch(
           (err) =>
             console.warn(`[kb-eval] trajectory dump failed for ${model}/${goldId}: ${String(err)}`)
@@ -426,11 +450,21 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
         // passRate and would zero passCaretK, conflating harness flakiness
         // with model quality.
         console.warn(
-          `[kb-eval] run for ${model}/${goldId} recorded as run-infra-error: ${String(err)}`
+          `[kb-eval] run for ${model}/${goldId} recorded as run-infra-error: ${describeError(err)}`
         );
         const infraErrorResult = infraErrorRun(model, goldId, err, Date.now() - runStart);
         allRuns.push(infraErrorResult);
         await appendRunResult(RESULT_LABEL, infraErrorResult);
+        consecutiveInfraErrors++;
+        if (sweepShouldAbort(consecutiveInfraErrors)) {
+          console.error(
+            `[kb-eval] ABORTING SWEEP: ${String(consecutiveInfraErrors)} consecutive ` +
+              `run-infra-errors — the endpoint is gone, not the run. The scorecard below ` +
+              `covers what was measured; every pair not yet attempted stays pending and ` +
+              `is picked up by the next run. Last failure: ${describeError(err)}`
+          );
+          break;
+        }
       }
     }
 

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -91,6 +91,7 @@ import { DEFAULT_ORG_ID } from "../../src/lib/knowledge/constants";
 import { fetchChunkTexts } from "./chunk-texts";
 import { seedSyntheticCorpus } from "./seed-corpus";
 import { resolveCitedSourcePaths } from "./resolve-cited-paths";
+import { withTransportRetry } from "../transport-retry";
 import { DEFAULT_KB_CANDIDATES } from "../candidates";
 import {
   KB_SWEEP_ALLOWED_TOOLS,
@@ -355,17 +356,30 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
       }
 
       const runStart = Date.now();
-      const chatId = randomUUID();
       try {
-        await loginViaUI(page, getAdminEmail(), getAdminPassword());
-
-        const since = new Date().toISOString();
-        await dispatchAndScrape(page, agentId, gold.query, { chatId, idleTimeoutMs: 120_000 });
-
-        const [answer, auditEntries] = await Promise.all([
-          getRawAssistantMessage(page, agentId, chatId),
-          collectKnowledgeSearchAuditEntries(cookie, agentId, since),
-        ]);
+        // Dispatch and grading retry SEPARATELY, and only across a transport
+        // fault. The uplink can drop at either end of this block and the two
+        // cost very different things: re-dispatching after a judge blip throws
+        // away a good answer and a minute of model time, while resuming a
+        // half-dispatched chat would grade a conversation the model already
+        // started answering. So each attempt mints its own chatId, and the
+        // judge retries on its own. `isTransportError` keeps a real defect —
+        // no assistant text, a grader disagreement — out of the retry entirely
+        // (#869: 15 of 48 runs lost to one offline stretch).
+        const { answer, auditEntries } = await withTransportRetry(
+          async () => {
+            await loginViaUI(page, getAdminEmail(), getAdminPassword());
+            const chatId = randomUUID();
+            const since = new Date().toISOString();
+            await dispatchAndScrape(page, agentId, gold.query, { chatId, idleTimeoutMs: 120_000 });
+            const [answer, auditEntries] = await Promise.all([
+              getRawAssistantMessage(page, agentId, chatId),
+              collectKnowledgeSearchAuditEntries(cookie, agentId, since),
+            ]);
+            return { answer, auditEntries };
+          },
+          { what: `dispatch ${model}/${goldId}` }
+        );
 
         const retrieved = retrievedSourcesFromAuditEntries(auditEntries);
         // The answer cites what the tool SHOWED (a path relative to the data
@@ -385,7 +399,13 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
           latencyMs: Date.now() - runStart,
         };
 
-        const result = await gradeKbRun(trajectory, gold, { nli, relevance });
+        // The judge is an Ollama Cloud call, so it fails exactly when the
+        // dispatch above does — but by this point the answer is already in
+        // hand and re-dispatching to recover it would be pure waste.
+        const result = await withTransportRetry(
+          () => gradeKbRun(trajectory, gold, { nli, relevance }),
+          { what: `judge ${model}/${goldId}` }
+        );
         const stampedResult: KbRunResult = { ...result, scenario: goldId };
         allRuns.push(stampedResult);
         await appendRunResult(RESULT_LABEL, stampedResult);

--- a/packages/web/eval/kb/run-kb-eval.test.ts
+++ b/packages/web/eval/kb/run-kb-eval.test.ts
@@ -243,6 +243,24 @@ describe("infraErrorRun", () => {
     expect(scorecardRuns([result])).toHaveLength(0);
   });
 
+  it("keeps the endpoint a fetch failure names, instead of the six words String() leaves", () => {
+    // The stored row is the whole record after the fact — the console scrolls
+    // away, the trajectory is never written for a failed run. 15 of 48 rows in
+    // the first sweep read exactly `TypeError: fetch failed`, which cannot say
+    // whether the local stack or the Ollama Cloud uplink went (#869).
+    const err = new TypeError("fetch failed");
+    (err as TypeError & { cause?: unknown }).cause = Object.assign(
+      new Error("getaddrinfo ENOTFOUND ollama.com"),
+      { code: "ENOTFOUND" }
+    );
+
+    const result = infraErrorRun("model-a", "gqa-happy-1", err, 17_000);
+
+    expect(result.notes[0]).toContain("ollama.com");
+    expect(result.notes[0]).toContain("ENOTFOUND");
+    expect(result.tags).toEqual(["run-infra-error"]);
+  });
+
   it("stringifies a non-Error thrown value without throwing", () => {
     const result = infraErrorRun("model-b", "gqa-happy-2", "plain string failure", 0);
 

--- a/packages/web/eval/kb/run-kb-eval.test.ts
+++ b/packages/web/eval/kb/run-kb-eval.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MAX_CONSECUTIVE_INFRA_ERRORS,
   corpusFromEnv,
   countRunsForPair,
   infraErrorRun,
@@ -16,6 +17,7 @@ import {
   pendingPairs,
   retrievedSourcesFromAuditEntries,
   scorecardRuns,
+  sweepShouldAbort,
 } from "./run-kb-eval";
 import type { KbRunResult } from "../../src/lib/eval/kb/answer-graders";
 import type { KnowledgeSearchAuditEntry } from "./run-kb-eval";
@@ -98,6 +100,43 @@ describe("pendingPairs (resume filter)", () => {
     const pending = pendingPairs(existing, ["model-a"], ["gqa-1"], 1);
 
     expect(pending).toEqual([{ model: "model-a", goldId: "gqa-1", alreadyDone: 0 }]);
+  });
+
+  it("counts an infra-error row as done, so a burnt pair is never re-asked on resume", () => {
+    // This is WHY the sweep stops instead of grinding when the endpoint is
+    // gone (see sweepShouldAbort). An infra-error row is a row, so resume
+    // treats the pair as answered and never revisits it — grinding through 48
+    // pairs against a dead stack does not merely waste the backoff, it burns
+    // every remaining pair into a row a later run will skip. A pair left
+    // UNSTARTED stays pending and is simply picked up next time.
+    const burnt: KbRunResult[] = [infraErrorRun("model-a", "gqa-1", new Error("stack gone"), 0)];
+
+    expect(pendingPairs(burnt, ["model-a"], ["gqa-1", "gqa-2"], 1)).toEqual([
+      { model: "model-a", goldId: "gqa-2", alreadyDone: 0 },
+    ]);
+  });
+});
+
+describe("sweepShouldAbort", () => {
+  it("keeps going while failures are isolated", () => {
+    // One bad pair is a bad pair. The sweep's whole value is that a single
+    // failure never aborts it — that contract must survive the breaker.
+    expect(sweepShouldAbort(0)).toBe(false);
+    expect(sweepShouldAbort(MAX_CONSECUTIVE_INFRA_ERRORS - 1)).toBe(false);
+  });
+
+  it("stops once consecutive failures say the endpoint is gone, not the run", () => {
+    // With transport faults now retried, a dead endpoint costs the FULL
+    // backoff per pair — about nine minutes — before its row is written. Over
+    // a 48-pair sweep that is some seven hours of sleeping, and every one of
+    // those pairs comes out burnt (see the resume test above). Consecutive
+    // infra errors are the signal that the fault is not this run's.
+    expect(sweepShouldAbort(MAX_CONSECUTIVE_INFRA_ERRORS)).toBe(true);
+    expect(sweepShouldAbort(MAX_CONSECUTIVE_INFRA_ERRORS + 5)).toBe(true);
+  });
+
+  it("needs more than one failure, or a single flaky pair would end the sweep", () => {
+    expect(MAX_CONSECUTIVE_INFRA_ERRORS).toBeGreaterThan(1);
   });
 });
 

--- a/packages/web/eval/kb/run-kb-eval.ts
+++ b/packages/web/eval/kb/run-kb-eval.ts
@@ -17,6 +17,7 @@
 import { mkdir, appendFile, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { describeError } from "../error-detail";
 import { buildScorecard } from "../../src/lib/eval/scorecard";
 import type { ScorecardEntry } from "../../src/lib/eval/scorecard";
 import type { KbRunResult, KbRunTrajectory } from "../../src/lib/eval/kb/answer-graders";
@@ -104,6 +105,13 @@ export function scorecardRuns(runs: KbRunResult[]): KbRunResult[] {
  * invalid trials, so a setup failure becomes VISIBLE in the on-disk record
  * (and in `excludedInfraErrors`) instead of a model silently vanishing from the
  * scorecard when it never even became dispatchable.
+ *
+ * The note goes through `describeError`, not `String(err)`: for a node fetch
+ * rejection the latter yields the six words `TypeError: fetch failed` and drops
+ * the `cause` that names the endpoint. This row IS the record — the console
+ * scrolls away and no trajectory is written for a failed run — so a row that
+ * cannot distinguish a dead local stack from a dropped uplink is a row that
+ * cannot be acted on (#869).
  */
 export function infraErrorRun(
   model: string,
@@ -116,7 +124,7 @@ export function infraErrorRun(
     scenario: goldId,
     passed: false,
     tags: ["run-infra-error"],
-    notes: [`[run-infra-error] ${String(err)}`],
+    notes: [`[run-infra-error] ${describeError(err)}`],
     latencyMs,
   };
 }

--- a/packages/web/eval/kb/run-kb-eval.ts
+++ b/packages/web/eval/kb/run-kb-eval.ts
@@ -129,6 +129,30 @@ export function infraErrorRun(
   };
 }
 
+/**
+ * Consecutive run-infra-errors that mean the endpoint is gone, not the run.
+ *
+ * More than one, because a single flaky pair must never end a sweep — that a
+ * failure does not abort the run is the whole reason infra-error rows exist.
+ * Small, because with transport faults now retried each burnt pair costs the
+ * full backoff (~9 min) before its row is written.
+ */
+export const MAX_CONSECUTIVE_INFRA_ERRORS = 3;
+
+/**
+ * Whether the sweep should stop rather than grind through what is left.
+ *
+ * Grinding is not merely slow. `countRunsForPair` counts an infra-error row
+ * like any other, so `pendingPairs` treats a burnt pair as answered and a
+ * resumed sweep never revisits it — pushing on against a dead endpoint spends
+ * hours writing rows that permanently replace the measurements they stand in
+ * for. Stopping leaves the remaining pairs UNSTARTED, which is the one state
+ * resume handles perfectly.
+ */
+export function sweepShouldAbort(consecutiveInfraErrors: number): boolean {
+  return consecutiveInfraErrors >= MAX_CONSECUTIVE_INFRA_ERRORS;
+}
+
 export async function writeScorecard(
   label: string,
   runs: KbRunResult[]

--- a/packages/web/eval/transport-retry.test.ts
+++ b/packages/web/eval/transport-retry.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Riding out an offline stretch instead of booking it as a result (#869).
+ *
+ * The laptop this sweep runs on travels, so losing the uplink for a few
+ * minutes is an operating condition, not an incident. The existing `withRetry`
+ * in the sweep covers only per-model setup (pin + dispatchable); the run
+ * itself — dispatch, audit read, and the Ollama Cloud judge call — had no
+ * retry at all. One tunnel cost 15 of 48 runs, and two model cells came out
+ * unreadable: nothing in the scorecard could say whether they scored zero or
+ * never got asked.
+ *
+ * Two properties carry the whole thing, and both are the point rather than
+ * polish:
+ *
+ *   - It retries ONLY transport faults. A wrong answer retried four times is
+ *     four wrong answers filed under a note blaming the network.
+ *   - The delays grow. A fixed 8s four times over rides out a hiccup and
+ *     nothing else; the gap between a hiccup and a tunnel is exactly where
+ *     this sweep kept dying.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { withTransportRetry } from "./transport-retry";
+
+function fetchFailure(): TypeError {
+  const err = new TypeError("fetch failed");
+  (err as TypeError & { cause?: unknown }).cause = Object.assign(
+    new Error("getaddrinfo EAI_AGAIN ollama.com"),
+    { code: "EAI_AGAIN" }
+  );
+  return err;
+}
+
+/** Collects the delays instead of waiting them out. */
+function recordingSleep(): { sleep: (ms: number) => Promise<void>; slept: number[] } {
+  const slept: number[] = [];
+  return {
+    slept,
+    sleep: (ms: number) => {
+      slept.push(ms);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("withTransportRetry", () => {
+  it("returns the value without sleeping when the first attempt works", async () => {
+    const { sleep, slept } = recordingSleep();
+    const fn = vi.fn().mockResolvedValue("answer");
+
+    await expect(withTransportRetry(fn, { what: "dispatch", sleep })).resolves.toBe("answer");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(slept).toEqual([]);
+  });
+
+  it("retries a dropped uplink and returns the later success", async () => {
+    const { sleep } = recordingSleep();
+    const fn = vi.fn().mockRejectedValueOnce(fetchFailure()).mockResolvedValue("answer");
+
+    await expect(withTransportRetry(fn, { what: "judge", sleep })).resolves.toBe("answer");
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a failure that is the measurement", async () => {
+    // The load-bearing half. A grader disagreement, a missing assistant
+    // message, a schema violation — all of them are the result, and retrying
+    // them buys nothing while making a real defect look intermittent.
+    const { sleep, slept } = recordingSleep();
+    const fn = vi.fn().mockRejectedValue(new Error("no assistant text found in the trajectory"));
+
+    await expect(withTransportRetry(fn, { what: "dispatch", sleep })).rejects.toThrow(
+      "no assistant text"
+    );
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(slept).toEqual([]);
+  });
+
+  it("waits longer after each failure, so a tunnel is survivable and not just a hiccup", async () => {
+    const { sleep, slept } = recordingSleep();
+    const fn = vi.fn().mockRejectedValue(fetchFailure());
+
+    await expect(withTransportRetry(fn, { what: "judge", sleep })).rejects.toThrow("fetch failed");
+
+    // Strictly growing, and enough total budget to cross a real dead zone
+    // rather than four attempts inside the same bad minute.
+    expect(slept.length).toBeGreaterThanOrEqual(3);
+    for (let i = 1; i < slept.length; i++) expect(slept[i]).toBeGreaterThan(slept[i - 1]);
+    expect(slept.reduce((a, b) => a + b, 0)).toBeGreaterThanOrEqual(5 * 60_000);
+  });
+
+  it("rethrows the final failure so the caller still records an invalid trial", async () => {
+    const { sleep } = recordingSleep();
+    const err = fetchFailure();
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(withTransportRetry(fn, { what: "judge", sleep })).rejects.toBe(err);
+  });
+
+  it("reports each retry with the endpoint the failure names", async () => {
+    // A sweep runs unattended for half an hour. If it silently waits out five
+    // minutes, the operator cannot tell it from a hang — and the endpoint is
+    // what says whether to restart the stack or find better wifi.
+    const { sleep } = recordingSleep();
+    const log = vi.fn();
+    const fn = vi.fn().mockRejectedValueOnce(fetchFailure()).mockResolvedValue("ok");
+
+    await withTransportRetry(fn, { what: "judge call", sleep, log });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const [line] = log.mock.calls[0] as [string];
+    expect(line).toContain("judge call");
+    expect(line).toContain("ollama.com");
+    expect(line).toContain("EAI_AGAIN");
+  });
+
+  it("gives each attempt a fresh try, passing the attempt number through", async () => {
+    // The KB sweep mints a new chatId per attempt: a half-dispatched chat
+    // must not be resumed, or the retry grades a conversation the model
+    // already half-answered before the network dropped.
+    const { sleep } = recordingSleep();
+    const seen: number[] = [];
+    const fn = vi.fn().mockImplementation((attempt: number) => {
+      seen.push(attempt);
+      return seen.length < 3 ? Promise.reject(fetchFailure()) : Promise.resolve("ok");
+    });
+
+    await withTransportRetry(fn, { what: "dispatch", sleep });
+
+    expect(seen).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/web/eval/transport-retry.test.ts
+++ b/packages/web/eval/transport-retry.test.ts
@@ -64,6 +64,30 @@ describe("withTransportRetry", () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
+  it("returns what the SUCCEEDING attempt produced, not anything a failed one left", async () => {
+    // The KB sweep leans on this for more than the answer: it stamps each
+    // attempt's own start time inside the callback and reads latency off that,
+    // because a `runStart` taken OUTSIDE this call would charge the model for
+    // every failed attempt plus the whole backoff — up to nine minutes of
+    // waiting out a dead uplink, landing in `medianLatencyMs`. At the sweep's
+    // default of one run per model that single number IS the cell. Booking the
+    // network as a model result is the exact thing this module exists to stop.
+    const { sleep } = recordingSleep();
+    const fn = vi.fn().mockImplementation((attempt: number) =>
+      attempt < 3
+        ? Promise.reject(fetchFailure())
+        : Promise.resolve({
+            startedAt: attempt * 1000,
+            answer: `from attempt ${String(attempt)}`,
+          })
+    );
+
+    await expect(withTransportRetry(fn, { what: "dispatch", sleep })).resolves.toEqual({
+      startedAt: 3000,
+      answer: "from attempt 3",
+    });
+  });
+
   it("does NOT retry a failure that is the measurement", async () => {
     // The load-bearing half. A grader disagreement, a missing assistant
     // message, a schema violation — all of them are the result, and retrying

--- a/packages/web/eval/transport-retry.ts
+++ b/packages/web/eval/transport-retry.ts
@@ -1,0 +1,69 @@
+/**
+ * Retries an eval step across a lost uplink, and nothing else.
+ *
+ * This laptop travels; an offline stretch is an operating condition, not an
+ * incident. The KB sweep's existing `withRetry` guards per-model setup only,
+ * so the run itself — dispatch, audit read, and the Ollama Cloud judge call —
+ * had no retry at all. One dead zone cost 15 of 48 runs and left two model
+ * cells unreadable: a run that never happened and a run that scored zero
+ * looked the same afterwards.
+ *
+ * Two decisions are load-bearing:
+ *
+ *   - **Transport faults only.** `isTransportError` errs towards "this is the
+ *     result": retrying a real defect makes it look intermittent and files it
+ *     under a note blaming the network.
+ *   - **Growing delays.** A fixed 8s×4 rides out a hiccup and nothing longer,
+ *     and the gap between a hiccup and a tunnel is exactly where the sweep
+ *     kept dying. The schedule below spends about nine minutes before giving
+ *     up — cheap against a 27-minute sweep, and it still gives up.
+ */
+
+import { describeError, isTransportError } from "./error-detail";
+
+/** Backoff between attempts. Total ≈ 9 min, so a tunnel is survivable. */
+const RETRY_DELAYS_MS = [10_000, 45_000, 150_000, 330_000];
+
+export interface TransportRetryOptions {
+  /** What is being attempted, for the operator-facing line. */
+  what: string;
+  /** Injectable for tests; defaults to a real timer. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable sink; defaults to console.warn. */
+  log?: (line: string) => void;
+}
+
+const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Runs `fn` until it succeeds, it fails for a reason that is not the network,
+ * or the backoff schedule is exhausted. `fn` receives the 1-based attempt
+ * number: the KB sweep uses it to mint a fresh chatId, because resuming a
+ * half-dispatched chat would grade a conversation the model already started
+ * answering before the connection dropped.
+ */
+export async function withTransportRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: TransportRetryOptions
+): Promise<T> {
+  const { what } = options;
+  const sleep = options.sleep ?? realSleep;
+  const log = options.log ?? ((line: string) => console.warn(line));
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      const delay = RETRY_DELAYS_MS[attempt - 1];
+      // Out of budget, or not our kind of failure: hand it back so the caller
+      // records an invalid trial rather than a model result.
+      if (delay === undefined || !isTransportError(err)) throw err;
+
+      log(
+        `[eval] ${what} attempt ${String(attempt)} hit a transport fault, ` +
+          `retrying in ${String(Math.round(delay / 1000))}s: ${describeError(err)}`
+      );
+      await sleep(delay);
+    }
+  }
+}


### PR DESCRIPTION
Closes the last open item from #869's list: the sweep had no retry on the run itself.

## An offline stretch is an operating condition, not an incident

This laptop travels. The first real Layer-3 KB sweep lost **15 of 48 runs** to one such stretch — a contiguous block spanning the tail of `glm-5.2` and the head of `qwen3.5:397b` — and left two model cells unreadable. Nothing in the scorecard could say whether they scored zero or were never asked, which is precisely the distinction an eval exists to preserve.

Two gaps, both inside the same try-block.

## The failure did not say what failed

All 15 rows read exactly this, and nothing else:

```
[run-infra-error] TypeError: fetch failed
```

That is `String(err)` on a node fetch rejection. Node puts the real fault — `ECONNREFUSED`, `ENOTFOUND`, the address — in `err.cause`, and `String()` drops it.

The cost is not cosmetic. The sweep calls **two very different places** from that block: the local stack on `:7781`, and Ollama Cloud for the NLI judge. One failure means "restart the stack", the other means "find better wifi", and the record could not tell them apart afterwards. It is the *only* record that survives, too — no trajectory is written for a failed run, and the console scrolls away.

`describeError` walks the cause chain, including `AggregateError.errors` (what node raises when every resolved address fails, which is the normal shape on a dual-stack host the moment the uplink drops) and terminating on a self-referential cause. `infraErrorRun` now uses it, so the stored row names the endpoint.

## The run itself had no retry

`withRetry` covered per-model setup (pin + dispatchable) only. `withTransportRetry` wraps **dispatch and grading separately**: the uplink can drop at either end, and re-dispatching to recover from a judge blip throws away a good answer and a minute of model time. Each dispatch attempt mints its own `chatId` rather than resuming a chat the model had already started answering.

Two properties are load-bearing, and both are tested as such rather than asserted in a comment:

- **Transport faults only.** An assertion failure, a missing assistant message, a run timeout — those *are* the measurement. Retrying one four times makes a real defect look intermittent and files it under a note blaming the network. `isTransportError` errs towards "this is the result": it keys on OS/undici codes and on message shapes that cannot also describe a product failure. "timeout" alone is deliberately excluded, because a Playwright wait and an unstoppable model both produce one and neither is the network.
- **The delays grow** — 10s / 45s / 2.5m / 5.5m, about nine minutes total. A fixed 8s×4 rides out a hiccup and nothing longer, and the gap between a hiccup and a tunnel is exactly where this sweep kept dying. Nine minutes is cheap against a 27-minute sweep, and it still gives up.

## Tests

`transport-retry.test.ts` injects the sleep, so the backoff curve is asserted rather than described: strictly growing, ≥5 min of total budget. It also pins the attempt number reaching the callback, which is what lets the sweep mint a fresh chatId per try.

`error-detail.test.ts` builds the failures the way node really does — a bare `TypeError` carrying the fault in `cause` — and asserts the two incidents come out distinguishable, which is the whole point.

## Gates

`pnpm test` 767 files / 10 819 tests · typecheck · `format:check` — green.

Unrelated, found on the way: this worktree was 62 commits behind and missing `@better-auth/api-key`, which failed 7 test files (16× the same cause). Fixed by `pnpm install`; nothing to do with this change.
