### PR TITLE
fix(security): validate and escape the domain-lock's Host value

### DIFF
--- a/docs/src/content/docs/guides/domain-lock.mdx
+++ b/docs/src/content/docs/guides/domain-lock.mdx
@@ -111,6 +111,8 @@ For the same reason the event is throttled to one row per minute. Reaching a loc
 
 From this point on, only the locked domain can reach the app. Domain Lock is the single source of truth for your public origin — there is no separate URL env var to keep in sync.
 
+Pinchy stores the canonical form of the host your proxy forwarded: lower-cased, and without a `:443` that HTTPS implies anyway. So the domain shown after locking can be slightly shorter than the header your proxy sent, and that is the value the host check compares every later request against. If your proxy forwards something that is not a hostname at all — a header rewritten with a path, a space, or markup in it — Pinchy refuses to lock rather than pinning your instance to a name no browser can ever send back.
+
 ## Remove the lock
 
 If the business needs change (different domain, temporary maintenance URL, etc.):

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -793,6 +793,8 @@ Lock Pinchy to a domain. **Takes no request body.** The domain is the hostname t
 
 The request must arrive over HTTPS (`X-Forwarded-Proto: https`).
 
+What gets stored is the canonical form of that hostname — lower-cased, with a default `:443` dropped — because that is the same folding the host check applies when it later matches an incoming request. A proxy sending `Host: EXAMPLE.COM` or `example.com:443` therefore locks to `example.com`, and the response echoes the value that was actually stored. A port that is not the default is kept (`pinchy.example.com:8443`), since it is part of the name a browser sends.
+
 **Response:** `{ "domain": "pinchy.example.com", "restart": true }`
 
 `restart: true` is not advisory. The process exits half a second later so the secure-cookie settings take effect, and your container runtime restarts it — expect a few seconds of downtime and one dropped WebSocket.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -799,7 +799,7 @@ The request must arrive over HTTPS (`X-Forwarded-Proto: https`).
 
 **Errors:**
 
-- `400` — the request did not arrive over HTTPS, or no hostname could be determined
+- `400` — the request did not arrive over HTTPS, no hostname could be determined, or the hostname is not a value a browser can send as `Host` (rejected before it is stored)
 - `401` — not authenticated
 - `403` — not an admin
 

--- a/packages/web/src/__tests__/api/settings-domain.test.ts
+++ b/packages/web/src/__tests__/api/settings-domain.test.ts
@@ -304,3 +304,59 @@ describe("domain lock stores a host that can actually match", () => {
     expect(mockSetDomainAndRefreshCache).toHaveBeenCalledWith("pinchy.example.com");
   });
 });
+
+// The resolved host is client-influenced (X-Forwarded-Host is attacker
+// controlled unless a trusted proxy strips it) and, once stored, is rendered
+// unescaped into the Access Denied page every unauthenticated visitor with a
+// mismatched Host header sees. A value that fails isValidLockableHost must
+// never reach setDomainAndRefreshCache — for injection, and because storing a
+// name no browser can literally send is a lockout too.
+//
+// This is deliberately NOT the stricter `isValidDomain` used for an agent's
+// `pinchy-web` allowed/excludedDomains (which forbids ports and bare
+// single-label hosts like "localhost" — appropriate there because it bounds
+// what an agent may browse). A locked domain is a Host value, and a real Host
+// value legitimately carries a port and can be a bare host: the integration
+// suite locks to "localhost:7779" (its own baseURL) precisely so subsequent
+// browser requests keep matching, and a self-hosted install can sit behind a
+// reverse proxy terminating on a non-default port.
+describe("domain lock rejects hostnames that are not valid Host values", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(adminSession);
+    mockGetSetting.mockResolvedValue(null);
+  });
+
+  it.each([
+    ['a"><script>alert(1)</script>', "embedded markup"],
+    ["evil example.com", "embedded space"],
+    ["evil.com:1;rm -rf /", "port/shell injection"],
+    ["evil.com/path", "path suffix"],
+    ["evil.com@attacker.com", "userinfo injection"],
+    ["evil.com#frag", "fragment suffix"],
+  ])("rejects %s (%s)", async (host) => {
+    const response = await POST(
+      makeRequest("POST", {
+        "x-forwarded-host": host,
+        "x-forwarded-proto": "https",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toMatch(/domain/i);
+    expect(mockSetDomainAndRefreshCache).not.toHaveBeenCalled();
+  });
+
+  it("accepts a bare host with a non-default port, matching what a real reverse-proxy Host header can carry", async () => {
+    const response = await POST(
+      makeRequest("POST", {
+        "x-forwarded-host": "localhost:7779",
+        "x-forwarded-proto": "https",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSetDomainAndRefreshCache).toHaveBeenCalledWith("localhost:7779");
+  });
+});

--- a/packages/web/src/__tests__/api/settings-domain.test.ts
+++ b/packages/web/src/__tests__/api/settings-domain.test.ts
@@ -308,7 +308,7 @@ describe("domain lock stores a host that can actually match", () => {
 // The resolved host is client-influenced (X-Forwarded-Host is attacker
 // controlled unless a trusted proxy strips it) and, once stored, is rendered
 // unescaped into the Access Denied page every unauthenticated visitor with a
-// mismatched Host header sees. A value that fails isValidLockableHost must
+// mismatched Host header sees. A value that fails normalizeLockableHost must
 // never reach setDomainAndRefreshCache — for injection, and because storing a
 // name no browser can literally send is a lockout too.
 //
@@ -333,6 +333,7 @@ describe("domain lock rejects hostnames that are not valid Host values", () => {
     ["evil.com:1;rm -rf /", "port/shell injection"],
     ["evil.com/path", "path suffix"],
     ["evil.com@attacker.com", "userinfo injection"],
+    ["evil.com@attacker.com:443", "userinfo injection ending in a default port"],
     ["evil.com#frag", "fragment suffix"],
   ])("rejects %s (%s)", async (host) => {
     const response = await POST(
@@ -358,5 +359,40 @@ describe("domain lock rejects hostnames that are not valid Host values", () => {
 
     expect(response.status).toBe(200);
     expect(mockSetDomainAndRefreshCache).toHaveBeenCalledWith("localhost:7779");
+  });
+
+  // What is stored has to be what the gate will later match, and the gate
+  // matches through `normalizeHost` — which folds a default port but does NOT
+  // fold case. Storing the header verbatim therefore has two failure shapes,
+  // and both end as a lockout rather than as a rejection anyone can see:
+  //
+  //   `Host: EXAMPLE.COM`     stored verbatim, never equals the lowercase
+  //                           Host every browser sends afterwards.
+  //   `Host: example.com:443` a proxy configured with `$host:$server_port`
+  //                           sends this; the gate would happily match it,
+  //                           so refusing to store it turns a working
+  //                           deployment into a 400 with no way forward.
+  //
+  // Both are answered by storing the canonical parse rather than the input.
+  it.each([
+    ["EXAMPLE.COM", "example.com", "lower-cases the host the gate compares case-sensitively"],
+    [
+      "pinchy.example.com:443",
+      "pinchy.example.com",
+      "drops the default port the gate folds away anyway",
+    ],
+  ])("stores %s as %s (%s)", async (sent, stored) => {
+    const response = await POST(
+      makeRequest("POST", {
+        "x-forwarded-host": sent,
+        "x-forwarded-proto": "https",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSetDomainAndRefreshCache).toHaveBeenCalledWith(stored);
+    // The response echoes the stored value, so the success toast and the
+    // audit row name the domain that is actually locked.
+    expect((await response.json()).domain).toBe(stored);
   });
 });

--- a/packages/web/src/__tests__/lib/domain-validation.test.ts
+++ b/packages/web/src/__tests__/lib/domain-validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isValidDomain,
-  isValidLockableHost,
+  normalizeLockableHost,
   validatePinchyWebConfig,
   pluginConfigSchema,
 } from "@/lib/domain-validation";
@@ -28,17 +28,25 @@ describe("isValidDomain", () => {
   });
 });
 
-describe("isValidLockableHost", () => {
+describe("normalizeLockableHost", () => {
+  // These assert the value that gets STORED, not merely that the input was
+  // accepted. Case and a default `:443` are folded here because that is
+  // exactly what `normalizeHost` folds when the gate later matches a request
+  // against the stored value — validating one form while storing another is
+  // how a lock stops matching the browser that created it.
   it.each([
-    "example.com",
-    "pinchy.example.com",
-    "localhost",
-    "localhost:7779",
-    "pinchy.example.com:8443",
-    "EXAMPLE.COM",
-    "xn--bcher-kva.example",
-  ])("accepts %s", (h) => {
-    expect(isValidLockableHost(h)).toBe(true);
+    ["example.com", "example.com"],
+    ["pinchy.example.com", "pinchy.example.com"],
+    ["localhost", "localhost"],
+    ["localhost:7779", "localhost:7779"],
+    ["pinchy.example.com:8443", "pinchy.example.com:8443"],
+    ["[::1]:8443", "[::1]:8443"],
+    ["xn--bcher-kva.example", "xn--bcher-kva.example"],
+    ["EXAMPLE.COM", "example.com"],
+    ["Pinchy.Example.COM:8443", "pinchy.example.com:8443"],
+    ["pinchy.example.com:443", "pinchy.example.com"],
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(normalizeLockableHost(input)).toBe(expected);
   });
 
   it.each([
@@ -50,11 +58,17 @@ describe("isValidLockableHost", () => {
     "evil.com:1;rm -rf /",
     "evil.com/path",
     "evil.com@attacker.com",
+    // Folding a default port must not fold a userinfo split that ends in one:
+    // the parsed host there is `attacker.com`, which is not what arrived.
+    "evil.com@attacker.com:443",
+    "evil.com:443/path",
     "evil.com#frag",
     "evil.com?x=1",
     "evil.com\\attacker.com",
+    "//evil.com",
+    ":443",
   ])("rejects %s", (h) => {
-    expect(isValidLockableHost(h)).toBe(false);
+    expect(normalizeLockableHost(h)).toBeNull();
   });
 });
 

--- a/packages/web/src/__tests__/lib/domain-validation.test.ts
+++ b/packages/web/src/__tests__/lib/domain-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isValidDomain,
+  isValidLockableHost,
   validatePinchyWebConfig,
   pluginConfigSchema,
 } from "@/lib/domain-validation";
@@ -24,6 +25,36 @@ describe("isValidDomain", () => {
     " example.com",
   ])("rejects %s", (d) => {
     expect(isValidDomain(d)).toBe(false);
+  });
+});
+
+describe("isValidLockableHost", () => {
+  it.each([
+    "example.com",
+    "pinchy.example.com",
+    "localhost",
+    "localhost:7779",
+    "pinchy.example.com:8443",
+    "EXAMPLE.COM",
+    "xn--bcher-kva.example",
+  ])("accepts %s", (h) => {
+    expect(isValidLockableHost(h)).toBe(true);
+  });
+
+  it.each([
+    "",
+    " pinchy.example.com",
+    "pinchy.example.com ",
+    "evil example.com",
+    'a"><script>alert(1)</script>',
+    "evil.com:1;rm -rf /",
+    "evil.com/path",
+    "evil.com@attacker.com",
+    "evil.com#frag",
+    "evil.com?x=1",
+    "evil.com\\attacker.com",
+  ])("rejects %s", (h) => {
+    expect(isValidLockableHost(h)).toBe(false);
   });
 });
 

--- a/packages/web/src/__tests__/middleware/host-gate.test.ts
+++ b/packages/web/src/__tests__/middleware/host-gate.test.ts
@@ -163,6 +163,28 @@ describe("applyDomainLockGate", () => {
     expect(res._statusCode).toBeUndefined();
   });
 
+  // Defense in depth: even though the write side now rejects anything that
+  // isn't a valid domain (isValidDomain), a row written before that guard
+  // existed — or edited directly in the database — must not turn into stored
+  // markup on a page served to every unauthenticated visitor with the wrong
+  // Host header.
+  it("escapes an unsafe locked domain in the Access Denied page", async () => {
+    vi.mocked(getCachedDomain).mockReturnValue('a"><script>alert(1)</script>');
+    const req = makeReq({
+      method: "GET",
+      url: "/dashboard",
+      host: "evil.example.com",
+      accept: "text/html,application/xhtml+xml",
+    });
+    const res = makeRes();
+
+    expect(await applyDomainLockGate(req, res)).toBe(true);
+    expect(res._statusCode).toBe(403);
+    expect(res._body).not.toContain("<script>alert(1)</script>");
+    expect(res._body).not.toContain('a">');
+    expect(res._body).toContain("&lt;script&gt;");
+  });
+
   it("answers before the audit write settles", async () => {
     // A blocked caller must not wait on the DB — and an audit failure must not
     // turn the 403 into a hung request or a 500.

--- a/packages/web/src/app/api/settings/domain/route.ts
+++ b/packages/web/src/app/api/settings/domain/route.ts
@@ -4,7 +4,7 @@ import { getSetting } from "@/lib/settings";
 import { setDomainAndRefreshCache, deleteDomainAndRefreshCache } from "@/lib/domain";
 import { appendAuditLog } from "@/lib/audit";
 import { readRequestHostFromHeaders } from "@/server/forwarded-host";
-import { isValidLockableHost } from "@/lib/domain-validation";
+import { normalizeLockableHost } from "@/lib/domain-validation";
 
 export async function POST(req: Request) {
   const session = await requireAdmin();
@@ -22,9 +22,9 @@ export async function POST(req: Request) {
   // "public.example.com, internal:7777", and storing that verbatim locks the
   // instance to a name no browser can send — the exact lockout this flow
   // exists to make impossible.
-  const domain = readRequestHostFromHeaders(req.headers);
+  const requestedHost = readRequestHostFromHeaders(req.headers);
 
-  if (!domain) {
+  if (!requestedHost) {
     return NextResponse.json(
       { error: "Could not determine hostname from request." },
       { status: 400 }
@@ -32,12 +32,23 @@ export async function POST(req: Request) {
   }
 
   // The resolved host is client-influenced (X-Forwarded-Host, unless a
-  // trusted proxy strips it before we see it) and gets stored verbatim as the
-  // locked domain — then rendered into the Access Denied page every
-  // unauthenticated visitor with a mismatched Host header is served. Reject
-  // anything that isn't a plausible Host value before it is ever persisted.
-  if (!isValidLockableHost(domain)) {
-    return NextResponse.json({ error: `"${domain}" is not a valid domain name.` }, { status: 400 });
+  // trusted proxy strips it before we see it) and gets stored as the locked
+  // domain — then rendered into the Access Denied page every unauthenticated
+  // visitor with a mismatched Host header is served. Reject anything that
+  // isn't a plausible Host value before it is ever persisted, and store the
+  // canonical parse rather than the header as typed, so that what is stored
+  // is what `isHostAllowed` will later compare a request against.
+  const domain = normalizeLockableHost(requestedHost);
+  if (!domain) {
+    // Bounded: `X-Forwarded-Host` is caller-sized, and the whole of it ends up
+    // in a toast. Enough to recognise what was sent, not enough to flood it.
+    const shown = requestedHost.length > 80 ? `${requestedHost.slice(0, 80)}…` : requestedHost;
+    return NextResponse.json(
+      {
+        error: `Cannot lock the domain to "${shown}" — that is not a hostname a browser can send as a Host header.`,
+      },
+      { status: 400 }
+    );
   }
 
   const previousDomain = await getSetting("domain");

--- a/packages/web/src/app/api/settings/domain/route.ts
+++ b/packages/web/src/app/api/settings/domain/route.ts
@@ -4,6 +4,7 @@ import { getSetting } from "@/lib/settings";
 import { setDomainAndRefreshCache, deleteDomainAndRefreshCache } from "@/lib/domain";
 import { appendAuditLog } from "@/lib/audit";
 import { readRequestHostFromHeaders } from "@/server/forwarded-host";
+import { isValidLockableHost } from "@/lib/domain-validation";
 
 export async function POST(req: Request) {
   const session = await requireAdmin();
@@ -28,6 +29,15 @@ export async function POST(req: Request) {
       { error: "Could not determine hostname from request." },
       { status: 400 }
     );
+  }
+
+  // The resolved host is client-influenced (X-Forwarded-Host, unless a
+  // trusted proxy strips it before we see it) and gets stored verbatim as the
+  // locked domain — then rendered into the Access Denied page every
+  // unauthenticated visitor with a mismatched Host header is served. Reject
+  // anything that isn't a plausible Host value before it is ever persisted.
+  if (!isValidLockableHost(domain)) {
+    return NextResponse.json({ error: `"${domain}" is not a valid domain name.` }, { status: 400 });
   }
 
   const previousDomain = await getSetting("domain");

--- a/packages/web/src/lib/domain-validation.ts
+++ b/packages/web/src/lib/domain-validation.ts
@@ -11,6 +11,42 @@ export function isValidDomain(domain: string): boolean {
 }
 
 /**
+ * Is `host` safe to store as the domain lock's target?
+ *
+ * Deliberately more permissive than `isValidDomain` above, and for a
+ * different reason: a locked domain is the request's own `Host`/
+ * `X-Forwarded-Host` value, not a public production domain an agent is
+ * allowed to browse. A real Host value legitimately carries a port (a
+ * reverse proxy terminating on a non-default port, or the integration
+ * suite locking to its own "localhost:7779" baseURL so subsequent
+ * requests keep matching) and can be a bare single-label host. Loosening
+ * `isValidDomain` itself to accept those would also loosen the
+ * `pinchy-web` allowedDomains/excludedDomains allow-list, which has a
+ * different, tighter, SSRF-relevant job.
+ *
+ * What still MUST be rejected: anything that isn't a bare `Host` value —
+ * markup, whitespace, a path/userinfo/query/fragment suffix, or any
+ * other character `Host` cannot carry. That combination (injection into
+ * the Access Denied page, plus storing a value the request that "proved"
+ * it can never send verbatim) is exactly the risk this function exists to
+ * close.
+ *
+ * Round-tripping through `URL` is the check: parse `https://<host>` and
+ * require the result's `.host` to equal the input, case-insensitively. A
+ * mismatch means the input carried something `Host` cannot (a path, an
+ * `@`, a `#`, a `?`, or characters the URL parser silently dropped/moved),
+ * which is precisely what must not be persisted verbatim.
+ */
+export function isValidLockableHost(host: string): boolean {
+  if (!host) return false;
+  try {
+    return new URL(`https://${host}`).host === host.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Zod schema for an agent's pluginConfig column. Mirrors the AgentPluginConfig
  * type in @/db/schema and is the shape-of-truth for both POST and PATCH agent
  * routes. Domain validity inside `pinchy-web` is layered on top via

--- a/packages/web/src/lib/domain-validation.ts
+++ b/packages/web/src/lib/domain-validation.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { normalizeHost } from "./domain-cache";
 import { isPathUnderDataRoot } from "./knowledge/citation-path";
 
 // Each label: 1-63 chars, alphanumeric + hyphens (not leading/trailing hyphen).
@@ -11,7 +12,8 @@ export function isValidDomain(domain: string): boolean {
 }
 
 /**
- * Is `host` safe to store as the domain lock's target?
+ * The form of `host` that is safe to store as the domain lock's target, or
+ * `null` when it is not a `Host` value at all.
  *
  * Deliberately more permissive than `isValidDomain` above, and for a
  * different reason: a locked domain is the request's own `Host`/
@@ -32,18 +34,41 @@ export function isValidDomain(domain: string): boolean {
  * close.
  *
  * Round-tripping through `URL` is the check: parse `https://<host>` and
- * require the result's `.host` to equal the input, case-insensitively. A
- * mismatch means the input carried something `Host` cannot (a path, an
- * `@`, a `#`, a `?`, or characters the URL parser silently dropped/moved),
- * which is precisely what must not be persisted verbatim.
+ * require the result's `.host` to equal the input. A mismatch means the input
+ * carried something `Host` cannot (a path, an `@`, a `#`, a `?`, or
+ * characters the URL parser silently dropped/moved), which is precisely what
+ * must not be persisted verbatim.
+ *
+ * It returns the parsed host rather than a yes/no, and that is the load-bearing
+ * part. The comparison has to tolerate the two differences that are pure
+ * canonicalisation — case, and a default `:443` — because both are things a
+ * real `Host` carries and both are things `isHostAllowed` folds away when it
+ * later matches a request against what we stored. Answering "valid" on a
+ * normalised reading and then storing the un-normalised input is how a lock
+ * stops matching the browser that created it:
+ *
+ *   - `normalizeHost` folds ports but NOT case, so a lock created from
+ *     `Host: EXAMPLE.COM` would never again equal the lowercase Host a browser
+ *     sends.
+ *   - a proxy configured with `$host:$server_port` sends `example.com:443`,
+ *     which the gate matches perfectly well — so refusing to store it turns a
+ *     working deployment into a 400 with no way forward.
+ *
+ * Storing the parse answers both. It does not weaken the check: the equality
+ * is still required, only read through the same folding the gate uses, so
+ * `evil.com@attacker.com:443` (which parses to a host that is not what
+ * arrived) still fails.
  */
-export function isValidLockableHost(host: string): boolean {
-  if (!host) return false;
+export function normalizeLockableHost(host: string): string | null {
+  if (!host) return null;
+  let parsed: string;
   try {
-    return new URL(`https://${host}`).host === host.toLowerCase();
+    parsed = new URL(`https://${host}`).host;
   } catch {
-    return false;
+    return null;
   }
+  if (!parsed) return null;
+  return normalizeHost(parsed) === normalizeHost(host.toLowerCase()) ? parsed : null;
 }
 
 /**

--- a/packages/web/src/server/host-check.ts
+++ b/packages/web/src/server/host-check.ts
@@ -81,7 +81,27 @@ export function shouldAuditHostBlock(pathname: string | null): boolean {
   return !!pathname && pathname.startsWith("/api/");
 }
 
+// `domain` is read from `getCachedDomain()`, ultimately client-influenced
+// (the value POST /api/settings/domain stores is the request's own resolved
+// Host). `POST /api/settings/domain` now rejects anything that isn't a valid
+// domain name before it is persisted, but a row written before that guard
+// existed — or edited directly in the database — must not turn into stored
+// markup on a page served to every unauthenticated visitor with a mismatched
+// Host header. Escape it here too, independent of the write-side guard.
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
+}
+
 function accessDeniedPage(domain: string | null): string {
+  const safeDomain = domain ? escapeHtml(domain) : null;
   return `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Access Denied — Pinchy</title>
@@ -90,7 +110,7 @@ function accessDeniedPage(domain: string | null): string {
 p{color:#a3a3a3;font-size:.875rem;line-height:1.5;margin:0 0 1rem}a{color:#f59e0b;text-decoration:none}a:hover{text-decoration:underline}</style></head>
 <body><div class="card"><div class="icon">🔒</div><h1>Access Denied</h1>
 <p>This Pinchy instance is locked to a specific domain. You're accessing it from an address that isn't allowed.</p>
-${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
+${safeDomain ? `<p><a href="https://${safeDomain}">Go to ${safeDomain} →</a></p>` : ""}
 </div></body></html>`;
 }
 


### PR DESCRIPTION
## Summary

- `POST /api/settings/domain` stored the resolved `Host`/`X-Forwarded-Host` verbatim, with no validation, before persisting it as the locked domain.
- `host-check.ts`'s `accessDeniedPage()` then interpolated that stored value into HTML **unescaped**, serving it to every unauthenticated visitor whose request Host doesn't match the lock — a stored HTML/script injection on the app's own origin, plus a lockout risk from storing a value no real browser could ever send back.
- Adds `isValidLockableHost()` in `packages/web/src/lib/domain-validation.ts` and calls it in the `POST` route before `setDomainAndRefreshCache()`, rejecting with `400` otherwise.
- Escapes the locked domain in `accessDeniedPage()` as defense in depth, independent of the write-side guard (a row written before this fix, or edited directly, must not become stored markup).

## Why a new validator instead of reusing `isValidDomain`

The brief pointed at the existing `isValidDomain()` (used for an agent's `pinchy-web` `allowedDomains`/`excludedDomains`, an SSRF-relevant allow-list that intentionally forbids ports and bare single-label hosts). Reusing it here broke a real, already-green integration test: `e2e/integration/agent-chat.spec.ts` deliberately locks the domain to `localhost:7779` (its own Playwright `baseURL`) so that subsequent same-suite requests keep matching the lock. A locked domain is fundamentally a `Host` value, not a public production domain name, and a real `Host` legitimately carries a port (e.g. a reverse proxy on a non-default port).

So `isValidLockableHost()` takes a different approach: round-trip the input through `new URL("https://" + host)` and require the parsed `.host` to equal the input case-insensitively. That accepts any value that could genuinely arrive as a `Host` header (including `localhost:7779`) while rejecting anything that isn't one — markup, whitespace, and path/userinfo/query/fragment injection all fail to round-trip.

## Tests added (red → green)

- `packages/web/src/__tests__/lib/domain-validation.test.ts` — `isValidLockableHost`: accepts plain domains, `localhost`, `localhost:7779`, a domain with a non-default port; rejects empty string, leading/trailing whitespace, embedded space, markup, port/shell injection, and path/userinfo/query/fragment suffixes.
- `packages/web/src/__tests__/api/settings-domain.test.ts` — `POST /api/settings/domain` returns 400 and never calls `setDomainAndRefreshCache` for markup/space/injection/path/userinfo/fragment payloads; still accepts and stores `localhost:7779` (mirrors the real integration-suite usage).
- `packages/web/src/__tests__/middleware/host-gate.test.ts` — `applyDomainLockGate` escapes an attacker-controlled locked domain (`a"><script>alert(1)</script>`) in the rendered Access Denied page.

All three files verified failing before the fix, passing after.

## Test plan

- [x] `pnpm test:related` (405 tests)
- [x] `pnpm test` (774 files / 10934 passed, 4 files / 18 skipped — pre-existing, unrelated)
- [x] `pnpm test:scripts` (894 passed)
- [x] `pnpm -C packages/web lint` (0 errors; pre-existing warnings unrelated to this change)
- [x] `pnpm -C packages/web typecheck` (clean)
- [x] `pnpm format:check` (clean)
- [x] `pnpm build` (via pre-push hook; production build succeeds)