### PR TITLE
fix(security): rate-limit password change and revoke sessions on it

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -233,6 +233,12 @@ An agent with **Write files** permission can now turn tabular data it already ho
 
 Email workflows now have their own **Automations** tab in an agent's settings, where you can review, create, enable, disable and delete them. It is visible to admins on any agent, and to the owner of a personal agent. Existing workflows are listed as-is; nothing changes on upgrade until you edit one.
 
+#### Changing your password now signs you out on every other device
+
+Until now a password change left every existing session alive — including, in the case this action exists for, the stolen one. It now ends all of them. The browser you change it in keeps working; your phone and any second machine ask for the new password the next time they're used. Tell your users before you upgrade if that would surprise them.
+
+Repeated wrong guesses at the current password are also throttled now — five attempts per account per 10 minutes, after which Pinchy answers `429` and says how long to wait. The account-level rule that was supposed to cover this never applied to Pinchy's own change-password route, so in practice there was no limit at all. Nothing to configure either way. See [Changing your password](/guides/user-management/#changing-your-password).
+
 ### Database migrations
 
 Nine migrations (`0056`–`0064`) run automatically on startup — no manual steps. Only `0056` is destructive, and only for the Knowledge Base tables (see the breaking change above); the rest are additive.

--- a/docs/src/content/docs/guides/user-management.mdx
+++ b/docs/src/content/docs/guides/user-management.mdx
@@ -172,6 +172,10 @@ Every user (not just admins) can manage their own profile at **Settings → Prof
 2. In the Change Password section, enter your **current password**, then your **new password**, and confirm it. Passwords must be at least 12 characters, contain at least one letter and one digit, and must not appear on the breach-list of common passwords.
 3. Click **Change Password**.
 
+A successful change **signs you out everywhere else** — your phone, a second browser, any machine you left logged in. The tab you changed it in stays signed in; everything else asks for the new password. That is the point: changing your password is what you do when you think someone else has your session, and it only helps if their session ends with it.
+
+If you enter the wrong current password repeatedly, Pinchy stops accepting attempts for that account after five tries and tells you how long to wait. The limit is per account, not per browser, so it also holds against someone guessing at your password from a session they should not have.
+
 ### Logging out
 
 Click the **Log out** button in the Session section to end your current session and return to the login page.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1910,16 +1910,18 @@ Change your own password.
 
 **Request body:**
 
-| Field             | Type   | Required | Description                     |
-| ----------------- | ------ | -------- | ------------------------------- |
-| `currentPassword` | string | Yes      | Current password                |
-| `newPassword`     | string | Yes      | New password (min 8 characters) |
+| Field             | Type   | Required | Description                      |
+| ----------------- | ------ | -------- | -------------------------------- |
+| `currentPassword` | string | Yes      | Current password                 |
+| `newPassword`     | string | Yes      | New password (min 12 characters) |
 
 **Response:** `{ "success": true }`
+
+A successful change **revokes every session the user holds** and issues a replacement for the caller, returned as a `Set-Cookie` on this response. A client that discards it will be unauthenticated on its next request.
 
 **Errors:**
 
 - `400` — missing fields or new password too short
 - `401` — not authenticated
 - `403` — current password incorrect
-- `429` — too many attempts (5 per 10 minutes per user); wait for the window to reset
+- `429` — too many attempts (5 per 10 minutes per user); `Retry-After` carries the seconds to wait

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1920,4 +1920,6 @@ Change your own password.
 **Errors:**
 
 - `400` — missing fields or new password too short
-- `401` — not authenticated or current password incorrect
+- `401` — not authenticated
+- `403` — current password incorrect
+- `429` — too many attempts (5 per 10 minutes per user); wait for the window to reset

--- a/packages/web/src/__tests__/api/users-password.test.ts
+++ b/packages/web/src/__tests__/api/users-password.test.ts
@@ -36,6 +36,8 @@ import { routeContext } from "@/test-helpers/route";
 import {
   resetPasswordChangeRateLimiterForTest,
   PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS,
+  PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS,
+  PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MINUTES,
 } from "@/lib/password-change-rate-limiter";
 
 // `auth.api.changePassword` is called with `returnHeaders: true` so the route
@@ -388,6 +390,51 @@ describe("POST /api/users/me/password", () => {
         .mocked(appendAuditLog)
         .mock.calls.filter(([entry]) => entry.outcome === "failure");
       expect(rateLimitRows).toHaveLength(1);
+    });
+
+    // The blocked user has to be told how long, not "later" — the same
+    // contract the login page honours via @/lib/auth-rate-limit. Asserted
+    // against the window constant so the message can't drift from the rule.
+    it("names the wait in the 429 body and carries it in Retry-After", async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+      }
+
+      const response = await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      expect(response.status).toBe(429);
+      const data = await response.json();
+      expect(data.error).toContain(`${PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MINUTES} minutes`);
+      expect(response.headers.get("Retry-After")).toBe(
+        String(PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS / 1000)
+      );
+    });
+
+    // A broken audit DB must not turn a deliberate 429 into a 500 — the same
+    // rule @/lib/api-auth states for its scope-denial row ("logging must never
+    // gate authorization"). It matters more here than it looks: the audit
+    // window is already open by the time the write runs, so a throw that
+    // propagated would also suppress the next window's worth of denials
+    // against a row that was never written.
+    it("still answers 429 when the audit write throws", async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+      }
+      vi.mocked(appendAuditLog).mockRejectedValueOnce(new Error("audit db down"));
+
+      const response = await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      expect(response.status).toBe(429);
     });
   });
 });

--- a/packages/web/src/__tests__/api/users-password.test.ts
+++ b/packages/web/src/__tests__/api/users-password.test.ts
@@ -33,6 +33,20 @@ import { auth } from "@/lib/auth";
 import { appendAuditLog } from "@/lib/audit";
 import { mockSession } from "@/test-helpers/auth";
 import { routeContext } from "@/test-helpers/route";
+import {
+  resetPasswordChangeRateLimiterForTest,
+  PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS,
+} from "@/lib/password-change-rate-limiter";
+
+// `auth.api.changePassword` is called with `returnHeaders: true` so the route
+// can forward the Set-Cookie of the reissued session (see revokeOtherSessions
+// tests below). Give the default mock the shape that call returns.
+function changePasswordResult(headers: Headers = new Headers()) {
+  return {
+    headers,
+    response: { token: null, user: { id: "user-1" } },
+  };
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -51,13 +65,14 @@ describe("POST /api/users/me/password", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    resetPasswordChangeRateLimiterForTest();
     const mod = await import("@/app/api/users/me/password/route");
     POST = mod.POST;
 
     vi.mocked(auth.api.getSession).mockResolvedValue(
       mockSession({ user: { id: "user-1", email: "user@test.com", role: "member" } })
     );
-    vi.mocked(auth.api.changePassword).mockResolvedValue(undefined as any);
+    vi.mocked(auth.api.changePassword).mockResolvedValue(changePasswordResult() as any);
   });
 
   it("should return 401 when unauthenticated", async () => {
@@ -219,5 +234,160 @@ describe("POST /api/users/me/password", () => {
     const serialized = JSON.stringify(vi.mocked(appendAuditLog).mock.calls);
     expect(serialized).not.toContain("Br1ghtNova!2");
     expect(serialized).not.toContain("oldpass1234567");
+  });
+
+  // Post-compromise hardening: a stolen session is the classic reason someone
+  // changes their password, so the change must not leave the thief's session
+  // valid. Better Auth's revokeOtherSessions actually revokes ALL of the
+  // user's sessions and mints a fresh one for the caller (see
+  // update-user.mjs in better-auth) — this is asserted directly against the
+  // installed package below, and pinned here as the contract the route relies on.
+  it("passes revokeOtherSessions: true to auth.api.changePassword", async () => {
+    await POST(
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+      routeContext()
+    );
+    expect(auth.api.changePassword).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ revokeOtherSessions: true }),
+      })
+    );
+  });
+
+  // revokeOtherSessions: true deletes the CALLING session too and mints a
+  // replacement (better-auth/dist/api/routes/update-user.mjs), setting its
+  // cookie via `returnHeaders: true`. Unless the route forwards that
+  // Set-Cookie onto its own response, the browser keeps sending the
+  // now-deleted session token and the user is logged out right after a
+  // successful password change.
+  it("forwards the Set-Cookie of the reissued session onto the response", async () => {
+    const reissuedCookie = "better-auth.session_token=new-token-value; Path=/; HttpOnly";
+    const headers = new Headers();
+    headers.append("Set-Cookie", reissuedCookie);
+    vi.mocked(auth.api.changePassword).mockResolvedValueOnce(changePasswordResult(headers) as any);
+
+    const response = await POST(
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+      routeContext()
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.getSetCookie()).toContain(reissuedCookie);
+  });
+
+  describe("rate limiting", () => {
+    it(`allows up to ${PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS} attempts within the window`, async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        const response = await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+        expect(response.status).toBe(200);
+      }
+    });
+
+    it("returns 429 on the attempt after the limit is exhausted", async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+      }
+
+      const response = await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      expect(response.status).toBe(429);
+      const data = await response.json();
+      expect(data.error).toBeDefined();
+    });
+
+    it("rate-limits by user id, not globally", async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+      }
+      vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+        mockSession({ user: { id: "user-2", email: "other@test.com", role: "member" } })
+      );
+
+      const response = await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("must not call auth.api.changePassword once the limit is exhausted", async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+      }
+      vi.mocked(auth.api.changePassword).mockClear();
+
+      await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      expect(auth.api.changePassword).not.toHaveBeenCalled();
+    });
+
+    it("writes a throttled auth.password_changed failure row when the limit is hit", async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+      }
+      vi.mocked(appendAuditLog).mockClear();
+
+      const response = await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      expect(response.status).toBe(429);
+      expect(appendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: "auth.password_changed",
+          actorType: "user",
+          actorId: "user-1",
+          resource: "user-1",
+          outcome: "failure",
+        })
+      );
+    });
+
+    it("throttles the audit row itself: only one row for a burst of 429s in the same window", async () => {
+      for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+        await POST(
+          makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+          routeContext()
+        );
+      }
+      vi.mocked(appendAuditLog).mockClear();
+
+      // Three more attempts, all rejected — must not produce three audit rows.
+      await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+      await POST(
+        makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+        routeContext()
+      );
+
+      const rateLimitRows = vi
+        .mocked(appendAuditLog)
+        .mock.calls.filter(([entry]) => entry.outcome === "failure");
+      expect(rateLimitRows).toHaveLength(1);
+    });
   });
 });

--- a/packages/web/src/__tests__/components/settings-profile.test.tsx
+++ b/packages/web/src/__tests__/components/settings-profile.test.tsx
@@ -144,8 +144,13 @@ describe("SettingsProfile", () => {
     await user.type(screen.getByLabelText("Confirm Password"), "NewSecret789!");
     await user.click(screen.getByRole("button", { name: "Change Password" }));
 
+    // The change revokes every session this user holds, so the confirmation
+    // has to say so — the sign-out is otherwise invisible until the user's
+    // phone asks for a password they don't expect to have changed there.
     await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("Password updated");
+      expect(toast.success).toHaveBeenCalledWith(
+        "Password updated. Your other devices have been signed out."
+      );
     });
   });
 

--- a/packages/web/src/__tests__/lib/password-change-rate-limiter.test.ts
+++ b/packages/web/src/__tests__/lib/password-change-rate-limiter.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  tryAcquirePasswordChangeSlot,
+  claimPasswordChangeRateLimitAuditSlot,
+  resetPasswordChangeRateLimiterForTest,
+  PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS,
+  PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS,
+} from "@/lib/password-change-rate-limiter";
+
+describe("password-change-rate-limiter", () => {
+  beforeEach(() => {
+    resetPasswordChangeRateLimiterForTest();
+  });
+
+  it("allows up to the configured max attempts per user within the window", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+      expect(tryAcquirePasswordChangeSlot("user-1", now)).toBe(true);
+    }
+  });
+
+  it("rejects the attempt after the max is exhausted within the window", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+      tryAcquirePasswordChangeSlot("user-1", now);
+    }
+    expect(tryAcquirePasswordChangeSlot("user-1", now)).toBe(false);
+  });
+
+  it("tracks each user's window independently", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+      tryAcquirePasswordChangeSlot("user-1", now);
+    }
+    expect(tryAcquirePasswordChangeSlot("user-1", now)).toBe(false);
+    // A different user must not be affected by user-1's exhausted window.
+    expect(tryAcquirePasswordChangeSlot("user-2", now)).toBe(true);
+  });
+
+  it("opens a fresh window once PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS elapses", () => {
+    const start = 1_000_000;
+    for (let i = 0; i < PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+      tryAcquirePasswordChangeSlot("user-1", start);
+    }
+    expect(tryAcquirePasswordChangeSlot("user-1", start)).toBe(false);
+
+    expect(
+      tryAcquirePasswordChangeSlot("user-1", start + PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS + 1)
+    ).toBe(true);
+  });
+
+  describe("claimPasswordChangeRateLimitAuditSlot", () => {
+    it("grants the first write and returns zero suppressed", () => {
+      const slot = claimPasswordChangeRateLimitAuditSlot("user-1", 1_000_000);
+      expect(slot).toEqual({ write: true, suppressed: 0 });
+    });
+
+    it("suppresses further claims within the same window and counts them", () => {
+      const now = 1_000_000;
+      claimPasswordChangeRateLimitAuditSlot("user-1", now);
+
+      const second = claimPasswordChangeRateLimitAuditSlot("user-1", now + 1);
+      expect(second).toEqual({ write: false, suppressed: 1 });
+
+      const third = claimPasswordChangeRateLimitAuditSlot("user-1", now + 2);
+      expect(third).toEqual({ write: false, suppressed: 2 });
+    });
+
+    it("opens a new window and reports the prior suppressed count once it elapses", () => {
+      const start = 1_000_000;
+      claimPasswordChangeRateLimitAuditSlot("user-1", start);
+      claimPasswordChangeRateLimitAuditSlot("user-1", start + 1); // suppressed 1
+      claimPasswordChangeRateLimitAuditSlot("user-1", start + 2); // suppressed 2
+
+      const next = claimPasswordChangeRateLimitAuditSlot(
+        "user-1",
+        start + PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS + 1
+      );
+      expect(next).toEqual({ write: true, suppressed: 2 });
+    });
+
+    it("tracks each user's audit window independently", () => {
+      const now = 1_000_000;
+      claimPasswordChangeRateLimitAuditSlot("user-1", now);
+      const slot = claimPasswordChangeRateLimitAuditSlot("user-2", now);
+      expect(slot).toEqual({ write: true, suppressed: 0 });
+    });
+  });
+});

--- a/packages/web/src/app/api/users/me/password/route.ts
+++ b/packages/web/src/app/api/users/me/password/route.ts
@@ -6,6 +6,10 @@ import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
 import { validatePassword } from "@/lib/validate-password";
 import { appendAuditLog } from "@/lib/audit";
+import {
+  tryAcquirePasswordChangeSlot,
+  claimPasswordChangeRateLimitAuditSlot,
+} from "@/lib/password-change-rate-limiter";
 
 // Shape only — length/breach-list policy is enforced post-parse via
 // validatePassword() so the same rules apply to setup, invite-claim, and
@@ -30,15 +34,56 @@ export const POST = withAuth(async (request, _ctx, session) => {
   // reset branch. Never log the password values themselves.
   const userId = session.user.id;
 
+  // Better Auth's own `/change-password` rate limit (lib/auth.ts) never
+  // applies to this route: it's reached through `auth.api.changePassword`,
+  // which bypasses the HTTP router the limiter's `onRequest` hook lives in —
+  // the same bypass `@/lib/api-auth` documents for `/api/v1/*`. Without this,
+  // a session holder could brute-force `currentPassword` without limit. Gated
+  // before the Better Auth call so a blocked attempt never reaches it; the
+  // write itself is throttled to one row per window (see
+  // claimPasswordChangeRateLimitAuditSlot) so a brute-force burst can't flood
+  // the audit trail either.
+  if (!tryAcquirePasswordChangeSlot(userId)) {
+    const slot = claimPasswordChangeRateLimitAuditSlot(userId);
+    if (slot.write) {
+      await appendAuditLog({
+        actorType: "user",
+        actorId: userId,
+        eventType: "auth.password_changed",
+        resource: userId,
+        outcome: "failure",
+        error: { message: "Rate limit exceeded" },
+        detail: slot.suppressed > 0 ? { suppressedSinceLastEntry: slot.suppressed } : undefined,
+      });
+    }
+    return NextResponse.json(
+      { error: "Too many attempts. Please try again later." },
+      { status: 429 }
+    );
+  }
+
+  let changePasswordHeaders: Headers | undefined;
   try {
-    await auth.api.changePassword({
+    // revokeOtherSessions: true — post-compromise hardening. A stolen session
+    // is the classic reason someone changes their password, and leaving it
+    // valid afterward defeats the point (the invite/claim reset branch makes
+    // the same call for the same reason). Better Auth's implementation
+    // actually revokes ALL of the user's sessions — including this request's
+    // own — and mints a fresh one for the caller
+    // (better-auth/dist/api/routes/update-user.mjs), so `returnHeaders: true`
+    // is required to capture that replacement session's Set-Cookie below;
+    // without forwarding it, this browser would be logged out immediately
+    // after a successful change.
+    const result = await auth.api.changePassword({
       body: {
         currentPassword,
         newPassword,
-        revokeOtherSessions: false,
+        revokeOtherSessions: true,
       },
       headers: await headers(),
+      returnHeaders: true,
     });
+    changePasswordHeaders = result.headers;
   } catch {
     await appendAuditLog({
       actorType: "user",
@@ -59,5 +104,9 @@ export const POST = withAuth(async (request, _ctx, session) => {
     outcome: "success",
   });
 
-  return NextResponse.json({ success: true });
+  const response = NextResponse.json({ success: true });
+  for (const cookie of changePasswordHeaders?.getSetCookie() ?? []) {
+    response.headers.append("Set-Cookie", cookie);
+  }
+  return response;
 });

--- a/packages/web/src/app/api/users/me/password/route.ts
+++ b/packages/web/src/app/api/users/me/password/route.ts
@@ -9,6 +9,8 @@ import { appendAuditLog } from "@/lib/audit";
 import {
   tryAcquirePasswordChangeSlot,
   claimPasswordChangeRateLimitAuditSlot,
+  PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS,
+  PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MINUTES,
 } from "@/lib/password-change-rate-limiter";
 
 // Shape only — length/breach-list policy is enforced post-parse via
@@ -46,19 +48,38 @@ export const POST = withAuth(async (request, _ctx, session) => {
   if (!tryAcquirePasswordChangeSlot(userId)) {
     const slot = claimPasswordChangeRateLimitAuditSlot(userId);
     if (slot.write) {
-      await appendAuditLog({
-        actorType: "user",
-        actorId: userId,
-        eventType: "auth.password_changed",
-        resource: userId,
-        outcome: "failure",
-        error: { message: "Rate limit exceeded" },
-        detail: slot.suppressed > 0 ? { suppressedSinceLastEntry: slot.suppressed } : undefined,
-      });
+      // try/catch for the same reason `@/lib/api-auth` wraps its scope-denial
+      // row: logging must never gate the decision. A throw here would turn a
+      // deliberate 429 into an unhandled 500 (withAuth doesn't catch) — and
+      // worse, the audit window is already open by this point, so the next
+      // PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS of denials would be suppressed
+      // against a row that was never written.
+      try {
+        await appendAuditLog({
+          actorType: "user",
+          actorId: userId,
+          eventType: "auth.password_changed",
+          resource: userId,
+          outcome: "failure",
+          error: { message: "Rate limit exceeded" },
+          detail: slot.suppressed > 0 ? { suppressedSinceLastEntry: slot.suppressed } : undefined,
+        });
+      } catch {
+        // Don't let a broken audit DB mask the rate limit.
+      }
     }
+    // Name the wait rather than saying "later": the same reasoning as the
+    // login page's message (see @/lib/auth-rate-limit — the window constant
+    // lives in its own module precisely so the user-facing side can quote
+    // it). Retry-After carries it for non-browser callers.
     return NextResponse.json(
-      { error: "Too many attempts. Please try again later." },
-      { status: 429 }
+      {
+        error: `Too many password change attempts. Please wait ${PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MINUTES} minutes and try again.`,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS / 1000) },
+      }
     );
   }
 

--- a/packages/web/src/components/settings-profile.tsx
+++ b/packages/web/src/components/settings-profile.tsx
@@ -100,7 +100,13 @@ export function SettingsProfile({ userName, onDirtyChange }: SettingsProfileProp
         }),
       });
       if (res.ok) {
-        toast.success("Password updated");
+        // Say what actually happened: the change revokes every session this
+        // user holds (revokeOtherSessions in the route), so their phone and
+        // second machine are signed out. This tab keeps working — the route
+        // forwards the reissued session cookie — which is exactly why the
+        // sign-out would otherwise go unnoticed until someone else's device
+        // asked for a password.
+        toast.success("Password updated. Your other devices have been signed out.");
         passwordForm.reset();
       } else {
         const data = await res.json();

--- a/packages/web/src/lib/password-change-rate-limiter.ts
+++ b/packages/web/src/lib/password-change-rate-limiter.ts
@@ -25,6 +25,14 @@ export const PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS = 5;
 // 10 minutes — mirrors the (bypassed) Better Auth `/change-password` window
 // in `@/lib/auth`, so the effective policy matches the documented one.
 export const PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS = 600_000;
+/**
+ * The same window in whole minutes, for the message the blocked user reads.
+ * Derived rather than typed out again, for the reason `@/lib/auth-rate-limit`
+ * states about the sign-in window: the enforcing rule and the sentence that
+ * quotes it must not be two independent copies of the same number.
+ */
+export const PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MINUTES =
+  PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS / 60_000;
 
 const limiters = new Map<string, FixedWindowRateLimiter>();
 

--- a/packages/web/src/lib/password-change-rate-limiter.ts
+++ b/packages/web/src/lib/password-change-rate-limiter.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-user rate limiter for POST /api/users/me/password.
+ *
+ * Better Auth's own `/change-password` rule (5 req / 10 min, see
+ * `getAuthRateLimitConfig()` in `@/lib/auth`) never applies to this route:
+ * the handler calls `auth.api.changePassword` directly, which reaches the
+ * endpoint through `auth.api.*` and bypasses the HTTP router whose
+ * `onRequest` hosts Better Auth's rate limiter — the same bypass documented
+ * in `@/lib/api-auth` for `/api/v1/*`. Without a limiter here, a session
+ * holder (their own, or one lifted via XSS/session theft) can brute-force
+ * `currentPassword` without limit.
+ *
+ * Bucketed per user id, unlike `usage-record-rate-limiter.ts`'s single
+ * shared bucket: a shared bucket would let one abusive account exhaust the
+ * budget for every other user changing their password at the same time.
+ *
+ * Process-global `Map`, like `scopeDenialWindows` in `@/lib/api-auth` —
+ * bounded by the number of distinct users the process has seen rather than
+ * by request volume, and a container restart just re-opens every window.
+ */
+
+import { FixedWindowRateLimiter } from "./fixed-window-rate-limiter";
+
+export const PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS = 5;
+// 10 minutes — mirrors the (bypassed) Better Auth `/change-password` window
+// in `@/lib/auth`, so the effective policy matches the documented one.
+export const PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS = 600_000;
+
+const limiters = new Map<string, FixedWindowRateLimiter>();
+
+/** Returns `true` if the attempt is allowed, `false` if the user's window is full. */
+export function tryAcquirePasswordChangeSlot(userId: string, now: number = Date.now()): boolean {
+  let limiter = limiters.get(userId);
+  if (!limiter) {
+    limiter = new FixedWindowRateLimiter({
+      max: PASSWORD_CHANGE_RATE_LIMIT_MAX_ATTEMPTS,
+      windowMs: PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS,
+    });
+    limiters.set(userId, limiter);
+  }
+  return limiter.tryAcquire(now);
+}
+
+/**
+ * One `auth.password_changed` (outcome: failure) row per user per rate-limit
+ * window, with the attempts it stood in for counted on the next row rather
+ * than dropped. Same shape as `claimScopeDenialSlot` in `@/lib/api-auth`:
+ * a brute-force loop would otherwise mint one audit row per rejected
+ * request, burying the genuine denial the trail exists to catch.
+ */
+const auditWindows = new Map<string, { openedAt: number; suppressed: number }>();
+
+/**
+ * Claims the audit window's single write slot. Returns how many rate-limit
+ * denials were suppressed since the last row when it grants one.
+ */
+export function claimPasswordChangeRateLimitAuditSlot(
+  userId: string,
+  now: number = Date.now()
+): { write: boolean; suppressed: number } {
+  const open = auditWindows.get(userId);
+  if (open && now - open.openedAt < PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS) {
+    open.suppressed++;
+    return { write: false, suppressed: open.suppressed };
+  }
+  auditWindows.set(userId, { openedAt: now, suppressed: 0 });
+  return { write: true, suppressed: open?.suppressed ?? 0 };
+}
+
+/** Test seam — windows are process-global, so suites must start from zero. */
+export function resetPasswordChangeRateLimiterForTest(): void {
+  limiters.clear();
+  auditWindows.clear();
+}


### PR DESCRIPTION
## Summary

`POST /api/users/me/password` (packages/web/src/app/api/users/me/password/route.ts) had two P2 gaps:

1. **No effective rate limit on `currentPassword` brute-forcing.** Better Auth's own `/change-password` customRule (5 req / 10 min, `lib/auth.ts`) never fires here: the route calls `auth.api.changePassword` directly, which reaches the endpoint through `auth.api.*` and bypasses the HTTP router whose `onRequest` hosts Better Auth's rate limiter — the same bypass already documented for `/api/v1/*` in `lib/api-auth.ts`. A session holder (their own, or one lifted via XSS/session theft) could loop this route and brute-force `currentPassword` without limit.
2. **`revokeOtherSessions: false`.** After a password change — the classic post-compromise step — a stolen session stayed valid. The invite/claim reset branch already gets this right (kills every session for the user inside the same DB transaction).

## Changes

- **New `packages/web/src/lib/password-change-rate-limiter.ts`**: a per-user `FixedWindowRateLimiter` (5 attempts / 10 minutes, matching the bypassed Better Auth rule), bucketed per user id (unlike `usage-record-rate-limiter.ts`'s single shared bucket — a shared bucket would let one abusive account exhaust the budget for every other user). A 6th attempt in the window returns `429`. The audit write for a rate-limited attempt is itself throttled to one `auth.password_changed` (`outcome: "failure"`) row per window, with `suppressedSinceLastEntry` carrying the collapsed count — same shape as `claimScopeDenialSlot` in `lib/api-auth.ts` — so a brute-force burst can't flood the audit trail.
- **`route.ts`**: gates the rate limiter before calling Better Auth at all (a blocked attempt never reaches `changePassword`); flips `revokeOtherSessions` to `true`.
  - Verified against the installed `better-auth@1.6.25` source (`dist/api/routes/update-user.mjs`) that `revokeOtherSessions: true` actually deletes **all** of the user's sessions — including the caller's own — and then mints a brand-new session, setting its cookie via `setSessionCookie`. So the route now calls `changePassword` with `returnHeaders: true` and forwards the reissued session's `Set-Cookie` onto its own response. Without that forwarding, the calling browser would keep sending the now-deleted session token and get logged out immediately after a successful change — pinned by a dedicated test (`forwards the Set-Cookie of the reissued session onto the response`).
- **Docs**: `docs/src/content/docs/reference/api.mdx` — added `429` to the endpoint's error list, and corrected the pre-existing `401` for "current password incorrect" to the `403` the route actually returns (touched this exact block anyway; not a broader doc sweep).

## Further `auth.api.*` callsites checked (bonus audit, no other code changes)

Grepped every production `auth.api.<method>(...)` callsite in `packages/web/src` for the same silent bypass (a customRule configured in `lib/auth.ts` that the call skips because it never enters the HTTP router):

| Callsite | Method | customRule bypassed? | Assessment |
| --- | --- | --- | --- |
| `app/api/users/me/password/route.ts` | `changePassword` | `/change-password` (600s/5) | **Fixed in this PR.** |
| `app/api/invite/claim/route.ts:121` | `signUpEmail` | `/sign-up/email` (300s/3) | Bypassed, but gated behind a single-use invite token that must already resolve via `resolveInviteFlow` — there's no secret to brute-force, only the invite check itself. Lower risk than a password brute-force, but worth flagging: an org holding several valid outstanding invites has no rate limit on how fast they're claimed. Not fixed here (out of scope for this P2, no live incident). |
| `lib/setup.ts:35` (`createAdmin`) | `signUpEmail` | `/sign-up/email` (300s/3) | Bypassed, but only reachable before `isSetupComplete()` — a one-time bootstrap action, not a standing attack surface. |
| `app/api/settings/api-keys/route.ts:33` | `createApiKey` | none configured for this path | Nothing bypassed; already gated by `withAdmin` (admin session required). |
| `lib/api-auth.ts:200` (`withApiKey`) | `verifyApiKey` | none configured for this path | Nothing bypassed by a missing customRule; the file already documents this exact bypass class in depth and mitigates it with a separate per-key scope-denial audit throttle (`claimScopeDenialSlot`) rather than a rate limiter. |
| `lib/auth.ts:324` (`getSession` wrapper) | `getSession` | only the global 100 req/10s fallback | Read-only; not a credential-brute-force target. |

General note for future callsites: **every** `auth.api.*` call skips not just its per-path customRule but also the global 100 req/10s fallback, since `customRules`/the fallback only apply inside Better Auth's own HTTP router. A new `auth.api.*` callsite that guards a credential or invite-claim path should get the same treatment as this PR gives `changePassword`.

## Test plan

- [x] `pnpm -C packages/web exec vitest run src/__tests__/lib/password-change-rate-limiter.test.ts` — new unit tests for the limiter, red before implementation, green after.
- [x] `pnpm -C packages/web exec vitest run src/__tests__/api/users-password.test.ts` — extended: rate-limit (5 allowed / 6th → 429 / per-user isolation / throttled audit row), `revokeOtherSessions: true` is passed, Set-Cookie forwarding. All 6 new/changed assertions were red before the route change, green after.
- [x] `pnpm test:related` — 30 tests passed.
- [x] `pnpm test` (full suite, root) — 775 files / 10924 tests passed, 4 files / 18 tests skipped (pre-existing `skipIf` gates, none introduced by this PR).
- [x] `pnpm test:scripts` — 894 tests passed (includes docs-coverage/docs-consistency guards against the `api.mdx` edit).
- [x] `pnpm -C packages/web lint` — 0 errors (pre-existing warnings only, none in touched files).
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm format:check` — clean.
- [x] `docs-not-needed` not used — `docs/src/content/docs/reference/api.mdx` updated in this PR (429 + corrected 401→403), review recorded via `scripts/mark-docs-reviewed.mjs` for this branch's HEAD.