### PR TITLE
fix(eval): stop reporting an unparsed Sources list as a hallucination

### DIFF
--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -81,7 +81,6 @@ import type { KnowledgeSearchAuditEntry } from "./run-kb-eval";
 import { getRawAssistantMessage } from "./getRawAssistantMessage";
 import { gradeKbRun } from "../../src/lib/eval/kb/answer-graders";
 import type { KbRunTrajectory, KbRunResult } from "../../src/lib/eval/kb/answer-graders";
-import { citedSourcePaths } from "../../src/lib/eval/kb/attribution-graders";
 import {
   DEFAULT_KB_JUDGE_MODEL,
   LlmNliClient,
@@ -91,7 +90,7 @@ import {
 import { DEFAULT_ORG_ID } from "../../src/lib/knowledge/constants";
 import { fetchChunkTexts } from "./chunk-texts";
 import { seedSyntheticCorpus } from "./seed-corpus";
-import { resolveCitedSourcePaths } from "./resolve-cited-paths";
+import { premiseSourcePaths } from "./resolve-cited-paths";
 import { withTransportRetry } from "../transport-retry";
 import { describeError } from "../error-detail";
 import { DEFAULT_KB_CANDIDATES } from "../candidates";
@@ -407,7 +406,7 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
         // root); kb_chunks is keyed by the absolute path. Resolving between
         // them against this run's own retrieved set is what makes the premise
         // lookup find anything at all — see resolve-cited-paths.ts.
-        const citedPaths = resolveCitedSourcePaths(citedSourcePaths(answer), retrieved);
+        const citedPaths = premiseSourcePaths(answer, retrieved);
         const chunkTextsByPath = await fetchChunkTexts(dbUrl, DEFAULT_ORG_ID, citedPaths);
         const citedPassageTexts = citedPaths.flatMap((p) => chunkTextsByPath.get(p) ?? []);
 

--- a/packages/web/eval/kb/resolve-cited-paths.ts
+++ b/packages/web/eval/kb/resolve-cited-paths.ts
@@ -25,7 +25,11 @@
 // `eval/` for `import type` (which erases). `run-eval.ts` reaches into `src/`
 // the same way, for the same reason — a Playwright spec loads these files
 // directly.
-import { citedSourcePaths, sourcesListCandidates } from "../../src/lib/eval/kb/attribution-graders";
+import {
+  citedSourcePaths,
+  citesInline,
+  sourcesListCandidates,
+} from "../../src/lib/eval/kb/attribution-graders";
 import { matchRetrievedDocument } from "../../src/lib/eval/kb/cited-path-match";
 
 export function resolveCitedSourcePaths(
@@ -69,14 +73,29 @@ export function resolveCitedSourcePaths(
  * looser second door: a fabricated path and an ambiguous bare basename resolve
  * to nothing on both routes.
  *
- * What bounds the fallback's lower precision, and why it is safe to be less
- * precise here: it runs ONLY when the strict parse found nothing, and an answer
- * whose list does not parse always carries `sources-format` or
- * `citation-unresolved` from `gradeAttribution`. The run therefore fails either
- * way — the fallback can never turn a failing run into a passing one, only stop
- * `ungrounded-claim` from firing on a claim whose source was never in doubt.
- * `kb-resolve-cited-paths.test.ts` asserts that bound against every shape this
- * exists for, rather than leaving it as an argument in a comment.
+ * What bounds the fallback's lower precision: it can never turn a failing run
+ * into a passing one, only stop `ungrounded-claim` from firing on a claim whose
+ * source was never in doubt. That is a proof rather than a hope, and the two
+ * conditions below are exactly what makes it one. Write C for the inline `[N]`
+ * numbers the body carries and E for the bullets `BULLET_LINE` parsed:
+ *
+ *   - C is non-empty (the second guard), and the strict result was empty.
+ *   - If E is empty, every number in C is unresolvable → `citation-unresolved`.
+ *   - If no bullet in E carries a number in C, likewise → `citation-unresolved`.
+ *   - Otherwise some bullet IS cited inline, and the strict result was still
+ *     empty, so that bullet's path names no retrieved document →
+ *     `path-not-cited`.
+ *
+ * So the fallback runs only where `gradeAttribution` already fails. The inline
+ * guard is what closes the one hole in that argument, and it is a real answer
+ * shape rather than a hypothetical: prose that asserts, then appends a Sources
+ * list it never cites into. `gradeSourcesFormat` returns early on zero `[N]`
+ * markers and `gradeCitationResolution` has nothing on either side to compare,
+ * so nothing charges it — the empty premise set was the only thing failing it,
+ * and recovering one would have made it pass. `kb-resolve-cited-paths.test.ts`
+ * asserts the bound as `gradeAttribution(...).passed === false` against every
+ * shape this exists for, and pins the guarded shape separately, rather than
+ * leaving either as an argument in a comment.
  */
 export function premiseSourcePaths(
   answer: string,
@@ -84,6 +103,7 @@ export function premiseSourcePaths(
 ): string[] {
   const strict = resolveCitedSourcePaths(citedSourcePaths(answer), retrieved);
   if (strict.length > 0) return strict;
+  if (!citesInline(answer)) return [];
 
   return resolveCitedSourcePaths(sourcesListCandidates(answer), retrieved);
 }

--- a/packages/web/eval/kb/resolve-cited-paths.ts
+++ b/packages/web/eval/kb/resolve-cited-paths.ts
@@ -25,6 +25,7 @@
 // `eval/` for `import type` (which erases). `run-eval.ts` reaches into `src/`
 // the same way, for the same reason — a Playwright spec loads these files
 // directly.
+import { citedSourcePaths, sourcesListCandidates } from "../../src/lib/eval/kb/attribution-graders";
 import { matchRetrievedDocument } from "../../src/lib/eval/kb/cited-path-match";
 
 export function resolveCitedSourcePaths(
@@ -43,4 +44,46 @@ export function resolveCitedSourcePaths(
   }
 
   return resolved;
+}
+
+/**
+ * The documents a claim may be checked against — strictly if the Sources list
+ * parses, and by naming alone if it does not.
+ *
+ * `citedSourcePaths` reads the list through `BULLET_LINE` and returns the
+ * INTERSECTION of inline citations and list entries. That intersection is a
+ * real guarantee — a source listed but never cited must not ground a claim —
+ * and it is kept wherever it can be computed. What it cannot survive is a list
+ * written any other way: the intersection comes back empty, so the premise set
+ * is empty, so `gradeGroundednessForGold` entailment-scores every sentence
+ * against `""` and charges `ungrounded-claim`. The 2026-08-03 sweep spent 23 of
+ * its 29 `ungrounded-claim` verdicts that way, including all 12 runs of
+ * `gpt-oss:120b` — whose 0/12 measured this parser rather than the model.
+ *
+ * The intersection is not computable in those shapes rather than merely
+ * inconvenient: `glm-5.2` writes `1. <path> — passage [1]`, with the number
+ * TRAILING the path, so no split attaches a citation number to a document. So
+ * an empty strict result falls back to what needs no structure at all — which
+ * retrieved documents the Sources region names — resolved through the same
+ * matcher, which means the fallback inherits its refusals rather than being a
+ * looser second door: a fabricated path and an ambiguous bare basename resolve
+ * to nothing on both routes.
+ *
+ * What bounds the fallback's lower precision, and why it is safe to be less
+ * precise here: it runs ONLY when the strict parse found nothing, and an answer
+ * whose list does not parse always carries `sources-format` or
+ * `citation-unresolved` from `gradeAttribution`. The run therefore fails either
+ * way — the fallback can never turn a failing run into a passing one, only stop
+ * `ungrounded-claim` from firing on a claim whose source was never in doubt.
+ * `kb-resolve-cited-paths.test.ts` asserts that bound against every shape this
+ * exists for, rather than leaving it as an argument in a comment.
+ */
+export function premiseSourcePaths(
+  answer: string,
+  retrieved: readonly { sourcePath: string }[]
+): string[] {
+  const strict = resolveCitedSourcePaths(citedSourcePaths(answer), retrieved);
+  if (strict.length > 0) return strict;
+
+  return resolveCitedSourcePaths(sourcesListCandidates(answer), retrieved);
 }

--- a/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
@@ -32,8 +32,15 @@
 
 import { describe, expect, it } from "vitest";
 
-import { resolveCitedSourcePaths } from "../../../../eval/kb/resolve-cited-paths";
-import { citedSourcePaths, gradePathCitation } from "@/lib/eval/kb/attribution-graders";
+import {
+  premiseSourcePaths,
+  resolveCitedSourcePaths,
+} from "../../../../eval/kb/resolve-cited-paths";
+import {
+  citedSourcePaths,
+  gradeAttribution,
+  gradePathCitation,
+} from "@/lib/eval/kb/attribution-graders";
 
 const RETRIEVED = [
   { sourcePath: "/data/it-equipment-policy.md" },
@@ -208,5 +215,106 @@ describe("gradePathCitation and resolveCitedSourcePaths agree on which document 
     expect(resolvesFor("OLD/afnor-certificate-2013.md", retrieved)).toEqual([
       "/data/quality/OLD/afnor-certificate-2013.md",
     ]);
+  });
+});
+
+/**
+ * The same false alarm, one layer down, and the one that mattered most.
+ *
+ * `citedSourcePaths` resolves the INTERSECTION of what the answer cites inline
+ * and what its Sources list holds — and it reads that list through
+ * `BULLET_LINE`, which requires `- [N] …`. When a model writes the list any
+ * other way the intersection is empty, so the premise set is empty, so
+ * `gradeGroundednessForGold` entailment-scores every sentence against `""` and
+ * charges `ungrounded-claim`. In the 2026-08-03 sweep that was 23 of 29
+ * `ungrounded-claim` verdicts, and 12 of 12 runs for `gpt-oss:120b` — whose
+ * 0/12 therefore measured this parser, not the model.
+ *
+ * The intersection is NOT dropped: where the list parses, a listed-but-uncited
+ * source must still not ground a claim, and that guarantee is free there. It is
+ * simply not computable in the shapes above — glm-5.2 writes
+ * `1. path — passage [1]`, with the number trailing — so an empty strict result
+ * falls back to "every retrieved document the Sources region names", which
+ * needs no structure at all.
+ *
+ * What bounds the fallback's lower precision: it only ever runs when the strict
+ * parse found nothing, and an answer whose list does not parse ALWAYS carries
+ * `sources-format` or `citation-unresolved` from `gradeAttribution`. So the
+ * fallback can never turn a failing run into a passing one — it can only stop
+ * `ungrounded-claim` from firing on a claim whose source was never in doubt.
+ */
+describe("premiseSourcePaths", () => {
+  const SWEEP_SHAPES: [string, string][] = [
+    [
+      "no list marker at all (kimi-k2.6, gpt-oss:120b)",
+      'Laptops are replaced on a 3-year cycle [1].\n\n**Sources**\n[1] `it-equipment-policy.md`: "…replaced on a 3-year refresh cycle…"',
+    ],
+    [
+      "an ordered list with the number trailing (glm-5.2)",
+      "Coverage expanded in 2012 [1].\n\n### Sources\n\n1. handbook-2012/policy.md — passage [1]",
+    ],
+    [
+      "an ordered list carrying the citation number (qwen3.5:397b)",
+      'The per diem rose to $60 [1].\n\n**Sources:**\n1. handbook-2012/policy.md — "…increased from $45 to $60…"',
+    ],
+    [
+      "a run-on paragraph, the shape sources-format was built for",
+      "One [1]. Two [2].\n\n**Sources:** [1] handbook-2011/policy.md — p. 1 [2] handbook-2012/policy.md — p. 2",
+    ],
+  ];
+
+  it.each(SWEEP_SHAPES)("recovers premise material from %s", (_label, answer) => {
+    expect(premiseSourcePaths(answer, RETRIEVED).length).toBeGreaterThan(0);
+  });
+
+  it("prefers the strict intersection whenever it resolves anything", () => {
+    // [2] is listed but never cited inline. The strict path excludes it, and
+    // because the strict path is non-empty the fallback never runs — so the
+    // guarantee that an uncited source cannot ground a claim is untouched.
+    const answer = `Fact one [1].
+
+**Sources:**
+
+- [1] it-equipment-policy.md — p. 1
+- [2] handbook-2012/policy.md — p. 2`;
+
+    expect(premiseSourcePaths(answer, RETRIEVED)).toEqual(["/data/it-equipment-policy.md"]);
+  });
+
+  it("still refuses a fabricated path and an ambiguous basename in the fallback", () => {
+    // No structure to parse, so the fallback runs — and it resolves through the
+    // same matcher, which means it inherits both refusals rather than being a
+    // looser second door into the premise set.
+    const fabricated = "A claim [1].\n\n**Sources**\n[1] invented-policy.md";
+    const ambiguous = "A claim [1].\n\n**Sources**\n[1] policy.md";
+
+    expect(premiseSourcePaths(fabricated, RETRIEVED)).toEqual([]);
+    expect(premiseSourcePaths(ambiguous, RETRIEVED)).toEqual([]);
+  });
+
+  it("returns nothing for an answer with no Sources list at all", () => {
+    // An abstention, or a model that asserted without citing. Nothing was
+    // claimed to be a source, so there is nothing to recover — and
+    // `ungrounded-claim` on an uncited assertion is a fair verdict, not an
+    // artefact.
+    expect(premiseSourcePaths("I couldn't find this in the knowledge base.", RETRIEVED)).toEqual(
+      []
+    );
+  });
+
+  it("cannot turn a failing run into a passing one — the bound the fallback rests on", () => {
+    // Every shape the fallback exists for is charged by gradeAttribution
+    // independently. Assert that rather than trusting the reasoning: if a
+    // future parser change made one of these shapes grade clean, the fallback's
+    // lower precision would start affecting verdicts and this test says so.
+    // `gradeAttribution` grades the full retrieved shape, so the citation
+    // number and page the tool reported are supplied here; the premise lookup
+    // above needs only the path and is typed accordingly.
+    const graded = RETRIEVED.map((source, i) => ({ ...source, n: i + 1, page: 1 }));
+
+    for (const [, answer] of SWEEP_SHAPES) {
+      const tags = gradeAttribution({ answer, retrieved: graded }).tags;
+      expect(tags.some((t) => t === "sources-format" || t === "citation-unresolved")).toBe(true);
+    }
   });
 });

--- a/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
@@ -237,34 +237,50 @@ describe("gradePathCitation and resolveCitedSourcePaths agree on which document 
  * falls back to "every retrieved document the Sources region names", which
  * needs no structure at all.
  *
- * What bounds the fallback's lower precision: it only ever runs when the strict
- * parse found nothing, and an answer whose list does not parse ALWAYS carries
- * `sources-format` or `citation-unresolved` from `gradeAttribution`. So the
- * fallback can never turn a failing run into a passing one — it can only stop
- * `ungrounded-claim` from firing on a claim whose source was never in doubt.
+ * What bounds the fallback's lower precision: it can never turn a failing run
+ * into a passing one — it can only stop `ungrounded-claim` from firing on a
+ * claim whose source was never in doubt. Two conditions make that a proof
+ * rather than a hope, and both are asserted below: the strict parse found
+ * nothing, AND the body carries at least one inline `[N]`. From there every
+ * branch is charged — no bullets, or none of them cited, leaves an inline
+ * number unresolvable (`citation-unresolved`); a bullet that IS cited and
+ * still resolved to nothing names no retrieved document (`path-not-cited`).
+ *
+ * The inline guard is not belt-and-braces. Without it the one shape no
+ * attribution axis charges — prose that asserts, then appends a Sources list it
+ * never cites into — would have started passing on premise material the
+ * fallback handed it.
  */
 describe("premiseSourcePaths", () => {
-  const SWEEP_SHAPES: [string, string][] = [
+  const SWEEP_SHAPES: [string, string, string[]][] = [
     [
       "no list marker at all (kimi-k2.6, gpt-oss:120b)",
       'Laptops are replaced on a 3-year cycle [1].\n\n**Sources**\n[1] `it-equipment-policy.md`: "…replaced on a 3-year refresh cycle…"',
+      ["/data/it-equipment-policy.md"],
     ],
     [
       "an ordered list with the number trailing (glm-5.2)",
       "Coverage expanded in 2012 [1].\n\n### Sources\n\n1. handbook-2012/policy.md — passage [1]",
+      ["/data/handbook-2012/policy.md"],
     ],
     [
       "an ordered list carrying the citation number (qwen3.5:397b)",
       'The per diem rose to $60 [1].\n\n**Sources:**\n1. handbook-2012/policy.md — "…increased from $45 to $60…"',
+      ["/data/handbook-2012/policy.md"],
     ],
     [
       "a run-on paragraph, the shape sources-format was built for",
       "One [1]. Two [2].\n\n**Sources:** [1] handbook-2011/policy.md — p. 1 [2] handbook-2012/policy.md — p. 2",
+      ["/data/handbook-2011/policy.md", "/data/handbook-2012/policy.md"],
     ],
   ];
 
-  it.each(SWEEP_SHAPES)("recovers premise material from %s", (_label, answer) => {
-    expect(premiseSourcePaths(answer, RETRIEVED).length).toBeGreaterThan(0);
+  // The exact set, not merely a non-empty one: recovering premise material from
+  // the WRONG retrieved document would satisfy a length check while grounding
+  // claims against a passage the answer never named — the failure this whole
+  // file exists to keep the two lookups from making.
+  it.each(SWEEP_SHAPES)("recovers premise material from %s", (_label, answer, expected) => {
+    expect(premiseSourcePaths(answer, RETRIEVED)).toEqual(expected);
   });
 
   it("prefers the strict intersection whenever it resolves anything", () => {
@@ -307,14 +323,44 @@ describe("premiseSourcePaths", () => {
     // independently. Assert that rather than trusting the reasoning: if a
     // future parser change made one of these shapes grade clean, the fallback's
     // lower precision would start affecting verdicts and this test says so.
+    //
+    // `passed`, not a chosen tag pair. Which axis charges a shape is an
+    // implementation detail that shifts as the parsers widen; that SOME axis
+    // does is the whole bound. An earlier draft asserted
+    // `sources-format || citation-unresolved` and was already too narrow — a
+    // parsing list the body never cites is charged `source-uncited`, a third
+    // tag the pair would have missed.
+    //
     // `gradeAttribution` grades the full retrieved shape, so the citation
     // number and page the tool reported are supplied here; the premise lookup
     // above needs only the path and is typed accordingly.
     const graded = RETRIEVED.map((source, i) => ({ ...source, n: i + 1, page: 1 }));
 
-    for (const [, answer] of SWEEP_SHAPES) {
-      const tags = gradeAttribution({ answer, retrieved: graded }).tags;
-      expect(tags.some((t) => t === "sources-format" || t === "citation-unresolved")).toBe(true);
+    for (const [label, answer] of SWEEP_SHAPES) {
+      expect(gradeAttribution({ answer, retrieved: graded }).passed, label).toBe(false);
     }
+  });
+
+  it("recovers nothing for an answer that never cites inline, the one shape nothing charges", () => {
+    // Prose that asserts and then appends a Sources list it never cites into.
+    // No attribution axis touches it: `gradeSourcesFormat` returns early on
+    // zero `[N]` markers in the Sources region, and `gradeCitationResolution`
+    // has nothing on either side to compare. So `ungrounded-claim` off an empty
+    // premise set is the ONLY thing failing this run — recover premise material
+    // here and the fallback turns a failing run into a passing one, which is
+    // exactly what it promises it cannot do.
+    const graded = RETRIEVED.map((source, i) => ({ ...source, n: i + 1, page: 1 }));
+    const uncited =
+      "Laptops are replaced on a 3-year cycle.\n\n**Sources**\nit-equipment-policy.md";
+
+    expect(gradeAttribution({ answer: uncited, retrieved: graded }).passed).toBe(true);
+    expect(premiseSourcePaths(uncited, RETRIEVED)).toEqual([]);
+
+    // The document IS named and IS retrieved — nothing about the matcher stops
+    // this. Only the inline guard does, so pin that it is the guard doing the
+    // work: add the citation the shape is missing and the same answer recovers.
+    const cited =
+      "Laptops are replaced on a 3-year cycle [1].\n\n**Sources**\nit-equipment-policy.md";
+    expect(premiseSourcePaths(cited, RETRIEVED)).toEqual(["/data/it-equipment-policy.md"]);
   });
 });

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -269,6 +269,31 @@ export function citedSourcePaths(answer: string): string[] {
   return paths;
 }
 
+/**
+ * The Sources region cut into candidate entries WITHOUT requiring a bullet.
+ *
+ * `citedSourcePaths` above reads the list through `BULLET_LINE` because the
+ * gate grades the taught shape (`- [N] <path> — <position>`). This one exists
+ * for the groundedness premise lookup, which needs a different question
+ * answered: not "did the model format its list correctly?" — `sources-format`
+ * owns that — but "which documents does the model say it used?". A model that
+ * writes a perfectly legible ordered list has answered the second question;
+ * charging it as if it answered neither is how one formatting defect became an
+ * `ungrounded-claim` verdict (#869).
+ *
+ * The split is on line breaks and BEFORE each `[N]` marker, which is the one
+ * token every shape the sweep produced has in common — bulleted, ordered,
+ * marker-only, and the single-line run-on that has no line breaks to split on
+ * at all. Empty and marker-only fragments fall out; a fragment that names no
+ * retrieved document resolves to nothing, so over-splitting costs nothing.
+ */
+export function sourcesListCandidates(answer: string): string[] {
+  return parseAnswer(answer)
+    .sourcesText.split(/\r?\n|(?=\[\d+\])/)
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => candidate.length > 0);
+}
+
 function passKb(): KbGraderResult {
   return { passed: true, tags: [], notes: [] };
 }

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -284,14 +284,31 @@ export function citedSourcePaths(answer: string): string[] {
  * The split is on line breaks and BEFORE each `[N]` marker, which is the one
  * token every shape the sweep produced has in common — bulleted, ordered,
  * marker-only, and the single-line run-on that has no line breaks to split on
- * at all. Empty and marker-only fragments fall out; a fragment that names no
- * retrieved document resolves to nothing, so over-splitting costs nothing.
+ * at all. Empty fragments are dropped here; everything else is left to the
+ * matcher, which resolves a fragment naming no retrieved document — a bare
+ * `[1]`, the tail of an entry over-split on a `[2]` inside its own quoted
+ * passage — to nothing. So over-splitting costs nothing.
  */
 export function sourcesListCandidates(answer: string): string[] {
   return parseAnswer(answer)
     .sourcesText.split(/\r?\n|(?=\[\d+\])/)
     .map((candidate) => candidate.trim())
     .filter((candidate) => candidate.length > 0);
+}
+
+/**
+ * Whether the answer BODY carries at least one inline `[N]` citation.
+ *
+ * Exported for the groundedness premise fallback, which is only sound for an
+ * answer that claims a source for its claims at all. An answer that asserts
+ * and then appends a Sources list without ever citing inline is charged by no
+ * attribution axis — `gradeSourcesFormat` returns early on zero markers,
+ * `gradeCitationResolution` has nothing on either side to compare — so it is
+ * the one shape where recovering premise material could turn a failing run
+ * into a passing one. See `premiseSourcePaths`.
+ */
+export function citesInline(answer: string): boolean {
+  return parseAnswer(answer).citedNumbers.size > 0;
 }
 
 function passKb(): KbGraderResult {


### PR DESCRIPTION
## Why

The 2026-08-03 sweep charged 29 runs with `ungrounded-claim`. Reading the trajectories rather than the tags: **23 of those verdicts were handed down against an empty premise set**, and 30 of 48 runs had one.

The chain is short and entirely mechanical:

```
BULLET_LINE requires "- [N] …"
  → any other shape yields zero entries
  → citedPassageTexts is empty
  → premise = [].join("\n\n") === ""
  → every sentence entailment-scored against ""
  → ungrounded-claim
```

A formatting deviation reported on the one axis Layer 3 exists for. `gpt-oss:120b` had an empty premise set in **12 of 12** runs — its 0/12 measured this parser, not the model.

And the models are not fabricating. All four name real retrieved documents with real passages; they just don't write bullets:

| model | what it actually wrote |
|---|---|
| kimi-k2.6, gpt-oss:120b | `` [1] `it-equipment-policy.md`: "…" `` — no list marker |
| glm-5.2 | `1. handbook-2012/policy.md — passage [1]` |
| qwen3.5:397b | `1. handbook-2012/policy.md — "…"` |

## What

**The strict intersection is not dropped.** Where the list parses, a source listed but never cited must still not ground a claim, and that guarantee is free there. It is *not computable* in the shapes above rather than merely awkward — glm writes the citation number **after** the path, so no split attaches a number to a document. So an empty strict result falls back to what needs no structure at all: which retrieved documents the Sources region names.

Two things keep the fallback honest:

- It resolves through the **same** `matchRetrievedDocument`, so it inherits both refusals instead of being a looser second door — a fabricated path and an ambiguous bare basename resolve to nothing on either route.
- **It cannot turn a failing run into a passing one.** It runs only when the strict parse found nothing, and every shape that reaches it carries `sources-format` or `citation-unresolved` independently. That bound is asserted against each shape rather than left as an argument in a comment.

## Verification

Replay over the 48 archived sweep answers, through the production function:

| model | empty premise sets before | after |
|---|---|---|
| kimi-k2.6 | 7/12 | 2/12 |
| glm-5.2 | 5/12 | 1/12 |
| qwen3.5:397b | 6/12 | 0/12 |
| gpt-oss:120b | **12/12** | 3/12 |
| **total** | **30/48** | **6/48** |

## The remaining 6, read rather than rounded off

- **3** are correct abstentions with no Sources list at all. Empty is right.
- **1** is glm answering a German question under `**Quellen:**`; `SOURCES_HEADING` is English and case-sensitive.
- **2** are gpt-oss writing `retention‑correct.md` with **U+2011 NON-BREAKING HYPHEN** instead of ASCII. That path is genuinely not the one the tool showed, and `source-links.ts` would not linkify it either — so the citation axis is right to charge it, and because the matcher is deliberately shared, loosening it here would loosen it there too.

Both residues are judgement calls about what the product **tolerates** versus what it **teaches**, so neither is decided in this PR.

## Test plan

- [x] `pnpm test` — 774 files, 10916 tests green
- [x] `pnpm -C packages/web typecheck`, `pnpm format:check`, lint (0 errors)
- [x] Replay of the 48 archived answers through the production function
- [ ] Fresh sweep once this lands — the numbers still are not publishable until it runs against a grader that measures grounding rather than parsing

Refs #869