### PR TITLE
fix: cap context content length to bound per-turn prompt injection

### DIFF
--- a/docs/src/content/docs/concepts/context.mdx
+++ b/docs/src/content/docs/concepts/context.mdx
@@ -68,6 +68,12 @@ Only admins can see and edit the organization context section, labeled **"Organi
   with the context they started with.
 </Aside>
 
+### How long can context be?
+
+Each context is capped at **16,000 characters** — roughly 2,500 words, and well past what most teams write. The editor shows a character count once you get close, and saving is blocked above the limit.
+
+The cap exists because context is not stored and forgotten: it goes into the prompt of every conversation that uses it, so every character is paid for again on every turn. Keeping it tight keeps agents fast and cheap. If you have more background than fits, put the details in a [knowledge base agent](/guides/create-knowledge-base-agent/) and keep context for the essentials.
+
 ## How Smithers collects context during onboarding
 
 When a new user first opens Pinchy, their personal Smithers agent has an onboarding mission: learn about the user through natural conversation. Smithers asks about your role, preferred language, and communication style, then uses the `pinchy-context` plugin to save what it learned as your user context.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -841,15 +841,15 @@ Update the organization context. This is synced to all shared agent workspaces a
 
 **Request body:**
 
-| Field     | Type   | Required | Description                     |
-| --------- | ------ | -------- | ------------------------------- |
-| `content` | string | Yes      | Organization context (Markdown) |
+| Field     | Type   | Required | Description                                            |
+| --------- | ------ | -------- | ------------------------------------------------------ |
+| `content` | string | Yes      | Organization context (Markdown), max 16,000 characters |
 
 **Response:** `{ "success": true }`
 
 **Errors:**
 
-- `400` — content is not a string
+- `400` — content is not a string, or exceeds 16,000 characters
 - `401` — not authenticated
 - `403` — not an admin
 
@@ -1906,15 +1906,15 @@ Update your personal context. This is synced to your Smithers agent's workspace 
 
 **Request body:**
 
-| Field     | Type   | Required | Description                      |
-| --------- | ------ | -------- | -------------------------------- |
-| `content` | string | Yes      | Your personal context (Markdown) |
+| Field     | Type   | Required | Description                                             |
+| --------- | ------ | -------- | ------------------------------------------------------- |
+| `content` | string | Yes      | Your personal context (Markdown), max 16,000 characters |
 
 **Response:** `{ "success": true }`
 
 **Errors:**
 
-- `400` — content is not a string
+- `400` — content is not a string, or exceeds 16,000 characters
 - `401` — not authenticated
 
 ### `POST /api/users/me/password`

--- a/packages/plugins/pinchy-context/index.test.ts
+++ b/packages/plugins/pinchy-context/index.test.ts
@@ -125,6 +125,38 @@ describe("pinchy-context plugin", () => {
     expect(result.content[0].text).toContain("Failed to save");
   });
 
+  it("save_user_context quotes the validation detail so the model can act on it", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_save_user_context"
+    )?.[0];
+    const tool = factory({ agentId: "agent-1" });
+
+    // Pinchy's 400 for an over-long context: `error` is the generic
+    // "Validation failed", the reason the model needs is in details.fieldErrors.
+    global.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: "Validation failed",
+          details: {
+            formErrors: [],
+            fieldErrors: {
+              content: ["Context is too long — the limit is 16,000 characters."],
+            },
+          },
+        }),
+        { status: 400 }
+      )
+    );
+
+    const result = await tool.execute("call-1", { content: "..." });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("the limit is 16,000 characters");
+  });
+
   it("save_user_context marks thrown errors with isError=true", async () => {
     const api = createMockApi(defaultConfig);
     const { default: plugin } = await import("./index");

--- a/packages/plugins/pinchy-context/index.ts
+++ b/packages/plugins/pinchy-context/index.ts
@@ -51,6 +51,30 @@ function getAgentConfig(
   return agents[agentId] ?? null;
 }
 
+/**
+ * Quote the reason the API gave, not just its headline. A rejected save answers
+ * `{ error: "Validation failed", details: { fieldErrors: { content: [...] } } }`
+ * — reporting `error` alone tells the model nothing it can act on (it would
+ * retry the same over-long content), while the field error says what to change.
+ */
+function describeApiError(data: unknown): string {
+  if (data && typeof data === "object") {
+    const { details, error } = data as {
+      details?: { fieldErrors?: Record<string, string[] | undefined> };
+      error?: unknown;
+    };
+
+    const fieldError = Object.values(details?.fieldErrors ?? {})
+      .flat()
+      .find((message): message is string => typeof message === "string" && message.length > 0);
+    if (fieldError) return fieldError;
+
+    if (typeof error === "string" && error.length > 0) return error;
+  }
+
+  return "Unknown error";
+}
+
 function deleteOnboardingFile(agentId: string): void {
   try {
     const workspacePath = `/root/.openclaw/workspaces/${agentId}`;
@@ -135,7 +159,7 @@ const plugin = {
                   content: [
                     {
                       type: "text",
-                      text: `Failed to save: ${data.error || "Unknown error"}`,
+                      text: `Failed to save: ${describeApiError(data)}`,
                     },
                   ],
                 };
@@ -214,7 +238,7 @@ const plugin = {
                   content: [
                     {
                       type: "text",
-                      text: `Failed to save: ${data.error || "Unknown error"}`,
+                      text: `Failed to save: ${describeApiError(data)}`,
                     },
                   ],
                 };

--- a/packages/web/src/__tests__/api/internal-settings-context.test.ts
+++ b/packages/web/src/__tests__/api/internal-settings-context.test.ts
@@ -17,6 +17,7 @@ import { validateGatewayToken } from "@/lib/gateway-auth";
 import { setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
 import { PUT } from "@/app/api/internal/settings/context/route";
+import { CONTEXT_CONTENT_MAX_LENGTH } from "@/lib/schemas/context";
 
 function makePutRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost/api/internal/settings/context", {
@@ -60,5 +61,18 @@ describe("PUT /api/internal/settings/context", () => {
   it("returns 400 when content is not a string", async () => {
     const res = await PUT(makePutRequest({ content: 42 }));
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when content exceeds the max length", async () => {
+    const tooLong = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH + 1);
+    const res = await PUT(makePutRequest({ content: tooLong }));
+    expect(res.status).toBe(400);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it("accepts content at exactly the max length", async () => {
+    const maxLength = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH);
+    const res = await PUT(makePutRequest({ content: maxLength }));
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/web/src/__tests__/api/internal-user-context.test.ts
+++ b/packages/web/src/__tests__/api/internal-user-context.test.ts
@@ -32,6 +32,7 @@ import { validateGatewayToken } from "@/lib/gateway-auth";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
 import { db } from "@/db";
 import { PUT } from "@/app/api/internal/users/[userId]/context/route";
+import { CONTEXT_CONTENT_MAX_LENGTH } from "@/lib/schemas/context";
 
 function makePutRequest(userId: string, body: Record<string, unknown>) {
   return new NextRequest(`http://localhost/api/internal/users/${userId}/context`, {
@@ -127,5 +128,18 @@ describe("PUT /api/internal/users/:userId/context", () => {
   it("returns 400 when content is not a string", async () => {
     const res = await PUT(makePutRequest("user-1", { content: 123 }), makeParams("user-1"));
     expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when content exceeds the max length", async () => {
+    const tooLong = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH + 1);
+    const res = await PUT(makePutRequest("user-1", { content: tooLong }), makeParams("user-1"));
+    expect(res.status).toBe(400);
+    expect(syncUserContextToWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it("accepts content at exactly the max length", async () => {
+    const maxLength = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH);
+    const res = await PUT(makePutRequest("user-1", { content: maxLength }), makeParams("user-1"));
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/web/src/__tests__/api/settings-context.test.ts
+++ b/packages/web/src/__tests__/api/settings-context.test.ts
@@ -35,6 +35,7 @@ import { GET, PUT } from "@/app/api/settings/context/route";
 import { NextRequest } from "next/server";
 import { mockSession } from "@/test-helpers/auth";
 import { routeContext } from "@/test-helpers/route";
+import { CONTEXT_CONTENT_MAX_LENGTH } from "@/lib/schemas/context";
 
 function makeGetRequest() {
   return new NextRequest("http://localhost/api/settings/context", { method: "GET" });
@@ -147,5 +148,26 @@ describe("PUT /api/settings/context", () => {
     const data = await response.json();
     expect(data.error).toBe("Validation failed");
     expect(data.details.fieldErrors.content).toBeDefined();
+  });
+
+  it("should return 400 when content exceeds the max length", async () => {
+    const tooLong = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH + 1);
+    const response = await PUT(makePutRequest({ content: tooLong }), routeContext());
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.content).toBeDefined();
+    expect(mockSetSetting).not.toHaveBeenCalled();
+  });
+
+  it("should accept content at exactly the max length", async () => {
+    const maxLength = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH);
+    const response = await PUT(makePutRequest({ content: maxLength }), routeContext());
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(mockSetSetting).toHaveBeenCalledWith("org_context", maxLength);
   });
 });

--- a/packages/web/src/__tests__/api/user-context.test.ts
+++ b/packages/web/src/__tests__/api/user-context.test.ts
@@ -52,7 +52,7 @@ import { GET, PUT } from "@/app/api/users/me/context/route";
 import { NextRequest } from "next/server";
 import { mockSession } from "@/test-helpers/auth";
 import { routeContext } from "@/test-helpers/route";
-import { CONTEXT_CONTENT_MAX_LENGTH } from "@/lib/schemas/context";
+import { CONTEXT_CONTENT_MAX_LENGTH, CONTEXT_TOO_LONG_MESSAGE } from "@/lib/schemas/context";
 
 function makeGetRequest() {
   return new NextRequest("http://localhost/api/users/me/context", { method: "GET" });
@@ -158,7 +158,11 @@ describe("PUT /api/users/me/context", () => {
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.error).toBe("Validation failed");
-    expect(data.details.fieldErrors.content).toBeDefined();
+    // The generic `error` is not actionable — the field error is the only text
+    // that can tell a user (or Smithers) what to change, so it has to name the
+    // limit rather than read "Too big: expected string to have <=16000 …".
+    expect(data.details.fieldErrors.content[0]).toBe(CONTEXT_TOO_LONG_MESSAGE);
+    expect(CONTEXT_TOO_LONG_MESSAGE).toContain("16,000");
     expect(mockSet).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/__tests__/api/user-context.test.ts
+++ b/packages/web/src/__tests__/api/user-context.test.ts
@@ -52,6 +52,7 @@ import { GET, PUT } from "@/app/api/users/me/context/route";
 import { NextRequest } from "next/server";
 import { mockSession } from "@/test-helpers/auth";
 import { routeContext } from "@/test-helpers/route";
+import { CONTEXT_CONTENT_MAX_LENGTH } from "@/lib/schemas/context";
 
 function makeGetRequest() {
   return new NextRequest("http://localhost/api/users/me/context", { method: "GET" });
@@ -148,5 +149,26 @@ describe("PUT /api/users/me/context", () => {
     const data = await response.json();
     expect(data.error).toBe("Validation failed");
     expect(data.details.fieldErrors.content).toBeDefined();
+  });
+
+  it("should return 400 when content exceeds the max length", async () => {
+    const tooLong = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH + 1);
+    const response = await PUT(makePutRequest({ content: tooLong }), routeContext());
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.content).toBeDefined();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("should accept content at exactly the max length", async () => {
+    const maxLength = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH);
+    const response = await PUT(makePutRequest({ content: maxLength }), routeContext());
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(mockSet).toHaveBeenCalledWith({ context: maxLength });
   });
 });

--- a/packages/web/src/__tests__/components/settings-context.test.tsx
+++ b/packages/web/src/__tests__/components/settings-context.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { SettingsContext } from "@/components/settings-context";
+import { CONTEXT_CONTENT_MAX_LENGTH, CONTEXT_TOO_LONG_MESSAGE } from "@/lib/schemas/context";
 
 vi.mock("@/components/markdown-editor", () => ({
   MarkdownEditor: ({
@@ -198,6 +199,64 @@ describe("SettingsContext", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces the field-level reason from a structured validation error", async () => {
+    // parseRequestBody's 400 puts the actionable text in details.fieldErrors —
+    // `error` alone is the generic "Validation failed", which tells the user
+    // nothing they can act on.
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({
+        error: "Validation failed",
+        details: {
+          formErrors: [],
+          fieldErrors: { content: [CONTEXT_TOO_LONG_MESSAGE] },
+        },
+      }),
+    } as Response);
+
+    render(<SettingsContext userContext="Some context" orgContext="" isAdmin={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(CONTEXT_TOO_LONG_MESSAGE)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Validation failed")).not.toBeInTheDocument();
+  });
+
+  describe("length limit", () => {
+    it("does not show a character count for ordinary short content", () => {
+      render(<SettingsContext userContext="Short" orgContext="" isAdmin={false} />);
+
+      expect(screen.queryByText(/characters/i)).not.toBeInTheDocument();
+    });
+
+    it("shows the character count as the content approaches the limit", () => {
+      const nearLimit = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH - 100);
+      render(<SettingsContext userContext={nearLimit} orgContext="" isAdmin={false} />);
+
+      expect(screen.getByText(/15,900 \/ 16,000 characters/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+    });
+
+    it("disables saving while the content is over the limit", () => {
+      const tooLong = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH + 1);
+      render(<SettingsContext userContext={tooLong} orgContext="" isAdmin={false} />);
+
+      expect(screen.getByText(/16,001 \/ 16,000 characters/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    });
+
+    it("re-enables saving once the content is trimmed back under the limit", () => {
+      const tooLong = "a".repeat(CONTEXT_CONTENT_MAX_LENGTH + 1);
+      render(<SettingsContext userContext={tooLong} orgContext="" isAdmin={false} />);
+
+      fireEvent.change(screen.getByRole("textbox"), { target: { value: "trimmed" } });
+
+      expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
     });
   });
 });

--- a/packages/web/src/app/api/internal/settings/context/route.ts
+++ b/packages/web/src/app/api/internal/settings/context/route.ts
@@ -1,12 +1,10 @@
 // audit-exempt: internal endpoint called by OpenClaw plugin (Smithers), not a user-facing action
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const internalOrgContextSchema = z.object({ content: z.string() });
+import { contextContentSchema as internalOrgContextSchema } from "@/lib/schemas/context";
 
 export async function PUT(request: NextRequest) {
   if (!validateGatewayToken(request.headers)) {

--- a/packages/web/src/app/api/internal/settings/context/route.ts
+++ b/packages/web/src/app/api/internal/settings/context/route.ts
@@ -4,14 +4,14 @@ import { validateGatewayToken } from "@/lib/gateway-auth";
 import { setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
 import { parseRequestBody } from "@/lib/api-validation";
-import { contextContentSchema as internalOrgContextSchema } from "@/lib/schemas/context";
+import { contextContentSchema } from "@/lib/schemas/context";
 
 export async function PUT(request: NextRequest) {
   if (!validateGatewayToken(request.headers)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const parsed = await parseRequestBody(internalOrgContextSchema, request);
+  const parsed = await parseRequestBody(contextContentSchema, request);
   if ("error" in parsed) return parsed.error;
   const { content } = parsed.data;
 

--- a/packages/web/src/app/api/internal/users/[userId]/context/route.ts
+++ b/packages/web/src/app/api/internal/users/[userId]/context/route.ts
@@ -1,6 +1,5 @@
 // audit-exempt: internal endpoint called by OpenClaw plugin (Smithers), not a user-facing action
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
@@ -8,8 +7,7 @@ import { eq } from "drizzle-orm";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
 import { getSetting } from "@/lib/settings";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const internalUserContextSchema = z.object({ content: z.string() });
+import { contextContentSchema as internalUserContextSchema } from "@/lib/schemas/context";
 
 export async function PUT(
   request: NextRequest,

--- a/packages/web/src/app/api/internal/users/[userId]/context/route.ts
+++ b/packages/web/src/app/api/internal/users/[userId]/context/route.ts
@@ -7,7 +7,7 @@ import { eq } from "drizzle-orm";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
 import { getSetting } from "@/lib/settings";
 import { parseRequestBody } from "@/lib/api-validation";
-import { contextContentSchema as internalUserContextSchema } from "@/lib/schemas/context";
+import { contextContentSchema } from "@/lib/schemas/context";
 
 export async function PUT(
   request: NextRequest,
@@ -18,7 +18,7 @@ export async function PUT(
   }
 
   const { userId } = await params;
-  const parsed = await parseRequestBody(internalUserContextSchema, request);
+  const parsed = await parseRequestBody(contextContentSchema, request);
   if ("error" in parsed) return parsed.error;
   const { content } = parsed.data;
 

--- a/packages/web/src/app/api/settings/context/route.ts
+++ b/packages/web/src/app/api/settings/context/route.ts
@@ -1,12 +1,10 @@
 // audit-exempt: org context editing is a content change, not a security-sensitive admin action
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { withAdmin } from "@/lib/api-auth";
 import { getSetting, setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const updateOrgContextSchema = z.object({ content: z.string() });
+import { contextContentSchema as updateOrgContextSchema } from "@/lib/schemas/context";
 
 export const GET = withAdmin(async () => {
   const content = await getSetting("org_context");

--- a/packages/web/src/app/api/settings/context/route.ts
+++ b/packages/web/src/app/api/settings/context/route.ts
@@ -4,7 +4,7 @@ import { withAdmin } from "@/lib/api-auth";
 import { getSetting, setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
 import { parseRequestBody } from "@/lib/api-validation";
-import { contextContentSchema as updateOrgContextSchema } from "@/lib/schemas/context";
+import { contextContentSchema } from "@/lib/schemas/context";
 
 export const GET = withAdmin(async () => {
   const content = await getSetting("org_context");
@@ -12,7 +12,7 @@ export const GET = withAdmin(async () => {
 });
 
 export const PUT = withAdmin(async (request) => {
-  const parsed = await parseRequestBody(updateOrgContextSchema, request);
+  const parsed = await parseRequestBody(contextContentSchema, request);
   if ("error" in parsed) return parsed.error;
   const { content } = parsed.data;
 

--- a/packages/web/src/app/api/users/me/context/route.ts
+++ b/packages/web/src/app/api/users/me/context/route.ts
@@ -6,7 +6,7 @@ import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
 import { parseRequestBody } from "@/lib/api-validation";
-import { contextContentSchema as updateContextSchema } from "@/lib/schemas/context";
+import { contextContentSchema } from "@/lib/schemas/context";
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const user = await db.query.users.findFirst({
@@ -17,7 +17,7 @@ export const GET = withAuth(async (_req, _ctx, session) => {
 });
 
 export const PUT = withAuth(async (request, _ctx, session) => {
-  const parsed = await parseRequestBody(updateContextSchema, request);
+  const parsed = await parseRequestBody(contextContentSchema, request);
   if ("error" in parsed) return parsed.error;
   const { content } = parsed.data;
 

--- a/packages/web/src/app/api/users/me/context/route.ts
+++ b/packages/web/src/app/api/users/me/context/route.ts
@@ -1,16 +1,12 @@
 // audit-exempt: users editing their own context is a self-service action
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const updateContextSchema = z.object({
-  content: z.string(),
-});
+import { contextContentSchema as updateContextSchema } from "@/lib/schemas/context";
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const user = await db.query.users.findFirst({

--- a/packages/web/src/components/settings-context.tsx
+++ b/packages/web/src/components/settings-context.tsx
@@ -4,6 +4,42 @@ import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { MarkdownEditor } from "@/components/markdown-editor";
+import { CONTEXT_CONTENT_MAX_LENGTH } from "@/lib/schemas/context";
+
+/**
+ * Below this the counter stays hidden — a limit nobody is near is noise. From
+ * here on it is the only thing that makes the disabled Save button explain
+ * itself, including for a context that was already over the limit when the cap
+ * landed.
+ */
+const COUNTER_VISIBLE_FROM = Math.floor(CONTEXT_CONTENT_MAX_LENGTH * 0.9);
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+/**
+ * `parseRequestBody` answers a failed validation with `error: "Validation
+ * failed"` and the actionable text in `details.fieldErrors`. Showing `error`
+ * alone leaves the user with nothing to correct, so prefer the field error.
+ */
+function readErrorMessage(data: unknown): string {
+  if (data && typeof data === "object") {
+    const { details, error } = data as {
+      details?: { fieldErrors?: Record<string, string[] | undefined> };
+      error?: unknown;
+    };
+
+    const fieldError = Object.values(details?.fieldErrors ?? {})
+      .flat()
+      .find((message): message is string => typeof message === "string" && message.length > 0);
+    if (fieldError) return fieldError;
+
+    if (typeof error === "string" && error.length > 0) return error;
+  }
+
+  return "Failed to save";
+}
 
 interface SettingsContextProps {
   userContext: string;
@@ -46,6 +82,8 @@ function ContextSection({
     onDirtyChange?.(content !== savedContent);
   }, [content, savedContent, onDirtyChange]);
 
+  const isOverLimit = content.length > CONTEXT_CONTENT_MAX_LENGTH;
+
   async function handleSave() {
     setSaving(true);
     setFeedback(null);
@@ -61,7 +99,7 @@ function ContextSection({
         const data = await res.json();
         setFeedback({
           type: "error",
-          message: data.error || "Failed to save",
+          message: readErrorMessage(data),
         });
         return;
       }
@@ -94,9 +132,20 @@ function ContextSection({
           }}
         />
 
-        <Button onClick={handleSave} disabled={saving}>
-          {saving ? "Saving..." : "Save"}
-        </Button>
+        <div className="flex items-center gap-3">
+          <Button onClick={handleSave} disabled={saving || isOverLimit}>
+            {saving ? "Saving..." : "Save"}
+          </Button>
+
+          {content.length >= COUNTER_VISIBLE_FROM && (
+            <span
+              className={isOverLimit ? "text-sm text-red-600" : "text-sm text-muted-foreground"}
+            >
+              {formatCount(content.length)} / {formatCount(CONTEXT_CONTENT_MAX_LENGTH)} characters
+              {isOverLimit && " — trim it to save."}
+            </span>
+          )}
+        </div>
 
         {feedback && (
           <p

--- a/packages/web/src/lib/schemas/context.ts
+++ b/packages/web/src/lib/schemas/context.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Upper bound on stored context content (user and org). This text is
+ * re-injected into the prompt on every chat turn, so an unbounded value is
+ * not just a storage concern: it's a permanent, per-turn token-cost and
+ * context-window tax for every conversation that uses it. 16,000 characters
+ * is generous for prose while keeping that injection bounded.
+ */
+export const CONTEXT_CONTENT_MAX_LENGTH = 16_000;
+
+/** Shared by the user-context (`/api/users/me/context`) and org-context
+ * (`/api/settings/context`) PUT routes. */
+export const contextContentSchema = z.object({
+  content: z.string().max(CONTEXT_CONTENT_MAX_LENGTH),
+});

--- a/packages/web/src/lib/schemas/context.ts
+++ b/packages/web/src/lib/schemas/context.ts
@@ -9,8 +9,18 @@ import { z } from "zod";
  */
 export const CONTEXT_CONTENT_MAX_LENGTH = 16_000;
 
+/**
+ * Every consumer of a rejected save reads one string and shows it: the
+ * settings UI renders it inline, and `pinchy-context` hands it back to the
+ * model as the tool's error. Zod's default ("Too big: expected string to have
+ * <=16000 characters") names neither the field in human terms nor what to do,
+ * so the message is written here and asserted by the route tests.
+ */
+export const CONTEXT_TOO_LONG_MESSAGE = `Context is too long — the limit is ${CONTEXT_CONTENT_MAX_LENGTH.toLocaleString("en-US")} characters.`;
+
 /** Shared by the user-context (`/api/users/me/context`) and org-context
- * (`/api/settings/context`) PUT routes. */
+ * (`/api/settings/context`) PUT routes, and by their gateway-authed
+ * `/api/internal/…` equivalents. */
 export const contextContentSchema = z.object({
-  content: z.string().max(CONTEXT_CONTENT_MAX_LENGTH),
+  content: z.string().max(CONTEXT_CONTENT_MAX_LENGTH, { message: CONTEXT_TOO_LONG_MESSAGE }),
 });

--- a/scripts/lib/docs-coverage.mjs
+++ b/scripts/lib/docs-coverage.mjs
@@ -62,9 +62,9 @@ export const API_DOC_EXEMPTIONS = {
     "gateway-only usage ingress, mirrors internal/audit/*",
   "/api/internal/channel-messages": "gateway-only channel-capture ingress",
   "/api/internal/settings/context":
-    "gateway-only context read for the pinchy-context plugin",
+    "gateway-only org-context write (PUT) for the pinchy-context plugin",
   "/api/internal/users/{}/context":
-    "gateway-only per-user context read for the pinchy-context plugin",
+    "gateway-only per-user context write (PUT) for the pinchy-context plugin",
 };
 
 /**


### PR DESCRIPTION
## Summary

- `PUT /api/users/me/context` and `PUT /api/settings/context` (org context) accepted an unbounded `content` string, validated only as `z.string()`. That content is synced to workspaces and re-injected into every chat turn's prompt, so an unbounded value is a permanent per-turn token-cost/context-window tax, not just a storage concern, plus a TOAST-sized `users.context` row.
- Adds `CONTEXT_CONTENT_MAX_LENGTH = 16_000` and a shared `contextContentSchema` in `packages/web/src/lib/schemas/context.ts`, imported by both routes (`content: z.string().max(CONTEXT_CONTENT_MAX_LENGTH)`).
- Also applied the same shared schema to the gateway-token-authed Smithers-onboarding equivalents, `PUT /api/internal/settings/context` and `PUT /api/internal/users/:userId/context` — they write to the identical `org_context` / `users.context` columns with the same unbounded schema, so it's the same defect reached via a different auth path. No docs change needed there: both are already listed in `API_DOC_EXEMPTIONS` (gateway-only, non-public).
- Client side: `settings-context.tsx`'s `ContextSection` already renders any non-2xx PUT response's `error` field via its existing inline `feedback` state (`type: "error"`), so a 400 from the new cap surfaces the same way any other validation failure already does. No UI change needed, per the brief.
- Existing overlong values: no migration script. They will be rejected on the next save attempt by the owning user (or admin, for org context) — an acceptable one-time UX bump given the cost/security motivation. Reads (`GET`) are unaffected; only writes are capped.

## Docs

Updated `docs/reference/api.mdx` for the two public routes (request-body table + `400` error case, both now note the 16,000-character cap). The internal-only variants are intentionally excluded from the API reference (see `API_DOC_EXEMPTIONS`).

## Test plan

TDD, red before green on every schema:

- `packages/web/src/__tests__/api/user-context.test.ts` — added `should return 400 when content exceeds the max length` and `should accept content at exactly the max length`.
- `packages/web/src/__tests__/api/settings-context.test.ts` — same two cases for the org-context route.
- `packages/web/src/__tests__/api/internal-user-context.test.ts` — same two cases for the internal per-user route.
- `packages/web/src/__tests__/api/internal-settings-context.test.ts` — same two cases for the internal org route.

Gates run from repo root:

- [x] `pnpm test:related` — 22/22, then 36/36 after the internal-route follow-up, all passing
- [x] `pnpm test` — 10916 passed, 18 skipped (774 files passed, 4 skipped) — skip count unchanged from before this branch
- [x] `pnpm test:scripts` — 894 passed
- [x] `pnpm -C packages/web lint` — 0 errors (981 pre-existing warnings, unrelated to this change)
- [x] `pnpm -C packages/web typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `.husky/pre-push` production build (`next build`) — succeeded