### PR TITLE
fix(plugins): bound every plugin fetch call against a hung endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -584,6 +584,18 @@ The drift guard `scripts/lib/plugin-typecheck.test.mjs` (pure logic in `scripts/
 
 Every plugin package must ship vitest unit tests and declare `"test": "vitest run"` in its package.json. The test files run twice in the CI quality job, deliberately: once inside `pnpm test` via the `../plugins/pinchy-*` include in `packages/web/vitest.config.ts` (web config), and once per package via `pnpm test:plugins` (each plugin's own config and dependencies, as run locally). Two drift guards in `packages/web/src/__tests__/lib/plugin-test-coverage.test.ts` enforce this: every plugin test file must match the include globs, and every plugin package must declare a `test` script (pnpm recursive runs silently skip packages without one).
 
+### Every plugin `fetch()` passes a signal
+
+An unbounded `fetch` has no failure mode that looks like a bug — the call simply never returns. A Pinchy container mid-deploy, or a blackhole that swallows packets without an RST, leaves the plugin waiting forever, and in `pinchy-audit`'s `before_tool_call` hook that stalls every tool call of every agent with nothing in any log naming the cause.
+
+`packages/web/src/__tests__/lib/plugin-fetch-timeout-coverage.test.ts` requires a `signal` on every `fetch()` in plugin production code. It exists because the change that added the 15 original timeouts also wrote, in a comment, that the mailbox providers "bound themselves separately (see graph-adapter.ts, gmail-adapter.ts, imap-adapter.ts)" — and `gmail-adapter.ts` did not: it reaches Gmail through googleapis, whose transport documents `timeout` as "No timeout by default". Prose asserted coverage the code lacked, and nothing could contradict it. Same argument as § "A Hand-Maintained List That Mirrors Code Will Be Wrong".
+
+Three things to know before editing it:
+
+- **Pick the bound from the call's legitimate worst case, not from a latency budget.** Too long merely delays an error; too short turns working calls into failures that read as product bugs. That asymmetry is why the vision API sits at 120s hosted / **300s for Ollama** — the offline path pays a model load before decoding starts, and a shared 30s bound would break exactly the self-hosted deployments Pinchy promises to support. Pinchy-internal, same-Docker-network calls use 10s; external APIs 30s; anything that streams a file body gets its own larger bound (`ATTACHMENT_TIMEOUT_MS`), because an AbortSignal covers the body read, not just the response headers.
+- **Never write `init.signal ?? AbortSignal.timeout(...)`.** It reads as a harmless escape hatch and is a trap: the first caller to pass a cancellation signal silently loses the timeout, and no test can see it. Both wrappers here (`GraphAdapter.req`, `fetchWithRetry`) type `signal` out of their options and take a `timeoutMs` instead. Create the signal **inside** a retry loop, too, so each attempt gets a fresh bound rather than all attempts sharing one deadline the first one spent.
+- **It sees `fetch` and nothing else.** A plugin reaching the network through another transport is invisible to it — today `gmail-adapter.ts` (googleapis/gaxios, bounded by its `timeout` option) and `imap-adapter.ts` (imapflow, `connectionTimeout`/`socketTimeout`). It also checks only that a signal is passed, never that the value is sane. Both limits are covered by per-call unit tests instead. Verify a change to the guard with a canary — delete a `signal:` from a plugin, watch it name that exact file and line, put it back.
+
 ### Tool dispatch coverage
 
 Every plugin tool must be covered at three layers:

--- a/packages/plugins/pinchy-audit/index.test.ts
+++ b/packages/plugins/pinchy-audit/index.test.ts
@@ -92,6 +92,7 @@ describe("pinchy-audit plugin", () => {
         sessionKey: "agent:agent-1:user-user-1",
         sessionId: "session-1",
       }),
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -145,6 +146,7 @@ describe("pinchy-audit plugin", () => {
         error: "Request failed",
         durationMs: 123,
       }),
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -190,6 +192,7 @@ describe("pinchy-audit plugin", () => {
         error: undefined,
         durationMs: undefined,
       }),
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -254,6 +257,7 @@ describe("pinchy-audit plugin", () => {
         error: undefined,
         durationMs: undefined,
       }),
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -543,6 +547,57 @@ describe("pinchy-audit plugin", () => {
           { toolName: "pinchy_read", agentId: "agent-1" }
         )
       ).rejects.toThrow(/audit endpoint returned 500/);
+    });
+
+    it("aborts a hung audit POST via AbortSignal.timeout(10_000) instead of blocking every tool call forever", async () => {
+      // A server that never responds and never resets the connection — the
+      // "hung endpoint" / "network blackhole" case the fetch timeout exists
+      // to bound. The mock fetch only ever settles via the AbortSignal the
+      // plugin passes in, exactly like real `fetch` does. AbortSignal.timeout
+      // itself is intercepted so the test proves the SAME behavior a real
+      // 10-second hang would produce, without the test taking 10+ seconds:
+      // it still asserts the plugin requests a 10_000ms bound and reacts
+      // correctly when that signal fires.
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+        const controller = new AbortController();
+        setTimeout(
+          () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+          1
+        );
+        return controller.signal;
+      });
+
+      const fetchMock = vi.fn((_url: string | URL, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener("abort", () => {
+            reject(signal.reason ?? new Error("The operation was aborted"));
+          });
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+      await expect(
+        beforeHook(
+          { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+          { toolName: "pinchy_read" }
+        )
+      ).rejects.toThrow();
+
+      // MAX_RETRIES = 2, so 3 total attempts, each racing its own timeout —
+      // never a single hang that blocks forever.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+      timeoutSpy.mockRestore();
     });
   });
 });

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -206,7 +206,9 @@ const MAX_RETRIES = 2;
 
 // Bounds every attempt against a hung Pinchy container / network blackhole.
 // This hook runs before EVERY tool call of EVERY agent, so an unbounded fetch
-// here blocks all tool dispatch indefinitely (#pinchy-fetch-timeouts).
+// here blocks all tool dispatch indefinitely. Note the worst case is this
+// times MAX_RETRIES + 1 — there is no backoff between attempts, so an
+// unreachable Pinchy costs ~30s per tool call before the hook fails closed.
 const FETCH_TIMEOUT_MS = 10_000;
 
 async function postToolAuditEvent(

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -204,6 +204,11 @@ function toolStartKey(
 
 const MAX_RETRIES = 2;
 
+// Bounds every attempt against a hung Pinchy container / network blackhole.
+// This hook runs before EVERY tool call of EVERY agent, so an unbounded fetch
+// here blocks all tool dispatch indefinitely (#pinchy-fetch-timeouts).
+const FETCH_TIMEOUT_MS = 10_000;
+
 async function postToolAuditEvent(
   cfg: PluginConfig,
   logger: PluginLogger | undefined,
@@ -221,6 +226,7 @@ async function postToolAuditEvent(
           Authorization: `Bearer ${cfg.gatewayToken}`,
         },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
 
       if (res.ok) return;

--- a/packages/plugins/pinchy-context/index.test.ts
+++ b/packages/plugins/pinchy-context/index.test.ts
@@ -142,6 +142,43 @@ describe("pinchy-context plugin", () => {
     expect(result.content[0].text).toBe("Network down");
   });
 
+  it("aborts a hung save_user_context POST via AbortSignal.timeout(10_000) instead of blocking forever", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_save_user_context"
+    )?.[0];
+    const tool = factory({ agentId: "agent-1" });
+
+    // Simulates a Pinchy container that never answers (mid-deploy, network
+    // blackhole) — the mock only ever settles via the AbortSignal the tool
+    // passes to fetch, exactly like a real hung `fetch` would once the
+    // signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    global.fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+
+    const result = await tool.execute("call-1", { content: "..." });
+    expect(result.isError).toBe(true);
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    timeoutSpy.mockRestore();
+  });
+
   it("save_org_context marks HTTP errors with isError=true", async () => {
     const api = createMockApi(defaultConfig);
     const { default: plugin } = await import("./index");

--- a/packages/plugins/pinchy-context/index.ts
+++ b/packages/plugins/pinchy-context/index.ts
@@ -1,6 +1,10 @@
 import { unlinkSync } from "fs";
 import { join } from "path";
 
+// Bounds every call to Pinchy's own internal API against a hung container /
+// network blackhole.
+const FETCH_TIMEOUT_MS = 10_000;
+
 interface PluginToolContext {
   agentId?: string;
 }
@@ -120,6 +124,7 @@ const plugin = {
                     Authorization: `Bearer ${gatewayToken}`,
                   },
                   body: JSON.stringify({ content }),
+                  signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
                 }
               );
 
@@ -199,6 +204,7 @@ const plugin = {
                   Authorization: `Bearer ${gatewayToken}`,
                 },
                 body: JSON.stringify({ content }),
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
               });
 
               if (!res.ok) {

--- a/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
@@ -584,11 +584,14 @@ describe("GmailAdapter", () => {
       expect(Buffer.isBuffer(result.data)).toBe(true);
       expect(result.data.toString("utf-8")).toBe("%PDF-");
 
-      expect(mockAttachmentsGet).toHaveBeenCalledWith({
-        userId: "me",
-        messageId: "msg-dl",
-        id: "att-dl",
-      });
+      expect(mockAttachmentsGet).toHaveBeenCalledWith(
+        {
+          userId: "me",
+          messageId: "msg-dl",
+          id: "att-dl",
+        },
+        { timeout: 120_000 }
+      );
     });
 
     it("decodes attachment bytes faithfully, including high-bit bytes", async () => {
@@ -1011,6 +1014,55 @@ describe("GmailAdapter", () => {
       const result = await adapter.read("msg-special");
 
       expect(result.body).toBe(originalText);
+    });
+  });
+
+  describe("request timeouts", () => {
+    // Gmail is the one mailbox provider that does NOT go through `fetch`, so
+    // no AbortSignal.timeout() reaches it. It talks through googleapis, whose
+    // transport (gaxios) documents `timeout` as "No timeout by default" — so
+    // without an explicit value every Gmail call is exactly the unbounded I/O
+    // the timeouts elsewhere in this plugin exist to close.
+    it("bounds every Gmail API call by configuring a client-level timeout", async () => {
+      const { google } = await import("googleapis");
+
+      new GmailAdapter({ accessToken: "test-token" });
+
+      expect(google.gmail).toHaveBeenCalledWith(
+        expect.objectContaining({ version: "v1", timeout: 30_000 })
+      );
+    });
+
+    it("gives the attachment download a longer bound than an ordinary call", async () => {
+      // attachments.get carries the whole file as base64 inside the JSON body
+      // (up to the 25 MB the tools layer accepts, ~33 MB on the wire). The
+      // bound that is generous for a metadata call is tight for that, so the
+      // download overrides it — a working-but-slow link must not be aborted.
+      mockGet.mockResolvedValue({
+        data: {
+          id: "msg-dl",
+          payload: {
+            mimeType: "multipart/mixed",
+            headers: [],
+            parts: [
+              {
+                filename: "invoice.pdf",
+                mimeType: "application/pdf",
+                body: { attachmentId: "att-dl", size: 5 },
+              },
+            ],
+          },
+        },
+      });
+      mockAttachmentsGet.mockResolvedValue({
+        data: { size: 5, data: Buffer.from("%PDF-").toString("base64url") },
+      });
+
+      await adapter.getAttachment("msg-dl", "att-dl");
+
+      const [, options] = mockAttachmentsGet.mock.calls[0];
+      expect(options.timeout).toBe(120_000);
+      expect(options.timeout).toBeGreaterThan(30_000);
     });
   });
 });

--- a/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
@@ -880,3 +880,50 @@ describe("GraphAdapter.send", () => {
     expect(result.messageId).toBe("reply42");
   });
 });
+
+describe("GraphAdapter request bounds", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("gives the attachment download a longer bound than an ordinary call", async () => {
+    // An AbortSignal covers the body read, not just the response headers, and
+    // getAttachment pulls the whole file as base64 inside the JSON body (up to
+    // the 25 MB the tools layer accepts, ~33 MB on the wire). The bound that is
+    // generous for a metadata call would abort a working-but-slow download, so
+    // this path must ask for its own.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        name: "invoice.pdf",
+        contentType: "application/pdf",
+        contentBytes: Buffer.from("%PDF-").toString("base64"),
+      }),
+    });
+
+    await adapter.getAttachment("msg-1", "att-1");
+
+    expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+    expect(timeoutSpy).not.toHaveBeenCalledWith(30_000);
+  });
+
+  it("still bounds an ordinary call at the default", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [] }),
+    });
+
+    await adapter.list({ folder: "INBOX" });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+  });
+});

--- a/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
@@ -73,6 +73,35 @@ describe("GraphAdapter.list", () => {
     await expect(adapter.list({ folder: "CUSTOM" as never })).rejects.toThrow(/unknown folder/i);
   });
 
+  it("aborts a hung Graph request via AbortSignal.timeout(30_000) instead of blocking forever", async () => {
+    // Simulates a Graph endpoint that never answers and never resets the
+    // connection (network blackhole) — the mock only ever settles via the
+    // AbortSignal req() passes to fetch, exactly like a real hung `fetch`
+    // would once the signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    (fetch as Mock).mockImplementation((_url: string | URL, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    await expect(adapter.list({})).rejects.toThrow();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    timeoutSpy.mockRestore();
+  });
+
   it("uses GRAPH_API_BASE_URL when set", async () => {
     process.env.GRAPH_API_BASE_URL = "http://graph-mock:9005";
     const adapter = new GraphAdapter({ accessToken: "tok" });

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -395,7 +395,10 @@ describe("credential fetching", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
       `http://pinchy:7777/api/internal/integrations/conn-1/credentials?agentId=${agentId}`,
-      { headers: { Authorization: "Bearer test-gateway-token" } }
+      {
+        headers: { Authorization: "Bearer test-gateway-token" },
+        signal: expect.any(AbortSignal),
+      }
     );
   });
 
@@ -432,6 +435,37 @@ describe("credential fetching", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("aborts a hung credentials fetch via AbortSignal.timeout(10_000) instead of blocking the tool call forever", async () => {
+    // Simulates a Pinchy container that never answers Pinchy's own internal
+    // credentials route (mid-deploy, network blackhole) — the mock only ever
+    // settles via the AbortSignal fetchCredentials passes in, exactly like a
+    // real hung `fetch` would once the signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    mockFetch.mockImplementation((_url: string | URL, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+    const result = await tool.execute("call-1", {});
+
+    expect(result.isError).toBe(true);
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    timeoutSpy.mockRestore();
   });
 
   it("creates GmailAdapter with fetched access token", async () => {

--- a/packages/plugins/pinchy-email/gmail-adapter.ts
+++ b/packages/plugins/pinchy-email/gmail-adapter.ts
@@ -57,6 +57,22 @@ function buildGmailQuery(opts: SearchOptions): string {
   return parts.join(" ");
 }
 
+// Gmail is the one mailbox provider that never touches `fetch`, so none of the
+// AbortSignal.timeout() bounds elsewhere in this plugin reach it. It talks
+// through googleapis, and that transport (gaxios) documents its `timeout`
+// option as "No timeout by default" — so an unset value is not a sane default,
+// it is the unbounded-I/O hole: a hung Gmail endpoint (or a network blackhole
+// that never sends an RST) would block the tool call forever. Set on the
+// client so all seven call sites inherit it and none can be forgotten.
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// The attachment download carries the whole file as base64 inside the JSON
+// body — up to the 25 MB the tools layer accepts, ~33 MB on the wire. The
+// bound that is generous for a metadata call is tight for that, so this path
+// gets its own; a working-but-slow link must not be aborted mid-download.
+// Per-method options win over the client-level ones in googleapis-common.
+const ATTACHMENT_TIMEOUT_MS = 120_000;
+
 export class GmailAdapter implements EmailAdapter {
   private gmail: ReturnType<typeof google.gmail>;
 
@@ -69,6 +85,7 @@ export class GmailAdapter implements EmailAdapter {
     this.gmail = google.gmail({
       version: "v1",
       auth,
+      timeout: REQUEST_TIMEOUT_MS,
       ...(rootUrl ? { rootUrl } : {}),
     });
   }
@@ -133,11 +150,14 @@ export class GmailAdapter implements EmailAdapter {
       );
     }
 
-    const response = await this.gmail.users.messages.attachments.get({
-      userId: "me",
-      messageId,
-      id: attachmentId,
-    });
+    const response = await this.gmail.users.messages.attachments.get(
+      {
+        userId: "me",
+        messageId,
+        id: attachmentId,
+      },
+      { timeout: ATTACHMENT_TIMEOUT_MS }
+    );
     const encoded = response.data.data ?? "";
     // Gmail returns base64url (URL-safe alphabet); decode explicitly with that
     // alphabet rather than Node's lenient "base64" decoder.

--- a/packages/plugins/pinchy-email/graph-adapter.ts
+++ b/packages/plugins/pinchy-email/graph-adapter.ts
@@ -77,6 +77,10 @@ interface GraphAttachment {
 
 const FILE_ATTACHMENT_TYPE = "#microsoft.graph.fileAttachment";
 
+// External API call — bounds a hung Microsoft Graph endpoint / network
+// blackhole.
+const FETCH_TIMEOUT_MS = 30_000;
+
 // Microsoft Graph v1.0 message-listing endpoints require every property named
 // in $orderby to also appear in $filter, in the same order, ahead of any other
 // filter properties — violating this returns HTTP 400 InefficientFilter ("The
@@ -122,6 +126,7 @@ export class GraphAdapter implements EmailAdapter {
         "Content-Type": "application/json",
         ...(init?.headers ?? {}),
       },
+      signal: init?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
       const txt = await res.text().catch(() => "");

--- a/packages/plugins/pinchy-email/graph-adapter.ts
+++ b/packages/plugins/pinchy-email/graph-adapter.ts
@@ -81,6 +81,13 @@ const FILE_ATTACHMENT_TYPE = "#microsoft.graph.fileAttachment";
 // blackhole.
 const FETCH_TIMEOUT_MS = 30_000;
 
+// The attachment download carries the whole file as base64 inside the JSON
+// body — up to the 25 MB the tools layer accepts, ~33 MB on the wire. An
+// AbortSignal covers the body read too, not just the response headers, so the
+// bound that is generous for a metadata call would abort a working-but-slow
+// download well before it finishes. Give that one path its own.
+const ATTACHMENT_TIMEOUT_MS = 120_000;
+
 // Microsoft Graph v1.0 message-listing endpoints require every property named
 // in $orderby to also appear in $filter, in the same order, ahead of any other
 // filter properties — violating this returns HTTP 400 InefficientFilter ("The
@@ -118,15 +125,24 @@ export class GraphAdapter implements EmailAdapter {
     return process.env.GRAPH_API_BASE_URL ?? "https://graph.microsoft.com";
   }
 
-  private async req(path: string, init?: RequestInit): Promise<Response> {
+  // `signal` is deliberately not accepted. The earlier shape took one and did
+  // `init.signal ?? AbortSignal.timeout(...)`, which reads like a harmless
+  // escape hatch and is a trap: the first caller to pass a cancellation signal
+  // would silently lose the timeout, with no test able to see it. A caller
+  // that needs a different bound asks for one by name instead.
+  private async req(
+    path: string,
+    init?: Omit<RequestInit, "signal"> & { timeoutMs?: number }
+  ): Promise<Response> {
+    const { timeoutMs = FETCH_TIMEOUT_MS, ...rest } = init ?? {};
     const res = await fetch(`${this.graphBase()}/v1.0${path}`, {
-      ...init,
+      ...rest,
       headers: {
         Authorization: `Bearer ${this.opts.accessToken}`,
         "Content-Type": "application/json",
         ...(init?.headers ?? {}),
       },
-      signal: init?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     if (!res.ok) {
       const txt = await res.text().catch(() => "");
@@ -198,7 +214,8 @@ export class GraphAdapter implements EmailAdapter {
     attachmentId: string
   ): Promise<{ filename: string; mimeType: string; data: Buffer }> {
     const res = await this.req(
-      `/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`
+      `/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`,
+      { timeoutMs: ATTACHMENT_TIMEOUT_MS }
     );
     const a = (await res.json()) as GraphAttachment;
     if (a.contentBytes == null) {

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -29,6 +29,12 @@ const DELIVERY_GID = 999;
 // so anything saved here is always small enough to hand off downstream.
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
+// Bounds every call to Pinchy's own internal API against a hung container /
+// network blackhole. The mailbox provider calls (Gmail/Graph/IMAP)
+// bound themselves separately (see graph-adapter.ts, gmail-adapter.ts,
+// imap-adapter.ts).
+const FETCH_TIMEOUT_MS = 10_000;
+
 const EXT_BY_MIME = new Map<string, string>([
   ["application/pdf", ".pdf"],
   ["image/jpeg", ".jpg"],
@@ -237,6 +243,7 @@ async function reportAuthFailure(
         "X-Plugin-Id": "pinchy-email",
       },
       body: JSON.stringify({ reason: reason.slice(0, 500) }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch {
     // best-effort — never mask the original tool error
@@ -636,7 +643,10 @@ async function fetchCredentials(
   const response = await fetch(
     `${apiBaseUrl}/api/internal/integrations/${connectionId}/credentials` +
       `?agentId=${encodeURIComponent(agentId)}`,
-    { headers: { Authorization: `Bearer ${gatewayToken}` } }
+    {
+      headers: { Authorization: `Bearer ${gatewayToken}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    }
   );
 
   if (!response.ok) {

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -30,9 +30,11 @@ const DELIVERY_GID = 999;
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
 // Bounds every call to Pinchy's own internal API against a hung container /
-// network blackhole. The mailbox provider calls (Gmail/Graph/IMAP)
-// bound themselves separately (see graph-adapter.ts, gmail-adapter.ts,
-// imap-adapter.ts).
+// network blackhole. The mailbox providers reach three different transports
+// and each bounds itself where that transport allows it: Graph via
+// AbortSignal.timeout on fetch (graph-adapter.ts), Gmail via googleapis'
+// `timeout` option — gaxios has none by default (gmail-adapter.ts), IMAP via
+// connectionTimeout/socketTimeout (imap-adapter.ts).
 const FETCH_TIMEOUT_MS = 10_000;
 
 const EXT_BY_MIME = new Map<string, string>([

--- a/packages/plugins/pinchy-files/pdf-vision-api.test.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-api.test.ts
@@ -144,7 +144,89 @@ describe("describePageImage", () => {
     setTimeoutSpy.mockRestore();
   });
 
-  it("aborts a hung vision API call via AbortSignal.timeout(30_000) instead of blocking forever", async () => {
+  it("clamps a negative Retry-After to zero instead of passing it through", async () => {
+    // `Math.min(x, 30)` alone lets a negative header past — -3600 is finite, so
+    // the "clamp" hands setTimeout -3_600_000. Harmless in effect today (the
+    // timer floors at 0), but then the constant does not bound what it claims
+    // to bound, and the next reader has to rediscover that.
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: new Headers({ "retry-after": "-3600" }),
+        text: async () => "Rate limited",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          content: [{ type: "text", text: "Extracted after retry" }],
+        }),
+      });
+    globalThis.fetch = mockFetch;
+
+    const waits: number[] = [];
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((cb: (...args: unknown[]) => void, ms?: number) => {
+        waits.push(ms ?? 0);
+        cb();
+        return 0 as unknown as NodeJS.Timeout;
+      });
+
+    const result = await describePageImage("base64data", {
+      model: "anthropic/claude-haiku-4-5-20251001",
+      resolveApiKey: async () => "test-key",
+    });
+
+    expect(result?.text).toBe("Extracted after retry");
+    expect(waits).toEqual([0]);
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("gives a local Ollama vision call a longer bound than a hosted one", async () => {
+    // Ollama is the offline/self-hosted path: a cold start pays the model load
+    // before decoding starts, and CPU-only inference on a full page runs into
+    // minutes. Sharing the hosted bound here would abort exactly the
+    // deployments the offline-first promise covers.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "Local text" } }] }),
+    });
+
+    const result = await describePageImage("base64data", {
+      model: "ollama/llama3.2-vision",
+      resolveApiKey: async () => "unused",
+      ollamaBaseUrl: "http://ollama:11434",
+    });
+
+    expect(result?.text).toBe("Local text");
+    expect(timeoutSpy).toHaveBeenCalledWith(300_000);
+    timeoutSpy.mockRestore();
+  });
+
+  it("bounds a hosted vision call well above a dense page's real decode time", async () => {
+    // The bound exists to make a blackhole terminate, not to enforce a latency
+    // budget. 4096 max_tokens of extracted text at typical decode rates is tens
+    // of seconds, so a bound anywhere near that turns working page reads into
+    // failures indistinguishable from a broken PDF.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [{ type: "text", text: "Extracted" }] }),
+    });
+
+    await describePageImage("base64data", {
+      model: "anthropic/claude-haiku-4-5-20251001",
+      resolveApiKey: async () => "test-key",
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+    timeoutSpy.mockRestore();
+  });
+
+  it("aborts a hung vision API call via AbortSignal.timeout instead of blocking forever", async () => {
     // Simulates a vision provider that never answers and never resets the
     // connection (network blackhole) — the mock only ever settles via the
     // AbortSignal fetchWithRetry passes in, exactly like a real hung `fetch`
@@ -173,7 +255,7 @@ describe("describePageImage", () => {
       })
     ).rejects.toThrow();
 
-    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    expect(timeoutSpy).toHaveBeenCalledWith(120_000);
     timeoutSpy.mockRestore();
   });
 

--- a/packages/plugins/pinchy-files/pdf-vision-api.test.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-api.test.ts
@@ -105,6 +105,78 @@ describe("describePageImage", () => {
     expect((globalThis.fetch as any).mock.calls.length).toBeLessThanOrEqual(4);
   });
 
+  it("clamps an oversized Retry-After header to 30s instead of sleeping for a day", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        // A malicious/misbehaving provider sending a 24h Retry-After.
+        headers: new Headers({ "retry-after": "86400" }),
+        text: async () => "Rate limited",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          content: [{ type: "text", text: "Extracted after retry" }],
+        }),
+      });
+    globalThis.fetch = mockFetch;
+
+    const waits: number[] = [];
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((cb: (...args: unknown[]) => void, ms?: number) => {
+        waits.push(ms ?? 0);
+        cb();
+        return 0 as unknown as NodeJS.Timeout;
+      });
+
+    const result = await describePageImage("base64data", {
+      model: "anthropic/claude-haiku-4-5-20251001",
+      resolveApiKey: async () => "test-key",
+    });
+
+    expect(result?.text).toBe("Extracted after retry");
+    // The 86400s (24h) header must be clamped to 30s (30_000ms), not honored
+    // verbatim — which would put this PDF read to sleep for a day.
+    expect(waits).toEqual([30_000]);
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("aborts a hung vision API call via AbortSignal.timeout(30_000) instead of blocking forever", async () => {
+    // Simulates a vision provider that never answers and never resets the
+    // connection (network blackhole) — the mock only ever settles via the
+    // AbortSignal fetchWithRetry passes in, exactly like a real hung `fetch`
+    // would once the signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    globalThis.fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+
+    await expect(
+      describePageImage("base64data", {
+        model: "anthropic/claude-haiku-4-5-20251001",
+        resolveApiKey: async () => "test-key",
+      })
+    ).rejects.toThrow();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    timeoutSpy.mockRestore();
+  });
+
   it("calls OpenAI API with image_url format", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/plugins/pinchy-files/pdf-vision-api.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-api.ts
@@ -9,29 +9,57 @@ const PROMPT =
 
 const MAX_RETRIES = 3;
 
-// External LLM vision API call — bounds a hung provider endpoint / network
-// blackhole.
-const FETCH_TIMEOUT_MS = 30_000;
+// Bounds a hung provider endpoint / network blackhole. The point of these is
+// to make a blackhole terminate, NOT to enforce a latency budget — so they sit
+// well above the legitimate worst case, because the cost of being wrong is
+// asymmetric: too long merely delays an error, too short turns working page
+// reads into failures nobody can distinguish from a broken PDF.
+//
+// A hosted vision call on a dense scanned page routinely runs tens of seconds
+// (4096 max_tokens of extracted text at typical decode rates), so a 30s bound
+// would abort real work.
+const CLOUD_VISION_TIMEOUT_MS = 120_000;
+
+// Ollama is the offline/self-hosted path and it is the slow one by design: the
+// first request after a cold start pays the model load before any decoding
+// begins, and CPU-only inference on a full page is minutes, not seconds.
+// Sharing the hosted bound here would break exactly the deployments Pinchy
+// promises to support.
+const LOCAL_VISION_TIMEOUT_MS = 300_000;
 
 // A malicious or misbehaving provider can send an arbitrarily large
 // Retry-After (e.g. 86400 = 24h), which would otherwise put this PDF read to
-// sleep for a day. Clamp to a sane upper bound instead of trusting the header
-// verbatim.
+// sleep for a day. Clamp to a sane range instead of trusting the header
+// verbatim — at BOTH ends: a negative value is finite too, and `Math.min`
+// alone passes it straight through.
 const MAX_RETRY_AFTER_SECONDS = 30;
 
-/** Fetch with automatic retry on 429 (rate limit). Respects Retry-After header. */
-async function fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
+/**
+ * Fetch with automatic retry on 429 (rate limit). Respects Retry-After header.
+ *
+ * `signal` is deliberately not accepted in `init`: the earlier shape did
+ * `init.signal ?? AbortSignal.timeout(...)`, so the first caller to pass a
+ * cancellation signal would have silently lost the timeout. A caller that
+ * needs a different bound passes `timeoutMs`.
+ */
+async function fetchWithRetry(
+  url: string,
+  init: Omit<RequestInit, "signal">,
+  timeoutMs: number = CLOUD_VISION_TIMEOUT_MS
+): Promise<Response> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    // Inside the loop on purpose: every attempt gets its own fresh bound,
+    // rather than all attempts sharing one deadline that the first one spent.
     const response = await fetch(url, {
       ...init,
-      signal: init.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
     if (response.status !== 429 || attempt === MAX_RETRIES) {
       return response;
     }
     const retryAfter = Number(response.headers.get("retry-after") || "1");
     const clampedSeconds = Math.min(
-      Number.isFinite(retryAfter) ? retryAfter : 1,
+      Math.max(Number.isFinite(retryAfter) ? retryAfter : 1, 0),
       MAX_RETRY_AFTER_SECONDS
     );
     const waitMs = clampedSeconds * 1000;
@@ -310,25 +338,29 @@ async function describeViaOllama(
 
   const url = `${config.ollamaBaseUrl.replace(/\/$/, "")}/v1/chat/completions`;
 
-  const response = await fetchWithRetry(url, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      model: modelId,
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "image_url",
-              image_url: { url: `data:image/png;base64,${imageBase64}` },
-            },
-            { type: "text", text: PROMPT },
-          ],
-        },
-      ],
-    }),
-  });
+  const response = await fetchWithRetry(
+    url,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image_url",
+                image_url: { url: `data:image/png;base64,${imageBase64}` },
+              },
+              { type: "text", text: PROMPT },
+            ],
+          },
+        ],
+      }),
+    },
+    LOCAL_VISION_TIMEOUT_MS
+  );
 
   if (!response.ok) {
     const error = await response.text().catch(() => "unknown error");

--- a/packages/plugins/pinchy-files/pdf-vision-api.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-api.ts
@@ -9,15 +9,32 @@ const PROMPT =
 
 const MAX_RETRIES = 3;
 
+// External LLM vision API call — bounds a hung provider endpoint / network
+// blackhole.
+const FETCH_TIMEOUT_MS = 30_000;
+
+// A malicious or misbehaving provider can send an arbitrarily large
+// Retry-After (e.g. 86400 = 24h), which would otherwise put this PDF read to
+// sleep for a day. Clamp to a sane upper bound instead of trusting the header
+// verbatim.
+const MAX_RETRY_AFTER_SECONDS = 30;
+
 /** Fetch with automatic retry on 429 (rate limit). Respects Retry-After header. */
 async function fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const response = await fetch(url, init);
+    const response = await fetch(url, {
+      ...init,
+      signal: init.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
     if (response.status !== 429 || attempt === MAX_RETRIES) {
       return response;
     }
     const retryAfter = Number(response.headers.get("retry-after") || "1");
-    const waitMs = (Number.isFinite(retryAfter) ? retryAfter : 1) * 1000;
+    const clampedSeconds = Math.min(
+      Number.isFinite(retryAfter) ? retryAfter : 1,
+      MAX_RETRY_AFTER_SECONDS
+    );
+    const waitMs = clampedSeconds * 1000;
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
   // unreachable, but TypeScript needs it

--- a/packages/plugins/pinchy-files/usage-reporter.test.ts
+++ b/packages/plugins/pinchy-files/usage-reporter.test.ts
@@ -128,6 +128,49 @@ describe("reportUsage", () => {
     errorSpy.mockRestore();
   });
 
+  it("aborts a hung usage report POST via AbortSignal.timeout(10_000) instead of blocking forever", async () => {
+    // Simulates a Pinchy container that never answers (mid-deploy, network
+    // blackhole) — the mock only ever settles via the AbortSignal reportUsage
+    // passes to fetch, exactly like a real hung `fetch` would once the
+    // signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    const fetchSpy = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+    globalThis.fetch = fetchSpy;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      reportUsage(
+        {
+          agentId: "kb-agent",
+          agentName: "KB Agent",
+          sessionKey: "plugin:pinchy-files",
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+        { apiBaseUrl: "http://pinchy:7777", gatewayToken: "gw-token" }
+      )
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    errorSpy.mockRestore();
+    timeoutSpy.mockRestore();
+  });
+
   it("swallows fetch errors so PDF reads never fail on telemetry hiccups", async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/plugins/pinchy-files/usage-reporter.ts
+++ b/packages/plugins/pinchy-files/usage-reporter.ts
@@ -24,6 +24,10 @@ export interface UsageReportConfig {
   gatewayToken: string;
 }
 
+// Bounds the call to Pinchy's own internal API against a hung container /
+// network blackhole.
+const FETCH_TIMEOUT_MS = 10_000;
+
 export async function reportUsage(report: UsageReport, config: UsageReportConfig): Promise<void> {
   if (report.inputTokens === 0 && report.outputTokens === 0) return;
 
@@ -45,6 +49,7 @@ export async function reportUsage(report: UsageReport, config: UsageReportConfig
         inputTokens: report.inputTokens,
         outputTokens: report.outputTokens,
       }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/packages/plugins/pinchy-knowledge/index.test.ts
+++ b/packages/plugins/pinchy-knowledge/index.test.ts
@@ -289,6 +289,40 @@ describe("pinchy-knowledge plugin", () => {
     expect(result.content[0].text).toContain("Network down");
   });
 
+  it("aborts a hung knowledge search POST via AbortSignal.timeout(10_000) instead of blocking forever", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    const factory = mockRegisterTool.mock.calls[0][0];
+    const tool = factory({ agentId: "agent-1" });
+
+    // Simulates a Pinchy container that never answers (mid-deploy, network
+    // blackhole) — the mock only ever settles via the AbortSignal the tool
+    // passes to fetch, exactly like a real hung `fetch` would once the
+    // signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    global.fetch = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+
+    const result = await tool.execute("call-1", { query: "test" });
+    expect(result.isError).toBe(true);
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    timeoutSpy.mockRestore();
+  });
+
   it("rejects an empty/whitespace query without calling fetch", async () => {
     const api = createMockApi(defaultConfig);
     const { default: plugin } = await import("./index");

--- a/packages/plugins/pinchy-knowledge/index.ts
+++ b/packages/plugins/pinchy-knowledge/index.ts
@@ -11,6 +11,10 @@
 
 import { formatLocator, type ChunkLocator } from "./locator";
 
+// Bounds the call to Pinchy's own internal API against a hung container /
+// network blackhole.
+const FETCH_TIMEOUT_MS = 10_000;
+
 interface PluginToolContext {
   agentId?: string;
 }
@@ -268,6 +272,7 @@ const plugin = {
                   agentId,
                   ...(includeArchived ? { includeArchived: true } : {}),
                 }),
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
               });
 
               if (!res.ok) {

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -3359,6 +3359,38 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
     );
     expect(reportCalls).toHaveLength(0);
   });
+
+  it("aborts a hung credentials fetch via AbortSignal.timeout(10_000) instead of blocking the tool call forever", async () => {
+    // Simulates a Pinchy container that never answers Pinchy's own internal
+    // credentials route (mid-deploy, network blackhole) — the mock only ever
+    // settles via the AbortSignal fetchCredentials passes in, exactly like a
+    // real hung `fetch` would once the signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    fetchMock.mockImplementation((_url: string | URL, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    expect(result.isError).toBe(true);
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    timeoutSpy.mockRestore();
+  });
 });
 
 describe("odoo_attach_file", () => {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -14,8 +14,7 @@ const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
 
 // Bounds every call to Pinchy's own internal API against a hung container /
 // network blackhole. These are Pinchy-internal, same-Docker-network calls
-// (credentials fetch, auth-failure report), never the Odoo call itself
-//.
+// (credentials fetch, auth-failure report), never the Odoo call itself.
 const FETCH_TIMEOUT_MS = 10_000;
 
 // 25 MB matches Odoo's default `web.max_file_upload_size` setting. Keeps the

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -12,6 +12,12 @@ import {
 
 const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
 
+// Bounds every call to Pinchy's own internal API against a hung container /
+// network blackhole. These are Pinchy-internal, same-Docker-network calls
+// (credentials fetch, auth-failure report), never the Odoo call itself
+//.
+const FETCH_TIMEOUT_MS = 10_000;
+
 // 25 MB matches Odoo's default `web.max_file_upload_size` setting. Keeps the
 // plugin process from OOMing on a single attachment (readFile + base64 string
 // roughly triple the file's footprint in memory).
@@ -199,7 +205,10 @@ async function fetchCredentials(
   const response = await fetch(
     `${apiBaseUrl}/api/internal/integrations/${connectionId}/credentials` +
       `?agentId=${encodeURIComponent(agentId)}`,
-    { headers: { Authorization: `Bearer ${gatewayToken}` } }
+    {
+      headers: { Authorization: `Bearer ${gatewayToken}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    }
   );
   if (!response.ok) {
     // The credentials route puts an actionable message in the JSON body (e.g. a
@@ -2144,6 +2153,7 @@ async function reportAuthFailure(
         "X-Plugin-Id": "pinchy-odoo",
       },
       body: JSON.stringify({ reason: reason.slice(0, 500) }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch {
     // best-effort — never mask the original tool error

--- a/packages/plugins/pinchy-transcript/index.test.ts
+++ b/packages/plugins/pinchy-transcript/index.test.ts
@@ -514,6 +514,37 @@ describe("postChannelMessage", () => {
     await expect(postChannelMessage(cfg, undefined, payload)).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(3); // 1 + MAX_RETRIES(2)
   });
+
+  it("aborts a hung capture POST via AbortSignal.timeout(10_000) instead of blocking message capture forever", async () => {
+    // Simulates a Pinchy container that never answers and never resets the
+    // connection (mid-deploy, network blackhole) — the mock fetch only ever
+    // settles via the AbortSignal the plugin passes in, exactly like a real
+    // hung `fetch` would once the signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+
+    const fetchMock = vi.fn((_url: string | URL, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(postChannelMessage(cfg, undefined, payload)).rejects.toThrow();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 + MAX_RETRIES(2)
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    timeoutSpy.mockRestore();
+  });
 });
 
 describe("plugin.register", () => {

--- a/packages/plugins/pinchy-transcript/index.ts
+++ b/packages/plugins/pinchy-transcript/index.ts
@@ -396,6 +396,11 @@ function surrogateId(direction: string, content: string, sentAt: number): string
 
 const MAX_RETRIES = 2;
 
+// Bounds every capture POST against a hung Pinchy container / network
+// blackhole so a stuck deploy can't stall channel-message capture forever
+//.
+const FETCH_TIMEOUT_MS = 10_000;
+
 // Keep the log line readable: the useful part of a Pinchy error body is the
 // `error` string, and anything longer than this is a stack trace or an HTML
 // error page, neither of which belongs in a one-line warning.
@@ -445,6 +450,7 @@ async function postChannelMessage(
           Authorization: `Bearer ${cfg.gatewayToken}`,
         },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
       // 2xx = stored (or idempotently skipped). 4xx = our bug; don't retry a
       // request the server will keep rejecting. 5xx = transient; retry.

--- a/packages/plugins/pinchy-transcript/index.ts
+++ b/packages/plugins/pinchy-transcript/index.ts
@@ -397,8 +397,7 @@ function surrogateId(direction: string, content: string, sentAt: number): string
 const MAX_RETRIES = 2;
 
 // Bounds every capture POST against a hung Pinchy container / network
-// blackhole so a stuck deploy can't stall channel-message capture forever
-//.
+// blackhole so a stuck deploy can't stall channel-message capture forever.
 const FETCH_TIMEOUT_MS = 10_000;
 
 // Keep the log line readable: the useful part of a Pinchy error body is the

--- a/packages/plugins/pinchy-web/brave-search.test.ts
+++ b/packages/plugins/pinchy-web/brave-search.test.ts
@@ -177,4 +177,32 @@ describe("braveSearch", () => {
     await expect(braveSearch("query", { apiKey: "" })).rejects.toThrow(/API key/i);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("aborts a hung Brave request via AbortSignal.timeout(30_000) instead of blocking forever", async () => {
+    // Simulates a Brave endpoint that never answers and never resets the
+    // connection (network blackhole) — the mock only ever settles via the
+    // AbortSignal braveSearch passes to fetch, exactly like a real hung
+    // `fetch` would once the signal fires.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+      const controller = new AbortController();
+      setTimeout(
+        () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+        1
+      );
+      return controller.signal;
+    });
+    fetchMock.mockImplementation((_url: string | URL, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(signal.reason ?? new Error("The operation was aborted"));
+        });
+      });
+    });
+
+    await expect(braveSearch("query", { apiKey: "key" })).rejects.toThrow();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    timeoutSpy.mockRestore();
+  });
 });

--- a/packages/plugins/pinchy-web/brave-search.ts
+++ b/packages/plugins/pinchy-web/brave-search.ts
@@ -60,6 +60,9 @@ export async function braveSearch(
       "X-Subscription-Token": config.apiKey,
       Accept: "application/json",
     },
+    // External API call — bounds a hung Brave endpoint / network blackhole
+    //. Matches web-fetch.ts's external-call timeout.
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!res.ok) {

--- a/packages/plugins/pinchy-web/brave-search.ts
+++ b/packages/plugins/pinchy-web/brave-search.ts
@@ -1,3 +1,7 @@
+// External API call — bounds a hung Brave endpoint / network blackhole.
+// Matches web-fetch.ts's external-call timeout.
+const FETCH_TIMEOUT_MS = 30_000;
+
 export interface BraveSearchConfig {
   apiKey: string;
   allowedDomains?: string[];
@@ -60,9 +64,7 @@ export async function braveSearch(
       "X-Subscription-Token": config.apiKey,
       Accept: "application/json",
     },
-    // External API call — bounds a hung Brave endpoint / network blackhole
-    //. Matches web-fetch.ts's external-call timeout.
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   if (!res.ok) {

--- a/packages/plugins/pinchy-web/index.test.ts
+++ b/packages/plugins/pinchy-web/index.test.ts
@@ -334,6 +334,43 @@ describe("pinchy-web plugin", () => {
       expect(result.content[0].text).toMatch(/no longer connected/i);
     });
 
+    it("aborts a hung credentials fetch via AbortSignal.timeout(10_000) instead of blocking forever", async () => {
+      // Simulates a Pinchy container that never answers Pinchy's own internal
+      // credentials route (mid-deploy, network blackhole) — the mock only
+      // ever settles via the AbortSignal fetchBraveCredentials passes in,
+      // exactly like a real hung `fetch` would once the signal fires.
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((_ms: number) => {
+        const controller = new AbortController();
+        setTimeout(
+          () => controller.abort(new DOMException("The operation timed out.", "TimeoutError")),
+          1
+        );
+        return controller.signal;
+      });
+      const fetchMock = vi.fn((_url: string | URL, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener("abort", () => {
+            reject(signal.reason ?? new Error("The operation was aborted"));
+          });
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"] },
+        })
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      const result = await tool.execute("call-1", { query: "test" });
+
+      expect(result.isError).toBe(true);
+      expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+      timeoutSpy.mockRestore();
+    });
+
     it("POSTs report-auth-failure when retry-once also returns a 401 from Brave", async () => {
       braveSearchMock
         .mockRejectedValueOnce(new Error("401 Unauthorized"))

--- a/packages/plugins/pinchy-web/index.ts
+++ b/packages/plugins/pinchy-web/index.ts
@@ -1,6 +1,11 @@
 import { braveSearch, type BraveSearchConfig } from "./brave-search.js";
 import { webFetch, type WebFetchConfig } from "./web-fetch.js";
 
+// Bounds every call to Pinchy's own internal API against a hung container /
+// network blackhole. webFetch/braveSearch each bound their OWN
+// external calls separately (see web-fetch.ts and brave-search.ts).
+const FETCH_TIMEOUT_MS = 10_000;
+
 interface PluginToolContext {
   agentId?: string;
 }
@@ -79,7 +84,10 @@ async function fetchBraveCredentials(
   const response = await fetch(
     `${apiBaseUrl}/api/internal/integrations/${connectionId}/credentials` +
       `?agentId=${encodeURIComponent(agentId)}`,
-    { headers: { Authorization: `Bearer ${gatewayToken}` } }
+    {
+      headers: { Authorization: `Bearer ${gatewayToken}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    }
   );
   if (!response.ok) {
     // The credentials route puts an actionable message in the JSON body (e.g. a
@@ -126,6 +134,7 @@ async function reportAuthFailure(
         "X-Plugin-Id": "pinchy-web",
       },
       body: JSON.stringify({ reason: reason.slice(0, 500) }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch {
     // best-effort — never mask the original tool error

--- a/packages/web/src/__tests__/lib/plugin-fetch-extraction.ts
+++ b/packages/web/src/__tests__/lib/plugin-fetch-extraction.ts
@@ -1,0 +1,183 @@
+// packages/web/src/__tests__/lib/plugin-fetch-extraction.ts
+//
+// Shared test helper for plugin-fetch-timeout-coverage.test.ts. Finds every
+// `fetch()` call in the plugin sources and reports whether the call passes a
+// `signal`.
+//
+// This file is not a *.test.ts and therefore is not executed by Vitest; it is
+// only imported from the guard above.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import ts from "typescript";
+import { PLUGINS_DIR, REPO_ROOT } from "./plugin-tool-extraction";
+
+export type FetchCallSite = {
+  /** Repo-relative path, e.g. "packages/plugins/pinchy-audit/index.ts". */
+  file: string;
+  line: number;
+  /** The identifier the call was made through ("fetch", "httpFetch", …). */
+  callee: string;
+  /** True when the call's init object carries a `signal` property. */
+  bounded: boolean;
+};
+
+/**
+ * Every `.ts` file that ships as plugin production code — tests excluded, since
+ * a mocked `fetch` in a test needs no timeout.
+ */
+export function findPluginSourceFiles(root: string = PLUGINS_DIR): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === "node_modules" || entry === "dist" || entry === "__tests__") continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!entry.endsWith(".ts") || entry.endsWith(".test.ts") || entry.endsWith(".d.ts")) continue;
+      out.push(full);
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+/** Strip `as X` / parentheses so the node underneath can be inspected. */
+function unwrap(node: ts.Expression): ts.Expression {
+  let current = node;
+  while (
+    ts.isAsExpression(current) ||
+    ts.isParenthesizedExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/**
+ * Names in this file that refer to the global `fetch`.
+ *
+ * Two indirections are real in this tree and both must be followed, or the
+ * scan silently reports zero call sites for the file that has the most
+ * interesting one: pinchy-web/web-fetch.ts does
+ * `import { fetch as undiciFetch } from "undici"` and then
+ * `export const httpFetch = undiciFetch as ...`. Resolution runs to a fixpoint
+ * rather than in source order, so a later alias of an earlier one is caught
+ * regardless of how the file is arranged.
+ */
+function collectFetchAliases(source: ts.SourceFile): Set<string> {
+  const aliases = new Set<string>(["fetch"]);
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    const add = (name: string) => {
+      if (!aliases.has(name)) {
+        aliases.add(name);
+        changed = true;
+      }
+    };
+
+    const visit = (node: ts.Node): void => {
+      // import { fetch as undiciFetch } from "undici"
+      if (ts.isImportDeclaration(node) && node.importClause?.namedBindings) {
+        const bindings = node.importClause.namedBindings;
+        if (ts.isNamedImports(bindings)) {
+          for (const spec of bindings.elements) {
+            if (spec.propertyName?.text === "fetch") add(spec.name.text);
+          }
+        }
+      }
+      // const httpFetch = undiciFetch as (...) => Promise<Response>
+      if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
+        const init = unwrap(node.initializer);
+        if (ts.isIdentifier(init) && aliases.has(init.text)) add(node.name.text);
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(source);
+  }
+
+  return aliases;
+}
+
+/**
+ * The callee name when this call goes through the global fetch, else null.
+ *
+ * A bare `x.fetch(...)` is NOT the global fetch — `imap-adapter.ts` calls
+ * `client.fetch(...)` on an ImapFlow connection, and counting that would make
+ * the guard demand an AbortSignal from an API that takes none. Only an
+ * explicit global receiver qualifies.
+ */
+function fetchCalleeName(call: ts.CallExpression, aliases: Set<string>): string | null {
+  const callee = unwrap(call.expression);
+
+  if (ts.isIdentifier(callee)) {
+    return aliases.has(callee.text) ? callee.text : null;
+  }
+
+  if (ts.isPropertyAccessExpression(callee) && callee.name.text === "fetch") {
+    const receiver = unwrap(callee.expression);
+    if (ts.isIdentifier(receiver) && ["globalThis", "global", "window"].includes(receiver.text)) {
+      return `${receiver.text}.fetch`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Does the call's init argument carry a `signal`?
+ *
+ * Only an object literal written at the call site can answer this. An init
+ * passed as a bare variable (`fetch(url, init)`) is deliberately reported as
+ * unbounded: the scan cannot see what is inside it, and answering "probably
+ * fine" is how a coverage gate becomes decoration.
+ */
+function callIsBounded(call: ts.CallExpression): boolean {
+  const init = call.arguments[1];
+  if (!init) return false;
+
+  const literal = unwrap(init as ts.Expression);
+  if (!ts.isObjectLiteralExpression(literal)) return false;
+
+  return literal.properties.some((prop) => {
+    const name = prop.name;
+    if (!name) return false;
+    return (ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === "signal";
+  });
+}
+
+export function findFetchCallSites(files: string[]): FetchCallSite[] {
+  const sites: FetchCallSite[] = [];
+
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const aliases = collectFetchAliases(source);
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const callee = fetchCalleeName(node, aliases);
+        if (callee) {
+          sites.push({
+            file: relative(REPO_ROOT, file),
+            line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+            callee,
+            bounded: callIsBounded(node),
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(source);
+  }
+
+  return sites;
+}

--- a/packages/web/src/__tests__/lib/plugin-fetch-timeout-coverage.test.ts
+++ b/packages/web/src/__tests__/lib/plugin-fetch-timeout-coverage.test.ts
@@ -1,0 +1,102 @@
+// packages/web/src/__tests__/lib/plugin-fetch-timeout-coverage.test.ts
+//
+// Every `fetch()` in the plugin sources must pass a `signal`.
+//
+// An unbounded fetch has no failure mode that looks like a bug: the call simply
+// never returns. A Pinchy container mid-deploy, or a network blackhole that
+// swallows packets without sending an RST, leaves the plugin waiting forever —
+// and in pinchy-audit's `before_tool_call` hook that stalls every tool call of
+// every agent, with nothing in any log naming the cause.
+//
+// The reason this is a guard and not a review note is the change that
+// introduced it. That change added timeouts to 15 call sites and wrote, in a
+// comment, that the mailbox providers "bound themselves separately (see
+// graph-adapter.ts, gmail-adapter.ts, imap-adapter.ts)". gmail-adapter.ts did
+// not: it talks through googleapis, whose transport documents `timeout` as "No
+// timeout by default". The prose asserted coverage the code did not have, and
+// nothing could contradict it. Same shape as AGENTS.md § "A Hand-Maintained
+// List That Mirrors Code Will Be Wrong" — the one list with a guard is the one
+// list that stays correct.
+//
+// Known limitations, stated plainly rather than left for a reader to assume
+// away:
+//
+//   • It sees `fetch` and nothing else. A plugin that reaches the network
+//     through another transport is invisible here — today that is
+//     gmail-adapter.ts (googleapis/gaxios, bounded by its `timeout` option) and
+//     imap-adapter.ts (imapflow, bounded by connectionTimeout/socketTimeout).
+//     Neither can this guard confirm; both are covered by their own unit tests.
+//   • It checks that a `signal` is passed, not that the signal is any good. A
+//     `signal: AbortSignal.timeout(86_400_000)` passes. The value belongs to
+//     review and to the per-call tests that assert it.
+import { describe, it, expect } from "vitest";
+import { findFetchCallSites, findPluginSourceFiles } from "./plugin-fetch-extraction";
+
+// A call site that genuinely cannot take a signal would go here, keyed by
+// "<repo-relative file>:<line>" with a reason. It is empty today, and a stale
+// entry fails below — a verdict must not outlive its evidence.
+const EXEMPT_CALL_SITES: Record<string, string> = {};
+
+describe("plugin fetch timeout coverage", () => {
+  const sites = findFetchCallSites(findPluginSourceFiles());
+
+  it("finds a real corpus of fetch call sites", () => {
+    // A walker that resolves nothing would pass every assertion below in
+    // silence, which is how a coverage gate turns into decoration. The floor
+    // sits under the count at the time of writing (16) with room for churn.
+    expect(
+      sites.length,
+      "Found almost no fetch() calls in packages/plugins — the scan is broken, not the tree."
+    ).toBeGreaterThanOrEqual(12);
+  });
+
+  it("resolves fetch through its aliases, not just the bare identifier", () => {
+    // pinchy-web/web-fetch.ts reaches fetch as `httpFetch`, an alias of an
+    // alias (`import { fetch as undiciFetch }` → `const httpFetch =
+    // undiciFetch as ...`). A scan that only matched the literal `fetch(`
+    // would report that file as clean while never having looked at it.
+    const aliased = sites.filter((s) => s.callee !== "fetch");
+    expect(
+      aliased.length,
+      "No aliased fetch call was resolved — check collectFetchAliases against web-fetch.ts."
+    ).toBeGreaterThan(0);
+  });
+
+  it("passes a signal at every fetch call site", () => {
+    const unbounded = sites
+      .filter((s) => !s.bounded)
+      .filter((s) => !(`${s.file}:${s.line}` in EXEMPT_CALL_SITES));
+
+    expect(
+      unbounded.map((s) => `${s.file}:${s.line} (${s.callee})`),
+      [
+        "These fetch() calls pass no `signal`, so a hung endpoint blocks them forever:",
+        ...unbounded.map((s) => `  ${s.file}:${s.line} — ${s.callee}(…)`),
+        "",
+        "Add `signal: AbortSignal.timeout(MS)` to the init object. Pick a bound",
+        "above the call's legitimate worst case — the point is to make a blackhole",
+        "terminate, not to enforce a latency budget.",
+        "",
+        "If the init object is built elsewhere and passed as a variable, inline the",
+        "signal at the call site; the scan cannot see into a variable and will not",
+        "guess on your behalf.",
+      ].join("\n")
+    ).toEqual([]);
+  });
+
+  it("has no exemption for a call site that is now bounded or gone", () => {
+    const live = new Set(sites.filter((s) => !s.bounded).map((s) => `${s.file}:${s.line}`));
+    const stale = Object.keys(EXEMPT_CALL_SITES).filter((key) => !live.has(key));
+
+    expect(
+      stale,
+      [
+        "These EXEMPT_CALL_SITES entries no longer describe an unbounded fetch:",
+        ...stale.map((key) => `  ${key} — ${EXEMPT_CALL_SITES[key]}`),
+        "",
+        "Delete them. An exemption that outlives its call site is the same drift",
+        "one level up, and line numbers move under it on every edit.",
+      ].join("\n")
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Almost no `fetch()` call across the OpenClaw plugins (`packages/plugins/pinchy-*`) had a timeout — only `pinchy-web/web-fetch.ts` (`AbortSignal.timeout(30000)`) and the IMAP adapter (`connectionTimeout`/`socketTimeout`) bounded their I/O. A hung endpoint (Pinchy container mid-deploy, a network blackhole with no RST) therefore blocked indefinitely, most critically `pinchy-audit`'s `before_tool_call` hook, which runs before **every** tool call of **every** agent.

- Added `AbortSignal.timeout(...)` to every previously-unbounded `fetch()`:
  - **10s** for Pinchy-internal API calls: `pinchy-audit` (tool audit hook), `pinchy-transcript` (channel-message capture hook), credentials fetches + `report-auth-failure` in `pinchy-odoo`/`pinchy-email`/`pinchy-web`, `pinchy-context` (save_user_context/save_org_context), `pinchy-knowledge` (knowledge_search), `pinchy-files/usage-reporter.ts`.
  - **30s** for external/LLM calls: `pinchy-web/brave-search.ts`, `pinchy-email/graph-adapter.ts` (`req()`), `pinchy-files/pdf-vision-api.ts` (all four vision providers).
- A timeout surfaces as an `AbortError`, which every caller already treats as an ordinary fetch failure (existing retry/fail-closed loops, `try/catch` → error tool results), so no new error-handling branches were needed anywhere.
- Clamped `pdf-vision-api.ts`'s `Retry-After` handling to a 30s max — previously an unclamped header (e.g. `Retry-After: 86400`) could put a PDF read to sleep for up to 24h.

## Test plan

- [x] Added a red→green test per changed plugin/file simulating a never-answering server (fetch mock that only settles via the `AbortSignal` passed in, with `AbortSignal.timeout` intercepted so the test doesn't take the real timeout duration) and asserting the call returns within bounds with a clear error, plus asserting the exact timeout value used.
- [x] Added a dedicated test for the `Retry-After` clamp.
- [x] `pnpm test:plugins` — 9/9 plugin packages pass.
- [x] `pnpm typecheck:plugins` — 9/9 plugin packages typecheck cleanly.
- [x] `pnpm test` — 774 files, 10920 tests passed, 18 skipped (pre-existing, unrelated).
- [x] `pnpm test:scripts` — 894 tests passed.
- [x] `pnpm format:check` — clean.
- [x] `pnpm build` — succeeds.

Docs-not-needed trailer included on the commit (internal robustness change, no reader-facing behavior).