### PR TITLE
fix(security): require admin session for channel-health snapshot

### DIFF
--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -74,6 +74,8 @@ Useful for monitoring the WebSocket gateway separately from the web process.
 
 `configPushesPending` is the number of configuration updates Pinchy has accepted but not yet confirmed inside the OpenClaw runtime (for example while OpenClaw's config-apply rate limit defers an update). A value of `0` means the runtime reflects every change you've made — useful for automation that needs to act right after a settings or permission change. While the gateway restarts, the response is `{ "status": "restarting", "connected": false, "since": <timestamp> }` instead.
 
+With `?channelHealth=1`, the response additionally includes a `channelHealth` array — the channel-health watchdog's per-account snapshot (used by the admin Telegram settings UI to show a "degraded" badge). **This mode requires an admin session** and returns `401`/`403` otherwise: entries carry `accountId` (a Pinchy agent id) and `lastError` (worker error text, passed through the same scrubbing used for the audit trail). The rest of this endpoint — the default `{ status, connected }` check and `?agentId=` — stays public.
+
 ## Setup (public)
 
 Setup endpoints handle the initial installation and first-admin account. They are accessible **only before setup has completed** — once an admin exists, they return `409 Conflict`.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -58,7 +58,7 @@ Database and OpenClaw reachability, plus the running version. **Public**, but th
 
 ### `GET /api/health/openclaw`
 
-OpenClaw gateway reachability check. **Public — no authentication required.**
+OpenClaw gateway reachability check. **Public — no authentication required**, except the `?channelHealth=1` mode described below, which requires an admin session.
 
 Useful for monitoring the WebSocket gateway separately from the web process.
 

--- a/packages/web/src/__tests__/api/health-openclaw.test.ts
+++ b/packages/web/src/__tests__/api/health-openclaw.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
+import { mockSession } from "@/test-helpers/auth";
 
 const mockRestartState = { isRestarting: false, triggeredAt: null as number | null };
 const mockConnectionState = { connected: false };
@@ -29,8 +29,6 @@ vi.mock("@/lib/api-auth", () => ({
 vi.mock("@/server/channel-health-singleton", () => ({
   getChannelHealthMonitor: () => mockGetChannelHealthMonitor(),
 }));
-
-import { mockSession } from "@/test-helpers/auth";
 
 function fakeRequest(url = "http://localhost/api/health/openclaw"): NextRequest {
   // Only `nextUrl.searchParams` is consumed by the route — minimal shim.
@@ -173,12 +171,36 @@ describe("GET /api/health/openclaw", () => {
       );
       const body = await response.json();
 
-      expect(body.channelHealth[0].lastError).not.toContain("someone@example.com");
+      // Assert the scrubbed VALUE, not merely the absence of the address: a
+      // `not.toContain` is equally satisfied by `null`, by `undefined`, and by
+      // the field being dropped altogether — so it would stay green if the
+      // mapping regressed to blanking `lastError` and the badge lost its title.
+      expect(body.channelHealth[0].lastError).toBe("conflict for user <email-redacted>");
     });
+  });
 
-    it("does NOT call requireAdmin for the default health check (stays public)", async () => {
+  describe("the unauthenticated modes stay unauthenticated", () => {
+    it("does NOT call requireAdmin for the default health check", async () => {
       await GET(fakeRequest());
 
+      expect(mockRequireAdmin).not.toHaveBeenCalled();
+    });
+
+    // The `?agentId=` probe is what every E2E stability gate polls, several of
+    // them with a bare `fetch` and no cookie (e2e/telegram/media.spec.ts,
+    // chats.spec.ts, agent-create-no-restart.spec.ts). If the admin gate ever
+    // moved above this branch those suites would fail as an opaque poll
+    // timeout, minutes into a Docker run — this pins it one unit test early.
+    it("does NOT call requireAdmin for the ?agentId= dispatchability probe", async () => {
+      mockConfigGet.mockResolvedValue({ config: { agents: { list: [{ id: "agent-1" }] } } });
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?agentId=agent-1")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.agentDispatchable).toBe(true);
       expect(mockRequireAdmin).not.toHaveBeenCalled();
     });
   });

--- a/packages/web/src/__tests__/api/health-openclaw.test.ts
+++ b/packages/web/src/__tests__/api/health-openclaw.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 const mockRestartState = { isRestarting: false, triggeredAt: null as number | null };
 const mockConnectionState = { connected: false };
 const mockConfigGet = vi.fn();
 const mockGetOpenClawClient = vi.fn();
+const mockRequireAdmin = vi.fn();
+const mockSnapshot = vi.fn();
+const mockGetChannelHealthMonitor = vi.fn();
 
 vi.mock("@/server/restart-state", () => ({
   restartState: mockRestartState,
@@ -17,6 +21,16 @@ vi.mock("@/server/openclaw-connection-state", () => ({
 vi.mock("@/server/openclaw-client", () => ({
   getOpenClawClient: () => mockGetOpenClawClient(),
 }));
+
+vi.mock("@/lib/api-auth", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+vi.mock("@/server/channel-health-singleton", () => ({
+  getChannelHealthMonitor: () => mockGetChannelHealthMonitor(),
+}));
+
+import { mockSession } from "@/test-helpers/auth";
 
 function fakeRequest(url = "http://localhost/api/health/openclaw"): NextRequest {
   // Only `nextUrl.searchParams` is consumed by the route — minimal shim.
@@ -34,6 +48,9 @@ describe("GET /api/health/openclaw", () => {
     mockRestartState.triggeredAt = null;
     mockConnectionState.connected = false;
     mockGetOpenClawClient.mockReturnValue({ config: { get: mockConfigGet } });
+    mockRequireAdmin.mockResolvedValue(mockSession());
+    mockSnapshot.mockReturnValue([]);
+    mockGetChannelHealthMonitor.mockReturnValue({ snapshot: mockSnapshot });
     // The push-state tracker is globalThis-backed (NOT mocked here): the route
     // must read the same counter `pushConfigInBackground` writes, across the
     // Next-route vs custom-server module-graph split.
@@ -79,6 +96,91 @@ describe("GET /api/health/openclaw", () => {
     pushState.trackConfigPushSettled();
     const after = await (await GET(fakeRequest())).json();
     expect(after.configPushesPending).toBe(0);
+  });
+
+  describe("with ?channelHealth=1 (admin-only snapshot)", () => {
+    it("returns 401 for an unauthenticated caller and does NOT read the snapshot", async () => {
+      mockRequireAdmin.mockResolvedValue(
+        NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      );
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?channelHealth=1")
+      );
+
+      expect(response.status).toBe(401);
+      expect(mockSnapshot).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 for a non-admin member and does NOT read the snapshot", async () => {
+      mockRequireAdmin.mockResolvedValue(
+        NextResponse.json({ error: "Forbidden" }, { status: 403 })
+      );
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?channelHealth=1")
+      );
+
+      expect(response.status).toBe(403);
+      expect(mockSnapshot).not.toHaveBeenCalled();
+    });
+
+    it("returns the snapshot for an admin", async () => {
+      mockRequireAdmin.mockResolvedValue(mockSession());
+      mockSnapshot.mockReturnValue([
+        {
+          channel: "telegram",
+          accountId: "agent-1",
+          state: "degraded",
+          connected: false,
+          running: false,
+          lastError: "getUpdates conflict",
+          reconnectAttempts: 3,
+          restartPending: false,
+          degradedSince: 1700000000000,
+        },
+      ]);
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?channelHealth=1")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.channelHealth).toEqual([
+        expect.objectContaining({ accountId: "agent-1", lastError: "getUpdates conflict" }),
+      ]);
+    });
+
+    it("scrubs lastError through safeProviderError before returning it", async () => {
+      mockRequireAdmin.mockResolvedValue(mockSession());
+      mockSnapshot.mockReturnValue([
+        {
+          channel: "telegram",
+          accountId: "agent-1",
+          state: "degraded",
+          connected: false,
+          running: false,
+          lastError: "conflict for user someone@example.com",
+          reconnectAttempts: 1,
+          restartPending: false,
+          degradedSince: 1700000000000,
+        },
+      ]);
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?channelHealth=1")
+      );
+      const body = await response.json();
+
+      expect(body.channelHealth[0].lastError).not.toContain("someone@example.com");
+    });
+
+    it("does NOT call requireAdmin for the default health check (stays public)", async () => {
+      await GET(fakeRequest());
+
+      expect(mockRequireAdmin).not.toHaveBeenCalled();
+    });
   });
 
   it("returns restarting with connected: false when restarting", async () => {

--- a/packages/web/src/__tests__/security/api-auth-check.test.ts
+++ b/packages/web/src/__tests__/security/api-auth-check.test.ts
@@ -36,6 +36,11 @@ const PUBLIC_ROUTES = [
   // Token possession is the auth factor, same as the claim route above.
   "api/invite/[token]/route.ts",
   "api/health/route.ts",
+  // Public in its default mode and for the `?agentId=` dispatchability probe
+  // (E2E stability gates poll that one without a cookie). The `?channelHealth=1`
+  // branch is NOT public — it calls `requireAdmin()` — but listing the file here
+  // makes this guard skip it entirely, so the admin gate is pinned by the 401/403
+  // cases in `__tests__/api/health-openclaw.test.ts` instead.
   "api/health/openclaw/route.ts",
   "api/diagnostics/route.ts",
   "api/version/route.ts",

--- a/packages/web/src/app/api/health/openclaw/route.ts
+++ b/packages/web/src/app/api/health/openclaw/route.ts
@@ -4,6 +4,8 @@ import { openClawConnectionState } from "@/server/openclaw-connection-state";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { getChannelHealthMonitor } from "@/server/channel-health-singleton";
 import { getPendingConfigPushCount } from "@/lib/openclaw-config/push-state";
+import { requireAdmin } from "@/lib/api-auth";
+import { safeProviderError } from "@/lib/audit";
 
 /**
  * GET `/api/health/openclaw[?agentId=<uuid>]`
@@ -27,6 +29,11 @@ import { getPendingConfigPushCount } from "@/lib/openclaw-config/push-state";
  *
  * Safe to expose publicly: only checks for presence of the id in
  * `agents.list`, returns no agent metadata.
+ *
+ * With `?channelHealth=1`: admin-only. The snapshot carries `accountId`
+ * (a Pinchy agent id for Telegram) and `lastError` (raw worker error text) —
+ * see the doc comment below. Everything else in this route stays
+ * unauthenticated on purpose; only this branch requires an admin session.
  */
 export async function GET(request: NextRequest) {
   if (restartState.isRestarting) {
@@ -53,8 +60,19 @@ export async function GET(request: NextRequest) {
   // the watchdog's debounced episode state (rather than a fresh classify)
   // avoids the badge flickering on a single-tick blip between OpenClaw's
   // auto-restart attempts. Empty (`[]`) until the watchdog has run a probe.
+  //
+  // Admin-only: the entries carry `accountId` (a Pinchy agent id for
+  // Telegram) and `lastError` (worker error text). `lastError` is also
+  // routed through `safeProviderError` here — defense in depth alongside the
+  // admin gate, matching the scrub already applied on the audit-log path in
+  // channel-health-watchdog.ts.
   if (request.nextUrl.searchParams.get("channelHealth")) {
-    const channelHealth = getChannelHealthMonitor()?.snapshot() ?? [];
+    const admin = await requireAdmin();
+    if (admin instanceof NextResponse) return admin;
+    const channelHealth = (getChannelHealthMonitor()?.snapshot() ?? []).map((entry) => ({
+      ...entry,
+      lastError: entry.lastError ? safeProviderError(entry.lastError) : null,
+    }));
     return NextResponse.json({ ...base, channelHealth });
   }
 

--- a/packages/web/src/server/channel-health-watchdog.ts
+++ b/packages/web/src/server/channel-health-watchdog.ts
@@ -418,7 +418,9 @@ export class ChannelHealthMonitor {
         // append-only HMAC-signed row. The classifier is channel-agnostic, so a
         // future email/Slack channel's lastError could carry an address — and
         // GDPR erasure on a signed audit row is impossible by design. The live
-        // snapshot/UI keeps the full text (ephemeral, admin-only).
+        // snapshot the monitor hands out is unscrubbed; `/api/health/openclaw`
+        // applies the same `safeProviderError` on its way out, behind an admin
+        // gate, so the badge and the audit row read alike.
         lastError: h.lastError ? safeProviderError(h.lastError) : null,
         reconnectAttempts: h.reconnectAttempts,
         consecutiveDegradedChecks,


### PR DESCRIPTION
## Summary
- `GET /api/health/openclaw?channelHealth=1` was completely unauthenticated but returned per-account `ChannelHealthSnapshotEntry[]` data the code itself calls "admin-only": `accountId` (Pinchy agent id for Telegram accounts) and raw, unscrubbed `lastError` worker text.
- The audit path for the same field (`channel-health-watchdog.ts`) already scrubs it via `safeProviderError`, with a comment noting the live snapshot was intended to stay admin-only — the route just never enforced that.
- Gate the `channelHealth` branch with `requireAdmin()` (401/403 as appropriate). The default `{ status, connected }` health check and the `?agentId=` dispatchability probe stay public and unchanged — only the `channelHealth` branch is affected.
- Also route `lastError` through `safeProviderError` on this path as defense in depth, so the admin UI now sees the same scrubbed text the audit trail does.
- Docs: noted the admin gating and scrubbing for `?channelHealth=1` in `docs/src/content/docs/reference/api.mdx`.

## Test plan
- [x] `pnpm test:related packages/web/src/app/api/health/openclaw/route.ts` — new tests fail red before the fix (401/403/scrub), pass green after.
- [x] Full suite: `pnpm test` — 10913 passed, 18 skipped (pre-existing skips, unrelated).
- [x] `pnpm test:scripts` — 894 passed.
- [x] `pnpm -C packages/web lint` — 0 errors (981 pre-existing warnings).
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm format:check` — clean.