### PR TITLE
fix(eval): grade a citation by the document it names, not by a slash

### DIFF
--- a/packages/web/e2e/integration/kb-attribution.spec.ts
+++ b/packages/web/e2e/integration/kb-attribution.spec.ts
@@ -72,8 +72,12 @@ const RETRIEVED_FIXTURES: Record<string, RetrievedSource[]> = {
     { n: 1, sourcePath: "/data/vacation-policy-en.md", page: 1 },
     { n: 2, sourcePath: "/data/quality-file.md", page: 2 },
   ],
+  // A document in a FOLDER, cited by its bare basename. The pairing is the
+  // fixture: `gradePathCitation` asks whether the entry names as much path as
+  // the document HAS, so a root-level document (which this used to be) would
+  // now legitimately pass and quietly stop testing anything (#869).
   [FAKE_OLLAMA_KB_BARE_FILENAME_TRIGGER]: [
-    { n: 1, sourcePath: "/data/product-insert.md", page: 2 },
+    { n: 1, sourcePath: "/data/handbook-2012/policy.md", page: 1 },
   ],
   [FAKE_OLLAMA_KB_RUNON_FORMAT_TRIGGER]: [
     { n: 1, sourcePath: "/data/handbook-2012/policy.md", page: 1 },
@@ -93,7 +97,7 @@ const SANITY_SUBSTRING: Record<string, string> = {
   [FAKE_OLLAMA_KB_UNLISTED_CITATION_TRIGGER]: "Employees accrue 2.5 days per month",
   [FAKE_OLLAMA_KB_UNCITED_SOURCE_TRIGGER]: "Employees accrue 2.5 days of leave per month",
   [FAKE_OLLAMA_KB_BARE_FILENAME_TRIGGER]:
-    "The filter cartridge should be replaced every six months",
+    "The 2012 handbook revision raised the daily meal per diem",
   [FAKE_OLLAMA_KB_RUNON_FORMAT_TRIGGER]: "The employee handbook requires an annual policy review",
 };
 
@@ -181,6 +185,14 @@ test.describe.serial("KB Eval Harness — Layer-2 attribution self-test", () => 
   for (const kase of CASES) {
     test(kase.name, async ({ page }, testInfo) => {
       testInfo.setTimeout(180_000);
+
+      // Before spending a stack round trip: the sanity substring is hand-picked
+      // (it must survive markdown rendering, so it cannot be derived), which
+      // means editing a RESPONSE constant silently invalidates it. Asserting it
+      // against the constant first turns that drift into an instant, named
+      // failure instead of a seven-minute "the chat did not contain X".
+      expect(kase.response).toContain(SANITY_SUBSTRING[kase.trigger]);
+
       await login(page);
 
       const { finalMessage } = await dispatchAndScrape(

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -397,7 +397,7 @@ const KB_UNCITED_SOURCE_RESPONSE =
 
 const KB_BARE_FILENAME_TRIGGER = "E2E_KB_BARE_FILENAME";
 const KB_BARE_FILENAME_RESPONSE =
-  "The employee handbook requires an annual policy review [1].\n\n" +
+  "The 2012 handbook revision raised the daily meal per diem [1].\n\n" +
   "**Sources:**\n\n" +
   "- [1] policy.md — p. 1";
 

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -333,9 +333,9 @@ const KNOWLEDGE_SEARCH_RESPONSE = "Knowledge base searched: coverage probe compl
 //   KB_UNLISTED_CITATION_TRIGGER     | citation-unresolved   | /data/vacation-policy-en.md
 //   KB_UNCITED_SOURCE_TRIGGER        | source-uncited        | /data/vacation-policy-en.md,
 //                                     |                       | /data/quality-file.md
-//   KB_BARE_FILENAME_TRIGGER         | path-not-cited        | product-insert.md (bare filename;
+//   KB_BARE_FILENAME_TRIGGER         | path-not-cited        | policy.md (bare basename;
 //                                     |                       | full path would be
-//                                     |                       | /data/product-insert.md)
+//                                     |                       | /data/handbook-2012/policy.md)
 //   KB_RUNON_FORMAT_TRIGGER          | sources-format (+     | /data/handbook-2012/policy.md
 //                                     | citation-unresolved,  |
 //                                     | see note below)       |
@@ -353,9 +353,17 @@ const KNOWLEDGE_SEARCH_RESPONSE = "Knowledge base searched: coverage probe compl
 //     /data/vacation-policy-en.md — the one path the response's Sources list
 //     actually cites — so `gradePathCitation` passes and only
 //     `citation-unresolved` fires.
-//   - KB_BARE_FILENAME: `gradePathCitation` fires on the bare filename
-//     regardless of what `retrieved` contains (no `/` in the cited entry is
-//     sufficient on its own).
+//   - KB_BARE_FILENAME: the cited entry is the BARE BASENAME of a document
+//     that lives in a FOLDER (`policy.md` for /data/handbook-2012/policy.md),
+//     and that pairing is the whole fixture. `gradePathCitation` asks whether
+//     the entry names as much path as the document HAS, not whether it
+//     contains a `/` — the slash test charged every correctly-cited root-level
+//     document as a defect and was replaced (#869). A root-level fixture
+//     (`product-insert.md`, which this response used to cite) would now
+//     legitimately PASS and silently stop testing anything.
+//     The tag still fires regardless of what `retrieved` contains, for three
+//     different reasons: handbook-2012 alone → a partial path; both handbooks
+//     → an unresolvable tie on the shared basename; neither → no match.
 //   - KB_RUNON_FORMAT: `retrieved` should contain
 //     /data/handbook-2012/policy.md, but note this does NOT isolate a single
 //     tag. Verified against the real `gradeAttribution` (not assumed): a
@@ -389,9 +397,9 @@ const KB_UNCITED_SOURCE_RESPONSE =
 
 const KB_BARE_FILENAME_TRIGGER = "E2E_KB_BARE_FILENAME";
 const KB_BARE_FILENAME_RESPONSE =
-  "The filter cartridge should be replaced every six months [1].\n\n" +
+  "The employee handbook requires an annual policy review [1].\n\n" +
   "**Sources:**\n\n" +
-  "- [1] product-insert.md — p. 2";
+  "- [1] policy.md — p. 1";
 
 const KB_RUNON_FORMAT_TRIGGER = "E2E_KB_RUNON_FORMAT";
 const KB_RUNON_FORMAT_RESPONSE =

--- a/packages/web/eval/kb/resolve-cited-paths.ts
+++ b/packages/web/eval/kb/resolve-cited-paths.ts
@@ -21,6 +21,10 @@
  * with that axis — see its header for why one implementation rather than two.
  */
 
+// Relative, not `@/`: this is a VALUE import, and the alias is only safe in
+// `eval/` for `import type` (which erases). `run-eval.ts` reaches into `src/`
+// the same way, for the same reason — a Playwright spec loads these files
+// directly.
 import { matchRetrievedDocument } from "../../src/lib/eval/kb/cited-path-match";
 
 export function resolveCitedSourcePaths(

--- a/packages/web/eval/kb/resolve-cited-paths.ts
+++ b/packages/web/eval/kb/resolve-cited-paths.ts
@@ -16,66 +16,12 @@
  *   - A basename shared by two retrieved documents stays unresolved. That
  *     ambiguity is exactly the `path-not-cited` defect the path-citation axis
  *     exists to catch; resolving it would grade a citation defect as grounded.
- */
-
-/**
- * Every path suffix of `sourcePath` at segment boundaries, longest last:
- * `/data/handbook-2012/policy.md` → `policy.md`, `handbook-2012/policy.md`,
- * `data/handbook-2012/policy.md`, `/data/handbook-2012/policy.md`.
  *
- * The leading-slash form is a candidate in its own right, not a cosmetic
- * duplicate: an entry that spells the path out absolutely must be able to win
- * with the WHOLE path, because a win is rejected below when more path precedes
- * it. Without this candidate the longest match would be `data/…`, preceded by
- * the `/` the entry does have, and a correctly-cited absolute path would be
- * thrown out as over-qualified.
+ * The matching itself lives in `src/lib/eval/kb/cited-path-match.ts`, shared
+ * with that axis — see its header for why one implementation rather than two.
  */
-function pathSuffixes(sourcePath: string): string[] {
-  const segments = sourcePath.split("/").filter(Boolean);
-  const suffixes = segments.map((_, i) => segments.slice(segments.length - 1 - i).join("/"));
-  if (sourcePath.startsWith("/")) suffixes.push(`/${segments.join("/")}`);
-  return suffixes;
-}
 
-/**
- * What may NOT flank a suffix occurrence for it to count as naming the
- * document. Both directions rule out a fabrication picking up real passages:
- *
- *   - to the left, any character that continues a segment (`my-policy.md`)
- *     AND `/` itself, because a preceding separator means the entry names a
- *     parent the document does not have. That is the whole distinction between
- *     `handbook-2012/policy.md` and `old-handbook-2012/policy.md`: the shorter
- *     suffix `policy.md` sits at a real boundary in both, and only the
- *     separator to its left says the second one is a different document.
- *   - to the right, a segment character (`policy.mdx`). `.` is deliberately
- *     absent here so an entry ending its sentence with "…in policy.md." still
- *     resolves; it IS present on the left, where `my.policy.md` needs it.
- */
-const SEGMENT_CHAR_BEFORE = /[A-Za-z0-9._/-]/;
-const SEGMENT_CHAR_AFTER = /[A-Za-z0-9_-]/;
-
-/** Whether `suffix` occurs in `entry` as a whole path segment, not mid-name. */
-function mentionsSuffix(entry: string, suffix: string): boolean {
-  // Every occurrence, not just the first: an entry may name the document twice
-  // and only the second one sit at a boundary.
-  let at = entry.indexOf(suffix);
-  while (at !== -1) {
-    const before = at === 0 ? "" : entry[at - 1];
-    const after = entry[at + suffix.length] ?? "";
-    if (!SEGMENT_CHAR_BEFORE.test(before) && !SEGMENT_CHAR_AFTER.test(after)) return true;
-    at = entry.indexOf(suffix, at + 1);
-  }
-  return false;
-}
-
-/** The longest suffix of `sourcePath` that `entry` names, or "" for none. */
-function longestSuffixIn(entry: string, sourcePath: string): string {
-  let best = "";
-  for (const suffix of pathSuffixes(sourcePath)) {
-    if (suffix.length > best.length && mentionsSuffix(entry, suffix)) best = suffix;
-  }
-  return best;
-}
+import { matchRetrievedDocument } from "../../src/lib/eval/kb/cited-path-match";
 
 export function resolveCitedSourcePaths(
   citedEntries: string[],
@@ -85,29 +31,11 @@ export function resolveCitedSourcePaths(
   const seen = new Set<string>();
 
   for (const entry of citedEntries) {
-    // Score every retrieved document by how specifically this entry names it.
-    // `handbook-2012/policy.md: "…"` scores 23 for the 2012 document and 9
-    // (`policy.md`) for its 2011 sibling, so the qualified path wins. A bare
-    // `policy.md` scores 9 for both — a tie, and a tie is the ambiguity that
-    // must NOT resolve.
-    let best: { sourcePath: string; score: number } | null = null;
-    let tied = false;
-
-    for (const { sourcePath } of retrieved) {
-      const score = longestSuffixIn(entry, sourcePath).length;
-      if (score === 0) continue;
-      if (best === null || score > best.score) {
-        best = { sourcePath, score };
-        tied = false;
-      } else if (score === best.score && sourcePath !== best.sourcePath) {
-        tied = true;
-      }
-    }
-
-    if (best === null || tied) continue;
-    if (seen.has(best.sourcePath)) continue;
-    seen.add(best.sourcePath);
-    resolved.push(best.sourcePath);
+    const match = matchRetrievedDocument(entry, retrieved);
+    if (match === null) continue;
+    if (seen.has(match.sourcePath)) continue;
+    seen.add(match.sourcePath);
+    resolved.push(match.sourcePath);
   }
 
   return resolved;

--- a/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
@@ -33,6 +33,7 @@
 import { describe, expect, it } from "vitest";
 
 import { resolveCitedSourcePaths } from "../../../../eval/kb/resolve-cited-paths";
+import { citedSourcePaths, gradePathCitation } from "@/lib/eval/kb/attribution-graders";
 
 const RETRIEVED = [
   { sourcePath: "/data/it-equipment-policy.md" },
@@ -138,5 +139,74 @@ describe("resolveCitedSourcePaths", () => {
 
   it("returns nothing when the search returned nothing", () => {
     expect(resolveCitedSourcePaths(["it-equipment-policy.md"], [])).toEqual([]);
+  });
+});
+
+/**
+ * The two readers of `matchRetrievedDocument`, asked the same question.
+ *
+ * Sharing one implementation is the point of `cited-path-match.ts`, and until
+ * this block nothing failed if someone gave either side a local copy back. The
+ * disagreement would not read as a harness bug either — it would be booked
+ * against the MODEL: an answer graded as citing a fabricated path while its
+ * premise material resolved fine, or one whose citation axis reads green while
+ * `citedPassageTexts` comes back empty and the NLI judge's conservative
+ * fallback charges every sentence `ungrounded-claim`. That is exactly the shape
+ * of #869, which cost a whole sweep.
+ *
+ * `citedSourcePaths` is what the real sweep hands the resolver
+ * (`kb-eval-models.spec.ts`), so the two sides here get the same string from
+ * the same parser — the wiring, not a re-statement of it.
+ */
+describe("gradePathCitation and resolveCitedSourcePaths agree on which document an entry names", () => {
+  const answerCiting = (entry: string) => `X [1].\n\n**Sources:**\n\n- [1] ${entry}`;
+
+  const resolvesFor = (entry: string, retrieved: { sourcePath: string }[]) =>
+    resolveCitedSourcePaths(citedSourcePaths(answerCiting(entry)), retrieved);
+
+  const graded = (entry: string, retrieved: { sourcePath: string }[]) =>
+    gradePathCitation({
+      answer: answerCiting(entry),
+      retrieved: retrieved.map((source, i) => ({
+        n: i + 1,
+        sourcePath: source.sourcePath,
+        page: 1,
+      })),
+    });
+
+  it.each([
+    ["the citation path the tool printed", "it-equipment-policy.md"],
+    ["the absolute path", "/data/it-equipment-policy.md"],
+    ["the path from the mount", "data/it-equipment-policy.md"],
+    ["a code span and a quoted passage", '`it-equipment-policy.md`: "…3-year refresh cycle."'],
+    ["a folder-qualified sibling", 'handbook-2012/policy.md — "the per diem was increased"'],
+  ])("a citation graded PASS resolves to one document (%s)", (_label, entry) => {
+    expect(graded(entry, RETRIEVED).passed).toBe(true);
+    expect(resolvesFor(entry, RETRIEVED)).toHaveLength(1);
+  });
+
+  it.each([
+    ["a shared bare basename", "policy.md"],
+    ["a path the search never returned", "invented-policy.md"],
+    ["a name that merely ends with a real one", "`my-it-equipment-policy.md`"],
+    ["an invented parent folder", "old-handbook-2012/policy.md"],
+  ])("a citation that resolves to nothing is graded FAIL (%s)", (_label, entry) => {
+    expect(resolvesFor(entry, RETRIEVED)).toEqual([]);
+    expect(graded(entry, RETRIEVED).tags).toEqual(["path-not-cited"]);
+  });
+
+  it("keeps the one asymmetry the two sides are meant to have", () => {
+    // An unambiguous PARTIAL path: the reader cannot act on `OLD/…` alone, so
+    // the citation axis charges it — but it names one document and nothing
+    // else, so groundedness may check the claim against that document's
+    // passages rather than fall back to "unsupported". Collapsing the two into
+    // one verdict would either excuse an unusable citation or withhold premise
+    // material from a claim whose source is not in doubt.
+    const retrieved = [{ sourcePath: "/data/quality/OLD/afnor-certificate-2013.md" }];
+
+    expect(graded("OLD/afnor-certificate-2013.md", retrieved).tags).toEqual(["path-not-cited"]);
+    expect(resolvesFor("OLD/afnor-certificate-2013.md", retrieved)).toEqual([
+      "/data/quality/OLD/afnor-certificate-2013.md",
+    ]);
   });
 });

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -229,6 +229,118 @@ describe("gradePathCitation", () => {
   });
 });
 
+/**
+ * The first real Layer-3 sweep (#869) charged 19 of 43 runs with
+ * `path-not-cited`, and reading the 19 answers showed that NOT ONE of them
+ * named a document retrieval had not returned. Two rules were wrong, and both
+ * were wrong in the direction that makes a citation-integrity metric read zero
+ * exactly when citation integrity is fine.
+ */
+describe("gradePathCitation against the shapes the first real sweep produced", () => {
+  // 12 of this corpus's 15 documents sit at the data root, so their FULL
+  // citation path is the bare filename. "contains a slash" therefore charged
+  // the correct citation of four documents out of five as a defect.
+  it("passes a document that lives at the data root, whose full path IS its filename", () => {
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:**
+
+- [1] quality-file.md`,
+      retrieved: [src(1, "/data/quality-file.md")],
+    };
+
+    expect(gradePathCitation(input)).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
+  });
+
+  // The entry still has to name as much path as the document HAS: the
+  // ambiguity a bare filename creates is real wherever the corpus has folders,
+  // and that is the Block-A regression this axis was built for.
+  it("still flags the bare filename of a document that lives in a folder", () => {
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:**
+
+- [1] afnor-certificate-2024.md`,
+      retrieved: [src(1, "/data/quality/afnor-certificate-2024.md")],
+    };
+
+    const result = gradePathCitation(input);
+
+    expect(result.passed).toBe(false);
+    expect(result.tags).toEqual(["path-not-cited"]);
+    expect(result.notes[0]).toMatch(/bare filename/);
+  });
+
+  // `PAGE_SUFFIX` only splits a trailing "— p. N". Every other trailing
+  // annotation a model writes stayed glued to the path and turned an exact
+  // match into a mismatch. All three shapes below are verbatim from the sweep.
+  it.each([
+    [
+      "a quoted passage after an em dash",
+      'handbook-2012/policy.md — "the daily meal per diem was increased from $45 to $60."',
+    ],
+    [
+      "a prose gloss after an em dash",
+      "quality-file.md — manufacturing and field-performance notes for the Aqua-Filter 200 line",
+    ],
+    [
+      "a code span with a quoted passage",
+      '`handbook-2012/policy.md` (undefined): "Effective the 2012 revision, ..."',
+    ],
+  ])("passes an entry whose path carries %s", (_label, entry) => {
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:**
+
+- [1] ${entry}`,
+      retrieved: [
+        src(
+          1,
+          entry.includes("handbook") ? "/data/handbook-2012/policy.md" : "/data/quality-file.md"
+        ),
+      ],
+    };
+
+    expect(gradePathCitation(input)).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
+  });
+
+  // The annotation must not become a way to pass, either: a fabricated path is
+  // still fabricated when a real passage is quoted beside it.
+  it("still flags a fabricated path that quotes a real passage beside it", () => {
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:**
+
+- [1] old-handbook-2012/policy.md — "the daily meal per diem was increased from $45 to $60."`,
+      retrieved: [src(1, "/data/handbook-2012/policy.md")],
+    };
+
+    const result = gradePathCitation(input);
+
+    expect(result.passed).toBe(false);
+    expect(result.tags).toEqual(["path-not-cited"]);
+  });
+
+  // A basename two retrieved documents share names neither of them. This is
+  // the ambiguity the axis exists to catch, and it must survive both fixes.
+  it("flags a filename that two retrieved documents share", () => {
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:**
+
+- [1] policy.md`,
+      retrieved: [src(1, "/data/handbook-2011/policy.md"), src(2, "/data/handbook-2012/policy.md")],
+    };
+
+    expect(gradePathCitation(input).tags).toEqual(["path-not-cited"]);
+  });
+});
+
 describe("gradeSourcesFormat", () => {
   it("flags a run-on (non-bullet) Sources list", () => {
     const input: AttributionInput = {

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -325,6 +325,25 @@ describe("gradePathCitation against the shapes the first real sweep produced", (
     expect(result.tags).toEqual(["path-not-cited"]);
   });
 
+  // The mount-relative form is the third way to spell the same whole path, and
+  // it is the one an equality check between two normalized strings misses:
+  // `toCitationPath` strips a LEADING "/data/", so the absolute form folds onto
+  // the citation path and this one does not. It was charged as a "partial path"
+  // — the exact opposite of what it is, since it names the whole document and
+  // the mount besides.
+  it("passes an entry that spells the path out from the mount, without a leading slash", () => {
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:**
+
+- [1] data/quality/afnor-certificate-2024.md`,
+      retrieved: [src(1, "/data/quality/afnor-certificate-2024.md")],
+    };
+
+    expect(gradePathCitation(input)).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
+  });
+
   // A basename two retrieved documents share names neither of them. This is
   // the ambiguity the axis exists to catch, and it must survive both fixes.
   it("flags a filename that two retrieved documents share", () => {

--- a/packages/web/src/lib/eval/kb/answer-graders.ts
+++ b/packages/web/src/lib/eval/kb/answer-graders.ts
@@ -94,10 +94,10 @@ export async function gradeAnswerRelevance(
  * model fabricated a citation.
  *
  * REUSE, not reimplementation: this is exactly `gradePathCitation`'s "cited
- * path not in retrieved" half — same Sources-list parsing, same regex, same
- * `path-not-cited` tag (the closest `KbFailureTag`: "citation used a path
- * not actually available"). The two call sites differ only in INTENT and in
- * what `retrieved` they are handed:
+ * path not in retrieved" half — same Sources-list parsing, same document
+ * matching (`cited-path-match.ts`), same `path-not-cited` tag (the closest
+ * `KbFailureTag`: "citation used a path not actually available"). The two call
+ * sites differ only in INTENT and in what `retrieved` they are handed:
  *   - `gradeAttribution`'s `gradePathCitation` is a Layer-2 integrity check,
  *     grading the answer against whatever `retrieved` set a caller supplies
  *     (in unit tests, often a hand-built fixture).

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -37,6 +37,8 @@
  */
 import { toCitationPath } from "@/lib/knowledge/citation-path";
 
+import { matchRetrievedDocument } from "./cited-path-match";
+
 import type { KbFailureTag, KbGraderResult } from "./types";
 
 /** A source `knowledge_search` returned for the query this answer responds to. */
@@ -320,38 +322,56 @@ export function gradeCitationResolution(input: AttributionInput): KbGraderResult
 }
 
 /**
- * `path-not-cited`: a Sources entry must reproduce the full path
- * `knowledge_search` gave the model, exactly. Flags either failure mode:
- * - a bare filename (no `/`) — unfindable in a deep corpus and ambiguous
- *   across same-named files in different folders;
- * - a path that does not match any `retrieved[].sourcePath` — a fabricated
- *   or mangled path the model didn't actually get from the tool.
+ * `path-not-cited`: a Sources entry must name, in full, a document
+ * `knowledge_search` actually returned. Three failure modes, one tag:
+ * - the entry names no returned document — a fabricated or mangled path;
+ * - it names two of them equally well (`policy.md` when both `handbook-2011/`
+ *   and `handbook-2012/` came back) — the reader cannot tell which;
+ * - it names only part of the path the document has — a bare filename where
+ *   the corpus has folders, unfindable and ambiguous with same-named siblings.
+ *
+ * The rule is "as much path as the document HAS", not "contains a slash". The
+ * first real Layer-3 sweep (#869) charged 19 of 43 runs here, and not one of
+ * them named an unretrieved document: 12 of that corpus's 15 documents sit at
+ * the data root, so their full citation path IS the bare filename, and the
+ * slash test failed four correct citations in five. A citation-integrity axis
+ * reading zero precisely when citation integrity is fine is worse than no axis.
+ *
+ * Matching is delegated to `cited-path-match.ts`, shared with the groundedness
+ * premise lookup so the two cannot answer "which document is this?"
+ * differently. It matches at segment boundaries, which is also what makes the
+ * trailing annotations models really write — a quoted passage, a prose gloss,
+ * a surrounding code span — irrelevant instead of fatal. `PAGE_SUFFIX` splits
+ * off `— p. N` and nothing else, so every other annotation used to stay glued
+ * to the path and turn an exact match into a mismatch.
  */
 export function gradePathCitation(input: AttributionInput): KbGraderResult {
   const { entries } = parseAnswer(input.answer);
-  // Compared in CITATION form on both sides. `retrieved` is built from the
-  // audit row, which records the absolute sourcePath because that is a
-  // document's identity; the answer reproduces what `knowledge_search` printed,
-  // which is data-root-relative (#933). `toCitationPath` is a no-op on a path
-  // that is already relative, so an answer echoing either form still resolves
-  // to the same document instead of reading as a fabrication.
-  const retrievedPaths = new Set(
-    input.retrieved.map((source) => toCitationPath(source.sourcePath))
-  );
 
   const notes: string[] = [];
   for (const entry of entries) {
-    if (!entry.path.includes("/")) {
+    const match = matchRetrievedDocument(entry.path, input.retrieved);
+    if (match === null) {
       notes.push(
-        `Sources entry [${entry.n}] cites the bare filename "${entry.path}" instead of the full path knowledge_search returned.`
+        `Sources entry [${entry.n}] cites path "${entry.path}", which does not match exactly one path in the returned sources.`
       );
       continue;
     }
-    if (!retrievedPaths.has(toCitationPath(entry.path))) {
-      notes.push(
-        `Sources entry [${entry.n}] cites path "${entry.path}", which does not match any path in the returned sources.`
-      );
-    }
+    // Compared in CITATION form on both sides. `retrieved` is built from the
+    // audit row, which records the absolute sourcePath because that is a
+    // document's identity; the answer reproduces what `knowledge_search`
+    // printed, which is data-root-relative (#933). `toCitationPath` is a no-op
+    // on a path that is already relative, so an answer echoing either form
+    // still counts as naming the whole path.
+    const full = toCitationPath(match.sourcePath);
+    const named = toCitationPath(match.named);
+    if (named === full) continue;
+
+    notes.push(
+      named.includes("/")
+        ? `Sources entry [${entry.n}] cites the partial path "${named}" instead of the full path "${full}" knowledge_search returned.`
+        : `Sources entry [${entry.n}] cites the bare filename "${named}" instead of the full path "${full}" knowledge_search returned.`
+    );
   }
 
   if (notes.length === 0) return passKb();

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -332,9 +332,9 @@ export function gradeCitationResolution(input: AttributionInput): KbGraderResult
  *
  * The rule is "as much path as the document HAS", not "contains a slash". The
  * first real Layer-3 sweep (#869) charged 19 of 43 runs here, and not one of
- * them named an unretrieved document: 12 of that corpus's 15 documents sit at
+ * them named an unretrieved document: 12 of that corpus's 16 documents sit at
  * the data root, so their full citation path IS the bare filename, and the
- * slash test failed four correct citations in five. A citation-integrity axis
+ * slash test failed three correct citations in four. A citation-integrity axis
  * reading zero precisely when citation integrity is fine is worse than no axis.
  *
  * Matching is delegated to `cited-path-match.ts`, shared with the groundedness
@@ -357,20 +357,28 @@ export function gradePathCitation(input: AttributionInput): KbGraderResult {
       );
       continue;
     }
-    // Compared in CITATION form on both sides. `retrieved` is built from the
-    // audit row, which records the absolute sourcePath because that is a
-    // document's identity; the answer reproduces what `knowledge_search`
-    // printed, which is data-root-relative (#933). `toCitationPath` is a no-op
-    // on a path that is already relative, so an answer echoing either form
-    // still counts as naming the whole path.
+    // The bar is the CITATION path: `retrieved` is built from the audit row,
+    // which records the absolute sourcePath because that is a document's
+    // identity, while the answer reproduces what `knowledge_search` printed,
+    // which is data-root-relative (#933).
+    //
+    // Compared by LENGTH, not by equality of two normalized strings. What the
+    // entry named is always one of `sourcePath`'s segment-boundary suffixes,
+    // and those are nested — so "at least as long as the citation path" IS
+    // "contains the whole citation path", for every form of it at once. An
+    // answer echoing the absolute `/data/handbook-2012/policy.md`, or the
+    // mount-relative `data/handbook-2012/policy.md`, named the whole document
+    // and more; normalizing the two sides instead let the first through
+    // (`toCitationPath` strips the `/data/`) and charged the second as a
+    // "partial path" it is the opposite of — the #869 false alarm one shape
+    // narrower, wearing a note that says the reverse of what happened.
     const full = toCitationPath(match.sourcePath);
-    const named = toCitationPath(match.named);
-    if (named === full) continue;
+    if (match.named.length >= full.length) continue;
 
     notes.push(
-      named.includes("/")
-        ? `Sources entry [${entry.n}] cites the partial path "${named}" instead of the full path "${full}" knowledge_search returned.`
-        : `Sources entry [${entry.n}] cites the bare filename "${named}" instead of the full path "${full}" knowledge_search returned.`
+      match.named.includes("/")
+        ? `Sources entry [${entry.n}] cites the partial path "${match.named}" instead of the full path "${full}" knowledge_search returned.`
+        : `Sources entry [${entry.n}] cites the bare filename "${match.named}" instead of the full path "${full}" knowledge_search returned.`
     );
   }
 

--- a/packages/web/src/lib/eval/kb/cited-path-match.ts
+++ b/packages/web/src/lib/eval/kb/cited-path-match.ts
@@ -1,0 +1,117 @@
+/**
+ * Does a Sources entry name a document retrieval returned, and how completely?
+ *
+ * One question, asked in two places that must not answer it differently: the
+ * `path-not-cited` grader decides whether a citation is *usable*, and the
+ * groundedness lookup (`eval/kb/resolve-cited-paths.ts`) decides which passages
+ * a claim may be checked against. Two implementations of "names this document"
+ * would eventually disagree, and the disagreement would look like a model
+ * defect — an answer graded as citing a fabricated path while its premise
+ * material resolved fine, or the reverse.
+ *
+ * Matching is at SEGMENT boundaries in both directions, because the string a
+ * model writes is not a path: it arrives wrapped in a code span, followed by a
+ * quoted passage, or glossed in prose. None of that changes which document is
+ * named; a character that continues a path segment does.
+ */
+
+/**
+ * Every path suffix of `sourcePath` at segment boundaries, longest last:
+ * `/data/handbook-2012/policy.md` → `policy.md`, `handbook-2012/policy.md`,
+ * `data/handbook-2012/policy.md`, `/data/handbook-2012/policy.md`.
+ *
+ * The leading-slash form is a candidate in its own right, not a cosmetic
+ * duplicate: an entry that spells the path out absolutely must be able to win
+ * with the WHOLE path, because a win is rejected below when more path precedes
+ * it. Without this candidate the longest match would be `data/…`, preceded by
+ * the `/` the entry does have, and a correctly-cited absolute path would be
+ * thrown out as over-qualified.
+ */
+export function pathSuffixes(sourcePath: string): string[] {
+  const segments = sourcePath.split("/").filter(Boolean);
+  const suffixes = segments.map((_, i) => segments.slice(segments.length - 1 - i).join("/"));
+  if (sourcePath.startsWith("/")) suffixes.push(`/${segments.join("/")}`);
+  return suffixes;
+}
+
+/**
+ * What may NOT flank a suffix occurrence for it to count as naming the
+ * document. Both directions rule out a fabrication picking up real passages:
+ *
+ *   - to the left, any character that continues a segment (`my-policy.md`)
+ *     AND `/` itself, because a preceding separator means the entry names a
+ *     parent the document does not have. That is the whole distinction between
+ *     `handbook-2012/policy.md` and `old-handbook-2012/policy.md`: the shorter
+ *     suffix `policy.md` sits at a real boundary in both, and only the
+ *     separator to its left says the second one is a different document.
+ *   - to the right, a segment character (`policy.mdx`). `.` is deliberately
+ *     absent here so an entry ending its sentence with "…in policy.md." still
+ *     resolves; it IS present on the left, where `my.policy.md` needs it.
+ */
+const SEGMENT_CHAR_BEFORE = /[A-Za-z0-9._/-]/;
+const SEGMENT_CHAR_AFTER = /[A-Za-z0-9_-]/;
+
+/** Whether `suffix` occurs in `entry` as a whole path segment, not mid-name. */
+export function mentionsSuffix(entry: string, suffix: string): boolean {
+  // Every occurrence, not just the first: an entry may name the document twice
+  // and only the second one sit at a boundary.
+  let at = entry.indexOf(suffix);
+  while (at !== -1) {
+    const before = at === 0 ? "" : entry[at - 1];
+    const after = entry[at + suffix.length] ?? "";
+    if (!SEGMENT_CHAR_BEFORE.test(before) && !SEGMENT_CHAR_AFTER.test(after)) return true;
+    at = entry.indexOf(suffix, at + 1);
+  }
+  return false;
+}
+
+/** The longest suffix of `sourcePath` that `entry` names, or "" for none. */
+export function longestSuffixIn(entry: string, sourcePath: string): string {
+  let best = "";
+  for (const suffix of pathSuffixes(sourcePath)) {
+    if (suffix.length > best.length && mentionsSuffix(entry, suffix)) best = suffix;
+  }
+  return best;
+}
+
+/** Which retrieved document an entry names, and how much of its path it spells. */
+export interface EntryMatch {
+  sourcePath: string;
+  /** The longest suffix of `sourcePath` the entry actually names. */
+  named: string;
+}
+
+/**
+ * The one retrieved document `entry` names, or null.
+ *
+ * Null covers the two distinct ways an entry fails to name a document, and the
+ * caller has to tell them apart from the outside because only it knows what to
+ * say about them: nothing matched (a fabricated path), or two documents matched
+ * equally well (`policy.md` when both handbooks were retrieved — the ambiguity
+ * a bare filename creates, which must NOT resolve).
+ */
+export function matchRetrievedDocument(
+  entry: string,
+  retrieved: readonly { sourcePath: string }[]
+): EntryMatch | null {
+  // Score every retrieved document by how specifically this entry names it.
+  // `handbook-2012/policy.md: "…"` scores 23 for the 2012 document and 9
+  // (`policy.md`) for its 2011 sibling, so the qualified path wins. A bare
+  // `policy.md` scores 9 for both — a tie, and a tie is the ambiguity that
+  // must not resolve.
+  let best: EntryMatch | null = null;
+  let tied = false;
+
+  for (const { sourcePath } of retrieved) {
+    const named = longestSuffixIn(entry, sourcePath);
+    if (named.length === 0) continue;
+    if (best === null || named.length > best.named.length) {
+      best = { sourcePath, named };
+      tied = false;
+    } else if (named.length === best.named.length && sourcePath !== best.sourcePath) {
+      tied = true;
+    }
+  }
+
+  return tied ? null : best;
+}

--- a/packages/web/src/lib/eval/kb/cited-path-match.ts
+++ b/packages/web/src/lib/eval/kb/cited-path-match.ts
@@ -13,6 +13,19 @@
  * model writes is not a path: it arrives wrapped in a code span, followed by a
  * quoted passage, or glossed in prose. None of that changes which document is
  * named; a character that continues a path segment does.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT CATCH, stated rather than left to be
+ * rediscovered: the whole entry is scanned, so an entry whose own path is
+ * fabricated resolves anyway if a real path appears ANYWHERE else in it —
+ * `fabricated.md — "as stated in handbook-2012/policy.md, …"` matches the
+ * handbook. Scanning the whole entry is precisely what makes the shapes the
+ * sweep really produced work (a leading code span, a trailing gloss, a
+ * `(undefined):` between path and quote), and the alternative — read only the
+ * entry's first token — would drop `see /data/deep/policy.md`, which
+ * `kb-resolve-cited-paths.test.ts` pins because groundedness hands this
+ * function whole prose entries. So this is a bounded hole in the FABRICATION
+ * direction, kept on purpose: it needs a model to quote a second, real path
+ * beside its invented one, and nothing in the 43 archived sweep answers does.
  */
 
 /**
@@ -27,7 +40,7 @@
  * the `/` the entry does have, and a correctly-cited absolute path would be
  * thrown out as over-qualified.
  */
-export function pathSuffixes(sourcePath: string): string[] {
+function pathSuffixes(sourcePath: string): string[] {
   const segments = sourcePath.split("/").filter(Boolean);
   const suffixes = segments.map((_, i) => segments.slice(segments.length - 1 - i).join("/"));
   if (sourcePath.startsWith("/")) suffixes.push(`/${segments.join("/")}`);
@@ -52,7 +65,7 @@ const SEGMENT_CHAR_BEFORE = /[A-Za-z0-9._/-]/;
 const SEGMENT_CHAR_AFTER = /[A-Za-z0-9_-]/;
 
 /** Whether `suffix` occurs in `entry` as a whole path segment, not mid-name. */
-export function mentionsSuffix(entry: string, suffix: string): boolean {
+function mentionsSuffix(entry: string, suffix: string): boolean {
   // Every occurrence, not just the first: an entry may name the document twice
   // and only the second one sit at a boundary.
   let at = entry.indexOf(suffix);
@@ -66,7 +79,7 @@ export function mentionsSuffix(entry: string, suffix: string): boolean {
 }
 
 /** The longest suffix of `sourcePath` that `entry` names, or "" for none. */
-export function longestSuffixIn(entry: string, sourcePath: string): string {
+function longestSuffixIn(entry: string, sourcePath: string): string {
   let best = "";
   for (const suffix of pathSuffixes(sourcePath)) {
     if (suffix.length > best.length && mentionsSuffix(entry, suffix)) best = suffix;

--- a/packages/web/src/lib/eval/kb/types.ts
+++ b/packages/web/src/lib/eval/kb/types.ts
@@ -96,7 +96,7 @@ export interface GoldQA extends GoldQuery {
 export type KbFailureTag =
   | "recall-miss" // an expected chunk was not retrieved
   | "dedup-inflation" // near-duplicate chunks counted as independent sources
-  | "path-not-cited" // citation used a bare filename, not the full path
+  | "path-not-cited" // citation does not name exactly one retrieved document, in full
   | "citation-unresolved" // an inline [N] has no Sources entry (cited-but-unlisted)
   | "source-uncited" // a Sources entry was never cited inline (listed-but-uncited)
   | "sources-format" // Sources list not rendered as markdown bullets


### PR DESCRIPTION
## Why

The first real Layer-3 groundedness sweep (#869) charged **19 of 43 runs** with `path-not-cited`. Reading all 19 answers found that **not one** of them named a document retrieval had not returned. The axis that exists to catch a fabricated citation was reporting almost nothing but false alarms — and a citation-integrity metric that reads zero exactly when citation integrity is fine is worse than no metric. The sweep numbers were held back because of it.

Two rules were wrong, both in that direction.

**"Contains a slash" is not "full path".** 12 of the sweep corpus's 15 documents sit at the data root, so their full citation path *is* the bare filename — `toCitationPath("/data/quality-file.md")` returns `"quality-file.md"`. Four correct citations in five were charged as a defect. The rule is now *as much path as the document has*, which keeps the Block-A regression this axis was built for and drops the false alarm.

**`PAGE_SUFFIX` splits off `— p. N` and nothing else.** Every other trailing annotation a model really writes — a quoted passage, a prose gloss, a surrounding code span, a literal `(undefined)` page — stayed glued to the path and turned an exact match into a mismatch.

## What

Both fixes come out of one move: `gradePathCitation` now asks `matchRetrievedDocument`, the same primitive the groundedness premise lookup uses. Two implementations of "which document does this entry name?" would eventually disagree, and the disagreement would read as a model defect — an answer graded as citing a fabricated path while its premises resolved fine. `resolve-cited-paths.ts` keeps its behaviour and loses its copy.

`path-not-cited` now covers three failure modes under one tag: the entry names no returned document, it names two equally well (an unresolvable tie on a shared basename), or it names only part of the path the document has.

## Verification

Replay, not reading. The production grader over the **43 archived sweep answers** goes from 19 `path-not-cited` to **0**, with no run newly failing. The negative cases all still fail:

| entry | corpus document | verdict |
|---|---|---|
| `quality-file.md` | `/data/quality-file.md` | pass (root document, full path) |
| `` `handbook-2012/policy.md` (undefined): "…" `` | `/data/handbook-2012/policy.md` | pass |
| `quality-file.md — manufacturing notes …` | `/data/quality-file.md` | pass |
| `policy.md` | both handbooks retrieved | **fail** — ambiguous |
| `afnor-certificate-2024.md` | `/data/quality/afnor-certificate-2024.md` | **fail** — bare filename |
| `old-handbook-2012/policy.md` | `/data/handbook-2012/policy.md` | **fail** — invented parent |
| `my-quality-file.md` | `/data/quality-file.md` | **fail** — merely ends with a real name |

## One fixture had the same bug, one level up

`KB_BARE_FILENAME` cited `product-insert.md` — a **root-level** document. Under the corrected rule that citation legitimately passes, so the fixture would have silently stopped testing anything while its name still claimed otherwise. It now cites `policy.md` for `/data/handbook-2012/policy.md`, and the tag fires whatever `retrieved` holds, for three different reasons (partial path / tie / no match).

## Test plan

- [x] `pnpm test` — 775 files, 10919 tests green
- [x] `pnpm test:scripts` — 894 green
- [x] `pnpm -C packages/web typecheck`, `pnpm format:check`, `pnpm -C packages/web lint` (0 errors)
- [x] Replay of the 43 archived sweep answers through the production grader
- [ ] `pnpm test:e2e` KB attribution self-test (CI) — the moved fixture

Refs #869