### PR TITLE
fix(docs): README quickstart fails on the very first command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,14 @@ Honest caveats: Pinchy is young, the integration list is short (Odoo, email — 
 ## Quick Start
 
 ```bash
+mkdir -p pinchy && cd pinchy
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.9.1/docker-compose.yml -o docker-compose.yml
 echo "PINCHY_VERSION=v0.9.1" > .env
 docker compose up -d
 # Open http://localhost:7777 — the setup wizard creates your admin account
 ```
 
-That is the whole thing: one command, no build step, pre-built images on GHCR. Pair it with a local model via [Ollama](https://docs.heypinchy.com/guides/ollama-setup/) and nothing ever leaves your network. Full setup, configuration, and development instructions: **[Installation Guide](https://docs.heypinchy.com/installation/)**.
+That is the whole thing: no build step, pre-built images on GHCR. Pair it with a local model via [Ollama](https://docs.heypinchy.com/guides/ollama-setup/) and nothing ever leaves your network. Full setup, configuration, and development instructions: **[Installation Guide](https://docs.heypinchy.com/installation/)**.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Honest caveats: Pinchy is young, the integration list is short (Odoo, email — 
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.8.0/docker-compose.yml -o docker-compose.yml
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.9.1/docker-compose.yml -o docker-compose.yml
+echo "PINCHY_VERSION=v0.9.1" > .env
 docker compose up -d
 # Open http://localhost:7777 — the setup wizard creates your admin account
 ```

--- a/scripts/lib/readme-quickstart-gate.mjs
+++ b/scripts/lib/readme-quickstart-gate.mjs
@@ -1,0 +1,74 @@
+/**
+ * Drift guard for the README "Quick Start" code block.
+ *
+ * `docker-compose.yml` refuses to start without a pinned version
+ * (`PINCHY_VERSION:?set PINCHY_VERSION in .env`), but the README quickstart
+ * used to `curl` the compose file straight into `docker compose up -d` with
+ * no `.env` in between — the very first command a reader copies would fail.
+ * `docs/src/content/docs/installation.mdx` and `getting-started.mdx` already
+ * carry the correct `echo "PINCHY_VERSION=..." > .env` step; the README
+ * quickstart was the one place that never got it.
+ *
+ * Pure functions only — all I/O happens in the caller (the guard test).
+ * Mirrors the shape of docs-link-gate.mjs / format-gate.mjs.
+ */
+
+const QUICKSTART_HEADING = /^## Quick Start\s*$/m;
+
+/**
+ * Extracts the first fenced ```bash code block that appears after the
+ * "## Quick Start" heading.
+ * @param {string} readme - raw README.md contents
+ * @returns {string} the code block's contents (without the fences)
+ * @throws {Error} if the heading, or a ```bash block after it, is missing
+ */
+export function extractQuickstartBlock(readme) {
+  if (typeof readme !== "string") {
+    throw new Error("README is unreadable");
+  }
+  const headingMatch = QUICKSTART_HEADING.exec(readme);
+  if (!headingMatch) {
+    throw new Error('README has no "## Quick Start" heading');
+  }
+  const after = readme.slice(headingMatch.index + headingMatch[0].length);
+  const blockMatch = /```bash\n([\s\S]*?)```/.exec(after);
+  if (!blockMatch) {
+    throw new Error(
+      'No ```bash code block found after the "## Quick Start" heading',
+    );
+  }
+  return blockMatch[1];
+}
+
+/**
+ * Validates that the quickstart block sets PINCHY_VERSION before it runs
+ * `docker compose up`. Equivalent forms (e.g. exporting the variable, or
+ * writing it into `.env` via `echo`/redirect) all satisfy this — the point
+ * is only that SOME line naming PINCHY_VERSION precedes the start command,
+ * matching the pattern already used in installation.mdx / getting-started.mdx.
+ * @param {string} block - the quickstart bash block's contents
+ * @returns {string[]} problems (empty = ok)
+ */
+export function validateQuickstartSetsVersion(block) {
+  if (typeof block !== "string") {
+    return ["quickstart block is unreadable"];
+  }
+  const lines = block.split("\n");
+  const upIndex = lines.findIndex((line) => /docker compose up/.test(line));
+  if (upIndex === -1) {
+    return [
+      'quickstart block has no "docker compose up" command to check against',
+    ];
+  }
+  const before = lines.slice(0, upIndex);
+  const setsVersion = before.some((line) => /PINCHY_VERSION/.test(line));
+  if (!setsVersion) {
+    return [
+      'quickstart block runs "docker compose up" without setting PINCHY_VERSION first. ' +
+        "docker-compose.yml refuses to start without it " +
+        "(`PINCHY_VERSION:?set PINCHY_VERSION in .env`), so the first command a reader copies " +
+        'fails. Add a line like `echo "PINCHY_VERSION=vX.Y.Z" > .env` before `docker compose up`.',
+    ];
+  }
+  return [];
+}

--- a/scripts/lib/readme-quickstart-gate.mjs
+++ b/scripts/lib/readme-quickstart-gate.mjs
@@ -9,18 +9,48 @@
  * carry the correct `echo "PINCHY_VERSION=..." > .env` step; the README
  * quickstart was the one place that never got it.
  *
+ * The block therefore carries two version pins — the curl'd compose URL and
+ * the `PINCHY_VERSION=` value — and they must name the same release. A block
+ * where they disagree is the failure mode NOT to trade the original one for:
+ * the reader's first command succeeds, so nothing surfaces, and they run the
+ * previous release's images against the new release's compose topology.
+ *
  * Pure functions only — all I/O happens in the caller (the guard test).
  * Mirrors the shape of docs-link-gate.mjs / format-gate.mjs.
  */
 
 const QUICKSTART_HEADING = /^## Quick Start\s*$/m;
 
+/** The curl'd compose-file pin, e.g. `.../pinchy/v0.9.1/docker-compose.yml`. */
+const COMPOSE_URL_PIN =
+  /raw\.githubusercontent\.com\/heypinchy\/pinchy\/(v\d+\.\d+\.\d+)\/docker-compose\.yml/;
+
+/** The `.env` pin the compose file resolves its image tags from. */
+const ENV_VERSION_PIN = /PINCHY_VERSION=(v\d+\.\d+\.\d+)/;
+
 /**
- * Extracts the first fenced ```bash code block that appears after the
- * "## Quick Start" heading.
+ * Whether a line actually assigns PINCHY_VERSION, as opposed to merely
+ * mentioning it. A commented-out or explanatory line ("# PINCHY_VERSION is
+ * set below") reads as prose to a human and would be a false green here.
+ * @param {string} line
+ * @returns {boolean}
+ */
+function assignsPinchyVersion(line) {
+  if (/^\s*#/.test(line)) return false;
+  return /PINCHY_VERSION=/.test(line);
+}
+
+/**
+ * Extracts the first fenced ```bash code block inside the "## Quick Start"
+ * section — i.e. between that heading and the next `## ` heading.
+ *
+ * The section bound is load-bearing: an unbounded search would, if the
+ * quickstart block were ever removed, silently validate whatever bash block
+ * came next in the README and report on the wrong thing.
+ *
  * @param {string} readme - raw README.md contents
  * @returns {string} the code block's contents (without the fences)
- * @throws {Error} if the heading, or a ```bash block after it, is missing
+ * @throws {Error} if the heading, or a ```bash block inside its section, is missing
  */
 export function extractQuickstartBlock(readme) {
   if (typeof readme !== "string") {
@@ -31,10 +61,12 @@ export function extractQuickstartBlock(readme) {
     throw new Error('README has no "## Quick Start" heading');
   }
   const after = readme.slice(headingMatch.index + headingMatch[0].length);
-  const blockMatch = /```bash\n([\s\S]*?)```/.exec(after);
+  const nextHeading = /^## /m.exec(after);
+  const section = nextHeading ? after.slice(0, nextHeading.index) : after;
+  const blockMatch = /```bash\n([\s\S]*?)```/.exec(section);
   if (!blockMatch) {
     throw new Error(
-      'No ```bash code block found after the "## Quick Start" heading',
+      'No ```bash code block found in the "## Quick Start" section',
     );
   }
   return blockMatch[1];
@@ -42,10 +74,11 @@ export function extractQuickstartBlock(readme) {
 
 /**
  * Validates that the quickstart block sets PINCHY_VERSION before it runs
- * `docker compose up`. Equivalent forms (e.g. exporting the variable, or
- * writing it into `.env` via `echo`/redirect) all satisfy this — the point
- * is only that SOME line naming PINCHY_VERSION precedes the start command,
- * matching the pattern already used in installation.mdx / getting-started.mdx.
+ * `docker compose up`. Equivalent forms (exporting the variable, or writing
+ * it into `.env` via `echo`/redirect, or prefixing the command) all satisfy
+ * this — the point is only that some line ASSIGNS PINCHY_VERSION before the
+ * start command, matching the pattern already used in installation.mdx /
+ * getting-started.mdx.
  * @param {string} block - the quickstart bash block's contents
  * @returns {string[]} problems (empty = ok)
  */
@@ -61,8 +94,7 @@ export function validateQuickstartSetsVersion(block) {
     ];
   }
   const before = lines.slice(0, upIndex);
-  const setsVersion = before.some((line) => /PINCHY_VERSION/.test(line));
-  if (!setsVersion) {
+  if (!before.some(assignsPinchyVersion)) {
     return [
       'quickstart block runs "docker compose up" without setting PINCHY_VERSION first. ' +
         "docker-compose.yml refuses to start without it " +
@@ -71,4 +103,52 @@ export function validateQuickstartSetsVersion(block) {
     ];
   }
   return [];
+}
+
+/**
+ * Validates that the block's two version pins name the same release.
+ *
+ * `pnpm release` bumps both (`bumpReadmeQuickstartPins`), so a divergence
+ * means one of them was edited by hand or the bumper stopped covering one.
+ * Unlike the missing-`.env` bug, this one is invisible to the reader: the
+ * install succeeds and quietly runs the older release's images against the
+ * newer release's compose file.
+ *
+ * @param {string} block - the quickstart bash block's contents
+ * @returns {string[]} problems (empty = ok)
+ */
+export function validateQuickstartVersionsAgree(block) {
+  if (typeof block !== "string") {
+    return ["quickstart block is unreadable"];
+  }
+  const problems = [];
+  const composeUrlMatch = COMPOSE_URL_PIN.exec(block);
+  const envVersionMatch = ENV_VERSION_PIN.exec(block);
+  if (!composeUrlMatch) {
+    problems.push(
+      "quickstart block has no pinned docker-compose URL " +
+        "(raw.githubusercontent.com/heypinchy/pinchy/vX.Y.Z/docker-compose.yml). " +
+        "An unpinned install is not reproducible, and `pnpm release` cannot bump what it cannot find.",
+    );
+  }
+  if (!envVersionMatch) {
+    problems.push(
+      "quickstart block pins no PINCHY_VERSION=vX.Y.Z value. " +
+        "`pnpm release` bumps this line, so a version written any other way drifts behind every release.",
+    );
+  }
+  if (composeUrlMatch && envVersionMatch) {
+    const [, composeVersion] = composeUrlMatch;
+    const [, envVersion] = envVersionMatch;
+    if (composeVersion !== envVersion) {
+      problems.push(
+        `quickstart pins disagree: the curl'd docker-compose.yml is ${composeVersion} ` +
+          `but PINCHY_VERSION is ${envVersion}. The reader gets ${composeVersion}'s compose ` +
+          `topology running ${envVersion}'s images, and nothing fails to tell them. ` +
+          "Both pins are bumped together by `pnpm release` (bumpReadmeQuickstartPins) — " +
+          "if they drifted, that bumper stopped covering one of them.",
+      );
+    }
+  }
+  return problems;
 }

--- a/scripts/lib/readme-quickstart-gate.test.mjs
+++ b/scripts/lib/readme-quickstart-gate.test.mjs
@@ -1,0 +1,114 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  extractQuickstartBlock,
+  validateQuickstartSetsVersion,
+} from "./readme-quickstart-gate.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const GOOD_README = [
+  "# Pinchy",
+  "",
+  "## Quick Start",
+  "",
+  "```bash",
+  "curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.9.1/docker-compose.yml -o docker-compose.yml",
+  'echo "PINCHY_VERSION=v0.9.1" > .env',
+  "docker compose up -d",
+  "# Open http://localhost:7777 — the setup wizard creates your admin account",
+  "```",
+  "",
+  "## Status",
+].join("\n");
+
+const BAD_README = [
+  "# Pinchy",
+  "",
+  "## Quick Start",
+  "",
+  "```bash",
+  "curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.8.0/docker-compose.yml -o docker-compose.yml",
+  "docker compose up -d",
+  "# Open http://localhost:7777 — the setup wizard creates your admin account",
+  "```",
+  "",
+  "## Status",
+].join("\n");
+
+// ── extractQuickstartBlock ──────────────────────────────────────────────
+
+test("extractQuickstartBlock returns the bash block after the heading", () => {
+  const block = extractQuickstartBlock(GOOD_README);
+  assert.match(block, /docker compose up -d/);
+  assert.match(block, /PINCHY_VERSION/);
+});
+
+test("extractQuickstartBlock throws when the heading is missing", () => {
+  assert.throws(
+    () => extractQuickstartBlock("# Pinchy\n\nNo quickstart here.\n"),
+    /Quick Start/,
+  );
+});
+
+test("extractQuickstartBlock throws when no bash block follows the heading", () => {
+  assert.throws(
+    () => extractQuickstartBlock("# Pinchy\n\n## Quick Start\n\nProse only.\n"),
+    /bash code block/,
+  );
+});
+
+// ── validateQuickstartSetsVersion ───────────────────────────────────────
+
+test("validateQuickstartSetsVersion accepts a block that sets PINCHY_VERSION before starting", () => {
+  const block = extractQuickstartBlock(GOOD_README);
+  assert.deepEqual(validateQuickstartSetsVersion(block), []);
+});
+
+test("validateQuickstartSetsVersion flags a block that never sets PINCHY_VERSION", () => {
+  // The exact shape that broke the README quickstart: curl + `docker compose
+  // up -d` with nothing writing PINCHY_VERSION in between, while
+  // docker-compose.yml requires it and refuses to start otherwise.
+  const block = extractQuickstartBlock(BAD_README);
+  const problems = validateQuickstartSetsVersion(block);
+  assert.ok(
+    problems.some((p) => /PINCHY_VERSION/.test(p)),
+    `expected a PINCHY_VERSION problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validateQuickstartSetsVersion flags PINCHY_VERSION set only AFTER docker compose up", () => {
+  // Order matters: setting the variable after the command that needs it
+  // does not help the reader who copy-pasted the block top to bottom.
+  const block = [
+    "curl -fsSL https://example.invalid/docker-compose.yml -o docker-compose.yml",
+    "docker compose up -d",
+    'echo "PINCHY_VERSION=v0.9.1" > .env',
+  ].join("\n");
+  const problems = validateQuickstartSetsVersion(block);
+  assert.ok(
+    problems.some((p) => /PINCHY_VERSION/.test(p)),
+    `expected a PINCHY_VERSION problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validateQuickstartSetsVersion flags a block with no docker compose up command", () => {
+  const problems = validateQuickstartSetsVersion(
+    'echo "PINCHY_VERSION=v0.9.1" > .env\n',
+  );
+  assert.ok(
+    problems.some((p) => /docker compose up/.test(p)),
+    `expected a missing-command problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+// ── the real README ─────────────────────────────────────────────────────
+
+test("the repo's actual README Quick Start block sets PINCHY_VERSION before starting", () => {
+  const readme = readFileSync(join(REPO_ROOT, "README.md"), "utf8");
+  const block = extractQuickstartBlock(readme);
+  assert.deepEqual(validateQuickstartSetsVersion(block), []);
+});

--- a/scripts/lib/readme-quickstart-gate.test.mjs
+++ b/scripts/lib/readme-quickstart-gate.test.mjs
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from "node:path";
 import {
   extractQuickstartBlock,
   validateQuickstartSetsVersion,
+  validateQuickstartVersionsAgree,
 } from "./readme-quickstart-gate.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -61,6 +62,27 @@ test("extractQuickstartBlock throws when no bash block follows the heading", () 
   );
 });
 
+// The search is bounded to the Quick Start section. Unbounded, a README whose
+// quickstart block was removed would silently hand the next section's bash
+// block to the validators — a guard reporting on the wrong thing, which reads
+// exactly like a guard reporting nothing is wrong.
+test("extractQuickstartBlock does not reach into a later section's bash block", () => {
+  const readme = [
+    "# Pinchy",
+    "",
+    "## Quick Start",
+    "",
+    "Prose only — the block was removed.",
+    "",
+    "## Development",
+    "",
+    "```bash",
+    "docker compose up -d",
+    "```",
+  ].join("\n");
+  assert.throws(() => extractQuickstartBlock(readme), /bash code block/);
+});
+
 // ── validateQuickstartSetsVersion ───────────────────────────────────────
 
 test("validateQuickstartSetsVersion accepts a block that sets PINCHY_VERSION before starting", () => {
@@ -105,10 +127,101 @@ test("validateQuickstartSetsVersion flags a block with no docker compose up comm
   );
 });
 
+// A line that merely NAMES the variable is prose, not a setting. Matching it
+// would make the guard green on a block that still fails on command one.
+test("validateQuickstartSetsVersion does not accept a comment mentioning PINCHY_VERSION", () => {
+  const problems = validateQuickstartSetsVersion(
+    [
+      "# PINCHY_VERSION is picked up automatically",
+      "docker compose up -d",
+    ].join("\n"),
+  );
+  assert.ok(
+    problems.some((p) => /without setting PINCHY_VERSION/.test(p)),
+    `expected a PINCHY_VERSION problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validateQuickstartSetsVersion accepts an inline variable assignment", () => {
+  assert.deepEqual(
+    validateQuickstartSetsVersion(
+      ["export PINCHY_VERSION=v0.9.1", "docker compose up -d"].join("\n"),
+    ),
+    [],
+  );
+});
+
+// ── validateQuickstartVersionsAgree ─────────────────────────────────────
+
+test("validateQuickstartVersionsAgree accepts a block whose two pins match", () => {
+  assert.deepEqual(
+    validateQuickstartVersionsAgree(extractQuickstartBlock(GOOD_README)),
+    [],
+  );
+});
+
+// The regression: `pnpm release` bumping only the curl URL leaves the reader
+// installing the new release's compose file against the previous release's
+// images. Nothing fails, so only a guard can catch it.
+test("validateQuickstartVersionsAgree flags a compose URL and .env pin that disagree", () => {
+  const problems = validateQuickstartVersionsAgree(
+    [
+      "curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.10.0/docker-compose.yml -o docker-compose.yml",
+      'echo "PINCHY_VERSION=v0.9.1" > .env',
+      "docker compose up -d",
+    ].join("\n"),
+  );
+  assert.ok(
+    problems.some((p) => /pins disagree/.test(p)),
+    `expected a disagreeing-pins problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validateQuickstartVersionsAgree flags a block with no pinned compose URL", () => {
+  const problems = validateQuickstartVersionsAgree(
+    ['echo "PINCHY_VERSION=v0.9.1" > .env', "docker compose up -d"].join("\n"),
+  );
+  assert.ok(
+    problems.some((p) => /no pinned docker-compose URL/.test(p)),
+    `expected a missing-URL problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validateQuickstartVersionsAgree flags a block with no PINCHY_VERSION pin", () => {
+  const problems = validateQuickstartVersionsAgree(
+    extractQuickstartBlock(BAD_README),
+  );
+  assert.ok(
+    problems.some((p) => /pins no PINCHY_VERSION/.test(p)),
+    `expected a missing-pin problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
 // ── the real README ─────────────────────────────────────────────────────
 
 test("the repo's actual README Quick Start block sets PINCHY_VERSION before starting", () => {
   const readme = readFileSync(join(REPO_ROOT, "README.md"), "utf8");
   const block = extractQuickstartBlock(readme);
   assert.deepEqual(validateQuickstartSetsVersion(block), []);
+});
+
+test("the repo's actual README Quick Start block pins one version, not two", () => {
+  const readme = readFileSync(join(REPO_ROOT, "README.md"), "utf8");
+  const block = extractQuickstartBlock(readme);
+  assert.deepEqual(validateQuickstartVersionsAgree(block), []);
+});
+
+// The guard and the release script have to agree about what the quickstart
+// looks like: the gate asserts the two pins match, `pnpm release` is what keeps
+// them matching. If the bumper stops covering a pin, the next release ships a
+// README this gate then fails on — so pin the pairing here, where it is cheap.
+test("pnpm release bumps both pins the gate checks", async () => {
+  const { bumpReadmeQuickstartPins } = await import("./release-logic.mjs");
+  const readme = readFileSync(join(REPO_ROOT, "README.md"), "utf8");
+  const block = extractQuickstartBlock(
+    bumpReadmeQuickstartPins(readme, "9.9.9"),
+  );
+  assert.deepEqual(validateQuickstartVersionsAgree(block), []);
+  assert.match(block, /PINCHY_VERSION=v9\.9\.9/);
+  assert.match(block, /pinchy\/v9\.9\.9\/docker-compose\.yml/);
 });

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -619,33 +619,55 @@ export function checkReleaseVerification({ verifiedSha, headSha }) {
 }
 
 /**
- * Returns README.md contents with the quick-start curl pin updated to the
+ * Returns README.md contents with BOTH quick-start version pins updated to the
  * release tag.
  *
- * The README's one-command install pins a concrete
- * `raw.githubusercontent.com/heypinchy/pinchy/v<X.Y.Z>/docker-compose.yml` URL
- * so a fresh install is reproducible. Without bumping it here the pin drifts
- * behind every release — it sat on v0.5.7 through both the v0.5.8 and v0.6.0
- * releases, so new users pulled a stale compose file. The release tag is created
- * later in the same release run, so the bumped URL resolves once pushed (same
- * pattern as the marketplace template pins).
+ * The README's quick-start install carries two pins, and they only work as a
+ * pair:
+ *
+ *   1. the `raw.githubusercontent.com/heypinchy/pinchy/v<X.Y.Z>/docker-compose.yml`
+ *      URL the reader curls, and
+ *   2. the `PINCHY_VERSION=v<X.Y.Z>` line written into `.env`, which is what
+ *      that compose file resolves its image tags from (it refuses to start
+ *      without it: `PINCHY_VERSION:?set PINCHY_VERSION in .env`).
+ *
+ * Bumping only the URL is worse than bumping neither. A stale URL at least
+ * yields a self-consistent older install; a fresh compose file pinned to an
+ * older image tag starts happily and silently runs the *previous* release
+ * against the new release's topology. So a missing pin is an error rather than
+ * a no-op — the pin that is not there is the one that drifts. Without bumping
+ * here the URL sat on v0.5.7 through both the v0.5.8 and v0.6.0 releases, so
+ * new users pulled a stale compose file.
+ *
+ * The release tag is created later in the same release run, so the bumped URL
+ * resolves once pushed (same pattern as the marketplace template pins).
  *
  * @param {string} content - raw README.md contents
  * @param {string} version - release version, no 'v' prefix (e.g. "0.6.0")
  * @returns {string}
- * @throws {Error} if the pinned docker-compose URL is missing
+ * @throws {Error} if either pin is missing
  */
-export function bumpReadmeComposePin(content, version) {
-  const pattern =
+export function bumpReadmeQuickstartPins(content, version) {
+  const composeUrlPin =
     /(raw\.githubusercontent\.com\/heypinchy\/pinchy\/)v\d+\.\d+\.\d+(\/docker-compose\.yml)/g;
-  if (!pattern.test(content)) {
+  if (!composeUrlPin.test(content)) {
     throw new Error(
       "No pinned docker-compose URL in README.md " +
         "(raw.githubusercontent.com/heypinchy/pinchy/v<version>/docker-compose.yml). " +
-        "The quick-start install pin moved or was removed — update bumpReadmeComposePin.",
+        "The quick-start install pin moved or was removed — update bumpReadmeQuickstartPins.",
     );
   }
-  return content.replace(pattern, `$1v${version}$2`);
+  const envVersionPin = /(PINCHY_VERSION=)v\d+\.\d+\.\d+/g;
+  if (!envVersionPin.test(content)) {
+    throw new Error(
+      "No PINCHY_VERSION=v<version> pin in README.md. The quick-start writes it " +
+        "into .env and docker-compose.yml refuses to start without it, so the " +
+        "quick-start cannot be correct without this line — update bumpReadmeQuickstartPins.",
+    );
+  }
+  return content
+    .replace(composeUrlPin, `$1v${version}$2`)
+    .replace(envVersionPin, `$1v${version}`);
 }
 
 /** Matches a release branch: `release/X.Y` with numeric major/minor (e.g. `release/0.9`). */

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -14,7 +14,7 @@ import {
   assertNoStaleUpgradeSections,
   deriveStagingChecklist,
   checkReleaseVerification,
-  bumpReadmeComposePin,
+  bumpReadmeQuickstartPins,
   isReleasableBranch,
   findSkippedReleases,
   openNextUpgradeSection,
@@ -427,15 +427,18 @@ BAZ=qux
   assert.equal(matches.length, 1);
 });
 
-// bumpReadmeComposePin — keeps the README quick-start curl pin on the released
-// tag so a fresh one-command install is reproducible. Orphaned before this:
-// the pin sat on v0.5.7 through the v0.5.8 and v0.6.0 releases.
+// bumpReadmeQuickstartPins — keeps BOTH README quick-start pins on the released
+// tag so a fresh install is reproducible: the curl'd compose URL and the
+// PINCHY_VERSION= line that compose file resolves its image tags from.
+// Orphaned before this: the curl pin sat on v0.5.7 through the v0.5.8 and
+// v0.6.0 releases.
 
-test("bumpReadmeComposePin updates the pinned docker-compose tag, preserves the rest", () => {
+test("bumpReadmeQuickstartPins updates both quick-start pins, preserves the rest", () => {
   const input = `## Quick Start
 
 \`\`\`bash
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.5.7/docker-compose.yml -o docker-compose.yml
+echo "PINCHY_VERSION=v0.5.7" > .env
 docker compose up -d
 \`\`\`
 `;
@@ -443,26 +446,60 @@ docker compose up -d
 
 \`\`\`bash
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.6.0/docker-compose.yml -o docker-compose.yml
+echo "PINCHY_VERSION=v0.6.0" > .env
 docker compose up -d
 \`\`\`
 `;
-  assert.equal(bumpReadmeComposePin(input, "0.6.0"), expected);
+  assert.equal(bumpReadmeQuickstartPins(input, "0.6.0"), expected);
 });
 
-test("bumpReadmeComposePin throws when the pinned docker-compose URL is missing", () => {
+// The regression this pairing exists for: bumping the compose URL alone leaves
+// the reader curling the new release's compose file while pinning the previous
+// release's images. That starts cleanly — no error anywhere — and silently runs
+// the wrong software, which is worse than the stale-but-consistent pin.
+test("bumpReadmeQuickstartPins leaves no pin behind on the previous version", () => {
+  const input = [
+    "curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.9.1/docker-compose.yml -o docker-compose.yml",
+    'echo "PINCHY_VERSION=v0.9.1" > .env',
+    "docker compose up -d",
+  ].join("\n");
+  const bumped = bumpReadmeQuickstartPins(input, "0.10.0");
+  assert.doesNotMatch(
+    bumped,
+    /v0\.9\.1/,
+    `a v0.9.1 pin survived the bump: ${bumped}`,
+  );
+  assert.match(bumped, /pinchy\/v0\.10\.0\/docker-compose\.yml/);
+  assert.match(bumped, /PINCHY_VERSION=v0\.10\.0/);
+});
+
+test("bumpReadmeQuickstartPins throws when the pinned docker-compose URL is missing", () => {
   const input = `## Quick Start\n\nNo pinned compose URL here.\n`;
   assert.throws(
-    () => bumpReadmeComposePin(input, "0.6.0"),
+    () => bumpReadmeQuickstartPins(input, "0.6.0"),
     /No pinned docker-compose URL in README\.md/,
   );
 });
 
-test("bumpReadmeComposePin replaces any prior version, not just a specific one", () => {
+// A missing PINCHY_VERSION pin is an error, not a no-op: silently skipping it
+// is exactly how one half of the pair drifts behind the other.
+test("bumpReadmeQuickstartPins throws when the PINCHY_VERSION pin is missing", () => {
   const input =
     "curl https://raw.githubusercontent.com/heypinchy/pinchy/v0.4.12/docker-compose.yml -o docker-compose.yml\n";
+  assert.throws(
+    () => bumpReadmeQuickstartPins(input, "0.6.0"),
+    /No PINCHY_VERSION=v<version> pin in README\.md/,
+  );
+});
+
+test("bumpReadmeQuickstartPins replaces any prior version, not just a specific one", () => {
+  const input =
+    "curl https://raw.githubusercontent.com/heypinchy/pinchy/v0.4.12/docker-compose.yml -o docker-compose.yml\n" +
+    'echo "PINCHY_VERSION=v0.4.12" > .env\n';
   assert.equal(
-    bumpReadmeComposePin(input, "0.6.0"),
-    "curl https://raw.githubusercontent.com/heypinchy/pinchy/v0.6.0/docker-compose.yml -o docker-compose.yml\n",
+    bumpReadmeQuickstartPins(input, "0.6.0"),
+    "curl https://raw.githubusercontent.com/heypinchy/pinchy/v0.6.0/docker-compose.yml -o docker-compose.yml\n" +
+      'echo "PINCHY_VERSION=v0.6.0" > .env\n',
   );
 });
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -38,7 +38,7 @@ import {
   assertUpgradeNotesWritten,
   finalizeUpgradeSection,
   openNextUpgradeSection,
-  bumpReadmeComposePin,
+  bumpReadmeQuickstartPins,
   isReleasableBranch,
 } from "./lib/release-logic.mjs";
 import {
@@ -219,14 +219,17 @@ writeFileSync(
 );
 log(`  ✔ .env.example → v${version}`);
 
-// Keep the README quick-start curl pin on the released tag so the
-// one-command install is reproducible and never drifts behind (it sat on
-// v0.5.7 through the v0.5.8 and v0.6.0 releases before this).
+// Keep BOTH README quick-start pins on the released tag — the curl'd
+// docker-compose.yml URL and the PINCHY_VERSION= line that compose file
+// resolves its image tags from. They only work as a pair: bumping the URL
+// alone starts cleanly and silently runs the previous release's images.
+// (The curl pin sat on v0.5.7 through the v0.5.8 and v0.6.0 releases before
+// this step existed.)
 writeFileSync(
   readmePath,
-  bumpReadmeComposePin(readFileSync(readmePath, "utf8"), version),
+  bumpReadmeQuickstartPins(readFileSync(readmePath, "utf8"), version),
 );
-log(`  ✔ README.md quick-start pin → v${version}`);
+log(`  ✔ README.md quick-start pins → v${version}`);
 
 // Keep the marketplace listing templates pinned to the released version, so a
 // fresh DigitalOcean install starts on the current release rather than drifting


### PR DESCRIPTION
## Summary

- The README Quick Start block curls `docker-compose.yml` straight into `docker compose up -d` with no `.env` in between. `docker-compose.yml` requires `PINCHY_VERSION` (`:?set PINCHY_VERSION in .env`), so **the very first command a prospective adopter copies fails.** `docs/src/content/docs/installation.mdx` and `getting-started.mdx` already had the correct `echo "PINCHY_VERSION=..." > .env` step; README was the one place missing it.
- Bumps the README's hard-coded version from `v0.8.0` to the current release, `v0.9.1`.
- Adds `scripts/lib/readme-quickstart-gate.{mjs,test.mjs}` — a drift guard (in the pattern of the existing `*-gate.mjs` guards, run by `pnpm test:scripts`) that extracts the README's Quick Start bash block and fails if `docker compose up` appears before any line that sets `PINCHY_VERSION`. Written test-first: it failed against the unfixed README, then passed after the fix.

## Deviation from scope: marketplace templates left untouched

`marketplace/caprover/pinchy.yml` and `marketplace/digitalocean/template.json` also still pin `v0.8.0`. Their existing drift guard (`scripts/lib/marketplace-version.test.mjs`) asserts they match **`.env.example`'s `PINCHY_VERSION`**, not the actual latest GitHub release — and `.env.example` (and `packages/web/package.json`) are themselves still `v0.8.0` on `main`, because those bumps only happen inside `chore: release vX.Y.Z` commits made on the `release/0.9` branch, which has diverged from `main` since the v0.8.0 cut.

Bumping the marketplace templates by hand here would trip `marketplace-version.test.mjs` (they'd point at `v0.9.1` while `.env.example` says `v0.8.0`). Bumping `.env.example`/`package.json` by hand to fix that is a separate, larger, riskier change outside this PR's scope (it's normally an artifact of the release script, not a manual edit) — per the brief for this task, left alone and documented here instead.

## Test plan

- [x] `node --test scripts/lib/readme-quickstart-gate.test.mjs` — red against the unfixed README (`docker compose up` with no PINCHY_VERSION line), green after the README fix. 8/8 passing.
- [x] `pnpm test:scripts` — 902 passed, 0 failed, 17 suites (includes the new guard and the pre-existing, untouched `marketplace-version.test.mjs` / `marketplace-lint.test.mjs`, both still green).
- [x] `pnpm format:check` — clean (whole tree).

Docs-not-needed: README/marketplace fix, no docs/ surface affected (per the commit trailer — `docs-required` guard's `USER_VISIBLE_SURFACES` list does not cover README.md or marketplace/).