### PR TITLE
fix(security): restrict diagnostics logs to admins and redact them

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -239,6 +239,12 @@ Until now a password change left every existing session alive — including, in 
 
 Repeated wrong guesses at the current password are also throttled now — five attempts per account per 10 minutes, after which Pinchy answers `429` and says how long to wait. The account-level rule that was supposed to cover this never applied to Pinchy's own change-password route, so in practice there was no limit at all. Nothing to configure either way. See [Changing your password](/guides/user-management/#changing-your-password).
 
+#### Server logs reach admins only
+
+A bug report filed from inside Pinchy used to carry the server's recent log lines for anyone signed in. That buffer is process-global — it holds error output from everyone's sessions, not only the reporter's — so it now goes to admins alone, and email addresses and secret-shaped strings are stripped out of it on the way in.
+
+Nothing to configure. A member's bug report simply asks them to paste the logs by hand instead; if one arrives without them, `docker compose logs pinchy --tail 200` on the host is the same output, unredacted.
+
 ### Database migrations
 
 Nine migrations (`0056`–`0064`) run automatically on startup — no manual steps. Only `0056` is destructive, and only for the Knowledge Base tables (see the breaking change above); the rest are additive.

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -243,7 +243,7 @@ Repeated wrong guesses at the current password are also throttled now — five a
 
 A bug report filed from inside Pinchy used to carry the server's recent log lines for anyone signed in. That buffer is process-global — it holds error output from everyone's sessions, not only the reporter's — so it now goes to admins alone, and email addresses and secret-shaped strings are stripped out of it on the way in.
 
-Nothing to configure. A member's bug report now says the logs were left out and asks them to forward it to you rather than to run anything on the host. When one reaches you, `docker compose logs pinchy --tail 200` gives you the same output, unredacted.
+Nothing to configure. A member's bug report now says the logs were left out and asks them to forward it to you rather than to run anything on the host. When one reaches you, `docker compose logs pinchy --tail 200` gives you the same lines — unredacted, so read them there before deciding what goes into a public issue.
 
 ### Database migrations
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -243,7 +243,7 @@ Repeated wrong guesses at the current password are also throttled now — five a
 
 A bug report filed from inside Pinchy used to carry the server's recent log lines for anyone signed in. That buffer is process-global — it holds error output from everyone's sessions, not only the reporter's — so it now goes to admins alone, and email addresses and secret-shaped strings are stripped out of it on the way in.
 
-Nothing to configure. A member's bug report simply asks them to paste the logs by hand instead; if one arrives without them, `docker compose logs pinchy --tail 200` on the host is the same output, unredacted.
+Nothing to configure. A member's bug report now says the logs were left out and asks them to forward it to you rather than to run anything on the host. When one reaches you, `docker compose logs pinchy --tail 200` gives you the same output, unredacted.
 
 ### Database migrations
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -56,7 +56,7 @@ This is the endpoint to check after an upgrade: it answers what the container ac
 
 Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated **admins** additionally get a `logs` field with recent server logs (redacted of email addresses and known secret patterns). Nobody else gets that field — the log buffer is process-global and can carry detail from other users' sessions.
 
-A signed-in non-admin also gets `"logsWithheld": "admin-only"`. It lets a client tell "your role may not read these" apart from "there are none": the in-app bug reporter uses it to ask the reporter to forward their report to an administrator, rather than pointing them at a host shell they have no account on. Anonymous callers never get the field — for them the missing `logs` really does mean "go and look", since whoever runs the setup wizard operates the host.
+A signed-in non-admin also gets `"logsWithheld": "admin-only"`. It lets a client tell "your role may not read these" apart from "there are none": the in-app bug reporter uses it to ask the reporter to forward their report to an administrator, rather than pointing them at a host shell they have no account on. Anonymous callers never get the field: with no session there is no role to withhold for, and that caller may be the setup wizard's pre-flight check — run by whoever is installing Pinchy, who does hold the host shell. Nothing in the request separates that person from a signed-out member, so the bug reporter's fallback names the host command and the administrator both.
 
 ### `GET /api/health/openclaw`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -54,7 +54,7 @@ This is the endpoint to check after an upgrade: it answers what the container ac
 
 ### `GET /api/diagnostics`
 
-Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated callers additionally get a `logs` field with recent server logs. Anonymous callers get the status only.
+Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated **admins** additionally get a `logs` field with recent server logs (redacted of email addresses and known secret patterns). Anonymous callers and non-admin members get the status only — the log buffer is process-global and can carry detail from other users' sessions.
 
 ### `GET /api/health/openclaw`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -54,7 +54,9 @@ This is the endpoint to check after an upgrade: it answers what the container ac
 
 ### `GET /api/diagnostics`
 
-Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated **admins** additionally get a `logs` field with recent server logs (redacted of email addresses and known secret patterns). Anonymous callers and non-admin members get the status only — the log buffer is process-global and can carry detail from other users' sessions.
+Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated **admins** additionally get a `logs` field with recent server logs (redacted of email addresses and known secret patterns). Nobody else gets that field — the log buffer is process-global and can carry detail from other users' sessions.
+
+A signed-in non-admin also gets `"logsWithheld": "admin-only"`. It lets a client tell "your role may not read these" apart from "there are none": the in-app bug reporter uses it to ask the reporter to forward their report to an administrator, rather than pointing them at a host shell they have no account on. Anonymous callers never get the field — for them the missing `logs` really does mean "go and look", since whoever runs the setup wizard operates the host.
 
 ### `GET /api/health/openclaw`
 

--- a/packages/web/src/__tests__/api/diagnostics.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics.test.ts
@@ -125,4 +125,22 @@ describe("GET /api/diagnostics", () => {
 
     expect(data).not.toHaveProperty("logs");
   });
+
+  // A session carrying no `role` at all is the shape this endpoint used to
+  // hand logs to. It must resolve to "not an admin", never to a lenient
+  // fallback — the check has to fail closed on an unexpected session shape,
+  // not on the absence of a known-bad one.
+  it("should omit logs when the session carries no role", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "1" } });
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+    mockLogCapture.formatAsText.mockReturnValueOnce(
+      "2026-03-04T08:00:00Z [ERROR] DB connection failed"
+    );
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).not.toHaveProperty("logs");
+  });
 });

--- a/packages/web/src/__tests__/api/diagnostics.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics.test.ts
@@ -84,8 +84,8 @@ describe("GET /api/diagnostics", () => {
     expect(data.openclaw).toBe("connected");
   });
 
-  it("should include captured logs when user is authenticated", async () => {
-    mockGetSession.mockResolvedValueOnce({ user: { id: "1" } });
+  it("should include captured logs when user is an admin", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "1", role: "admin" } });
     mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
     vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
     mockLogCapture.formatAsText.mockReturnValueOnce(
@@ -100,6 +100,20 @@ describe("GET /api/diagnostics", () => {
 
   it("should omit logs when user is not authenticated", async () => {
     mockGetSession.mockResolvedValueOnce(null);
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+    mockLogCapture.formatAsText.mockReturnValueOnce(
+      "2026-03-04T08:00:00Z [ERROR] DB connection failed"
+    );
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).not.toHaveProperty("logs");
+  });
+
+  it("should omit logs when authenticated user is a plain member (not admin)", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "1", role: "member" } });
     mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
     vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
     mockLogCapture.formatAsText.mockReturnValueOnce(

--- a/packages/web/src/__tests__/api/diagnostics.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics.test.ts
@@ -170,9 +170,12 @@ describe("GET /api/diagnostics", () => {
     expect(data).not.toHaveProperty("logsWithheld");
   });
 
-  // The anonymous caller here is the setup wizard's pre-flight check, run by
-  // whoever is installing Pinchy — they hold the host shell. Telling them to
-  // ask an administrator would send them looking for themselves.
+  // No session means no role to withhold for, so there is nothing to mark.
+  // This is not an assertion that the caller operates the host: it may be the
+  // setup wizard's pre-flight check, or a signed-out member hitting the error
+  // boundary on `/login`. Nothing in the request separates them, which is why
+  // the client's fallback copy names both routes rather than this endpoint
+  // picking one for it.
   it("should not mark logs as withheld for an anonymous caller", async () => {
     mockGetSession.mockResolvedValueOnce(null);
     mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);

--- a/packages/web/src/__tests__/api/diagnostics.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics.test.ts
@@ -143,4 +143,44 @@ describe("GET /api/diagnostics", () => {
 
     expect(data).not.toHaveProperty("logs");
   });
+
+  // A missing `logs` field has two very different causes, and the bug
+  // reporter that consumes this endpoint has to tell them apart: "your role
+  // may not read these" needs different copy from "there are none". Only the
+  // signed-in non-admin gets the marker.
+  it("should mark logs as withheld for role when the user is a signed-in member", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "1", role: "member" } });
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.logsWithheld).toBe("admin-only");
+  });
+
+  it("should not mark logs as withheld when the user is an admin", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "1", role: "admin" } });
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).not.toHaveProperty("logsWithheld");
+  });
+
+  // The anonymous caller here is the setup wizard's pre-flight check, run by
+  // whoever is installing Pinchy — they hold the host shell. Telling them to
+  // ask an administrator would send them looking for themselves.
+  it("should not mark logs as withheld for an anonymous caller", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).not.toHaveProperty("logsWithheld");
+  });
 });

--- a/packages/web/src/__tests__/lib/github-issue.test.ts
+++ b/packages/web/src/__tests__/lib/github-issue.test.ts
@@ -199,6 +199,57 @@ describe("buildIssueBody", () => {
     expect(body).toContain("docker compose logs pinchy");
   });
 
+  // Since logs became admin-only, a member's report reaches this branch every
+  // time — so it may not send them to a host shell they have no account on.
+  // The reporter's one workable next step is their own administrator.
+  it("should ask the reporter to forward the report when logs were withheld for role", () => {
+    const body = buildIssueBody({
+      error: "Setup failed",
+      page: "/setup",
+      diagnostics: {
+        database: "connected",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+        logsWithheld: "admin-only",
+      },
+    });
+    expect(body).toMatch(/forward this report to your Pinchy administrator/i);
+  });
+
+  it("should not instruct a reporter without log access to run a host command", () => {
+    const body = buildIssueBody({
+      error: "Setup failed",
+      page: "/setup",
+      diagnostics: {
+        database: "connected",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+        logsWithheld: "admin-only",
+      },
+    });
+    expect(body).not.toContain("docker compose");
+  });
+
+  // The distinction the marker exists for: no marker means the logs are
+  // simply not there (anonymous setup-wizard caller, or diagnostics that
+  // never answered), and whoever sees that does hold the host shell.
+  it("should keep the host command when diagnostics carry no logs and no withheld marker", () => {
+    const body = buildIssueBody({
+      error: "Setup failed",
+      page: "/setup",
+      diagnostics: {
+        database: "unreachable",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+      },
+    });
+    expect(body).toContain("docker compose logs pinchy");
+    expect(body).not.toMatch(/administrator/i);
+  });
+
   it("should handle special characters in error messages", () => {
     const body = buildIssueBody({
       error: "Failed: key=abc&status=error#hash",

--- a/packages/web/src/__tests__/lib/github-issue.test.ts
+++ b/packages/web/src/__tests__/lib/github-issue.test.ts
@@ -233,8 +233,9 @@ describe("buildIssueBody", () => {
   });
 
   // The distinction the marker exists for: no marker means the logs are
-  // simply not there (anonymous setup-wizard caller, or diagnostics that
-  // never answered), and whoever sees that does hold the host shell.
+  // simply not there (an anonymous caller, or diagnostics that never
+  // answered), so the host command stays. It must NOT read as the withheld
+  // case, which drops that command entirely.
   it("should keep the host command when diagnostics carry no logs and no withheld marker", () => {
     const body = buildIssueBody({
       error: "Setup failed",
@@ -247,7 +248,26 @@ describe("buildIssueBody", () => {
       },
     });
     expect(body).toContain("docker compose logs pinchy");
-    expect(body).not.toMatch(/administrator/i);
+    expect(body).not.toMatch(/only admins can read server logs/i);
+  });
+
+  // An anonymous caller is not necessarily the installer: `app/error.tsx` is
+  // the app's only error boundary, so it renders the reporter on `/login` and
+  // `/invite/[token]` as well, where the caller is a member with no host
+  // account. The server cannot tell the two apart from a missing session, so
+  // the copy carries a second route for whoever has no shell.
+  it("should offer the administrator as a fallback when no marker says who the reporter is", () => {
+    const body = buildIssueBody({
+      error: "Invite could not be claimed",
+      page: "/invite/abc123",
+      diagnostics: {
+        database: "connected",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+      },
+    });
+    expect(body).toMatch(/ask your Pinchy administrator/i);
   });
 
   it("should handle special characters in error messages", () => {

--- a/packages/web/src/__tests__/lib/log-capture.test.ts
+++ b/packages/web/src/__tests__/lib/log-capture.test.ts
@@ -53,6 +53,25 @@ describe("logCapture", () => {
     expect(logCapture.getEntries()).toHaveLength(0);
   });
 
+  it("should redact email addresses in captured messages", () => {
+    logCapture.add("error", "Provider rejected request for user@example.com");
+    const entries = logCapture.getEntries();
+
+    expect(entries[0].message).not.toContain("user@example.com");
+    expect(entries[0].message).toContain("<email-redacted>");
+  });
+
+  it("should redact known secret patterns in captured messages", () => {
+    logCapture.add(
+      "error",
+      "OpenAI request failed with key sk-ant-abcdefghijklmnopqrstuvwxyz0123456789"
+    );
+    const entries = logCapture.getEntries();
+
+    expect(entries[0].message).not.toContain("sk-ant-abcdefghijklmnopqrstuvwxyz0123456789");
+    expect(entries[0].message).toContain("[REDACTED]");
+  });
+
   it("should install console hooks", () => {
     const originalError = console.error;
     const originalWarn = console.warn;

--- a/packages/web/src/app/api/diagnostics/route.ts
+++ b/packages/web/src/app/api/diagnostics/route.ts
@@ -29,6 +29,15 @@ export async function GET() {
   // member has no business reading another user's error traces.
   if (session?.user?.role === "admin") {
     response.logs = logCapture.formatAsText();
+  } else if (session?.user) {
+    // Signed in, but not an admin. An absent `logs` field on its own cannot
+    // say WHY it is absent, and the in-app bug reporter has to tell the two
+    // causes apart: it can send whoever is holding the host shell to
+    // `docker compose logs`, but a member has no account there and needs
+    // their administrator instead. The anonymous caller is the setup
+    // wizard's pre-flight check — that person IS the host operator, so no
+    // marker for them.
+    response.logsWithheld = "admin-only";
   }
 
   return NextResponse.json(response);

--- a/packages/web/src/app/api/diagnostics/route.ts
+++ b/packages/web/src/app/api/diagnostics/route.ts
@@ -32,11 +32,14 @@ export async function GET() {
   } else if (session?.user) {
     // Signed in, but not an admin. An absent `logs` field on its own cannot
     // say WHY it is absent, and the in-app bug reporter has to tell the two
-    // causes apart: it can send whoever is holding the host shell to
-    // `docker compose logs`, but a member has no account there and needs
-    // their administrator instead. The anonymous caller is the setup
-    // wizard's pre-flight check — that person IS the host operator, so no
-    // marker for them.
+    // causes apart: a member has no account on the host, so sending them to
+    // `docker compose logs` yields a report with no logs and an instruction
+    // they cannot follow — their administrator is the step they can take.
+    // An anonymous caller gets no marker, because with no session there is
+    // no role to withhold for. That is deliberately NOT a claim that the
+    // caller holds the host shell: nothing in the request separates whoever
+    // is running the setup wizard from a signed-out member, so the client's
+    // fallback copy names both routes instead.
     response.logsWithheld = "admin-only";
   }
 

--- a/packages/web/src/app/api/diagnostics/route.ts
+++ b/packages/web/src/app/api/diagnostics/route.ts
@@ -1,7 +1,8 @@
 // auth-direct: public diagnostics endpoint — the session lookup is OPTIONAL,
-// used only to decide whether to include server logs in the response.
-// withAuth/withAdmin would force a 401 on unauthenticated requests, which
-// would break the public health-check use case.
+// used only to decide whether to include server logs in the response (admin
+// role only — see below). withAuth/withAdmin would force a 401 on
+// unauthenticated requests, which would break the public health-check use
+// case.
 import { NextResponse } from "next/server";
 import { logCapture } from "@/lib/log-capture";
 import { getSession } from "@/lib/auth";
@@ -22,8 +23,11 @@ export async function GET() {
     nodeEnv: process.env.NODE_ENV ?? "unknown",
   };
 
-  // Only include server logs for authenticated users
-  if (session?.user) {
+  // Server logs can contain unredacted provider errors, stack traces, and
+  // other diagnostic detail from OTHER users' sessions (the capture buffer
+  // is process-global, not per-user). Restrict to admins only — a plain
+  // member has no business reading another user's error traces.
+  if (session?.user?.role === "admin") {
     response.logs = logCapture.formatAsText();
   }
 

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -3,6 +3,7 @@ import { asc, desc, eq, gt, gte, lte, and, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { auditLog, users, type AuditDetail } from "@/db/schema";
 import { getOrCreateSecret } from "@/lib/encryption";
+import { scrubEmails } from "@/lib/scrub-emails";
 // Type-only (erased at build time), so the IMAP probe's runtime dependencies
 // never enter audit.ts's module graph.
 import type { ProbeFailureCode } from "@/lib/integrations/imap-probe";
@@ -293,32 +294,11 @@ export function redactEmail(email: string): RedactedEmail {
   };
 }
 
-/**
- * Defence-in-depth for free-text audit fields (e.g. `providerError` on
- * `chat.agent_error`). When an upstream provider validation error gets
- * echoed back — `"Invalid input: user@example.com is not …"` — we never
- * want the raw address to land in the append-only HMAC-signed audit
- * table: GDPR Art. 17 erasure on an HMAC-signed row is impossible by
- * design, so we substitute any email-shaped run with `<email-redacted>`.
- *
- * Distinct from `redactEmail`, which returns a structured
- * `{emailHash, emailPreview}` pair for fields where we KNOW an email
- * is identity data and may want to match it later. Here we operate on
- * opaque free text — the only goal is "don't store the raw address".
- *
- * The regex deliberately requires a TLD (`\.[A-Za-z]{2,}`) so social
- * `@handle` mentions in free text don't get mistaken for emails.
- */
-// Unicode-aware: \p{L} covers internationalized-domain (IDN) emails like
-// user@münchen.de, and the bracket alternative covers IP-literal domains like
-// user@[192.168.1.1] — both of which the old ASCII-only class let through into
-// the HMAC-signed, un-redactable audit detail. The TLD-required branch is kept
-// so a social `@handle` mention isn't mistaken for an email.
-const EMAIL_LIKE_PATTERN = /[\p{L}\p{N}._%+-]+@(?:\[[^\]\s]+\]|[\p{L}\p{N}.-]+\.[\p{L}]{2,})/gu;
-
-export function scrubEmails(text: string): string {
-  return text.replace(EMAIL_LIKE_PATTERN, "<email-redacted>");
-}
+// `scrubEmails` lives in its own dependency-free module so callers that must
+// not pull in `@/db` (which this module does, and which opens a postgres pool
+// on evaluation) can reach it. Re-exported here because every existing call
+// site imports it from `@/lib/audit` alongside the other audit helpers.
+export { scrubEmails };
 
 /**
  * Canonical way to land an upstream `providerError` string in audit

--- a/packages/web/src/lib/github-issue.ts
+++ b/packages/web/src/lib/github-issue.ts
@@ -122,9 +122,16 @@ export function buildIssueBody(context: IssueContext): string {
       "```"
     );
   } else {
+    // No marker means the server did not say why the logs are missing —
+    // either there was no session to withhold for, or diagnostics never
+    // answered. That is not the same as "this reporter holds the host
+    // shell": `app/error.tsx` is the only error boundary in the app, so it
+    // renders this link on `/login` and `/invite/[token]` too, where the
+    // anonymous caller is a member and not the installer. The copy names
+    // both routes rather than guessing which one is reading it.
     sections.push(
       "",
-      "**Logs:** (run `docker compose logs pinchy --tail 200` and paste below)",
+      "**Logs:** (run `docker compose logs pinchy --tail 200` on the server and paste below — if you have no shell there, ask your Pinchy administrator)",
       "```",
       "",
       "```"

--- a/packages/web/src/lib/github-issue.ts
+++ b/packages/web/src/lib/github-issue.ts
@@ -125,10 +125,13 @@ export function buildIssueBody(context: IssueContext): string {
     // No marker means the server did not say why the logs are missing —
     // either there was no session to withhold for, or diagnostics never
     // answered. That is not the same as "this reporter holds the host
-    // shell": `app/error.tsx` is the only error boundary in the app, so it
-    // renders this link on `/login` and `/invite/[token]` too, where the
-    // anonymous caller is a member and not the installer. The copy names
-    // both routes rather than guessing which one is reading it.
+    // shell": `ReportIssueLink` renders from both root error boundaries
+    // (`app/error.tsx`, `app/global-error.tsx`), which cover `/login`,
+    // `/invite/[token]` and `/share-target`, and from four components
+    // besides. A signed-out reporter is as likely to be a member on one of
+    // those pages as the person running the setup wizard, and nothing here
+    // separates them — so the copy names both routes rather than guessing
+    // which one is reading it.
     sections.push(
       "",
       "**Logs:** (run `docker compose logs pinchy --tail 200` on the server and paste below — if you have no shell there, ask your Pinchy administrator)",

--- a/packages/web/src/lib/github-issue.ts
+++ b/packages/web/src/lib/github-issue.ts
@@ -4,6 +4,13 @@ export interface DiagnosticsResult {
   version: string;
   nodeEnv: string;
   logs?: string;
+  /**
+   * Set by `GET /api/diagnostics` when the caller is signed in and the server
+   * deliberately held the logs back for their role — never when the logs are
+   * merely missing. The two need different copy in the report body, and an
+   * absent `logs` field alone cannot tell them apart.
+   */
+  logsWithheld?: "admin-only";
 }
 
 export interface IssueContext {
@@ -102,6 +109,18 @@ export function buildIssueBody(context: IssueContext): string {
 
   if (diagnostics?.logs) {
     sections.push("", "**Logs:**", "```", diagnostics.logs, "```");
+  } else if (diagnostics?.logsWithheld === "admin-only") {
+    // Since logs became admin-only this is what every member sees, so it is
+    // no longer a rare fallback. Pointing them at a host shell they have no
+    // account on produces a report with no logs and an instruction the
+    // reporter cannot follow — their administrator is the workable step.
+    sections.push(
+      "",
+      "**Logs:** Not included — only admins can read server logs. Forward this report to your Pinchy administrator, who can paste them below.",
+      "```",
+      "",
+      "```"
+    );
   } else {
     sections.push(
       "",

--- a/packages/web/src/lib/log-capture.ts
+++ b/packages/web/src/lib/log-capture.ts
@@ -1,3 +1,6 @@
+import { scrubEmails } from "@/lib/audit";
+import { sanitizeDetail } from "@/lib/audit-sanitize";
+
 type LogLevel = "error" | "warn";
 
 interface LogEntry {
@@ -16,7 +19,14 @@ class LogCapture {
     this.entries.push({
       timestamp: new Date().toISOString(),
       level,
-      message,
+      // Even restricted to admins (see the diagnostics route), this buffer
+      // is process-global and can carry provider error text or stack traces
+      // from OTHER users' chat runs — apply the same redaction other
+      // free-text audit fields get before it lands anywhere. scrubEmails
+      // strips email addresses; sanitizeDetail (on a string) strips known
+      // secret patterns (sk-ant-*, ghp_*, Bearer *, …). Order doesn't matter
+      // here since the two patterns don't overlap.
+      message: sanitizeDetail(scrubEmails(message)),
     });
     if (this.entries.length > MAX_ENTRIES) {
       this.entries.shift();

--- a/packages/web/src/lib/log-capture.ts
+++ b/packages/web/src/lib/log-capture.ts
@@ -1,4 +1,8 @@
-import { scrubEmails } from "@/lib/audit";
+// Both imports are deliberately the dependency-free redaction leaves, not
+// `@/lib/audit` — that module opens a postgres pool when it is evaluated, and
+// this one is imported by `server.ts` before anything else and is a plausible
+// future import from a Client Component.
+import { scrubEmails } from "@/lib/scrub-emails";
 import { sanitizeDetail } from "@/lib/audit-sanitize";
 
 type LogLevel = "error" | "warn";
@@ -24,8 +28,16 @@ class LogCapture {
       // from OTHER users' chat runs — apply the same redaction other
       // free-text audit fields get before it lands anywhere. scrubEmails
       // strips email addresses; sanitizeDetail (on a string) strips known
-      // secret patterns (sk-ant-*, ghp_*, Bearer *, …). Order doesn't matter
-      // here since the two patterns don't overlap.
+      // secret patterns (sk-ant-*, ghp_*, Bearer *, …). Order is safe either
+      // way: no secret pattern contains an `@`, so scrubbing first can never
+      // eat a secret before sanitizeDetail sees it. The two do overlap on an
+      // env line like `SMTP_PASSWORD=user@example.com` — which ends up
+      // redacted whichever runs first.
+      //
+      // The console hook still forwards the ORIGINAL args to the real
+      // console.error/warn, so stdout — and therefore
+      // `docker compose logs pinchy` — keeps the unredacted line for whoever
+      // operates the host.
       message: sanitizeDetail(scrubEmails(message)),
     });
     if (this.entries.length > MAX_ENTRIES) {

--- a/packages/web/src/lib/scrub-emails.ts
+++ b/packages/web/src/lib/scrub-emails.ts
@@ -1,0 +1,36 @@
+/**
+ * Defence-in-depth for free-text audit fields (e.g. `providerError` on
+ * `chat.agent_error`). When an upstream provider validation error gets
+ * echoed back — `"Invalid input: user@example.com is not …"` — we never
+ * want the raw address to land in the append-only HMAC-signed audit
+ * table: GDPR Art. 17 erasure on an HMAC-signed row is impossible by
+ * design, so we substitute any email-shaped run with `<email-redacted>`.
+ *
+ * Distinct from `redactEmail`, which returns a structured
+ * `{emailHash, emailPreview}` pair for fields where we KNOW an email
+ * is identity data and may want to match it later. Here we operate on
+ * opaque free text — the only goal is "don't store the raw address".
+ *
+ * The regex deliberately requires a TLD (`\.[A-Za-z]{2,}`) so social
+ * `@handle` mentions in free text don't get mistaken for emails.
+ *
+ * This lives in its own module, not in `@/lib/audit`, because that module
+ * imports `@/db` and therefore constructs a postgres pool the moment it is
+ * evaluated. `scrubEmails` is a pure regex substitution wanted by callers
+ * that have no business touching the database — `@/lib/log-capture` is the
+ * first, and it is exactly the kind of leaf a Client Component might import
+ * one day, which would drag the DB driver into the client bundle and fail
+ * `next build` with a "module not found" that points at postgres instead of
+ * at the real mistake. `@/lib/audit` re-exports it, so existing call sites
+ * are unaffected.
+ */
+// Unicode-aware: \p{L} covers internationalized-domain (IDN) emails like
+// user@münchen.de, and the bracket alternative covers IP-literal domains like
+// user@[192.168.1.1] — both of which the old ASCII-only class let through into
+// the HMAC-signed, un-redactable audit detail. The TLD-required branch is kept
+// so a social `@handle` mention isn't mistaken for an email.
+const EMAIL_LIKE_PATTERN = /[\p{L}\p{N}._%+-]+@(?:\[[^\]\s]+\]|[\p{L}\p{N}.-]+\.[\p{L}]{2,})/gu;
+
+export function scrubEmails(text: string): string {
+  return text.replace(EMAIL_LIKE_PATTERN, "<email-redacted>");
+}


### PR DESCRIPTION
## Finding

`GET /api/diagnostics` returned the entire process-global log buffer (`logCapture.formatAsText()`) to **any authenticated user**, including plain members. The buffer holds unredacted `console.error`/`console.warn` output from *all* users' sessions — provider error text, stack traces, OAuth/DB failures — so any member could read other users' error detail through this endpoint. Cross-user information leak.

## Fix

1. `response.logs` is now only populated when `session.user.role === "admin"` (`packages/web/src/app/api/diagnostics/route.ts`).
2. `LogCapture.add()` (`packages/web/src/lib/log-capture.ts`) now redacts every captured message before storing it, reusing existing helpers rather than inventing new ones:
   - `scrubEmails()` from `@/lib/audit` — strips email addresses.
   - `sanitizeDetail()` from `@/lib/audit-sanitize` — strips known secret patterns (`sk-ant-*`, `ghp_*`, `Bearer *`, Telegram bot tokens, …), the same redactor the diagnostics-export path (`sanitizeBundle`) already relies on.
3. Docs updated in the same PR: `docs/src/content/docs/reference/api.mdx` now documents the `logs` field as admin-only and redacted.

## Tests (TDD, red → green)

- `packages/web/src/__tests__/api/diagnostics.test.ts`
  - Renamed "should include captured logs when user is authenticated" → **"should include captured logs when user is an admin"** (now asserts with `role: "admin"`).
  - Added **"should omit logs when authenticated user is a plain member (not admin)"** — red before the fix (member got `logs`), green after.
- `packages/web/src/__tests__/lib/log-capture.test.ts`
  - Added **"should redact email addresses in captured messages"** — red before (message contained the raw address), green after.
  - Added **"should redact known secret patterns in captured messages"** — red before (message contained the raw `sk-ant-...` key), green after.

Verified red state via `pnpm test:related` before implementing, then green after.

## Gates run

- `pnpm test` (full suite): **10911 passed, 18 skipped** (774 files passed, 4 skipped).
- `pnpm test:scripts`: **894 passed, 0 failed** (includes the docs-coverage guard, confirming the API reference still matches every route/method).
- `pnpm -C packages/web lint`: 0 errors (981 pre-existing warnings, unrelated to this change).
- `pnpm -C packages/web typecheck`: clean.
- `pnpm format:check`: clean.
- Pre-push hook ran the real `pnpm build` (Next.js build) successfully.

## Test plan

- [x] Member session hitting `GET /api/diagnostics` no longer sees a `logs` field.
- [x] Admin session still sees `logs`, now redacted of emails/secrets.
- [x] Anonymous caller still gets status-only response (unchanged, public health-check use case preserved).