### PR TITLE
fix(security): realpath-check symlinks in uploads/artifacts serving routes

### DIFF
--- a/packages/web/src/__tests__/lib/agent-file-access.test.ts
+++ b/packages/web/src/__tests__/lib/agent-file-access.test.ts
@@ -22,7 +22,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSyn
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { resolveAllowedFile, FILE_SERVE_ROOTS } from "@/lib/agent-file-access";
+import { resolveAllowedFile, realpathWithinDir, FILE_SERVE_ROOTS } from "@/lib/agent-file-access";
 
 let tmpRoot: string;
 let serveRoot: string;
@@ -102,6 +102,60 @@ describe("resolveAllowedFile — absolute serve-root ceiling", () => {
   it("keeps denying an empty allowlist", async () => {
     const res = await resolveAllowedFile(insideFile, [], [serveRoot]);
     expect(res).toEqual({ ok: false, status: 403 });
+  });
+});
+
+/**
+ * `realpathWithinDir` is the single-directory sibling used by the two routes
+ * that serve one fixed workspace subdirectory (`uploads/`, `artifacts/`).
+ * Those routes cover it end to end, but only through the one shape they
+ * produce — a filename that already passed `sanitizeFilename` — so the edge
+ * cases below (unreadable dir, prefix-sibling directory, the returned value's
+ * own contract) have no other home.
+ */
+describe("realpathWithinDir — single-directory real-path containment", () => {
+  it("returns the resolved path for a plain file inside the directory", async () => {
+    expect(await realpathWithinDir(insideFile, serveRoot)).toBe(insideFile);
+  });
+
+  it("returns the symlink's TARGET when the target stays inside the directory", async () => {
+    // The return value is the contract: callers must open THIS path rather
+    // than the one they passed in, or the symlink is followed a second time
+    // at open() and the check buys nothing.
+    const target = join(serveRoot, "real.pdf");
+    writeFileSync(target, "%PDF-1.4\n");
+    const link = join(serveRoot, "link.pdf");
+    symlinkSync(target, link);
+
+    expect(await realpathWithinDir(link, serveRoot)).toBe(target);
+  });
+
+  it("returns null for a symlink inside the directory pointing outside it", async () => {
+    const trap = join(serveRoot, "looks-innocent.pdf");
+    symlinkSync(outsideFile, trap);
+    expect(await realpathWithinDir(trap, serveRoot)).toBeNull();
+  });
+
+  it("returns null for a path that does not exist", async () => {
+    expect(await realpathWithinDir(join(serveRoot, "nope.pdf"), serveRoot)).toBeNull();
+  });
+
+  it("returns null when the directory itself does not exist", async () => {
+    // Fails closed rather than throwing: a workspace whose zone was never
+    // created is a 404 for the caller, not a 500.
+    const missingDir = join(tmpRoot, "no-such-zone");
+    expect(await realpathWithinDir(join(missingDir, "invoice.pdf"), missingDir)).toBeNull();
+  });
+
+  it("returns null for a sibling directory that merely shares a name prefix", async () => {
+    // `/…/data-evil` must not count as inside `/…/data`. The separator-bounded
+    // comparison is what makes that true; a raw startsWith would serve it.
+    const prefixSibling = join(tmpRoot, "data-evil");
+    mkdirSync(prefixSibling, { recursive: true });
+    const leak = join(prefixSibling, "leak.pdf");
+    writeFileSync(leak, "%PDF-1.4\n");
+
+    expect(await realpathWithinDir(leak, serveRoot)).toBeNull();
   });
 });
 

--- a/packages/web/src/__tests__/lib/serve-workspace-file.test.ts
+++ b/packages/web/src/__tests__/lib/serve-workspace-file.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, symlinkSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { streamWorkspaceFile } from "@/lib/serve-workspace-file";
@@ -58,5 +58,25 @@ describe("streamWorkspaceFile xlsx support (#788)", () => {
     const res = await streamWorkspaceFile(path, "report.docx");
 
     expect(res.status).toBe(415);
+  });
+});
+
+describe("streamWorkspaceFile refuses to follow a symlink", () => {
+  // The helper's contract is that the caller has already resolved symlinks and
+  // checked containment on the RESULT. A doc comment saying so protects
+  // nothing; O_NOFOLLOW makes it a check. A caller that passes the requested
+  // path instead of the resolved one would otherwise re-follow the link here,
+  // against whatever it points at by then — which is the whole defect the
+  // containment check in the uploads/artifacts routes exists to close.
+  it("returns 404 for a symlink even when its target is perfectly servable", async () => {
+    const target = join(tmpRoot, "real.pdf");
+    writeFileSync(target, Buffer.from("%PDF-1.4\n" + "\x00".repeat(128)));
+    const link = join(tmpRoot, "link.pdf");
+    symlinkSync(target, link);
+
+    // The target itself serves fine — so a 404 for the link is the flag doing
+    // its job, not an unservable fixture.
+    expect((await streamWorkspaceFile(target, "real.pdf")).status).toBe(200);
+    expect((await streamWorkspaceFile(link, "link.pdf")).status).toBe(404);
   });
 });

--- a/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { makeNextRequest, routeContext } from "@/test-helpers/route";
@@ -151,5 +151,29 @@ describe("GET /api/agents/[agentId]/artifacts/[filename]", () => {
     const res = await callGET("agent-1", "report.pdf");
     expect(res.status).toBe(200);
     expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
+  });
+
+  // Defence in depth beyond sanitizeFilename + the lexical startsWith check:
+  // a symlink placed inside a delivery zone (its own filename passes
+  // sanitizeFilename) can point anywhere on disk. The lexical containment
+  // check only sees the symlink's in-scope path, never its target — only a
+  // realpath-based check catches this. 404, not 403 (or 200), matching every
+  // other not-found path in this route.
+  it("returns 404 when a symlink inside a delivery zone resolves outside the workspace", async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "pinchy-artifacts-escape-target-"));
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, "SECRET CONTENTS, NOT A DELIVERY");
+
+    const workbenchDir = join(tmpRoot, "agent-1", "workbench");
+    mkdirSync(workbenchDir, { recursive: true });
+    symlinkSync(secretPath, join(workbenchDir, "escape.pdf"));
+    mockGrantLookup.mockResolvedValue([{ id: "grant-1" }]);
+
+    try {
+      const res = await callGET("agent-1", "escape.pdf");
+      expect(res.status).toBe(404);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
@@ -52,6 +52,17 @@ afterEach(() => {
 
 const PDF_BYTES = Buffer.from("%PDF-1.4\n" + "\x00".repeat(128));
 
+// The bytes a symlink escape must never deliver. Shaped so the route WOULD
+// serve them without the containment check: real PDF magic bytes, so
+// `file-type` sniffs `application/pdf` and the MIME allowlist waves them
+// through. Content with no magic bytes is the weaker fixture — `.pdf` is
+// absent from EXTENSION_TO_MIME, so the unfixed route answers 415 and the
+// test then passes on a MIME rejection rather than on the leak. Verified by
+// reproduction: reverted to the pre-fix routes, this payload is answered 200
+// with the secret in the body.
+const SECRET_MARKER = "SECRET-CONTENTS-NOT-A-DELIVERY";
+const SECRET_PDF_BYTES = Buffer.from("%PDF-1.4\n" + SECRET_MARKER + "\n" + "\x00".repeat(128));
+
 function writeArtifact(agentId: string, zone: string, filename: string, bytes: Buffer) {
   const dir = join(tmpRoot, agentId, zone);
   mkdirSync(dir, { recursive: true });
@@ -162,16 +173,45 @@ describe("GET /api/agents/[agentId]/artifacts/[filename]", () => {
   it("returns 404 when a symlink inside a delivery zone resolves outside the workspace", async () => {
     const outsideDir = mkdtempSync(join(tmpdir(), "pinchy-artifacts-escape-target-"));
     const secretPath = join(outsideDir, "secret.pdf");
-    writeFileSync(secretPath, "SECRET CONTENTS, NOT A DELIVERY");
+    writeFileSync(secretPath, SECRET_PDF_BYTES);
 
     const workbenchDir = join(tmpRoot, "agent-1", "workbench");
     mkdirSync(workbenchDir, { recursive: true });
     symlinkSync(secretPath, join(workbenchDir, "escape.pdf"));
-    mockGrantLookup.mockResolvedValue([{ id: "grant-1" }]);
 
     try {
       const res = await callGET("agent-1", "escape.pdf");
+      // Both assertions, deliberately: the status alone would still pass if a
+      // future change served the bytes under some other code, and the body
+      // alone would pass on a 403 that hands an attacker an existence oracle.
       expect(res.status).toBe(404);
+      const body = Buffer.from(await res.arrayBuffer());
+      expect(body.includes(SECRET_MARKER)).toBe(false);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  // The branch the escape test above cannot reach: a failed containment check
+  // must `continue` to the next zone, not short-circuit the whole search. So
+  // an escaping symlink in `workbench` must neither be served NOR shadow the
+  // legitimate file of the same name in `uploads`. Pre-fix this test is red in
+  // the worst way — 200 carrying the secret.
+  it("skips an escaping symlink in workbench and still serves the real file from uploads", async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "pinchy-artifacts-escape-target-"));
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, SECRET_PDF_BYTES);
+
+    const workbenchDir = join(tmpRoot, "agent-1", "workbench");
+    mkdirSync(workbenchDir, { recursive: true });
+    symlinkSync(secretPath, join(workbenchDir, "report.pdf"));
+    writeArtifact("agent-1", "uploads", "report.pdf", PDF_BYTES);
+
+    try {
+      const res = await callGET("agent-1", "report.pdf");
+      expect(res.status).toBe(200);
+      const body = Buffer.from(await res.arrayBuffer());
+      expect(body.equals(PDF_BYTES)).toBe(true);
     } finally {
       rmSync(outsideDir, { recursive: true, force: true });
     }

--- a/packages/web/src/__tests__/server/agent-uploads-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-uploads-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { makeNextRequest, routeContext } from "@/test-helpers/route";
@@ -182,5 +182,29 @@ describe("GET /api/agents/[agentId]/uploads/[filename]", () => {
     writeUpload("agent-1", "Profile (38).pdf", PDF_BYTES);
     const res = await callGET("agent-1", "Profile (38).pdf");
     expect(res.status).toBe(200);
+  });
+
+  // Defence in depth beyond sanitizeFilename + the lexical startsWith check:
+  // a symlink placed inside uploads/ (its filename itself passes
+  // sanitizeFilename) can point anywhere on disk. The lexical containment
+  // check above sees only the symlink's own in-scope path, never its target
+  // — only a realpath-based check catches this. 404, not 403 (or 200), so an
+  // escape attempt looks identical to a missing file.
+  it("returns 404 when a symlink inside uploads/ resolves outside the workspace", async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "pinchy-uploads-escape-target-"));
+    const secretPath = join(outsideDir, "secret.pdf");
+    writeFileSync(secretPath, "SECRET CONTENTS, NOT AN UPLOAD");
+
+    const uploadsDir = join(tmpRoot, "agent-1", "uploads");
+    mkdirSync(uploadsDir, { recursive: true });
+    symlinkSync(secretPath, join(uploadsDir, "escape.pdf"));
+    mockOwnershipLookup.mockResolvedValue([{ id: "file-1" }]);
+
+    try {
+      const res = await callGET("agent-1", "escape.pdf");
+      expect(res.status).toBe(404);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/web/src/__tests__/server/agent-uploads-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-uploads-route.test.ts
@@ -51,6 +51,18 @@ afterEach(() => {
 
 const PDF_BYTES = Buffer.from("%PDF-1.4\n" + "\x00".repeat(128));
 
+// The bytes a symlink escape must never deliver. Shaped so the route WOULD
+// serve them without the containment check: real PDF magic bytes, so
+// `file-type` sniffs `application/pdf` and the MIME allowlist waves them
+// through. Content with no magic bytes is the weaker fixture — `.pdf` is
+// absent from EXTENSION_TO_MIME, so the unfixed route answers 415 and the
+// test then passes on a MIME rejection rather than on the leak (a check that
+// only ever turned 415 into 404 would satisfy it). Verified by reproduction:
+// reverted to the pre-fix routes, this payload is answered 200 with the
+// secret in the body.
+const SECRET_MARKER = "SECRET-CONTENTS-NOT-AN-UPLOAD";
+const SECRET_PDF_BYTES = Buffer.from("%PDF-1.4\n" + SECRET_MARKER + "\n" + "\x00".repeat(128));
+
 function writeUpload(agentId: string, filename: string, bytes: Buffer) {
   const dir = join(tmpRoot, agentId, "uploads");
   mkdirSync(dir, { recursive: true });
@@ -193,18 +205,37 @@ describe("GET /api/agents/[agentId]/uploads/[filename]", () => {
   it("returns 404 when a symlink inside uploads/ resolves outside the workspace", async () => {
     const outsideDir = mkdtempSync(join(tmpdir(), "pinchy-uploads-escape-target-"));
     const secretPath = join(outsideDir, "secret.pdf");
-    writeFileSync(secretPath, "SECRET CONTENTS, NOT AN UPLOAD");
+    writeFileSync(secretPath, SECRET_PDF_BYTES);
 
     const uploadsDir = join(tmpRoot, "agent-1", "uploads");
     mkdirSync(uploadsDir, { recursive: true });
     symlinkSync(secretPath, join(uploadsDir, "escape.pdf"));
-    mockOwnershipLookup.mockResolvedValue([{ id: "file-1" }]);
 
     try {
       const res = await callGET("agent-1", "escape.pdf");
+      // Both assertions, deliberately: the status alone would still pass if a
+      // future change served the bytes under some other code, and the body
+      // alone would pass on a 403 that hands an attacker an existence oracle.
       expect(res.status).toBe(404);
+      const body = Buffer.from(await res.arrayBuffer());
+      expect(body.includes(SECRET_MARKER)).toBe(false);
     } finally {
       rmSync(outsideDir, { recursive: true, force: true });
     }
+  });
+
+  // The counterpart the escape test cannot give: what is enforced is
+  // CONTAINMENT, not "no symlinks". Without this, rejecting every symlink
+  // outright would satisfy the test above while silently breaking any
+  // workspace that uses one.
+  it("still serves a symlink inside uploads/ whose target stays inside uploads/", async () => {
+    writeUpload("agent-1", "invoice.pdf", PDF_BYTES);
+    const uploadsDir = join(tmpRoot, "agent-1", "uploads");
+    symlinkSync(join(uploadsDir, "invoice.pdf"), join(uploadsDir, "link.pdf"));
+
+    const res = await callGET("agent-1", "link.pdf");
+    expect(res.status).toBe(200);
+    const body = Buffer.from(await res.arrayBuffer());
+    expect(body.equals(PDF_BYTES)).toBe(true);
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/artifacts/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/artifacts/[filename]/route.ts
@@ -64,10 +64,9 @@ export const GET = withAuth<Params>(async (_req, { params }, session) => {
   // The grant authorizes the file but no longer says which zone it lives in.
   // Try each known zone in order; for each, re-resolve the final path and verify
   // it stays inside <workspace>/<zone> (defence in depth, even though
-  // sanitizeFilename already rejects "/" and ".."). streamWorkspaceFile opens
-  // the path directly and returns 404 when it doesn't exist — so we serve the
-  // first zone that yields a non-404 (no check-then-open TOCTOU). Found in
-  // none => 404.
+  // sanitizeFilename already rejects "/" and ".."). streamWorkspaceFile returns
+  // 404 when the file isn't there, so we serve the first zone that yields a
+  // non-404. Found in none => 404.
   const workspace = getWorkspacePath(agentId);
   for (const zone of DELIVERY_ZONES) {
     const zoneDir = join(workspace, zone);
@@ -79,7 +78,17 @@ export const GET = withAuth<Params>(async (_req, { params }, session) => {
     // symlinks on both sides and re-check containment — see
     // agent-file-access.ts's realpathWithinDir. A symlink resolving outside
     // this zone is treated the same as "not in this zone" (continue to the
-    // next), matching the lexical-miss branch above.
+    // next), matching the lexical-miss branch above. Note this is per ZONE,
+    // not per workspace: a symlink in workbench pointing into uploads is
+    // refused here and then found on the uploads pass, or not at all.
+    //
+    // This is a check before an open, which is why what gets opened is the
+    // RESOLVED path and never `fullPath` again: re-pointing the symlink after
+    // this line changes nothing, because nothing reads that path a second
+    // time. The window that does remain — replacing the resolved, in-zone
+    // file itself between these two lines — needs the same write access the
+    // symlink did and is strictly narrower than the unchecked read this
+    // replaces.
     const realPath = await realpathWithinDir(fullPath, zoneDir);
     if (!realPath) continue;
 

--- a/packages/web/src/app/api/agents/[agentId]/artifacts/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/artifacts/[filename]/route.ts
@@ -13,6 +13,7 @@ import { db } from "@/db";
 import { agentDeliveredFiles } from "@/db/schema";
 import { sanitizeFilename } from "@/lib/upload-validation";
 import { streamWorkspaceFile } from "@/lib/serve-workspace-file";
+import { realpathWithinDir } from "@/lib/agent-file-access";
 
 type Params = { params: Promise<{ agentId: string; filename: string }> };
 
@@ -72,7 +73,17 @@ export const GET = withAuth<Params>(async (_req, { params }, session) => {
     const zoneDir = join(workspace, zone);
     const fullPath = resolve(zoneDir, safeName);
     if (!fullPath.startsWith(resolve(zoneDir) + sep)) continue;
-    const res = await streamWorkspaceFile(fullPath, safeName);
+
+    // Real-path containment: the lexical check above only sees the requested
+    // path itself, never what a symlink at that path points at. Resolve
+    // symlinks on both sides and re-check containment — see
+    // agent-file-access.ts's realpathWithinDir. A symlink resolving outside
+    // this zone is treated the same as "not in this zone" (continue to the
+    // next), matching the lexical-miss branch above.
+    const realPath = await realpathWithinDir(fullPath, zoneDir);
+    if (!realPath) continue;
+
+    const res = await streamWorkspaceFile(realPath, safeName);
     if (res.status !== 404) return res;
   }
 

--- a/packages/web/src/app/api/agents/[agentId]/uploads/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/uploads/[filename]/route.ts
@@ -11,6 +11,7 @@ import { db } from "@/db";
 import { uploadedFiles } from "@/db/schema";
 import { sanitizeFilename } from "@/lib/upload-validation";
 import { streamWorkspaceFile } from "@/lib/serve-workspace-file";
+import { realpathWithinDir } from "@/lib/agent-file-access";
 
 type Params = { params: Promise<{ agentId: string; filename: string }> };
 
@@ -62,8 +63,18 @@ export const GET = withAuth<Params>(async (_req, { params }, session) => {
     return new NextResponse("Not found", { status: 404 });
   }
 
+  // Real-path containment: the lexical check above only sees the requested
+  // path itself, never what a symlink at that path points at. Resolve
+  // symlinks on both sides and re-check containment — see
+  // agent-file-access.ts's realpathWithinDir. Serve the resolved real path
+  // (not fullPath) so nothing re-resolves the symlink again at open() time.
+  const realPath = await realpathWithinDir(fullPath, uploadsDir);
+  if (!realPath) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
   // Uploads are capped at 15 MB at upload time, so the helper's in-memory read
   // is fine. It also refuses anything outside the MIME allowlist (a sneaked-in
   // .exe must never reach the browser as application/octet-stream).
-  return streamWorkspaceFile(fullPath, safeName);
+  return streamWorkspaceFile(realPath, safeName);
 });

--- a/packages/web/src/lib/agent-file-access.ts
+++ b/packages/web/src/lib/agent-file-access.ts
@@ -62,6 +62,46 @@ function isContained(path: string, root: string): boolean {
   return path.startsWith(rootWithSep);
 }
 
+/**
+ * Real-path containment for a single directory the caller has already
+ * lexically verified `fullPath` is inside (see `isContained` above). Used by
+ * routes with a fixed, single serve directory — `uploads/[filename]` and
+ * `artifacts/[filename]` — where the two-list model of `resolveAllowedFile`
+ * (agent grant + serve-root ceiling) doesn't apply; they serve a single
+ * workspace subdirectory per request, not an admin-configured allowlist.
+ *
+ * Resolves symlinks on BOTH `fullPath` and `dir`, then re-checks containment
+ * on the resolved forms — this is what defeats a symlink planted inside the
+ * serve directory that points outside it, exactly as `resolveAllowedFile`'s
+ * stage 2 does. Returns the resolved real path when it stays contained, or
+ * `null` for every other case (missing file, unreadable directory, or an
+ * escape) — callers here don't distinguish 403 from 404 the way
+ * `resolveAllowedFile`'s callers do, they already reduce every failure to a
+ * uniform 404 (or, for `artifacts`, to trying the next zone).
+ */
+export async function realpathWithinDir(fullPath: string, dir: string): Promise<string | null> {
+  let realDir: string;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- dir is a fixed workspace subdirectory the caller constructed, not request input.
+    realDir = await realpath(resolve(dir));
+  } catch {
+    return null;
+  }
+
+  let realTarget: string;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- fullPath already passed lexical containment against dir; resolving it is the security boundary itself (defeats symlink escapes), not an unchecked read.
+    realTarget = await realpath(fullPath);
+  } catch {
+    // Covers ENOENT (legitimately missing — the caller's own 404 handles it)
+    // and any other error (permission denied, symlink loop): neither can be
+    // verified safe, so deny either way.
+    return null;
+  }
+
+  return isContained(realTarget, realDir) ? realTarget : null;
+}
+
 export async function resolveAllowedFile(
   requestedPath: string,
   allowedPaths: string[],

--- a/packages/web/src/lib/agent-file-access.ts
+++ b/packages/web/src/lib/agent-file-access.ts
@@ -78,6 +78,12 @@ function isContained(path: string, root: string): boolean {
  * escape) — callers here don't distinguish 403 from 404 the way
  * `resolveAllowedFile`'s callers do, they already reduce every failure to a
  * uniform 404 (or, for `artifacts`, to trying the next zone).
+ *
+ * Callers MUST open the RETURNED path, never the `fullPath` they passed in.
+ * This is a check that precedes an open, so opening the input would follow the
+ * symlink a second time — against whatever it points at by then — and the
+ * check would buy nothing. Opening the returned path leaves only the much
+ * narrower window of the resolved file itself being replaced in between.
  */
 export async function realpathWithinDir(fullPath: string, dir: string): Promise<string | null> {
   let realDir: string;

--- a/packages/web/src/lib/serve-workspace-file.ts
+++ b/packages/web/src/lib/serve-workspace-file.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { open } from "fs/promises";
+import { constants as fsConstants } from "fs";
 import { extname } from "path";
 import { fileTypeFromBuffer } from "file-type";
 import { ALLOWED_ATTACHMENT_MIMES, ALLOWED_TEXT_MIMES } from "@/lib/upload-validation";
@@ -24,6 +25,24 @@ import { EXTENSION_TO_MIME } from "@/lib/attachment-mime";
 const DELIVERY_ONLY_BINARY_MIMES = new Set<string>([
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ]);
+
+/**
+ * Read-only, and refuse to follow a symlink at the final component.
+ *
+ * Every caller has already resolved symlinks and checked containment on the
+ * RESULT (`resolveAllowedFile`, `realpathWithinDir`), so a path arriving here
+ * is never legitimately a link — a realpath's output cannot be one. That makes
+ * `O_NOFOLLOW` free for correct callers and load-bearing for two wrong ones:
+ * a future caller that passes the REQUESTED path instead of the resolved one
+ * (the containment check would then be read once and the link followed again
+ * here, buying nothing), and the window between a caller's check and this
+ * open, in which a link could be swapped in. Both surface as ELOOP → 404
+ * rather than as bytes from outside the workspace.
+ *
+ * `?? 0` because Windows has no `O_NOFOLLOW`: there the flag degrades to a
+ * plain read rather than poisoning the mask with `undefined` (`NaN`).
+ */
+const READ_NO_SYMLINK = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 
 /**
  * The MIME types this serving route can actually stream — the union of the
@@ -53,7 +72,10 @@ export const SERVABLE_DELIVERED_MIMES: ReadonlySet<string> = new Set<string>([
  *
  * The caller MUST have already sanitized the filename and verified `fullPath`
  * is contained within the intended workspace zone — this helper does not
- * re-validate the path.
+ * re-validate the path. Pass the SYMLINK-RESOLVED path (what
+ * `resolveAllowedFile` and `realpathWithinDir` return), not the requested one:
+ * the open below follows symlinks, so handing it an unresolved path would
+ * re-follow a link the caller's containment check has already read once.
  *
  * Returns 404 if the file is missing/not a regular file, 415 if its content-type
  * is outside the upload allowlist, 200 with the bytes otherwise.
@@ -66,10 +88,12 @@ export async function streamWorkspaceFile(
   // check-then-open on the path is a TOCTOU race (js/file-system-race). A
   // missing/permission-denied file surfaces as the open throwing → 404. The
   // handle's own stat is authoritative for the bytes we're about to read.
+  // O_NOFOLLOW (see READ_NO_SYMLINK) makes "the caller passed the resolved
+  // path" a check rather than a comment: a link here is ELOOP → 404.
   let fh;
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- caller sanitized + containment-checked the path
-    fh = await open(fullPath, "r");
+    fh = await open(fullPath, READ_NO_SYMLINK);
   } catch {
     return new NextResponse("Not found", { status: 404 });
   }


### PR DESCRIPTION
## Summary

- `uploads/[filename]` and `artifacts/[filename]` only did lexical (`resolve()` + `startsWith(dir + sep)`) containment before serving a file, unlike the sibling `workspace-file` route, which already does two-stage lexical + realpath containment (`agent-file-access.ts`). A symlink placed inside `uploads/` or a delivery zone — its own filename passes `sanitizeFilename`, so it isn't blocked upstream — would be followed straight through to the browser, since the lexical check only ever sees the symlink's own in-scope path, never its target.
- No demonstrated exploit path plants such a symlink today (defense-in-depth gap, not a proven bypass).
- Extracted `realpathWithinDir(fullPath, dir)` in `agent-file-access.ts` — a single-directory sibling of `resolveAllowedFile()`'s existing stage-2 real-path check — and wired it into both routes. An escape resolves to 404, matching every other not-found path in these routes (no new information disclosure, no 403 introduced).

## Test plan

- [x] Added failing tests first (red): "returns 404 when a symlink inside uploads/ resolves outside the workspace" and "returns 404 when a symlink inside a delivery zone resolves outside the workspace" — both initially observed a 415 (proving the symlinked file's real bytes were being read), then 404 after the fix.
- [x] `pnpm test:related` — 97 passed
- [x] `pnpm test` — 774 files / 10910 tests passed, 18 skipped (pre-existing)
- [x] `pnpm -C packages/web lint` — 0 errors (987 pre-existing warnings, unrelated)
- [x] `pnpm -C packages/web typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:scripts` — 894 passed
- [x] Verified no regression on `frame-options-route-coverage.test.ts` / `security-headers.test.ts` (18 passed) — header behavior untouched, only the containment check was added.