### PR TITLE
fix(security): truncate audit values beyond the sanitizer's recursion cap

### DIFF
--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -245,6 +245,7 @@ Tool parameters and results are automatically sanitized before being stored in t
 - **Sensitive field names** — Any JSON field whose name contains `password`, `secret`, `token`, `apiKey`, `credential`, or similar terms has its value replaced with `[REDACTED]`.
 - **Known secret patterns** — String values matching known formats (OpenAI keys `sk-…`, GitHub tokens `ghp_…`, Slack tokens `xoxb-…`, Bearer tokens, Telegram bot tokens, Meta access tokens, and others) are replaced with `[REDACTED]`.
 - **Environment file content** — When a tool reads a file containing lines like `SECRET_KEY=value`, the value portion is redacted while the key name is preserved.
+- **Anything nested too deep to check** — Sanitization walks a value ten levels down. A tool payload that nests deeper than that is replaced with `[TRUNCATED]` at that point, because a row is append-only: we can't inspect what's below, and we'd rather lose the detail than write an unchecked secret we could never take back. Individual values at that boundary are still redacted normally — only whole sub-objects are collapsed.
 
 ### Defense in Depth
 

--- a/docs/src/content/docs/guides/reporting-issues.mdx
+++ b/docs/src/content/docs/guides/reporting-issues.mdx
@@ -20,6 +20,8 @@ The diagnostics export is a single JSON file that captures:
 
 Secrets are filtered out before the file is generated. API keys, Bearer tokens, and any values under sensitive keys (`password`, `apikey`, `authorization`, and friends) are automatically redacted, and the OpenClaw `sessionKey` is hashed with SHA-256 so it can't be replayed. Your agent's instructions are never written into the file — only a hash of them, so we can spot when they've changed without reading your custom prompt.
 
+The filter reads ten levels into a structure. If you spot a `[TRUNCATED]` marker in the file, that's a sub-object nested deeper than the filter could check — we collapse it rather than ship a value we haven't looked at. Everything else at that depth is still there, redacted as usual.
+
 ## Choosing which chat to export
 
 If you have more than one conversation with an agent, you can pick which one to export. The selector lists all of your own chats with that agent — including named chats and read-only Telegram conversations linked to your account. You can only export your own chats.

--- a/packages/plugins/pinchy-audit/index.test.ts
+++ b/packages/plugins/pinchy-audit/index.test.ts
@@ -469,6 +469,59 @@ describe("pinchy-audit plugin", () => {
       expect(level).toBe("[TRUNCATED]");
     });
 
+    it("truncates only the containers it could not inspect, keeping leaves at the cap (SYNC with web)", async () => {
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const afterHook = mockOn.mock.calls.find((c) => c[0] === "after_tool_call")?.[1];
+
+      // A container past the cap is replaced because we never get to look
+      // inside it. A leaf has no inside: its key was checked by the object one
+      // level up, and pattern redaction is depth-independent — so it is exactly
+      // as sanitized at depth 10 as at depth 1, and keeping it is what leaves a
+      // diagnostics bundle's deepest tool arguments readable.
+      let nested: any = {
+        opcode: 6,
+        password: "boundary-secret",
+        note: "the model echoed sk-abcdefghijklmnopqrstuvwx back",
+        child: { deep: "unreachable" },
+      };
+      // 9 wrappers put this object at depth 9, so its own values land on the
+      // depth-10 boundary the cap governs.
+      for (let i = 0; i < 9; i++) {
+        nested = { nested };
+      }
+
+      await afterHook(
+        {
+          toolName: "odoo_write",
+          params: nested,
+          result: "ok",
+          durationMs: 5,
+        },
+        {
+          agentId: "agent-1",
+          sessionKey: "agent:agent-1:user-user-1",
+          toolName: "odoo_write",
+        }
+      );
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      let level = body.params;
+      for (let i = 0; i < 9; i++) {
+        level = level.nested;
+      }
+      expect(level.opcode).toBe(6);
+      expect(level.password).toBe("[REDACTED]");
+      expect(level.note).toBe("the model echoed [REDACTED] back");
+      expect(level.child).toBe("[TRUNCATED]");
+    });
+
     it("also sanitizes params in before_tool_call events", async () => {
       const { default: plugin } = await import("./index");
       plugin.register?.(

--- a/packages/plugins/pinchy-audit/index.test.ts
+++ b/packages/plugins/pinchy-audit/index.test.ts
@@ -424,6 +424,51 @@ describe("pinchy-audit plugin", () => {
       expect(body.result).toContain("[REDACTED]");
     });
 
+    it("truncates values beyond max depth instead of leaking them unredacted (SYNC with web)", async () => {
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const afterHook = mockOn.mock.calls.find((c) => c[0] === "after_tool_call")?.[1];
+
+      // Build a 12-level deep object: depth 0 is outermost, secret lives at depth 12.
+      // The depth cap is a cycle/stack-depth guard, not a redaction bypass — a
+      // real Odoo command tuple nests to depth ~6, well within reach of a
+      // secret this cap must not pass through verbatim.
+      let nested: any = { password: "deep-secret" };
+      for (let i = 0; i < 12; i++) {
+        nested = { nested };
+      }
+
+      await afterHook(
+        {
+          toolName: "odoo_write",
+          params: nested,
+          result: "ok",
+          durationMs: 5,
+        },
+        {
+          agentId: "agent-1",
+          sessionKey: "agent:agent-1:user-user-1",
+          toolName: "odoo_write",
+        }
+      );
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(JSON.stringify(body.params)).not.toContain("deep-secret");
+      // The MAX_DEPTH (10) check fires 10 hops in, at the object whose own
+      // subtree still holds the secret two levels further down.
+      let level = body.params;
+      for (let i = 0; i < 10; i++) {
+        level = level.nested;
+      }
+      expect(level).toBe("[TRUNCATED]");
+    });
+
     it("also sanitizes params in before_tool_call events", async () => {
       const { default: plugin } = await import("./index");
       plugin.register?.(

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -70,6 +70,7 @@ interface RecentToolStart {
 // ── Standalone sanitization (no imports from @pinchy/web) ───────────
 
 const REDACTED = "[REDACTED]";
+const TRUNCATED = "[TRUNCATED]";
 const MAX_DEPTH = 10;
 
 // SYNC: This sanitization logic is duplicated in packages/web/src/lib/audit-sanitize.ts
@@ -132,7 +133,13 @@ function redactPatterns(value: string): string {
 
 function sanitizeValue(value: unknown, depth: number): unknown {
   if (value === null || value === undefined) return value;
-  if (depth >= MAX_DEPTH) return value;
+  // The depth cap exists to stop unbounded recursion (a cyclic or
+  // pathologically deep structure), not to grant an escape hatch from
+  // redaction. Returning `value` here would forward it UNREDACTED into an
+  // append-only, HMAC-chained audit row that can never be rewritten — a real
+  // Odoo command tuple nests to depth ~6, well within reach of a secret this
+  // cap would otherwise pass through verbatim.
+  if (depth >= MAX_DEPTH) return TRUNCATED;
   if (Array.isArray(value)) return value.map((item) => sanitizeValue(item, depth + 1));
   // Dates have no own enumerable properties — the generic object branch below
   // would strip them to {}. Serialize like JSON.stringify would.

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -135,11 +135,20 @@ function sanitizeValue(value: unknown, depth: number): unknown {
   if (value === null || value === undefined) return value;
   // The depth cap exists to stop unbounded recursion (a cyclic or
   // pathologically deep structure), not to grant an escape hatch from
-  // redaction. Returning `value` here would forward it UNREDACTED into an
-  // append-only, HMAC-chained audit row that can never be rewritten — a real
-  // Odoo command tuple nests to depth ~6, well within reach of a secret this
-  // cap would otherwise pass through verbatim.
-  if (depth >= MAX_DEPTH) return TRUNCATED;
+  // redaction. Returning the container here would forward every key inside it
+  // UNREDACTED into an append-only, HMAC-chained audit row that can never be
+  // rewritten — a real Odoo command tuple nests to depth ~6, well within reach
+  // of a secret this cap would otherwise pass through verbatim.
+  //
+  // Only containers are truncated, because only containers are what the cap
+  // stops us from inspecting. A leaf at this depth was handed down by an object
+  // at depth < MAX_DEPTH, which already applied the sensitive-key check to it,
+  // and pattern redaction below is depth-independent — so a deep scalar is
+  // exactly as sanitized as a shallow one. Replacing it too would cost
+  // diagnostics bundles their deepest tool arguments for no gain.
+  if (depth >= MAX_DEPTH && typeof value === "object" && !(value instanceof Date)) {
+    return TRUNCATED;
+  }
   if (Array.isArray(value)) return value.map((item) => sanitizeValue(item, depth + 1));
   // Dates have no own enumerable properties — the generic object branch below
   // would strip them to {}. Serialize like JSON.stringify would.

--- a/packages/web/src/__tests__/lib/audit-sanitize.test.ts
+++ b/packages/web/src/__tests__/lib/audit-sanitize.test.ts
@@ -207,6 +207,36 @@ describe("sanitizeDetail", () => {
       expect(level).toBe("[TRUNCATED]");
       expect(JSON.stringify(result)).not.toContain("deep-secret");
     });
+
+    it("truncates only the containers it could not inspect, keeping leaves at the cap", () => {
+      // A container past the cap is replaced because we never get to look
+      // inside it. A leaf has no inside: its key was checked by the object one
+      // level up, and pattern redaction is depth-independent — so it is exactly
+      // as sanitized at depth 10 as at depth 1, and keeping it is what leaves a
+      // diagnostics bundle's deepest tool arguments readable.
+      let obj: any = {
+        opcode: 6,
+        password: "boundary-secret",
+        note: "the model echoed sk-abcdefghijklmnopqrstuvwx back",
+        child: { deep: "unreachable" },
+      };
+      // 9 wrappers put this object at depth 9, so its own values land on the
+      // depth-10 boundary the cap governs.
+      for (let i = 0; i < 9; i++) {
+        obj = { nested: obj };
+      }
+
+      const result = sanitizeDetail(obj) as any;
+
+      let level = result;
+      for (let i = 0; i < 9; i++) {
+        level = level.nested;
+      }
+      expect(level.opcode).toBe(6);
+      expect(level.password).toBe("[REDACTED]");
+      expect(level.note).toBe("the model echoed [REDACTED] back");
+      expect(level.child).toBe("[TRUNCATED]");
+    });
   });
 
   describe("pattern redaction", () => {

--- a/packages/web/src/__tests__/lib/audit-sanitize.test.ts
+++ b/packages/web/src/__tests__/lib/audit-sanitize.test.ts
@@ -176,8 +176,21 @@ describe("sanitizeDetail", () => {
       expect(result).toEqual({ count: 42, active: true, password: "[REDACTED]" });
     });
 
-    it("stops recursion at max depth", () => {
+    it("stops recursion at max depth without throwing", () => {
       // Build a 12-level deep object: depth 0 is outermost, password lives at depth 12
+      let obj: any = { password: "deep-secret" };
+      for (let i = 0; i < 12; i++) {
+        obj = { nested: obj };
+      }
+
+      expect(() => sanitizeDetail(obj)).not.toThrow();
+    });
+
+    it("truncates values beyond max depth instead of leaking them unredacted", () => {
+      // The depth cap is a cycle/stack-depth guard, not a redaction bypass.
+      // A real Odoo command tuple nests to depth ~6, well within reach of a
+      // secret this cap must not pass through verbatim into an append-only,
+      // HMAC-chained audit row.
       let obj: any = { password: "deep-secret" };
       for (let i = 0; i < 12; i++) {
         obj = { nested: obj };
@@ -185,13 +198,14 @@ describe("sanitizeDetail", () => {
 
       const result = sanitizeDetail(obj) as any;
 
-      // Should not throw. The password key at depth 12 is beyond the limit
-      // of 10, so it must NOT be redacted.
+      // The MAX_DEPTH (10) check fires 10 hops in, at the object whose own
+      // subtree still holds the secret two levels further down.
       let level = result;
-      for (let i = 0; i < 12; i++) {
+      for (let i = 0; i < 10; i++) {
         level = level.nested;
       }
-      expect(level.password).toBe("deep-secret");
+      expect(level).toBe("[TRUNCATED]");
+      expect(JSON.stringify(result)).not.toContain("deep-secret");
     });
   });
 

--- a/packages/web/src/app/api/diagnostics/export/route.ts
+++ b/packages/web/src/app/api/diagnostics/export/route.ts
@@ -193,11 +193,13 @@ export const POST = withAuth(async (request, _ctx, session) => {
     userDescription,
   });
   // Pipeline-order invariant: sanitize BEFORE enforceSizeCap.
-  // `sanitizeDetail` only substitutes (`[REDACTED]` is shorter than every
-  // secret-shaped string it matches), so it never grows the bundle. Running
-  // it first means enforceSizeCap's byte measurement reflects exactly what
-  // ships to the user. Swapping the order would mean we could overshoot the
-  // cap by however much sanitization shrinks the payload.
+  // Sanitizing moves the byte count in BOTH directions — `[REDACTED]` is
+  // shorter than the secret-shaped strings it matches but longer than a short
+  // value under a sensitive key, and `[TRUNCATED]` collapses a whole subtree
+  // past the depth cap. So the cap has to be measured on the sanitized bundle:
+  // enforceSizeCap's byte count then reflects exactly what ships to the user.
+  // Swapping the order would let the shipped bundle drift from the measured
+  // one — undershooting the cap in one direction, overshooting it in the other.
   const sanitized = sanitizeBundle(bundle);
   const { bundle: capped, dropped, truncated } = enforceSizeCap(sanitized);
 

--- a/packages/web/src/lib/audit-sanitize.ts
+++ b/packages/web/src/lib/audit-sanitize.ts
@@ -1,4 +1,5 @@
 const REDACTED = "[REDACTED]";
+const TRUNCATED = "[TRUNCATED]";
 const MAX_DEPTH = 10;
 
 // SYNC: This sanitization logic is duplicated in packages/plugins/pinchy-audit/index.ts
@@ -71,7 +72,13 @@ function redactPatterns(value: string): string {
 
 function sanitizeValue(value: unknown, depth: number): unknown {
   if (value === null || value === undefined) return value;
-  if (depth >= MAX_DEPTH) return value;
+  // The depth cap exists to stop unbounded recursion (a cyclic or
+  // pathologically deep structure), not to grant an escape hatch from
+  // redaction. Returning `value` here would forward it UNREDACTED into an
+  // append-only, HMAC-chained audit row that can never be rewritten — a real
+  // Odoo command tuple nests to depth ~6, well within reach of a secret this
+  // cap would otherwise pass through verbatim.
+  if (depth >= MAX_DEPTH) return TRUNCATED;
 
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeValue(item, depth + 1));

--- a/packages/web/src/lib/audit-sanitize.ts
+++ b/packages/web/src/lib/audit-sanitize.ts
@@ -74,11 +74,20 @@ function sanitizeValue(value: unknown, depth: number): unknown {
   if (value === null || value === undefined) return value;
   // The depth cap exists to stop unbounded recursion (a cyclic or
   // pathologically deep structure), not to grant an escape hatch from
-  // redaction. Returning `value` here would forward it UNREDACTED into an
-  // append-only, HMAC-chained audit row that can never be rewritten — a real
-  // Odoo command tuple nests to depth ~6, well within reach of a secret this
-  // cap would otherwise pass through verbatim.
-  if (depth >= MAX_DEPTH) return TRUNCATED;
+  // redaction. Returning the container here would forward every key inside it
+  // UNREDACTED into an append-only, HMAC-chained audit row that can never be
+  // rewritten — a real Odoo command tuple nests to depth ~6, well within reach
+  // of a secret this cap would otherwise pass through verbatim.
+  //
+  // Only containers are truncated, because only containers are what the cap
+  // stops us from inspecting. A leaf at this depth was handed down by an object
+  // at depth < MAX_DEPTH, which already applied the sensitive-key check to it,
+  // and pattern redaction below is depth-independent — so a deep scalar is
+  // exactly as sanitized as a shallow one. Replacing it too would cost
+  // diagnostics bundles their deepest tool arguments for no gain.
+  if (depth >= MAX_DEPTH && typeof value === "object" && !(value instanceof Date)) {
+    return TRUNCATED;
+  }
 
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeValue(item, depth + 1));


### PR DESCRIPTION
## Summary
- `sanitizeValue`'s depth cap (`MAX_DEPTH = 10`) returned the raw, unredacted value once recursion hit the limit — a cycle/stack-depth guard that doubled as a redaction bypass. A secret nested that deep (a real Odoo command tuple nests to ~6 levels) would land verbatim in the append-only, HMAC-chained audit row, which can never be rewritten after the fact.
- Both copies of the sanitizer had the same gap: `packages/plugins/pinchy-audit/index.ts` (`sanitizeValue`) and `packages/web/src/lib/audit-sanitize.ts` (`sanitizeValue`).
- Fix: past `MAX_DEPTH`, return `"[TRUNCATED]"` instead of the raw value, in both copies.

## Drift guard decision
Checked for an existing drift guard pinning the two sanitizer copies together (like `normalize-docx-table-html-drift.test.ts`) — none exists. Diffed the two files: they are **not** structurally/textually identical beyond the shared logic (different constant names — `SENSITIVE_KEYS` vs `SENSITIVE_KEY_PATTERNS`, different comment styles, `index.ts` carries a lot of plugin-specific code around it). Per the brief, a normalize-docx-style textual-identity guard only fits when the copies are genuinely structurally identical, so I did not add one. Both copies already carry a `// SYNC:` comment pointing at each other, and both test suites now assert the same truncation behavior with tests explicitly labeled "SYNC with web" / referencing the other copy.

## Test plan
- [x] `packages/web/src/__tests__/lib/audit-sanitize.test.ts` — split the old `"stops recursion at max depth"` test (which asserted the raw secret leaked through, i.e. documented the vulnerability) into `"stops recursion at max depth without throwing"` (kept: no-throw guarantee) and a new `"truncates values beyond max depth instead of leaking them unredacted"` (red before the fix, green after).
- [x] `packages/plugins/pinchy-audit/index.test.ts` — new test `"truncates values beyond max depth instead of leaking them unredacted (SYNC with web)"`, exercised through the real `after_tool_call` hook dispatch path.
- [x] `pnpm test:related` — 6 files, 153 passed.
- [x] `pnpm test` — 774 passed | 4 skipped test files, 10910 passed | 18 skipped tests.
- [x] `pnpm test:plugins` — all 9 plugin packages pass.
- [x] `pnpm typecheck:plugins` — all 9 plugin packages typecheck cleanly.
- [x] `pnpm -C packages/web lint` — 0 errors (pre-existing warnings only, unrelated).
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm format:check` — clean.