### PR TITLE
fix(security): resolve DNS before classifying Odoo integration URLs

### DIFF
--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -45,6 +45,8 @@ The API key inherits the Odoo permissions of the user who created it. If you wan
 
 Pinchy verifies the credentials and probes the available data models. If the connection fails, double-check the URL and API key.
 
+If Pinchy answers that the URL targets a private network, see [Odoo on your own network](#odoo-on-your-own-network) below.
+
 ## 3. Review the sync
 
 After a successful connection, Pinchy shows which data categories are accessible — Sales, Inventory, Contacts, Accounting, and others. This depends on the Odoo modules you have installed and the permissions of the API user.
@@ -190,6 +192,22 @@ model an agent runs. This complements the existing read-back guarantee on
 it done. Verification only runs where it is deterministic; writes that cannot be
 confirmed this way are covered instead by the confirmation-before-write habit the
 read-write finance templates carry.
+
+## Odoo on your own network
+
+Pinchy fetches the URL you enter from its own server, so an admin who can add a connection can point it at anything that server can reach. That's why we only connect to a URL that lands on a public address — and we check the address it actually resolves to, not just how the hostname reads. A name like `erp.yourcompany.com` pointing at `10.0.0.5` is the same request as typing `10.0.0.5` directly.
+
+If your Odoo genuinely lives on your own network — on `10.x`, `172.16–31.x`, `192.168.x`, or an IPv6 unique-local range — set the environment variable on the Pinchy container and restart it:
+
+```bash
+ALLOW_PRIVATE_URLS=1
+```
+
+:::caution
+`ALLOW_PRIVATE_URLS=1` turns the address check off completely, including for loopback and the cloud-metadata address `169.254.169.254`. It is not the two-tier switch that [`ALLOW_PRIVATE_MAIL_HOSTS`](/guides/connect-email-imap/#mail-servers-on-your-own-network) is for mail servers. Set it only on an instance whose admins you'd trust with that reach anyway.
+:::
+
+The same check runs everywhere a URL is accepted, not only on the first connect: adding a connection, editing one, testing credentials, listing databases, previewing a sync, and re-syncing the schema. So a blocked address can't be stored and quietly reconnected to later.
 
 ## Re-syncing when Odoo permissions change
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -209,6 +209,12 @@ sed -i 's/^PINCHY_VERSION=.*/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
 
+#### An Odoo URL is now checked against the address it resolves to
+
+The SSRF guard on the Odoo connection routes only ever read the hostname as a string, so a name pointing at `169.254.169.254` or an internal address passed a check that a bare `10.0.0.5` failed. It now resolves the name and classifies every address it gets back.
+
+That closes the hole, and it also catches a setup that used to work by accident: **an on-premise Odoo reached by a hostname that resolves into your own network** — `erp.internal:8069` on `10.x`, `172.16–31.x`, `192.168.x` or an IPv6 unique-local range. Typing its IP address directly was already refused; the hostname now is too. The refusal says so and names the fix — set `ALLOW_PRIVATE_URLS=1` on the Pinchy container and restart it. Nothing to change if your Odoo is reachable at a public address, which includes every `odoo.com` instance. See [Odoo on your own network](/guides/connect-odoo/#odoo-on-your-own-network).
+
 #### A provider key that can't reach the runtime now says so
 
 Pinchy and the agent runtime share one config volume under two different users, and each agent has a directory in it that both of them write to. If the runtime got there first, the directory came out owned by the wrong user and Pinchy could no longer store that agent's credentials — which stopped the whole config from reaching the runtime. The agent then simply stopped answering, with the real reason only in `docker compose logs pinchy`.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1156,6 +1156,8 @@ Remove Telegram from every agent at once. **Admin only.** This is the backend fo
 
 External system integrations — **Odoo**, **email** (Gmail and Microsoft 365 via OAuth), and **Web Search**. See [Integrations](/concepts/integrations/) for the conceptual overview, [Connect Odoo](/guides/connect-odoo/) for the Odoo setup guide, and [Connect Email](/guides/connect-email/) for the email setup guide.
 
+Every route below that accepts an Odoo URL — create, update, sync, `test-credentials`, `list-databases` and `sync-preview` — runs the same SSRF guard. An address literal is classified as it stands; a hostname is resolved first and **every** address it answers with is classified, so a name pointing at an internal address is refused exactly like the address itself. A name that does not resolve is allowed through — it is far more likely a typo, and the request fails on its own. `ALLOW_PRIVATE_URLS=1` turns the check off for an on-premise Odoo; see [Odoo on your own network](/guides/connect-odoo/#odoo-on-your-own-network).
+
 ### `GET /api/integrations`
 
 List all integration connections with masked credentials.

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -120,7 +120,7 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
   }
   if (parsedCredentials !== undefined) {
     if (existing.type === "odoo" && "url" in parsedCredentials) {
-      const urlCheck = validateExternalUrl(parsedCredentials.url as string);
+      const urlCheck = await validateExternalUrl(parsedCredentials.url as string);
       if (!urlCheck.valid) {
         return NextResponse.json({ error: urlCheck.error }, { status: 400 });
       }

--- a/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
@@ -34,7 +34,7 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
       );
     }
 
-    const urlCheck = validateExternalUrl(parsed.data.url);
+    const urlCheck = await validateExternalUrl(parsed.data.url);
     if (!urlCheck.valid) {
       return NextResponse.json({ success: false, error: urlCheck.error }, { status: 200 });
     }

--- a/packages/web/src/app/api/integrations/list-databases/route.ts
+++ b/packages/web/src/app/api/integrations/list-databases/route.ts
@@ -14,7 +14,7 @@ export const POST = withAdmin(async (request) => {
   if ("error" in parsed) return parsed.error;
   const { url } = parsed.data;
 
-  const urlCheck = validateExternalUrl(url);
+  const urlCheck = await validateExternalUrl(url);
   if (!urlCheck.valid) {
     return NextResponse.json({ error: urlCheck.error }, { status: 400 });
   }

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -85,7 +85,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
   }
 
   if (parsed.data.type === "odoo") {
-    const urlCheck = validateExternalUrl(parsed.data.credentials.url);
+    const urlCheck = await validateExternalUrl(parsed.data.credentials.url);
     if (!urlCheck.valid) {
       return NextResponse.json({ error: urlCheck.error }, { status: 400 });
     }

--- a/packages/web/src/app/api/integrations/sync-preview/route.ts
+++ b/packages/web/src/app/api/integrations/sync-preview/route.ts
@@ -22,7 +22,7 @@ export const POST = withAdmin(async (request) => {
   if ("error" in parsed) return parsed.error;
   const { credentials } = parsed.data;
 
-  const urlCheck = validateExternalUrl(credentials.url);
+  const urlCheck = await validateExternalUrl(credentials.url);
   if (!urlCheck.valid) {
     return NextResponse.json({ error: urlCheck.error }, { status: 400 });
   }

--- a/packages/web/src/app/api/integrations/test-credentials/route.ts
+++ b/packages/web/src/app/api/integrations/test-credentials/route.ts
@@ -45,7 +45,7 @@ export const POST = withAdmin(async (request) => {
 
   const { credentials } = parsed.data;
 
-  const urlCheck = validateExternalUrl(credentials.url);
+  const urlCheck = await validateExternalUrl(credentials.url);
   if (!urlCheck.valid) {
     return NextResponse.json({ error: urlCheck.error }, { status: 400 });
   }

--- a/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
@@ -16,10 +16,25 @@ const unresolvable: UrlHostResolver = async () => {
   throw new Error("ENOTFOUND");
 };
 
-/** Resolver stub that throws if invoked — proves a code path never reaches DNS. */
-const mustNotBeCalled: UrlHostResolver = async () => {
-  throw new Error("resolver should not have been called");
-};
+/**
+ * Runs `validateExternalUrl` and asserts the resolver was never reached.
+ *
+ * A stub that merely throws does NOT assert this, however it reads: the
+ * function's fail-open catch swallows a resolver throw and answers
+ * `{ valid: true }`, which is exactly what the bypass path returns too. Proven
+ * by canary — with `ALLOW_PRIVATE_URLS` unset, a throwing stub against
+ * `http://odoo-mock:8069` still produced `{ valid: true }`, so the earlier
+ * version of the bypass test would have stayed green with the bypass deleted.
+ * Only a spy can tell "not called" from "called and ignored".
+ */
+async function validateWithoutDns(urlString: string) {
+  const resolver = vi.fn<UrlHostResolver>(async () => {
+    throw new Error("resolver must not be called");
+  });
+  const result = await validateExternalUrl(urlString, resolver);
+  expect(resolver).not.toHaveBeenCalled();
+  return result;
+}
 
 describe("isPrivateUrl", () => {
   it("rejects localhost", () => {
@@ -166,41 +181,78 @@ describe("validateExternalUrl", () => {
   });
 
   it("rejects non-HTTP scheme (ftp)", async () => {
-    const result = await validateExternalUrl("ftp://odoo.example.com", mustNotBeCalled);
+    const result = await validateWithoutDns("ftp://odoo.example.com");
     expect(result).toEqual({ valid: false, error: expect.stringContaining("HTTP") });
   });
 
   it("rejects non-HTTP scheme (file)", async () => {
-    const result = await validateExternalUrl("file:///etc/passwd", mustNotBeCalled);
+    const result = await validateWithoutDns("file:///etc/passwd");
     expect(result).toEqual({ valid: false, error: expect.stringContaining("HTTP") });
   });
 
   it("rejects invalid URL", async () => {
-    const result = await validateExternalUrl("not-a-url", mustNotBeCalled);
+    const result = await validateWithoutDns("not-a-url");
     expect(result).toEqual({ valid: false, error: expect.any(String) });
   });
 
   it("rejects empty string", async () => {
-    const result = await validateExternalUrl("", mustNotBeCalled);
+    const result = await validateWithoutDns("");
     expect(result).toEqual({ valid: false, error: expect.any(String) });
   });
 
   it("rejects localhost (well-known hostname, no DNS needed)", async () => {
-    const result = await validateExternalUrl("http://localhost:8069", mustNotBeCalled);
-    expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    const result = await validateWithoutDns("http://localhost:8069");
+    expect(result).toEqual({ valid: false, error: expect.stringContaining("loopback") });
   });
 
   it("rejects 127.0.0.1 (IP literal, no DNS needed)", async () => {
-    const result = await validateExternalUrl("http://127.0.0.1:8069", mustNotBeCalled);
-    expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    const result = await validateWithoutDns("http://127.0.0.1:8069");
+    expect(result).toEqual({ valid: false, error: expect.stringContaining("loopback") });
   });
 
   it("rejects AWS metadata endpoint (IP literal, no DNS needed)", async () => {
-    const result = await validateExternalUrl(
-      "http://169.254.169.254/latest/meta-data/",
-      mustNotBeCalled
-    );
-    expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    const result = await validateWithoutDns("http://169.254.169.254/latest/meta-data/");
+    expect(result).toEqual({ valid: false, error: expect.stringContaining("link-local") });
+  });
+
+  it("rejects an IPv6 loopback literal without handing '[::1]' to the resolver", async () => {
+    // `URL.hostname` keeps the brackets, and `dns.lookup("[::1]")` throws — so a
+    // literal that reaches the resolver lands in the fail-open catch and is
+    // allowed. That is the bug `provider-url-guard.ts` shipped; this pins that
+    // this module classifies the literal instead of resolving it.
+    const result = await validateWithoutDns("http://[::1]:8069");
+    expect(result).toEqual({ valid: false, error: expect.stringContaining("loopback") });
+  });
+
+  it("rejects an IPv4-mapped IPv6 metadata literal without touching the resolver", async () => {
+    const result = await validateWithoutDns("http://[::ffff:169.254.169.254]/");
+    expect(result).toEqual({ valid: false, error: expect.stringContaining("link-local") });
+  });
+
+  it("accepts a public IPv6 literal without touching the resolver", async () => {
+    // Already fully classified from the string — DNS has nothing to add, and
+    // asking it would only reintroduce the bracket problem above.
+    const result = await validateWithoutDns("https://[2606:4700:4700::1111]");
+    expect(result).toEqual({ valid: true, url: "https://[2606:4700:4700::1111]" });
+  });
+
+  it("accepts a public IPv4 literal without touching the resolver", async () => {
+    const result = await validateWithoutDns("https://203.0.113.10:8069");
+    expect(result).toEqual({ valid: true, url: "https://203.0.113.10:8069" });
+  });
+
+  it("names the ALLOW_PRIVATE_URLS opt-out for an RFC-1918 address, and only there", async () => {
+    // An on-premise Odoo on 10.x is a legitimate deployment, so that refusal
+    // has to say how to allow it. Loopback and cloud metadata never are, so
+    // theirs must not suggest an opt-out that is the wrong answer for them.
+    const onPrem = await validateWithoutDns("http://10.0.0.5:8069");
+    expect(onPrem).toEqual({
+      valid: false,
+      error: expect.stringContaining("ALLOW_PRIVATE_URLS=1"),
+    });
+
+    const metadata = await validateWithoutDns("http://169.254.169.254/");
+    expect(metadata).toEqual({ valid: false, error: expect.not.stringContaining("ALLOW_") });
   });
 
   it("accepts HTTPS public domain (resolves to a public address)", async () => {
@@ -245,11 +297,16 @@ describe("validateExternalUrl", () => {
 
   describe("DNS resolution (the actual SSRF-via-DNS / DNS-rebinding case)", () => {
     it("rejects a hostname that resolves to a private address", async () => {
+      // The one blocked case that is a plausible real deployment, so this is
+      // also the one whose message has to name the way to allow it.
       const result = await validateExternalUrl(
         "https://internal-odoo.attacker.example",
         resolveTo(["10.0.0.5"])
       );
-      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+      expect(result).toEqual({
+        valid: false,
+        error: expect.stringContaining("ALLOW_PRIVATE_URLS=1"),
+      });
     });
 
     it("rejects a hostname that resolves to the cloud-metadata address", async () => {
@@ -257,7 +314,7 @@ describe("validateExternalUrl", () => {
         "https://metadata.attacker.example",
         resolveTo(["169.254.169.254"])
       );
-      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("link-local") });
     });
 
     it("rejects a hostname that resolves to loopback", async () => {
@@ -265,7 +322,7 @@ describe("validateExternalUrl", () => {
         "https://rebind.attacker.example",
         resolveTo(["127.0.0.1"])
       );
-      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("loopback") });
     });
 
     it("rejects a hostname where only one of several resolved addresses is private", async () => {
@@ -275,7 +332,7 @@ describe("validateExternalUrl", () => {
         "https://mixed.attacker.example",
         resolveTo(["203.0.113.10", "127.0.0.1"])
       );
-      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("loopback") });
     });
 
     it("rejects a hostname that resolves to an IPv4-mapped IPv6 metadata address", async () => {
@@ -283,7 +340,7 @@ describe("validateExternalUrl", () => {
         "https://mapped.attacker.example",
         resolveTo(["::ffff:169.254.169.254"])
       );
-      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("link-local") });
     });
 
     it("allows a hostname that resolves only to public addresses", async () => {
@@ -303,28 +360,30 @@ describe("validateExternalUrl", () => {
   describe("ALLOW_PRIVATE_URLS bypass", () => {
     it("allows private URLs when ALLOW_PRIVATE_URLS=1", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      const result = await validateExternalUrl("http://localhost:8069", mustNotBeCalled);
+      const result = await validateWithoutDns("http://localhost:8069");
       expect(result).toEqual({ valid: true, url: "http://localhost:8069" });
     });
 
     it("allows internal Docker hostnames when ALLOW_PRIVATE_URLS=1, without touching DNS", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      // odoo-e2e / eval stacks set this flag so the wizard can reach
-      // odoo-mock on the Docker-internal network. The resolver must not even
-      // be invoked — the bypass short-circuits before DNS.
-      const result = await validateExternalUrl("http://odoo-mock:8069", mustNotBeCalled);
+      // odoo-e2e / eval stacks set this flag so the wizard can reach odoo-mock
+      // on the Docker-internal network, where there is no resolver answer to
+      // be had. `validateWithoutDns` fails if the bypass ever stops
+      // short-circuiting: a bare name like this one would otherwise be handed
+      // to DNS, and the resulting failure is silently allowed.
+      const result = await validateWithoutDns("http://odoo-mock:8069");
       expect(result).toEqual({ valid: true, url: "http://odoo-mock:8069" });
     });
 
     it("still rejects non-HTTP schemes even with ALLOW_PRIVATE_URLS=1", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      const result = await validateExternalUrl("ftp://localhost:8069", mustNotBeCalled);
+      const result = await validateWithoutDns("ftp://localhost:8069");
       expect(result).toEqual({ valid: false, error: expect.stringContaining("HTTP") });
     });
 
     it("still rejects invalid URLs even with ALLOW_PRIVATE_URLS=1", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      const result = await validateExternalUrl("not-a-url", mustNotBeCalled);
+      const result = await validateWithoutDns("not-a-url");
       expect(result).toEqual({ valid: false, error: expect.any(String) });
     });
   });

--- a/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/url-validation.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { validateExternalUrl, isPrivateUrl, classifyIpAddress } from "../url-validation";
+import {
+  validateExternalUrl,
+  isPrivateUrl,
+  classifyIpAddress,
+  type UrlHostResolver,
+} from "../url-validation";
+
+/** Resolver stub: returns the given addresses, never touches real DNS. */
+function resolveTo(addresses: string[]): UrlHostResolver {
+  return async () => addresses;
+}
+
+/** Resolver stub that fails, as `dns.lookup` does for an unresolvable name. */
+const unresolvable: UrlHostResolver = async () => {
+  throw new Error("ENOTFOUND");
+};
+
+/** Resolver stub that throws if invoked — proves a code path never reaches DNS. */
+const mustNotBeCalled: UrlHostResolver = async () => {
+  throw new Error("resolver should not have been called");
+};
 
 describe("isPrivateUrl", () => {
   it("rejects localhost", () => {
@@ -145,88 +165,166 @@ describe("validateExternalUrl", () => {
     vi.unstubAllEnvs();
   });
 
-  it("rejects non-HTTP scheme (ftp)", () => {
-    const result = validateExternalUrl("ftp://odoo.example.com");
+  it("rejects non-HTTP scheme (ftp)", async () => {
+    const result = await validateExternalUrl("ftp://odoo.example.com", mustNotBeCalled);
     expect(result).toEqual({ valid: false, error: expect.stringContaining("HTTP") });
   });
 
-  it("rejects non-HTTP scheme (file)", () => {
-    const result = validateExternalUrl("file:///etc/passwd");
+  it("rejects non-HTTP scheme (file)", async () => {
+    const result = await validateExternalUrl("file:///etc/passwd", mustNotBeCalled);
     expect(result).toEqual({ valid: false, error: expect.stringContaining("HTTP") });
   });
 
-  it("rejects invalid URL", () => {
-    const result = validateExternalUrl("not-a-url");
+  it("rejects invalid URL", async () => {
+    const result = await validateExternalUrl("not-a-url", mustNotBeCalled);
     expect(result).toEqual({ valid: false, error: expect.any(String) });
   });
 
-  it("rejects empty string", () => {
-    const result = validateExternalUrl("");
+  it("rejects empty string", async () => {
+    const result = await validateExternalUrl("", mustNotBeCalled);
     expect(result).toEqual({ valid: false, error: expect.any(String) });
   });
 
-  it("rejects localhost", () => {
-    const result = validateExternalUrl("http://localhost:8069");
+  it("rejects localhost (well-known hostname, no DNS needed)", async () => {
+    const result = await validateExternalUrl("http://localhost:8069", mustNotBeCalled);
     expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
   });
 
-  it("rejects 127.0.0.1", () => {
-    const result = validateExternalUrl("http://127.0.0.1:8069");
+  it("rejects 127.0.0.1 (IP literal, no DNS needed)", async () => {
+    const result = await validateExternalUrl("http://127.0.0.1:8069", mustNotBeCalled);
     expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
   });
 
-  it("rejects AWS metadata endpoint", () => {
-    const result = validateExternalUrl("http://169.254.169.254/latest/meta-data/");
+  it("rejects AWS metadata endpoint (IP literal, no DNS needed)", async () => {
+    const result = await validateExternalUrl(
+      "http://169.254.169.254/latest/meta-data/",
+      mustNotBeCalled
+    );
     expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
   });
 
-  it("accepts HTTPS public domain", () => {
-    const result = validateExternalUrl("https://odoo.example.com");
+  it("accepts HTTPS public domain (resolves to a public address)", async () => {
+    const result = await validateExternalUrl(
+      "https://odoo.example.com",
+      resolveTo(["203.0.113.10"])
+    );
     expect(result).toEqual({ valid: true, url: "https://odoo.example.com" });
   });
 
-  it("accepts HTTPS odoo.com subdomain", () => {
-    const result = validateExternalUrl("https://mycompany.odoo.com");
+  it("accepts HTTPS odoo.com subdomain (resolves to a public address)", async () => {
+    const result = await validateExternalUrl(
+      "https://mycompany.odoo.com",
+      resolveTo(["203.0.113.10"])
+    );
     expect(result).toEqual({ valid: true, url: "https://mycompany.odoo.com" });
   });
 
-  it("accepts HTTP for on-prem (public domain)", () => {
-    const result = validateExternalUrl("http://odoo.example.com:8069");
+  it("accepts HTTP for on-prem (resolves to a public address)", async () => {
+    const result = await validateExternalUrl(
+      "http://odoo.example.com:8069",
+      resolveTo(["203.0.113.10"])
+    );
     expect(result).toEqual({ valid: true, url: "http://odoo.example.com:8069" });
   });
 
-  it("normalizes trailing slash", () => {
-    const result = validateExternalUrl("https://odoo.example.com/");
+  it("normalizes trailing slash", async () => {
+    const result = await validateExternalUrl(
+      "https://odoo.example.com/",
+      resolveTo(["203.0.113.10"])
+    );
     expect(result).toEqual({ valid: true, url: "https://odoo.example.com" });
   });
 
-  it("strips path for origin-only output", () => {
-    const result = validateExternalUrl("https://odoo.example.com/web/login");
+  it("strips path for origin-only output", async () => {
+    const result = await validateExternalUrl(
+      "https://odoo.example.com/web/login",
+      resolveTo(["203.0.113.10"])
+    );
     expect(result).toEqual({ valid: true, url: "https://odoo.example.com" });
+  });
+
+  describe("DNS resolution (the actual SSRF-via-DNS / DNS-rebinding case)", () => {
+    it("rejects a hostname that resolves to a private address", async () => {
+      const result = await validateExternalUrl(
+        "https://internal-odoo.attacker.example",
+        resolveTo(["10.0.0.5"])
+      );
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    });
+
+    it("rejects a hostname that resolves to the cloud-metadata address", async () => {
+      const result = await validateExternalUrl(
+        "https://metadata.attacker.example",
+        resolveTo(["169.254.169.254"])
+      );
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    });
+
+    it("rejects a hostname that resolves to loopback", async () => {
+      const result = await validateExternalUrl(
+        "https://rebind.attacker.example",
+        resolveTo(["127.0.0.1"])
+      );
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    });
+
+    it("rejects a hostname where only one of several resolved addresses is private", async () => {
+      // A resolver can legitimately return multiple A/AAAA records; every one
+      // of them must be classified, not just the first.
+      const result = await validateExternalUrl(
+        "https://mixed.attacker.example",
+        resolveTo(["203.0.113.10", "127.0.0.1"])
+      );
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    });
+
+    it("rejects a hostname that resolves to an IPv4-mapped IPv6 metadata address", async () => {
+      const result = await validateExternalUrl(
+        "https://mapped.attacker.example",
+        resolveTo(["::ffff:169.254.169.254"])
+      );
+      expect(result).toEqual({ valid: false, error: expect.stringContaining("private") });
+    });
+
+    it("allows a hostname that resolves only to public addresses", async () => {
+      const result = await validateExternalUrl(
+        "https://real-odoo.example",
+        resolveTo(["203.0.113.10", "2606:4700:4700::1111"])
+      );
+      expect(result).toEqual({ valid: true, url: "https://real-odoo.example" });
+    });
+
+    it("fails open when the hostname does not resolve at all (typo, not an attack)", async () => {
+      const result = await validateExternalUrl("https://typo.example", unresolvable);
+      expect(result).toEqual({ valid: true, url: "https://typo.example" });
+    });
   });
 
   describe("ALLOW_PRIVATE_URLS bypass", () => {
-    it("allows private URLs when ALLOW_PRIVATE_URLS=1", () => {
+    it("allows private URLs when ALLOW_PRIVATE_URLS=1", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      const result = validateExternalUrl("http://localhost:8069");
+      const result = await validateExternalUrl("http://localhost:8069", mustNotBeCalled);
       expect(result).toEqual({ valid: true, url: "http://localhost:8069" });
     });
 
-    it("allows internal Docker hostnames when ALLOW_PRIVATE_URLS=1", () => {
+    it("allows internal Docker hostnames when ALLOW_PRIVATE_URLS=1, without touching DNS", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      const result = validateExternalUrl("http://odoo-mock:8069");
+      // odoo-e2e / eval stacks set this flag so the wizard can reach
+      // odoo-mock on the Docker-internal network. The resolver must not even
+      // be invoked — the bypass short-circuits before DNS.
+      const result = await validateExternalUrl("http://odoo-mock:8069", mustNotBeCalled);
       expect(result).toEqual({ valid: true, url: "http://odoo-mock:8069" });
     });
 
-    it("still rejects non-HTTP schemes even with ALLOW_PRIVATE_URLS=1", () => {
+    it("still rejects non-HTTP schemes even with ALLOW_PRIVATE_URLS=1", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      const result = validateExternalUrl("ftp://localhost:8069");
+      const result = await validateExternalUrl("ftp://localhost:8069", mustNotBeCalled);
       expect(result).toEqual({ valid: false, error: expect.stringContaining("HTTP") });
     });
 
-    it("still rejects invalid URLs even with ALLOW_PRIVATE_URLS=1", () => {
+    it("still rejects invalid URLs even with ALLOW_PRIVATE_URLS=1", async () => {
       vi.stubEnv("ALLOW_PRIVATE_URLS", "1");
-      const result = validateExternalUrl("not-a-url");
+      const result = await validateExternalUrl("not-a-url", mustNotBeCalled);
       expect(result).toEqual({ valid: false, error: expect.any(String) });
     });
   });

--- a/packages/web/src/lib/integrations/url-validation.ts
+++ b/packages/web/src/lib/integrations/url-validation.ts
@@ -164,8 +164,12 @@ export function classifyIpAddress(address: string): IpAddressClass | null {
  * that resolves to a private IP (DNS rebinding) would pass this check —
  * `validateExternalUrl` below closes that gap for its own callers by also
  * resolving a DNS name and classifying every returned address. A caller that
- * uses `isPrivateUrl` directly (`imap-autodiscover.ts`'s prefill-only guard)
- * still only gets the string-only check.
+ * uses `isPrivateUrl` directly gets the string-only check and nothing more:
+ * today that is `imap-autodiscover.ts`, which compensates by rejecting every
+ * address literal outright and only ever fetching over HTTPS. A name with an
+ * internal A record is still not covered there — narrower than it sounds
+ * (HTTPS only, and the host is derived from the user's own email domain), but
+ * not closed.
  */
 export function isPrivateUrl(urlString: string): boolean {
   let url: URL;
@@ -175,17 +179,31 @@ export function isPrivateUrl(urlString: string): boolean {
     return false; // Can't determine — let validateExternalUrl handle parse errors
   }
 
-  const hostname = url.hostname;
+  const hostClass = classifyHostname(url.hostname);
+  return hostClass !== null && hostClass !== "public";
+}
 
-  // Check well-known private hostnames
-  if (PRIVATE_HOSTNAMES.has(hostname.toLowerCase())) return true;
+/**
+ * Classifies a URL's host from the string alone: the address class for an IP
+ * literal, and null for a genuine DNS name — which no amount of string
+ * inspection can answer for, only a resolver can.
+ *
+ * Both string-only callers go through here so they cannot drift: `isPrivateUrl`
+ * collapses the answer to a boolean, and `validateExternalUrl` keeps the class
+ * so it can phrase the right refusal and decide whether DNS is still needed.
+ */
+function classifyHostname(hostname: string): IpAddressClass | null {
+  // A well-known private name is loopback wherever it resolves at all; naming
+  // the class rather than returning a bare `true` is what lets the caller say
+  // "never a real server" instead of suggesting an opt-out that doesn't apply.
+  if (PRIVATE_HOSTNAMES.has(hostname.toLowerCase())) return "loopback";
 
-  // Everything else is decided by the address ranges. A hostname that is not
-  // an IP literal classifies as null and passes — see the DNS caveat above.
-  // (`URL.hostname` keeps the brackets around an IPv6 literal; classifyIpAddress
-  // strips them.)
-  const addressClass = classifyIpAddress(hostname);
-  return addressClass !== null && addressClass !== "public";
+  // `URL.hostname` keeps the brackets around an IPv6 literal ("[::1]"), which
+  // `classifyIpAddress` strips — and which `dns.lookup` chokes on, so this is
+  // also the step that keeps a literal away from the resolver. Exactly that
+  // step was missing in `provider-url-guard.ts`, whose fail-open catch then
+  // waved every IPv6 literal through.
+  return classifyIpAddress(hostname);
 }
 
 type ValidationResult = { valid: true; url: string } | { valid: false; error: string };
@@ -198,7 +216,25 @@ const defaultUrlHostResolver: UrlHostResolver = async (host) => {
   return results.map((result) => result.address);
 };
 
-const PRIVATE_NETWORK_ERROR = "URLs targeting private or internal networks are not allowed";
+// Two messages, because the two cases deserve different advice. Loopback,
+// link-local (cloud metadata) and the unspecified address are never a real
+// Odoo server, so there is nothing to trade off and nothing to suggest. An
+// RFC-1918 / ULA address, on the other hand, is exactly where an on-premise
+// Odoo legitimately lives — so that one names the way to allow it. Same split
+// as `mail-host-guard.ts`; both strings keep the word "private" so a caller
+// asserting on it stays honest.
+const INTERNAL_NETWORK_ERROR =
+  "Blocked: this URL targets a loopback, link-local or cloud-metadata address, " +
+  "which is never a private Odoo server.";
+
+const PRIVATE_NETWORK_ERROR =
+  "Blocked: this URL targets a private network address. " +
+  "Set ALLOW_PRIVATE_URLS=1 to allow an Odoo server on your own network.";
+
+/** The message to answer with for the address class that caused the block. */
+function blockMessageFor(addressClass: IpAddressClass): string {
+  return addressClass === "private" ? PRIVATE_NETWORK_ERROR : INTERNAL_NETWORK_ERROR;
+}
 
 /**
  * Validates a user-supplied URL for server-side requests.
@@ -211,14 +247,17 @@ const PRIVATE_NETWORK_ERROR = "URLs targeting private or internal networks are n
  * resolution.
  *
  * A hostname that is an IP literal, or one of the well-known private names
- * (`localhost`, …), is classified from the string alone via `isPrivateUrl` —
- * no DNS involved. A hostname that is a genuine DNS name is additionally
- * RESOLVED and every returned address is classified, so a name that points at
- * 169.254.169.254 (cloud metadata) or an RFC-1918 address — including one
- * that only starts resolving there after the URL is saved (DNS rebinding) —
- * can't sneak past a check that only ever read the hostname string. Resolving
- * again at request time is out of scope here; see `probe.ts`'s callers for
- * that caveat, shared with the mail-host guard.
+ * (`localhost`, …), is classified from the string alone via `classifyHostname`
+ * — no DNS involved, and no literal is ever handed to the resolver. A hostname
+ * that is a genuine DNS name is additionally RESOLVED and every returned
+ * address is classified, so a name that points at 169.254.169.254 (cloud
+ * metadata) or an RFC-1918 address can't sneak past a check that only ever
+ * read the hostname string.
+ *
+ * What this does NOT cover is rebinding between the two lookups: the address
+ * is classified here, and the eventual Odoo request resolves the name again.
+ * Closing that would mean pinning the connection to the address we checked,
+ * the same caveat `mail-host-guard.ts` carries for imapflow/nodemailer.
  *
  * Fails open on DNS resolution failure: a name that doesn't resolve can't be
  * classified, and the far more likely cause is a typo — blocking it here
@@ -246,17 +285,20 @@ export async function validateExternalUrl(
 
   const allowPrivate = process.env.ALLOW_PRIVATE_URLS === "1";
   if (!allowPrivate) {
-    // Literal address / well-known private hostname: string-only check, no DNS.
-    if (isPrivateUrl(urlString)) {
-      return { valid: false, error: PRIVATE_NETWORK_ERROR };
-    }
-
-    // A DNS name that passed the literal check above still might resolve to
-    // a private address — resolve it and classify every returned address.
     const hostname = url.hostname;
-    const isLiteralOrWellKnown =
-      classifyIpAddress(hostname) !== null || PRIVATE_HOSTNAMES.has(hostname.toLowerCase());
-    if (!isLiteralOrWellKnown) {
+    // Address literal or well-known private name: decided from the string
+    // alone, no DNS involved.
+    const hostClass = classifyHostname(hostname);
+    if (hostClass !== null) {
+      if (hostClass !== "public") {
+        return { valid: false, error: blockMessageFor(hostClass) };
+      }
+      // A public literal is already fully classified — DNS has nothing to add.
+    } else {
+      // A genuine DNS name. The address it points at is what actually gets
+      // connected to, so resolve it and classify every answer: a name aimed at
+      // 169.254.169.254 (cloud metadata) or an RFC-1918 address must not walk
+      // past a check that only ever read the hostname string.
       let addresses: string[];
       try {
         addresses = await resolver(hostname);
@@ -266,7 +308,7 @@ export async function validateExternalUrl(
       for (const address of addresses) {
         const addressClass = classifyIpAddress(address);
         if (addressClass !== null && addressClass !== "public") {
-          return { valid: false, error: PRIVATE_NETWORK_ERROR };
+          return { valid: false, error: blockMessageFor(addressClass) };
         }
       }
     }

--- a/packages/web/src/lib/integrations/url-validation.ts
+++ b/packages/web/src/lib/integrations/url-validation.ts
@@ -3,6 +3,8 @@
  * private/internal networks (AWS metadata, localhost, RFC-1918, etc.).
  */
 
+import { lookup as dnsLookup } from "node:dns/promises";
+
 const PRIVATE_HOSTNAMES = new Set(["localhost", "localhost.", "ip6-localhost", "ip6-loopback"]);
 
 /**
@@ -159,8 +161,11 @@ export function classifyIpAddress(address: string): IpAddressClass | null {
 /**
  * Returns true if the given URL string targets a private/internal address.
  * Note: This checks the hostname string only, not DNS resolution. A hostname
- * that resolves to a private IP (DNS rebinding) would pass this check. For a
- * self-hosted product where admins control the network, this is acceptable.
+ * that resolves to a private IP (DNS rebinding) would pass this check —
+ * `validateExternalUrl` below closes that gap for its own callers by also
+ * resolving a DNS name and classifying every returned address. A caller that
+ * uses `isPrivateUrl` directly (`imap-autodiscover.ts`'s prefill-only guard)
+ * still only gets the string-only check.
  */
 export function isPrivateUrl(urlString: string): boolean {
   let url: URL;
@@ -185,14 +190,45 @@ export function isPrivateUrl(urlString: string): boolean {
 
 type ValidationResult = { valid: true; url: string } | { valid: false; error: string };
 
+/** Resolves a hostname to all of its A/AAAA addresses. Injected in tests. */
+export type UrlHostResolver = (host: string) => Promise<string[]>;
+
+const defaultUrlHostResolver: UrlHostResolver = async (host) => {
+  const results = await dnsLookup(host, { all: true });
+  return results.map((result) => result.address);
+};
+
+const PRIVATE_NETWORK_ERROR = "URLs targeting private or internal networks are not allowed";
+
 /**
  * Validates a user-supplied URL for server-side requests.
  * Returns the normalized origin or an error message.
  *
- * Set env var ALLOW_PRIVATE_URLS=1 to bypass private IP checks
- * (useful for Docker dev environments with internal service hostnames).
+ * Set env var ALLOW_PRIVATE_URLS=1 to bypass private IP checks entirely
+ * (useful for Docker dev/test environments with internal service hostnames,
+ * e.g. the odoo-e2e and eval stacks reaching odoo-mock on the Docker-internal
+ * network). The bypass short-circuits before any check below, including DNS
+ * resolution.
+ *
+ * A hostname that is an IP literal, or one of the well-known private names
+ * (`localhost`, …), is classified from the string alone via `isPrivateUrl` —
+ * no DNS involved. A hostname that is a genuine DNS name is additionally
+ * RESOLVED and every returned address is classified, so a name that points at
+ * 169.254.169.254 (cloud metadata) or an RFC-1918 address — including one
+ * that only starts resolving there after the URL is saved (DNS rebinding) —
+ * can't sneak past a check that only ever read the hostname string. Resolving
+ * again at request time is out of scope here; see `probe.ts`'s callers for
+ * that caveat, shared with the mail-host guard.
+ *
+ * Fails open on DNS resolution failure: a name that doesn't resolve can't be
+ * classified, and the far more likely cause is a typo — blocking it here
+ * would misreport a config mistake as a security error, and the subsequent
+ * fetch fails naturally anyway.
  */
-export function validateExternalUrl(urlString: string): ValidationResult {
+export async function validateExternalUrl(
+  urlString: string,
+  resolver: UrlHostResolver = defaultUrlHostResolver
+): Promise<ValidationResult> {
   let url: URL;
   try {
     url = new URL(urlString);
@@ -208,13 +244,32 @@ export function validateExternalUrl(urlString: string): ValidationResult {
     };
   }
 
-  // Check for private/internal addresses (unless bypassed)
   const allowPrivate = process.env.ALLOW_PRIVATE_URLS === "1";
-  if (!allowPrivate && isPrivateUrl(urlString)) {
-    return {
-      valid: false,
-      error: "URLs targeting private or internal networks are not allowed",
-    };
+  if (!allowPrivate) {
+    // Literal address / well-known private hostname: string-only check, no DNS.
+    if (isPrivateUrl(urlString)) {
+      return { valid: false, error: PRIVATE_NETWORK_ERROR };
+    }
+
+    // A DNS name that passed the literal check above still might resolve to
+    // a private address — resolve it and classify every returned address.
+    const hostname = url.hostname;
+    const isLiteralOrWellKnown =
+      classifyIpAddress(hostname) !== null || PRIVATE_HOSTNAMES.has(hostname.toLowerCase());
+    if (!isLiteralOrWellKnown) {
+      let addresses: string[];
+      try {
+        addresses = await resolver(hostname);
+      } catch {
+        addresses = []; // unresolvable name — fail open, see doc-comment above
+      }
+      for (const address of addresses) {
+        const addressClass = classifyIpAddress(address);
+        if (addressClass !== null && addressClass !== "public") {
+          return { valid: false, error: PRIVATE_NETWORK_ERROR };
+        }
+      }
+    }
   }
 
   // Return normalized origin (scheme + host + port, no path/query)


### PR DESCRIPTION
## Summary

- `validateExternalUrl()` (`packages/web/src/lib/integrations/url-validation.ts`) classified only the hostname **string**, never resolving DNS — its own comment said so. A hostname that resolves to `169.254.169.254`, `127.0.0.1`, or an RFC1918 address passed the check (SSRF via DNS / DNS rebinding), reachable through six admin-only Odoo integration routes.
- `provider-url-guard.ts` and `mail-host-guard.ts` already do this correctly for other integrations; the Odoo path never got the same treatment.
- `validateExternalUrl` is now **async**. It still classifies IP literals and well-known private hostnames from the string alone (no DNS needed — `isPrivateUrl` unchanged), but a genuine DNS name is now resolved through an injectable `UrlHostResolver` and every returned address is classified; any non-public address rejects the request. Fails open on an unresolvable name (typo, not an attack — the fetch fails naturally afterward).
- `ALLOW_PRIVATE_URLS=1` still short-circuits the entire check *before* any DNS resolution, so `odoo-e2e` and `eval` Docker stacks keep reaching `odoo-mock` on the container-internal network without needing DNS at all.
- Updated all six call sites (`POST /api/integrations`, `PATCH /api/integrations/:connectionId`, `POST /api/integrations/:connectionId/sync`, `POST /api/integrations/sync-preview`, `POST /api/integrations/list-databases`, `POST /api/integrations/test-credentials`) to `await` the new signature — all were already inside async admin-only route handlers.

## Test plan

- [x] New tests (red before the fix, green after): hostname resolving to a private address is rejected, to the cloud-metadata IP, to loopback, to an IPv4-mapped IPv6 metadata address, and when only one of several resolved addresses is private (all via mocked `UrlHostResolver`, no real DNS in tests).
- [x] Public hostname (mocked to a public address) continues to be allowed.
- [x] `ALLOW_PRIVATE_URLS=1` continues to bypass the whole check, and the resolver is proven to never be invoked in that path (`mustNotBeCalled` stub).
- [x] Unresolvable hostname fails open (allowed) — matches `provider-url-guard.ts`/`mail-host-guard.ts` convention.
- [x] All pre-existing `validateExternalUrl`/`isPrivateUrl` tests extended (not deleted) to the new async signature.
- [x] `pnpm test` — 774 passed, 4 skipped test files; 10915 tests passed, 18 skipped.
- [x] `pnpm test:scripts` — 894 passed.
- [x] `pnpm -C packages/web lint` — 0 errors (pre-existing unrelated warnings only).
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm format:check` — clean.
- [x] `pnpm build` (via pre-push hook) — succeeded.

Docs-not-needed trailer included: `docs/reference/api.mdx` already documents `POST /api/integrations` as rejecting a URL that "resolves to a disallowed address (SSRF guard)" — this fix makes the implementation match that existing documented behavior.