### PR TITLE
fix(plugins): route every tool error through details.error (#404 contract)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -653,6 +653,22 @@ Three things to know before editing it:
 - **Never write `init.signal ?? AbortSignal.timeout(...)`.** It reads as a harmless escape hatch and is a trap: the first caller to pass a cancellation signal silently loses the timeout, and no test can see it. Both wrappers here (`GraphAdapter.req`, `fetchWithRetry`) type `signal` out of their options and take a `timeoutMs` instead. Create the signal **inside** a retry loop, too, so each attempt gets a fresh bound rather than all attempts sharing one deadline the first one spent.
 - **It sees `fetch` and nothing else.** A plugin reaching the network through another transport is invisible to it — today `gmail-adapter.ts` (googleapis/gaxios, bounded by its `timeout` option) and `imap-adapter.ts` (imapflow, `connectionTimeout`/`socketTimeout`). It also checks only that a signal is passed, never that the value is sane. Both limits are covered by per-call unit tests instead. Verify a change to the guard with a canary — delete a `signal:` from a plugin, watch it name that exact file and line, put it back.
 
+### A Failing Tool Result Needs `details.error`, Not Just `isError`
+
+OpenClaw strips the MCP `isError` flag before forwarding a tool result to `/api/internal/audit/tool-use` (#404), so the audit route's only remaining failure signal is `result.details.error` — see the three-source precedence comment in that route. A tool that fails while setting only `isError: true` is written to the audit trail as **`outcome: success`**. The failure is not merely unlogged; it is logged as its opposite, which is worse than silence for anyone reading the trail afterwards. pinchy-odoo and pinchy-email carried a `toolError()` helper for this; five other plugins did not.
+
+Every plugin now routes error results through its own `toolError(text)` helper, and `packages/web/src/__tests__/lib/plugin-tool-error-details-drift.test.ts` (scan in `plugin-error-details-extraction.ts`) enforces it by AST-walking each `packages/plugins/pinchy-*/index.ts`.
+
+Three details are load-bearing, each because the first draft got it wrong and a canary caught it:
+
+- **The scan unwraps `as const` and parentheses.** An `expr.kind === TrueKeyword` test skips `isError: true as const` entirely — and pinchy-email's session-less tool stub is written exactly that way, so the strict check silently exempted one of the very results it was written to cover.
+- **A computed `isError` is flagged, not waved through.** `isError: result.isError` is how `pinchy_web_fetch` shipped without `details.error` in the first place. A scan that judges only the literal `true` cannot see that shape come back, so it is reported as `dynamic-is-error`: branch on the flag and return `toolError(...)` on the error side.
+- **An unreadable `index.ts` throws.** Every assertion here is an _absence_, so a failed read and a clean file are the same empty list — returning `[]` would turn the guard green for a plugin it never opened. This is the one place it must diverge from `deriveToolsFromSource`, where an empty list turns the manifest comparison red instead. A corpus floor (`checked >= 10`, against 14 present when this landed) covers the same failure one level up.
+
+Verify a change to the scan by reproduction, not by reading it: break one plugin result, watch the guard name that plugin, put it back. The `scanErrorResults` fixtures in the guard's second `describe` pin all four shapes above.
+
+Known limitation: the scan reads `index.ts` only, matching `deriveToolsFromSource`. A plugin that builds an MCP result in a sibling module escapes it. Nothing does today — pinchy-web's `web-fetch.ts` returns an internal `{ content: string; isError }` DTO that `index.ts` translates through `toolError()`.
+
 ### Tool dispatch coverage
 
 Every plugin tool must be covered at three layers:

--- a/packages/plugins/pinchy-context/index.test.ts
+++ b/packages/plugins/pinchy-context/index.test.ts
@@ -157,6 +157,11 @@ describe("pinchy-context plugin", () => {
     expect(result.content[0].text).toContain("the limit is 16,000 characters");
   });
 
+  // OpenClaw strips the MCP `isError` flag before forwarding the tool result
+  // to /api/internal/audit/tool-use, so details.error is the audit route's
+  // only remaining failure signal (#404). Without it a failed save is
+  // silently audited as outcome: success — hence the details assertion here
+  // and on the save_org_context sibling below.
   it("save_user_context marks thrown errors with isError=true", async () => {
     const api = createMockApi(defaultConfig);
     const { default: plugin } = await import("./index");
@@ -172,6 +177,7 @@ describe("pinchy-context plugin", () => {
     const result = await tool.execute("call-1", { content: "..." });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe("Network down");
+    expect(result.details).toEqual({ error: "Network down" });
   });
 
   it("aborts a hung save_user_context POST via AbortSignal.timeout(10_000) instead of blocking forever", async () => {
@@ -245,43 +251,6 @@ describe("pinchy-context plugin", () => {
     const result = await tool.execute("call-1", { content: "..." });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe("Timeout");
-  });
-
-  it("save_user_context error path sets details.error (#404 audit contract)", async () => {
-    // OpenClaw strips the MCP `isError` flag before forwarding the tool
-    // result to /api/internal/audit/tool-use; details.error is the audit
-    // route's only remaining failure signal. Without it a failed
-    // pinchy_save_user_context call is silently audited as outcome: success.
-    const api = createMockApi(defaultConfig);
-    const { default: plugin } = await import("./index");
-    plugin.register!(api as any);
-
-    const factory = mockRegisterTool.mock.calls.find(
-      (call: any[]) => call[1]?.name === "pinchy_save_user_context"
-    )?.[0];
-    const tool = factory({ agentId: "agent-1" });
-
-    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Network down"));
-
-    const result = await tool.execute("call-1", { content: "..." });
-    expect(result.isError).toBe(true);
-    expect(result.details).toEqual({ error: "Network down" });
-  });
-
-  it("save_org_context error path sets details.error (#404 audit contract)", async () => {
-    const api = createMockApi(defaultConfig);
-    const { default: plugin } = await import("./index");
-    plugin.register!(api as any);
-
-    const factory = mockRegisterTool.mock.calls.find(
-      (call: any[]) => call[1]?.name === "pinchy_save_org_context"
-    )?.[0];
-    const tool = factory({ agentId: "agent-2" });
-
-    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Timeout"));
-
-    const result = await tool.execute("call-1", { content: "..." });
-    expect(result.isError).toBe(true);
     expect(result.details).toEqual({ error: "Timeout" });
   });
 

--- a/packages/plugins/pinchy-context/index.test.ts
+++ b/packages/plugins/pinchy-context/index.test.ts
@@ -247,6 +247,44 @@ describe("pinchy-context plugin", () => {
     expect(result.content[0].text).toBe("Timeout");
   });
 
+  it("save_user_context error path sets details.error (#404 audit contract)", async () => {
+    // OpenClaw strips the MCP `isError` flag before forwarding the tool
+    // result to /api/internal/audit/tool-use; details.error is the audit
+    // route's only remaining failure signal. Without it a failed
+    // pinchy_save_user_context call is silently audited as outcome: success.
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_save_user_context"
+    )?.[0];
+    const tool = factory({ agentId: "agent-1" });
+
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Network down"));
+
+    const result = await tool.execute("call-1", { content: "..." });
+    expect(result.isError).toBe(true);
+    expect(result.details).toEqual({ error: "Network down" });
+  });
+
+  it("save_org_context error path sets details.error (#404 audit contract)", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_save_org_context"
+    )?.[0];
+    const tool = factory({ agentId: "agent-2" });
+
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Timeout"));
+
+    const result = await tool.execute("call-1", { content: "..." });
+    expect(result.isError).toBe(true);
+    expect(result.details).toEqual({ error: "Timeout" });
+  });
+
   it("exports plugin definition with id and configSchema", async () => {
     const { default: plugin } = await import("./index");
     expect(plugin.id).toBe("pinchy-context");

--- a/packages/plugins/pinchy-context/index.ts
+++ b/packages/plugins/pinchy-context/index.ts
@@ -84,6 +84,27 @@ function deleteOnboardingFile(agentId: string): void {
   }
 }
 
+/**
+ * Build an MCP-style error result. Every error result MUST carry
+ * `details.error`, not just the `isError` flag: OpenClaw strips `isError`
+ * before forwarding the result to `/api/internal/audit/tool-use` (OC bug
+ * #404), and the audit endpoint then falls back to `result.details.error` to
+ * record `outcome: failure`. Without it, a failed pinchy-context tool call
+ * is silently audited as success. Route ALL error results through this
+ * helper so that invariant cannot be forgotten at an individual call site.
+ */
+function toolError(text: string): {
+  content: Array<{ type: string; text: string }>;
+  isError: true;
+  details: { error: string };
+} {
+  return {
+    isError: true,
+    content: [{ type: "text", text }],
+    details: { error: text },
+  };
+}
+
 const plugin = {
   id: "pinchy-context",
   name: "Pinchy Context",
@@ -154,15 +175,7 @@ const plugin = {
 
               if (!res.ok) {
                 const data = await res.json();
-                return {
-                  isError: true,
-                  content: [
-                    {
-                      type: "text",
-                      text: `Failed to save: ${describeApiError(data)}`,
-                    },
-                  ],
-                };
+                return toolError(`Failed to save: ${describeApiError(data)}`);
               }
 
               const data = await res.json();
@@ -183,10 +196,7 @@ const plugin = {
               };
             } catch (error) {
               const message = error instanceof Error ? error.message : "Unknown error";
-              return {
-                isError: true,
-                content: [{ type: "text", text: message }],
-              };
+              return toolError(message);
             }
           },
         };
@@ -233,15 +243,7 @@ const plugin = {
 
               if (!res.ok) {
                 const data = await res.json();
-                return {
-                  isError: true,
-                  content: [
-                    {
-                      type: "text",
-                      text: `Failed to save: ${describeApiError(data)}`,
-                    },
-                  ],
-                };
+                return toolError(`Failed to save: ${describeApiError(data)}`);
               }
 
               const data = await res.json();
@@ -260,10 +262,7 @@ const plugin = {
               };
             } catch (error) {
               const message = error instanceof Error ? error.message : "Unknown error";
-              return {
-                isError: true,
-                content: [{ type: "text", text: message }],
-              };
+              return toolError(message);
             }
           },
         };

--- a/packages/plugins/pinchy-docs/index.test.ts
+++ b/packages/plugins/pinchy-docs/index.test.ts
@@ -232,23 +232,11 @@ describe("pinchy-docs plugin", () => {
     const result = await tool.execute("call-1", { path: "nonexistent.mdx" });
     expect(result.content[0].text.toLowerCase()).toMatch(/not found|no such/);
     expect(result.isError).toBe(true);
-  });
-
-  it("docs_read sets details.error on failure (#404 audit contract)", async () => {
     // OpenClaw strips the MCP `isError` flag before forwarding the tool
-    // result to /api/internal/audit/tool-use; details.error is the audit
-    // route's only remaining failure signal. Without it a failed docs_read
-    // call is silently audited as outcome: success.
-    const api = createMockApi({ docsPath: docsRoot, agents: { "agent-1": {} } });
-    const { default: plugin } = await import("./index");
-    plugin.register!(api as any);
-
-    const factory = mockRegisterTool.mock.calls.find((c: any[]) => c[1]?.name === "docs_read")?.[0];
-    const tool = factory({ agentId: "agent-1" });
-    const result = await tool.execute("call-1", { path: "nonexistent.mdx" });
-    expect(result.isError).toBe(true);
-    expect(typeof result.details?.error).toBe("string");
-    expect(result.details.error).toBe(result.content[0].text);
+    // result to /api/internal/audit/tool-use, so details.error is the audit
+    // route's only remaining failure signal (#404). Without it a failed
+    // docs_read is silently audited as outcome: success.
+    expect(result.details).toEqual({ error: result.content[0].text });
   });
 
   it("docs_read factory returns null for non-allowed agent", async () => {

--- a/packages/plugins/pinchy-docs/index.test.ts
+++ b/packages/plugins/pinchy-docs/index.test.ts
@@ -234,6 +234,23 @@ describe("pinchy-docs plugin", () => {
     expect(result.isError).toBe(true);
   });
 
+  it("docs_read sets details.error on failure (#404 audit contract)", async () => {
+    // OpenClaw strips the MCP `isError` flag before forwarding the tool
+    // result to /api/internal/audit/tool-use; details.error is the audit
+    // route's only remaining failure signal. Without it a failed docs_read
+    // call is silently audited as outcome: success.
+    const api = createMockApi({ docsPath: docsRoot, agents: { "agent-1": {} } });
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find((c: any[]) => c[1]?.name === "docs_read")?.[0];
+    const tool = factory({ agentId: "agent-1" });
+    const result = await tool.execute("call-1", { path: "nonexistent.mdx" });
+    expect(result.isError).toBe(true);
+    expect(typeof result.details?.error).toBe("string");
+    expect(result.details.error).toBe(result.content[0].text);
+  });
+
   it("docs_read factory returns null for non-allowed agent", async () => {
     const api = createMockApi({ docsPath: docsRoot, agents: { "agent-1": {} } });
     const { default: plugin } = await import("./index");

--- a/packages/plugins/pinchy-docs/index.ts
+++ b/packages/plugins/pinchy-docs/index.ts
@@ -43,6 +43,27 @@ interface DocEntry {
 }
 
 /**
+ * Build an MCP-style error result. Every error result MUST carry
+ * `details.error`, not just the `isError` flag: OpenClaw strips `isError`
+ * before forwarding the result to `/api/internal/audit/tool-use` (OC bug
+ * #404), and the audit endpoint then falls back to `result.details.error` to
+ * record `outcome: failure`. Without it, a failed pinchy-docs tool call is
+ * silently audited as success. Route ALL error results through this helper
+ * so that invariant cannot be forgotten at an individual call site.
+ */
+function toolError(text: string): {
+  content: Array<{ type: string; text: string }>;
+  isError: true;
+  details: { error: string };
+} {
+  return {
+    isError: true,
+    content: [{ type: "text", text }],
+    details: { error: text },
+  };
+}
+
+/**
  * Map a doc-relative `.mdx`/`.md` path to its rendered Astro Starlight URL.
  * Rules mirror Starlight defaults:
  *   - strip extension and trailing `/index`
@@ -247,10 +268,7 @@ const plugin = {
               };
             } catch (error) {
               const message = error instanceof Error ? error.message : "Unknown error";
-              return {
-                isError: true,
-                content: [{ type: "text", text: `Error listing docs: ${message}` }],
-              };
+              return toolError(`Error listing docs: ${message}`);
             }
           },
         };
@@ -283,23 +301,14 @@ const plugin = {
             const relPath = params.path as string;
             const safe = resolveSafe(docsPath, relPath);
             if (!safe) {
-              return {
-                isError: true,
-                content: [
-                  {
-                    type: "text",
-                    text: `Invalid path: ${relPath}. Path must be a relative path inside the docs directory.`,
-                  },
-                ],
-              };
+              return toolError(
+                `Invalid path: ${relPath}. Path must be a relative path inside the docs directory.`
+              );
             }
             try {
               const stat = statSync(safe);
               if (!stat.isFile()) {
-                return {
-                  isError: true,
-                  content: [{ type: "text", text: `Not a file: ${relPath}` }],
-                };
+                return toolError(`Not a file: ${relPath}`);
               }
               const content = readFileSync(safe, "utf-8");
               const body = preprocessMdx(content);
@@ -308,10 +317,7 @@ const plugin = {
               return { content: [{ type: "text", text }] };
             } catch (error) {
               const message = error instanceof Error ? error.message : "Unknown error";
-              return {
-                isError: true,
-                content: [{ type: "text", text: `File not found: ${relPath} (${message})` }],
-              };
+              return toolError(`File not found: ${relPath} (${message})`);
             }
           },
         };

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -330,6 +330,10 @@ describe("pinchy-files plugin", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].type).toBe("text");
     expect(typeof result.content[0].text).toBe("string");
+    // #404 audit contract: OpenClaw strips isError before forwarding the
+    // tool result to /api/internal/audit/tool-use, so details.error is the
+    // audit route's only remaining failure signal.
+    expect((result as any).details).toEqual({ error: result.content[0].text });
   });
 
   it("pinchy_ls filters out system files (Thumbs.db, desktop.ini, .DS_Store)", async () => {
@@ -395,6 +399,10 @@ describe("pinchy_read PDF integration", { timeout: PDF_INTEGRATION_SUITE_TIMEOUT
     expect(result.isError).toBe(true);
     expect(result.content[0].type).toBe("text");
     expect(result.content[0].text).toMatch(/ENOENT|no such file/);
+    // #404 audit contract: OpenClaw strips isError before forwarding the
+    // tool result to /api/internal/audit/tool-use, so details.error is the
+    // audit route's only remaining failure signal.
+    expect((result as any).details).toEqual({ error: result.content[0].text });
   });
 
   it("returns XML-wrapped content for PDF files", async () => {
@@ -928,6 +936,10 @@ describe("pinchy_read image integration", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/too large/i);
+    // #404 audit contract: OpenClaw strips isError before forwarding the
+    // tool result to /api/internal/audit/tool-use, so details.error is the
+    // audit route's only remaining failure signal.
+    expect((result as any).details).toEqual({ error: result.content[0].text });
   });
 });
 

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -333,7 +333,7 @@ describe("pinchy-files plugin", () => {
     // #404 audit contract: OpenClaw strips isError before forwarding the
     // tool result to /api/internal/audit/tool-use, so details.error is the
     // audit route's only remaining failure signal.
-    expect((result as any).details).toEqual({ error: result.content[0].text });
+    expect(result.details).toEqual({ error: result.content[0].text });
   });
 
   it("pinchy_ls filters out system files (Thumbs.db, desktop.ini, .DS_Store)", async () => {
@@ -402,7 +402,7 @@ describe("pinchy_read PDF integration", { timeout: PDF_INTEGRATION_SUITE_TIMEOUT
     // #404 audit contract: OpenClaw strips isError before forwarding the
     // tool result to /api/internal/audit/tool-use, so details.error is the
     // audit route's only remaining failure signal.
-    expect((result as any).details).toEqual({ error: result.content[0].text });
+    expect(result.details).toEqual({ error: result.content[0].text });
   });
 
   it("returns XML-wrapped content for PDF files", async () => {
@@ -939,7 +939,7 @@ describe("pinchy_read image integration", () => {
     // #404 audit contract: OpenClaw strips isError before forwarding the
     // tool result to /api/internal/audit/tool-use, so details.error is the
     // audit route's only remaining failure signal.
-    expect((result as any).details).toEqual({ error: result.content[0].text });
+    expect(result.details).toEqual({ error: result.content[0].text });
   });
 });
 

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -89,6 +89,30 @@ type ContentBlock =
   // bytes from disk, so this block never carries the file content itself.
   | { type: "file"; filename: string; mimeType: string };
 
+/**
+ * Build an MCP-style error result. Every error result MUST carry
+ * `details.error`, not just the `isError` flag: OpenClaw strips `isError`
+ * before forwarding the result to `/api/internal/audit/tool-use` (OC bug
+ * #404), and the audit endpoint then falls back to `result.details.error` to
+ * record `outcome: failure`. Without it, a failed pinchy-files tool call is
+ * silently audited as success. Route ALL error results through this helper
+ * so that invariant cannot be forgotten at an individual call site. (Some
+ * call sites below curate their own richer `details` — e.g. pinchy_write's
+ * error path also snapshots `path`/`overwrite` — and construct the object
+ * literal directly instead of using this helper.)
+ */
+function toolError(text: string): {
+  content: ContentBlock[];
+  isError: true;
+  details: { error: string };
+} {
+  return {
+    isError: true,
+    content: [{ type: "text", text }],
+    details: { error: text },
+  };
+}
+
 // Image extensions pinchy_read returns as image content blocks rather than
 // utf-8 text. Reading the bytes as utf-8 would hand the model binary garbage
 // (issue #420). Keys are lowercase; lookup lowercases the file extension.
@@ -354,10 +378,7 @@ const plugin = {
               };
             } catch (error) {
               const message = error instanceof Error ? error.message : "Unknown error";
-              return {
-                isError: true,
-                content: [{ type: "text", text: message }],
-              };
+              return toolError(message);
             }
           },
         };
@@ -406,15 +427,9 @@ const plugin = {
               if (isPdf) {
                 const stats = statSync(realPath);
                 if (stats.size > MAX_PDF_FILE_SIZE) {
-                  return {
-                    isError: true,
-                    content: [
-                      {
-                        type: "text",
-                        text: `File too large (${stats.size} bytes). Maximum: ${MAX_PDF_FILE_SIZE} bytes.`,
-                      },
-                    ],
-                  };
+                  return toolError(
+                    `File too large (${stats.size} bytes). Maximum: ${MAX_PDF_FILE_SIZE} bytes.`
+                  );
                 }
 
                 // Resolve agent name + model from OpenClaw config in one walk.
@@ -472,15 +487,7 @@ const plugin = {
                 const { size } = await fh.stat();
                 const sizeLimit = isDocx ? MAX_DOCX_FILE_SIZE : MAX_FILE_SIZE;
                 if (size > sizeLimit) {
-                  return {
-                    isError: true,
-                    content: [
-                      {
-                        type: "text",
-                        text: `File too large (${size} bytes). Maximum: ${sizeLimit} bytes.`,
-                      },
-                    ],
-                  };
+                  return toolError(`File too large (${size} bytes). Maximum: ${sizeLimit} bytes.`);
                 }
                 buffer = await fh.readFile();
               } finally {
@@ -515,10 +522,7 @@ const plugin = {
               return { content: [{ type: "text", text: buffer.toString("utf-8") }] };
             } catch (error) {
               const message = error instanceof Error ? error.message : "Unknown error";
-              return {
-                isError: true,
-                content: [{ type: "text", text: message }],
-              };
+              return toolError(message);
             }
           },
         };

--- a/packages/plugins/pinchy-knowledge/index.test.ts
+++ b/packages/plugins/pinchy-knowledge/index.test.ts
@@ -341,7 +341,7 @@ describe("pinchy-knowledge plugin", () => {
     // audit route's only remaining failure signal. The two HTTP/network
     // failure paths above already set details.error (see "curated details"
     // below); this covers the third — the local, pre-fetch validation path.
-    expect((result as any).details).toEqual({ error: "A search query is required." });
+    expect(result.details).toEqual({ error: "A search query is required." });
   });
 
   it("exports plugin definition with id, name, and configSchema", async () => {

--- a/packages/plugins/pinchy-knowledge/index.test.ts
+++ b/packages/plugins/pinchy-knowledge/index.test.ts
@@ -336,6 +336,12 @@ describe("pinchy-knowledge plugin", () => {
     const result = await tool.execute("call-1", { query: "   " });
     expect(result.isError).toBe(true);
     expect(fetchMock).not.toHaveBeenCalled();
+    // #404 audit contract: OpenClaw strips isError before forwarding the
+    // tool result to /api/internal/audit/tool-use, so details.error is the
+    // audit route's only remaining failure signal. The two HTTP/network
+    // failure paths above already set details.error (see "curated details"
+    // below); this covers the third — the local, pre-fetch validation path.
+    expect((result as any).details).toEqual({ error: "A search query is required." });
   });
 
   it("exports plugin definition with id, name, and configSchema", async () => {

--- a/packages/plugins/pinchy-knowledge/index.ts
+++ b/packages/plugins/pinchy-knowledge/index.ts
@@ -254,6 +254,9 @@ const plugin = {
               return {
                 isError: true,
                 content: [{ type: "text", text: "A search query is required." }],
+                // details.error mirrors the two failure paths below — see the
+                // comment there for why this is error-only (no other keys).
+                details: { error: "A search query is required." },
               };
             }
             // Forwarded only when true so the route's audit detail stays

--- a/packages/plugins/pinchy-web/index.test.ts
+++ b/packages/plugins/pinchy-web/index.test.ts
@@ -26,7 +26,11 @@ interface ToolFactory {
       toolCallId: string,
       params: Record<string, unknown>,
       signal?: AbortSignal
-    ) => Promise<{ content: { type: string; text: string }[]; isError?: boolean }>;
+    ) => Promise<{
+      content: { type: string; text: string }[];
+      isError?: boolean;
+      details?: unknown;
+    }>;
   } | null;
 }
 
@@ -289,7 +293,7 @@ describe("pinchy-web plugin", () => {
       // #404 audit contract: OpenClaw strips isError before forwarding the
       // tool result to /api/internal/audit/tool-use, so details.error is the
       // audit route's only remaining failure signal.
-      expect((result as any).details).toEqual({ error: result.content[0].text });
+      expect(result.details).toEqual({ error: result.content[0].text });
     });
 
     it("returns isError when braveSearch throws", async () => {
@@ -308,7 +312,7 @@ describe("pinchy-web plugin", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Search failed");
       expect(result.content[0].text).toContain("API rate limit");
-      expect((result as any).details).toEqual({ error: result.content[0].text });
+      expect(result.details).toEqual({ error: result.content[0].text });
     });
 
     it("surfaces the actionable credentials-endpoint message when the connection was deleted (404)", async () => {
@@ -588,7 +592,7 @@ describe("pinchy-web plugin", () => {
       // #404 audit contract: OpenClaw strips isError before forwarding the
       // tool result to /api/internal/audit/tool-use, so details.error is the
       // audit route's only remaining failure signal.
-      expect((result as any).details).toEqual({ error: "Domain blocked for this agent." });
+      expect(result.details).toEqual({ error: "Domain blocked for this agent." });
     });
 
     it("returns isError when webFetch throws", async () => {
@@ -607,7 +611,7 @@ describe("pinchy-web plugin", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Fetch failed");
       expect(result.content[0].text).toContain("Network timeout");
-      expect((result as any).details).toEqual({ error: result.content[0].text });
+      expect(result.details).toEqual({ error: result.content[0].text });
     });
 
     it("handles non-Error throws from webFetch", async () => {

--- a/packages/plugins/pinchy-web/index.test.ts
+++ b/packages/plugins/pinchy-web/index.test.ts
@@ -286,6 +286,10 @@ describe("pinchy-web plugin", () => {
       expect(result.content[0].text).toContain("not configured");
       expect(result.content[0].text).toContain("Brave Search API key");
       expect(braveSearchMock).not.toHaveBeenCalled();
+      // #404 audit contract: OpenClaw strips isError before forwarding the
+      // tool result to /api/internal/audit/tool-use, so details.error is the
+      // audit route's only remaining failure signal.
+      expect((result as any).details).toEqual({ error: result.content[0].text });
     });
 
     it("returns isError when braveSearch throws", async () => {
@@ -304,6 +308,7 @@ describe("pinchy-web plugin", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Search failed");
       expect(result.content[0].text).toContain("API rate limit");
+      expect((result as any).details).toEqual({ error: result.content[0].text });
     });
 
     it("surfaces the actionable credentials-endpoint message when the connection was deleted (404)", async () => {
@@ -580,6 +585,10 @@ describe("pinchy-web plugin", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toBe("Domain blocked for this agent.");
+      // #404 audit contract: OpenClaw strips isError before forwarding the
+      // tool result to /api/internal/audit/tool-use, so details.error is the
+      // audit route's only remaining failure signal.
+      expect((result as any).details).toEqual({ error: "Domain blocked for this agent." });
     });
 
     it("returns isError when webFetch throws", async () => {
@@ -598,6 +607,7 @@ describe("pinchy-web plugin", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Fetch failed");
       expect(result.content[0].text).toContain("Network timeout");
+      expect((result as any).details).toEqual({ error: result.content[0].text });
     });
 
     it("handles non-Error throws from webFetch", async () => {

--- a/packages/plugins/pinchy-web/index.ts
+++ b/packages/plugins/pinchy-web/index.ts
@@ -32,7 +32,28 @@ interface AgentTool {
     toolCallId: string,
     params: Record<string, unknown>,
     signal?: AbortSignal
-  ) => Promise<{ content: ContentBlock[]; isError?: boolean }>;
+  ) => Promise<{ content: ContentBlock[]; isError?: boolean; details?: unknown }>;
+}
+
+/**
+ * Build an MCP-style error result. Every error result MUST carry
+ * `details.error`, not just the `isError` flag: OpenClaw strips `isError`
+ * before forwarding the result to `/api/internal/audit/tool-use` (OC bug
+ * #404), and the audit endpoint then falls back to `result.details.error` to
+ * record `outcome: failure`. Without it, a failed pinchy-web tool call is
+ * silently audited as success. Route ALL error results through this helper
+ * so that invariant cannot be forgotten at an individual call site.
+ */
+function toolError(text: string): {
+  content: ContentBlock[];
+  isError: true;
+  details: { error: string };
+} {
+  return {
+    isError: true,
+    content: [{ type: "text", text }],
+    details: { error: text },
+  };
 }
 
 interface PluginConfig {
@@ -229,15 +250,9 @@ const plugin = {
           },
           async execute(_toolCallId, params) {
             if (!haveCredentialsConfig) {
-              return {
-                isError: true,
-                content: [
-                  {
-                    type: "text",
-                    text: "Web search is not configured. Ask an admin to add a Brave Search API key in Settings \u2192 Integrations.",
-                  },
-                ],
-              };
+              return toolError(
+                "Web search is not configured. Ask an admin to add a Brave Search API key in Settings \u2192 Integrations."
+              );
             }
             try {
               const result = await withAuthRetry(agentId, (apiKey) => {
@@ -273,10 +288,7 @@ const plugin = {
               };
             } catch (error) {
               const msg = error instanceof Error ? error.message : String(error);
-              return {
-                isError: true,
-                content: [{ type: "text", text: `Search failed: ${msg}` }],
-              };
+              return toolError(`Search failed: ${msg}`);
             }
           },
         };
@@ -311,16 +323,15 @@ const plugin = {
                 excludedDomains: agentConfig.excludedDomains,
               };
               const result = await webFetch(params.url as string, fetchConfig);
+              if (result.isError) {
+                return toolError(result.content);
+              }
               return {
-                isError: result.isError,
                 content: [{ type: "text", text: result.content }],
               };
             } catch (error) {
               const msg = error instanceof Error ? error.message : String(error);
-              return {
-                isError: true,
-                content: [{ type: "text", text: `Fetch failed: ${msg}` }],
-              };
+              return toolError(`Fetch failed: ${msg}`);
             }
           },
         };

--- a/packages/web/src/__tests__/lib/plugin-error-details-extraction.ts
+++ b/packages/web/src/__tests__/lib/plugin-error-details-extraction.ts
@@ -1,0 +1,108 @@
+// packages/web/src/__tests__/lib/plugin-error-details-extraction.ts
+//
+// Static AST scan backing plugin-tool-error-details-drift.test.ts.
+//
+// The #404 contract (see pinchy-odoo's and pinchy-email's `toolError()` doc
+// comments): OpenClaw strips the MCP `isError` flag before forwarding a tool
+// result to /api/internal/audit/tool-use, so the audit route's only
+// remaining failure signal is `result.details.error`. A return literal that
+// sets `isError: true` without a sibling `details.error` is therefore
+// audited as `outcome: success` — a failed tool call reads as a successful
+// one in the audit trail.
+//
+// This file is not a *.test.ts and therefore is not executed by Vitest; it is
+// only imported from plugin-tool-error-details-drift.test.ts.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+import {
+  KNOWN_PINCHY_PLUGINS,
+  type KnownPinchyPlugin,
+} from "@/lib/openclaw-config/plugin-manifest-loader";
+import { PLUGINS_DIR } from "./plugin-tool-extraction";
+
+export { KNOWN_PINCHY_PLUGINS };
+export type { KnownPinchyPlugin };
+
+export interface MissingErrorDetail {
+  /** 1-based line number in the plugin's index.ts. */
+  line: number;
+  /** First line of the offending object literal, for a readable failure message. */
+  snippet: string;
+}
+
+function isLiteralTrue(expr: ts.Expression): boolean {
+  return expr.kind === ts.SyntaxKind.TrueKeyword;
+}
+
+function findProperty(
+  node: ts.ObjectLiteralExpression,
+  name: string
+): ts.PropertyAssignment | undefined {
+  const prop = node.properties.find(
+    (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === name
+  );
+  return prop as ts.PropertyAssignment | undefined;
+}
+
+function hasErrorProperty(details: ts.Expression): boolean {
+  if (!ts.isObjectLiteralExpression(details)) return false;
+  return findProperty(details, "error") !== undefined;
+}
+
+/**
+ * Find every object-literal MCP tool result in a plugin's index.ts that sets
+ * `isError: true` but does not also carry a `details` object with an `error`
+ * key. Mirrors the AST-walk style of `plugin-tool-extraction.ts`'s
+ * `skippedRanges` rather than a line-oriented regex, because the two
+ * properties in question (`isError` and `details`) can be reordered or
+ * separated by other curated fields (see pinchy-files' `pinchy_write`, which
+ * also carries `path`/`mode`/`overwrite`) and a regex anchored on adjacency
+ * would miss those.
+ *
+ * Deliberately a static scan, not a type check: it inspects
+ * ObjectLiteralExpression nodes only, so a dynamically-computed `isError`
+ * value (e.g. `isError: someFlag`) is out of scope. Every call site in this
+ * repo assigns the literal `true` (or routes through a `toolError()`-style
+ * helper, which is itself scanned once at its own declaration site).
+ */
+export function findMissingErrorDetails(pluginId: KnownPinchyPlugin): MissingErrorDetail[] {
+  const indexPath = join(PLUGINS_DIR, pluginId, "index.ts");
+  let source: string;
+  try {
+    source = readFileSync(indexPath, "utf8");
+  } catch {
+    return [];
+  }
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS
+  );
+
+  const issues: MissingErrorDetail[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isObjectLiteralExpression(node)) {
+      const isErrorProp = findProperty(node, "isError");
+      if (isErrorProp && isLiteralTrue(isErrorProp.initializer)) {
+        const detailsProp = findProperty(node, "details");
+        const ok = detailsProp !== undefined && hasErrorProperty(detailsProp.initializer);
+        if (!ok) {
+          const { line } = sourceFile.getLineAndCharacterOfPosition(
+            isErrorProp.getStart(sourceFile)
+          );
+          issues.push({
+            line: line + 1,
+            snippet: isErrorProp.getText(sourceFile).trim(),
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return issues;
+}

--- a/packages/web/src/__tests__/lib/plugin-error-details-extraction.ts
+++ b/packages/web/src/__tests__/lib/plugin-error-details-extraction.ts
@@ -25,58 +25,118 @@ import { PLUGINS_DIR } from "./plugin-tool-extraction";
 export { KNOWN_PINCHY_PLUGINS };
 export type { KnownPinchyPlugin };
 
+/**
+ * Why a result literal was flagged.
+ *
+ * - `missing-details-error`: it sets `isError: true` with no sibling
+ *   `details.error`, so the audit route records `outcome: success`.
+ * - `dynamic-is-error`: `isError` is neither literal `true` nor literal
+ *   `false`, so this scan cannot tell whether the failure path carries
+ *   `details.error`. That is not a hypothetical shape — `pinchy_web_fetch`
+ *   forwarded `isError: result.isError` straight from webFetch(), which is
+ *   exactly how it shipped without details.error. Branch on the flag and
+ *   return a `toolError()` on the error side instead, so the contract is
+ *   visible to this scan.
+ */
+export type ErrorDetailIssueReason = "missing-details-error" | "dynamic-is-error";
+
 export interface MissingErrorDetail {
   /** 1-based line number in the plugin's index.ts. */
   line: number;
   /** First line of the offending object literal, for a readable failure message. */
   snippet: string;
+  reason: ErrorDetailIssueReason;
 }
 
-function isLiteralTrue(expr: ts.Expression): boolean {
-  return expr.kind === ts.SyntaxKind.TrueKeyword;
-}
-
-function findProperty(
-  node: ts.ObjectLiteralExpression,
-  name: string
-): ts.PropertyAssignment | undefined {
-  const prop = node.properties.find(
-    (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === name
-  );
-  return prop as ts.PropertyAssignment | undefined;
-}
-
-function hasErrorProperty(details: ts.Expression): boolean {
-  if (!ts.isObjectLiteralExpression(details)) return false;
-  return findProperty(details, "error") !== undefined;
+export interface ErrorResultScan {
+  /**
+   * How many result literals carried an `isError` worth judging (everything
+   * but a literal `false`). The guard asserts this against a floor: a walk
+   * that silently stops finding anything would otherwise pass as "no drift".
+   */
+  checked: number;
+  issues: MissingErrorDetail[];
 }
 
 /**
- * Find every object-literal MCP tool result in a plugin's index.ts that sets
- * `isError: true` but does not also carry a `details` object with an `error`
- * key. Mirrors the AST-walk style of `plugin-tool-extraction.ts`'s
- * `skippedRanges` rather than a line-oriented regex, because the two
- * properties in question (`isError` and `details`) can be reordered or
- * separated by other curated fields (see pinchy-files' `pinchy_write`, which
- * also carries `path`/`mode`/`overwrite`) and a regex anchored on adjacency
- * would miss those.
- *
- * Deliberately a static scan, not a type check: it inspects
- * ObjectLiteralExpression nodes only, so a dynamically-computed `isError`
- * value (e.g. `isError: someFlag`) is out of scope. Every call site in this
- * repo assigns the literal `true` (or routes through a `toolError()`-style
- * helper, which is itself scanned once at its own declaration site).
+ * Strip the wrappers TypeScript allows around a literal so `true as const`
+ * and `(true)` read the same as a bare `true`. `true as const` is not
+ * hypothetical: pinchy-email's session-less tool stub is written that way,
+ * and an `expr.kind === TrueKeyword` check skips the whole literal — silently
+ * exempting exactly one of the results this guard exists to cover.
  */
-export function findMissingErrorDetails(pluginId: KnownPinchyPlugin): MissingErrorDetail[] {
-  const indexPath = join(PLUGINS_DIR, pluginId, "index.ts");
-  let source: string;
-  try {
-    source = readFileSync(indexPath, "utf8");
-  } catch {
-    return [];
+function unwrapExpression(expr: ts.Expression): ts.Expression {
+  let current = expr;
+  for (;;) {
+    if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+      current = current.expression;
+    } else if (ts.isParenthesizedExpression(current)) {
+      current = current.expression;
+    } else if (ts.isSatisfiesExpression(current)) {
+      current = current.expression;
+    } else {
+      return current;
+    }
   }
+}
+
+/**
+ * A property is present when it is assigned (`error: msg`), written in
+ * shorthand (`error`), or quoted (`"error": msg`). Matching only
+ * PropertyAssignment+Identifier reports correct shorthand code as a
+ * violation, which is the failure mode that gets a guard switched off.
+ */
+function findProperty(
+  node: ts.ObjectLiteralExpression,
+  name: string
+): { initializer: ts.Expression | undefined; node: ts.ObjectLiteralElementLike } | undefined {
+  for (const prop of node.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      const propName = prop.name;
+      const matches =
+        (ts.isIdentifier(propName) && propName.text === name) ||
+        (ts.isStringLiteral(propName) && propName.text === name);
+      if (matches) return { initializer: prop.initializer, node: prop };
+    } else if (ts.isShorthandPropertyAssignment(prop) && prop.name.text === name) {
+      // `{ error }` — the value is the identifier itself, which this static
+      // scan cannot resolve. Presence is what the contract asks for.
+      return { initializer: undefined, node: prop };
+    }
+  }
+  return undefined;
+}
+
+function hasErrorProperty(details: ts.Expression | undefined): boolean {
+  if (details === undefined) return false;
+  const unwrapped = unwrapExpression(details);
+  if (!ts.isObjectLiteralExpression(unwrapped)) return false;
+  return findProperty(unwrapped, "error") !== undefined;
+}
+
+/**
+ * Find every object-literal MCP tool result in `source` that signals a
+ * failure without a `details.error` the audit route can read. Mirrors the
+ * AST-walk style of `plugin-tool-extraction.ts`'s `skippedRanges` rather
+ * than a line-oriented regex, because the two properties in question
+ * (`isError` and `details`) can be reordered or separated by other curated
+ * fields (see pinchy-files' `pinchy_write`, which also carries
+ * `path`/`mode`/`overwrite`) and a regex anchored on adjacency would miss
+ * those.
+ *
+ * Takes a source string rather than a path so the scan itself is testable
+ * against fixtures, the way `extractCoveredTools` is — a scan only ever
+ * exercised against healthy real sources can degrade into a no-op and stay
+ * green.
+ *
+ * Known limitation, stated plainly: a `details` that is not an object
+ * literal (`details: buildDetails(x)`) is reported as missing. That is
+ * deliberate — the scan cannot follow the value, and a guard that assumes
+ * the best about what it cannot read is the same silence it exists to
+ * remove. Route such a result through a `toolError()`-style helper.
+ */
+export function scanErrorResults(source: string, fileName = "index.ts"): ErrorResultScan {
   const sourceFile = ts.createSourceFile(
-    "index.ts",
+    fileName,
     source,
     ts.ScriptTarget.Latest,
     /* setParentNodes */ true,
@@ -84,25 +144,68 @@ export function findMissingErrorDetails(pluginId: KnownPinchyPlugin): MissingErr
   );
 
   const issues: MissingErrorDetail[] = [];
+  let checked = 0;
+
+  const flag = (element: ts.Node, reason: ErrorDetailIssueReason): void => {
+    const { line } = sourceFile.getLineAndCharacterOfPosition(element.getStart(sourceFile));
+    issues.push({ line: line + 1, snippet: element.getText(sourceFile).trim(), reason });
+  };
+
   const visit = (node: ts.Node): void => {
     if (ts.isObjectLiteralExpression(node)) {
       const isErrorProp = findProperty(node, "isError");
-      if (isErrorProp && isLiteralTrue(isErrorProp.initializer)) {
-        const detailsProp = findProperty(node, "details");
-        const ok = detailsProp !== undefined && hasErrorProperty(detailsProp.initializer);
-        if (!ok) {
-          const { line } = sourceFile.getLineAndCharacterOfPosition(
-            isErrorProp.getStart(sourceFile)
-          );
-          issues.push({
-            line: line + 1,
-            snippet: isErrorProp.getText(sourceFile).trim(),
-          });
+      if (isErrorProp !== undefined) {
+        const initializer =
+          isErrorProp.initializer !== undefined
+            ? unwrapExpression(isErrorProp.initializer)
+            : undefined;
+        // `isError: false` is a success result; nothing to check.
+        if (initializer === undefined || initializer.kind !== ts.SyntaxKind.FalseKeyword) {
+          checked++;
+          if (initializer !== undefined && initializer.kind === ts.SyntaxKind.TrueKeyword) {
+            if (!hasErrorProperty(findProperty(node, "details")?.initializer)) {
+              flag(isErrorProp.node, "missing-details-error");
+            }
+          } else {
+            flag(isErrorProp.node, "dynamic-is-error");
+          }
         }
       }
     }
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
-  return issues;
+  return { checked, issues };
+}
+
+/**
+ * Scan a plugin's `index.ts`.
+ *
+ * Scope is `index.ts` alone, matching `deriveToolsFromSource`: every plugin
+ * registers its tools there, and a result literal travels with the handler
+ * that builds it. A plugin that ever builds an MCP result in a sibling
+ * module escapes this scan — pinchy-web's `web-fetch.ts` returns a
+ * different, internal `{ content: string; isError }` DTO that index.ts
+ * translates, so nothing escapes today.
+ *
+ * An unreadable index.ts throws rather than reporting "no issues": every
+ * finding here is an absence, so a failed read and a clean file are the same
+ * empty list. `deriveToolsFromSource` can afford to swallow it — an empty
+ * tool list turns its manifest comparison red — but here it would turn the
+ * guard green for a plugin it never opened.
+ */
+export function scanPlugin(pluginId: KnownPinchyPlugin): ErrorResultScan {
+  const indexPath = join(PLUGINS_DIR, pluginId, "index.ts");
+  let source: string;
+  try {
+    source = readFileSync(indexPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Cannot read ${indexPath} for plugin ${pluginId}. This guard reports absences, so an ` +
+        `unreadable file would otherwise pass as "no drift". If the plugin moved its tool ` +
+        `results out of index.ts, widen this scan rather than dropping the plugin. ` +
+        `(${err instanceof Error ? err.message : String(err)})`
+    );
+  }
+  return scanErrorResults(source, `${pluginId}/index.ts`);
 }

--- a/packages/web/src/__tests__/lib/plugin-tool-error-details-drift.test.ts
+++ b/packages/web/src/__tests__/lib/plugin-tool-error-details-drift.test.ts
@@ -9,28 +9,149 @@
 // catch. pinchy-odoo and pinchy-email already enforce this via a shared
 // `toolError()` helper; this guard extends the same contract to every
 // KNOWN_PINCHY_PLUGINS package.
+//
+// The scan's own fixtures live in the second describe below. They are the
+// half that matters: a guard whose scanner quietly stops matching reports
+// "no drift" against a healthy tree and never goes red — the same silence
+// the #404 bug itself had.
 import { describe, it, expect } from "vitest";
-import { findMissingErrorDetails, KNOWN_PINCHY_PLUGINS } from "./plugin-error-details-extraction";
+import {
+  scanErrorResults,
+  scanPlugin,
+  KNOWN_PINCHY_PLUGINS,
+  type MissingErrorDetail,
+} from "./plugin-error-details-extraction";
+
+function explain(pluginId: string, issues: MissingErrorDetail[]): string {
+  return [
+    `Plugin ${pluginId}: index.ts signals a tool failure the audit route cannot`,
+    `see, at these locations:`,
+    ...issues.map((i) => `  line ${i.line} [${i.reason}]: ${i.snippet}`),
+    ``,
+    `OpenClaw strips the isError flag before forwarding a tool result to`,
+    `/api/internal/audit/tool-use (#404); details.error is the audit route's`,
+    `only remaining failure signal, so a tool call that fails without it is`,
+    `audited as outcome: success.`,
+    ``,
+    `missing-details-error → route this result through a toolError()-style`,
+    `  helper that sets details: { error: <message> }, mirroring`,
+    `  pinchy-odoo's/pinchy-email's toolError().`,
+    `dynamic-is-error → isError is computed, so this scan cannot tell whether`,
+    `  the failure path carries details.error. Branch on the flag and return`,
+    `  toolError(...) on the error side (see pinchy_web_fetch).`,
+  ].join("\n");
+}
 
 describe("plugin-tool-error-details-drift", () => {
+  // Scanned inside each `it`, not once at collect time: scanPlugin throws on
+  // an unreadable index.ts, and a throw during collection fails the whole
+  // file — taking the scanErrorResults fixtures below with it, so a missing
+  // plugin file would also silence the tests that prove the scanner works.
   for (const pluginId of KNOWN_PINCHY_PLUGINS) {
-    it(`${pluginId}: every isError:true result carries details.error`, () => {
-      const issues = findMissingErrorDetails(pluginId);
-      expect(
-        issues,
-        [
-          `Plugin ${pluginId}: index.ts returns isError: true without a sibling`,
-          `details.error at these locations:`,
-          ...issues.map((i) => `  line ${i.line}: ${i.snippet}`),
-          ``,
-          `OpenClaw strips the isError flag before forwarding a tool result to`,
-          `/api/internal/audit/tool-use (#404); details.error is the audit route's`,
-          `only remaining failure signal, so a tool call that fails without it is`,
-          `audited as outcome: success. Route this error result through a`,
-          `toolError()-style helper that sets details: { error: <message> },`,
-          `mirroring pinchy-odoo's/pinchy-email's toolError() helper.`,
-        ].join("\n")
-      ).toHaveLength(0);
+    it(`${pluginId}: every failing result carries details.error`, () => {
+      const { issues } = scanPlugin(pluginId);
+      expect(issues, explain(pluginId, issues)).toHaveLength(0);
     });
   }
+
+  // A corpus floor, not a metric. Every assertion above is an absence, so a
+  // walk that stops matching — a renamed AST helper, a bad PLUGINS_DIR —
+  // reports a clean tree instead of a broken scan. 14 result literals were
+  // present when this landed (pinchy-audit and pinchy-transcript register no
+  // tools and contribute none); 10 leaves room for ordinary churn while
+  // still failing loudly if the walk goes quiet.
+  it("scans a real corpus of result literals", () => {
+    const checked = KNOWN_PINCHY_PLUGINS.reduce((sum, id) => sum + scanPlugin(id).checked, 0);
+    expect(
+      checked,
+      `Only ${checked} isError result literals were scanned across ${KNOWN_PINCHY_PLUGINS.length} ` +
+        `plugins. That is too few to be a real corpus — the AST walk is probably matching ` +
+        `nothing, which reads as "no drift" while checking nothing.`
+    ).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe("scanErrorResults", () => {
+  const RESULT = `content: [{ type: "text", text: msg }]`;
+
+  it("accepts a result carrying details.error", () => {
+    const scan = scanErrorResults(
+      `const r = { isError: true, ${RESULT}, details: { error: msg } };`
+    );
+    expect(scan.issues).toEqual([]);
+    expect(scan.checked).toBe(1);
+  });
+
+  it("flags isError: true with no details at all", () => {
+    const scan = scanErrorResults(`const r = { isError: true, ${RESULT} };`);
+    expect(scan.issues.map((i) => i.reason)).toEqual(["missing-details-error"]);
+  });
+
+  it("flags details that carries no error key", () => {
+    const scan = scanErrorResults(`const r = { isError: true, ${RESULT}, details: { path: p } };`);
+    expect(scan.issues.map((i) => i.reason)).toEqual(["missing-details-error"]);
+  });
+
+  it("sees through `true as const` (pinchy-email writes its stub that way)", () => {
+    // An `expr.kind === TrueKeyword` check skips the literal entirely, which
+    // exempts a real result in the tree instead of judging it.
+    const scan = scanErrorResults(`const r = { isError: true as const, ${RESULT} };`);
+    expect(scan.issues.map((i) => i.reason)).toEqual(["missing-details-error"]);
+    expect(scan.checked).toBe(1);
+  });
+
+  it("sees through parentheses", () => {
+    const scan = scanErrorResults(`const r = { isError: (true), ${RESULT} };`);
+    expect(scan.issues.map((i) => i.reason)).toEqual(["missing-details-error"]);
+  });
+
+  it("flags a computed isError — the shape pinchy_web_fetch shipped with", () => {
+    // `isError: result.isError` forwarded webFetch()'s flag verbatim and
+    // carried no details.error on the failure side. A scan that only judges
+    // literal `true` cannot see that shape come back.
+    const scan = scanErrorResults(`const r = { isError: result.isError, ${RESULT} };`);
+    expect(scan.issues.map((i) => i.reason)).toEqual(["dynamic-is-error"]);
+    expect(scan.checked).toBe(1);
+  });
+
+  it("accepts shorthand details.error", () => {
+    // `details: { error }` is correct code; reporting it is the false
+    // positive that gets a guard switched off.
+    const scan = scanErrorResults(`const r = { isError: true, ${RESULT}, details: { error } };`);
+    expect(scan.issues).toEqual([]);
+  });
+
+  it("accepts a quoted error key", () => {
+    const scan = scanErrorResults(
+      `const r = { isError: true, ${RESULT}, details: { "error": msg } };`
+    );
+    expect(scan.issues).toEqual([]);
+  });
+
+  it("ignores a success result", () => {
+    const scan = scanErrorResults(`const r = { isError: false, ${RESULT} };`);
+    expect(scan.issues).toEqual([]);
+    expect(scan.checked).toBe(0);
+  });
+
+  it("ignores a result that spreads an already-checked error base", () => {
+    // pinchy-email's withEmailAuditDetails re-wraps a toolError() result.
+    // The literal it spreads is judged at its own site; re-flagging here
+    // would demand a redundant `error` key on every wrapper.
+    const scan = scanErrorResults(`const r = { ...base, details: { ...curated, error: e } };`);
+    expect(scan.issues).toEqual([]);
+    expect(scan.checked).toBe(0);
+  });
+
+  it("reports the line of the offending property", () => {
+    const scan = scanErrorResults(`const a = 1;\nconst r = {\n  isError: true,\n  ${RESULT},\n};`);
+    expect(scan.issues[0]?.line).toBe(3);
+  });
+
+  it("finds a result nested inside a function body", () => {
+    const scan = scanErrorResults(
+      `function f() { if (x) { return { isError: true, ${RESULT} }; } }`
+    );
+    expect(scan.issues).toHaveLength(1);
+  });
 });

--- a/packages/web/src/__tests__/lib/plugin-tool-error-details-drift.test.ts
+++ b/packages/web/src/__tests__/lib/plugin-tool-error-details-drift.test.ts
@@ -1,0 +1,36 @@
+// packages/web/src/__tests__/lib/plugin-tool-error-details-drift.test.ts
+//
+// #404 contract: OpenClaw strips the MCP `isError` flag before forwarding a
+// tool result to /api/internal/audit/tool-use, so the audit route's only
+// remaining failure signal is `result.details.error`
+// (see route.ts's "3. result.details.error" comment). A plugin tool result
+// that sets `isError: true` without a sibling `details.error` is silently
+// audited as `outcome: success` — that's the drift this guard exists to
+// catch. pinchy-odoo and pinchy-email already enforce this via a shared
+// `toolError()` helper; this guard extends the same contract to every
+// KNOWN_PINCHY_PLUGINS package.
+import { describe, it, expect } from "vitest";
+import { findMissingErrorDetails, KNOWN_PINCHY_PLUGINS } from "./plugin-error-details-extraction";
+
+describe("plugin-tool-error-details-drift", () => {
+  for (const pluginId of KNOWN_PINCHY_PLUGINS) {
+    it(`${pluginId}: every isError:true result carries details.error`, () => {
+      const issues = findMissingErrorDetails(pluginId);
+      expect(
+        issues,
+        [
+          `Plugin ${pluginId}: index.ts returns isError: true without a sibling`,
+          `details.error at these locations:`,
+          ...issues.map((i) => `  line ${i.line}: ${i.snippet}`),
+          ``,
+          `OpenClaw strips the isError flag before forwarding a tool result to`,
+          `/api/internal/audit/tool-use (#404); details.error is the audit route's`,
+          `only remaining failure signal, so a tool call that fails without it is`,
+          `audited as outcome: success. Route this error result through a`,
+          `toolError()-style helper that sets details: { error: <message> },`,
+          `mirroring pinchy-odoo's/pinchy-email's toolError() helper.`,
+        ].join("\n")
+      ).toHaveLength(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- OpenClaw strips the MCP `isError` flag before forwarding a tool result to `/api/internal/audit/tool-use` (#404 contract). The audit route's only remaining failure signal is `result.details.error`. pinchy-odoo and pinchy-email already enforce this via a `toolError()` helper; several other plugins did not, so their tool failures were silently audited as `outcome: success`.
- Fixed: pinchy-web (`pinchy_web_search`, `pinchy_web_fetch`), pinchy-docs (`docs_list`, `docs_read`), pinchy-context (`pinchy_save_user_context`, `pinchy_save_org_context`), pinchy-files (`pinchy_ls`, `pinchy_read`), pinchy-knowledge (`knowledge_search`'s empty-query validation path).
- Added a `toolError()` helper to pinchy-web, pinchy-docs, pinchy-context, and pinchy-files (mirroring pinchy-odoo's/pinchy-email's), routing every bare `isError: true` result through it. pinchy-knowledge's fix is a one-line `details: { error }` addition matching its two existing HTTP/network failure paths.
- Added a static AST drift guard (`packages/web/src/__tests__/lib/plugin-tool-error-details-drift.test.ts` + `plugin-error-details-extraction.ts`) that scans every `packages/plugins/pinchy-*/index.ts` and fails when an `isError: true` result literal has no sibling `details.error` — the read-side sibling of `manifest-tools-drift.test.ts`.
- Extended each affected plugin's own vitest suite with an assertion that the error path's `result.details` carries `{ error: <message> }`.

## Test plan

- [x] New guard (`plugin-tool-error-details-drift.test.ts`) verified red on the pre-fix state (stashed the plugin fixes, ran the guard, confirmed it named exactly the 5 affected plugins and lines from the brief), then green after applying the fixes.
- [x] `pnpm test:related` — 171 passed, 2 skipped (pre-existing, unrelated).
- [x] `pnpm test:plugins` — all 9 plugin packages pass (pinchy-files: 244 passed, 2 skipped pre-existing/unrelated; others green).
- [x] `pnpm test` (full suite) — 10920 passed, 18 skipped (pre-existing).
- [x] `pnpm test:scripts` — 894 passed.
- [x] `pnpm typecheck:plugins` — all 9 plugins typecheck cleanly.
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm -C packages/web lint` — 0 errors (pre-existing warnings only).
- [x] `pnpm format:check` — clean.

Docs: checked `docs/src/content/docs/concepts/audit-trail.mdx` — it does not describe plugin-internal `isError`/`details.error` semantics, so nothing there is incorrect. Used the `Docs-not-needed` commit trailer (restores documented audit-outcome semantics, no reader-facing change).