### PR TITLE
fix(lint): scope require-audit-log exemptions per handler, not per file

### DIFF
--- a/packages/web/eslint-rules/require-audit-log.js
+++ b/packages/web/eslint-rules/require-audit-log.js
@@ -8,7 +8,7 @@ module.exports = {
     },
     messages: {
       missingAuditLog:
-        "Mutation handler '{{method}}' must call appendAuditLog() or deferAuditLog(). If this endpoint doesn't need auditing, add a file-level comment: // audit-exempt: <reason>",
+        "Mutation handler '{{method}}' must call appendAuditLog() or deferAuditLog(). If this endpoint doesn't need auditing, add a comment directly above it: // audit-exempt: <reason> (or above the file's imports to exempt every handler in the file).",
       missingExemptReason: "audit-exempt comment must include a reason: // audit-exempt: <reason>",
       noFireAndForgetAudit:
         "Do not chain .catch() onto appendAuditLog(): silently swallowed audit failures break the audit-trail contract (see #231). Either `await appendAuditLog(...)` (fail-closed, returns 500) or wrap with `deferAuditLog(...)` from @/lib/audit-deferred (deferred + structured failure signal).",
@@ -44,46 +44,66 @@ module.exports = {
     }
 
     const sourceCode = context.sourceCode || context.getSourceCode();
-    const comments = sourceCode.getAllComments();
-    const exemptComment = comments.find((c) => c.value.trim().startsWith("audit-exempt"));
-
-    if (exemptComment) {
-      const text = exemptComment.value.trim();
-      if (!text.match(/^audit-exempt:\s*\S/)) {
-        context.report({
-          node: exemptComment,
-          messageId: "missingExemptReason",
-        });
-      }
-      return fireAndForgetVisitors;
-    }
-
     const MUTATION_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 
-    return {
-      ...fireAndForgetVisitors,
-      ExportNamedDeclaration(node) {
-        const decl = node.declaration;
-        if (!decl) return;
+    // Only a comment whose trimmed text starts with "audit-exempt", followed
+    // immediately by a colon, whitespace, or the end of the comment, counts as
+    // an attempt at the marker. This keeps prose that merely MENTIONS the
+    // phrase mid-sentence (e.g. "deliberately carries NO audit-exempt:
+    // marker") — or a different word that happens to share the prefix (e.g.
+    // "audit-exemptions:") — from being misread as one.
+    const EXEMPT_ATTEMPT = /^audit-exempt(?::|\s|$)/;
+    const EXEMPT_WITH_REASON = /^audit-exempt:\s*\S/;
 
-        if (decl.type === "FunctionDeclaration" && decl.id) {
-          const name = decl.id.name;
-          if (!MUTATION_METHODS.includes(name)) return;
-          checkFunctionBody(context, decl.body, name);
-        }
+    function findExemptAttempt(comments) {
+      return comments.find((c) => EXEMPT_ATTEMPT.test(c.value.trim())) ?? null;
+    }
 
-        if (decl.type === "VariableDeclaration") {
-          for (const declarator of decl.declarations) {
-            if (
-              declarator.id.type === "Identifier" &&
-              MUTATION_METHODS.includes(declarator.id.name)
-            ) {
-              checkInitializer(context, declarator.init, declarator.id.name);
-            }
-          }
-        }
-      },
-    };
+    // Validates format and reports missingExemptReason if malformed. Caches by
+    // comment identity so a comment consulted from more than one code path
+    // (the file-wide check and a per-handler check can resolve to the very
+    // same physical comment, e.g. in a file with no imports whose only
+    // statement is the exempted handler) is only ever reported once.
+    const exemptValidationCache = new Map();
+    function validateExempt(comment) {
+      if (exemptValidationCache.has(comment)) {
+        return exemptValidationCache.get(comment);
+      }
+      const valid = EXEMPT_WITH_REASON.test(comment.value.trim());
+      if (!valid) {
+        context.report({ node: comment, messageId: "missingExemptReason" });
+      }
+      exemptValidationCache.set(comment, valid);
+      return valid;
+    }
+
+    // A single marker before the file's first import — or, if the file has no
+    // imports, before its first statement — covers every handler in the file.
+    // This is the only place one comment can exempt more than the handler
+    // it's directly attached to.
+    function findFileWideExemptComment(program) {
+      const body = program.body;
+      if (body.length === 0) return null;
+      const firstImport = body.find((n) => n.type === "ImportDeclaration");
+      const boundary = firstImport ?? body[0];
+      return findExemptAttempt(sourceCode.getCommentsBefore(boundary));
+    }
+
+    let hasFileWideExemptAttempt = false;
+
+    // True when this handler's own audit requirement was waived — either by a
+    // comment directly above its export (nothing else in between) or by the
+    // file-wide marker. Also true when an attempt was made but is malformed:
+    // validateExempt has already reported that, and piling on a second,
+    // unrelated "missing audit log" error would only be confusing.
+    function isExemptAttempted(exportNode) {
+      const handlerExempt = findExemptAttempt(sourceCode.getCommentsBefore(exportNode));
+      if (handlerExempt) {
+        validateExempt(handlerExempt);
+        return true;
+      }
+      return hasFileWideExemptAttempt;
+    }
 
     function bodyMentionsAudit(text) {
       return text.includes("appendAuditLog") || text.includes("deferAuditLog");
@@ -114,5 +134,39 @@ module.exports = {
         });
       }
     }
+
+    return {
+      ...fireAndForgetVisitors,
+      Program(programNode) {
+        const exempt = findFileWideExemptComment(programNode);
+        if (exempt) {
+          hasFileWideExemptAttempt = true;
+          validateExempt(exempt);
+        }
+      },
+      ExportNamedDeclaration(node) {
+        const decl = node.declaration;
+        if (!decl) return;
+
+        if (decl.type === "FunctionDeclaration" && decl.id) {
+          const name = decl.id.name;
+          if (!MUTATION_METHODS.includes(name)) return;
+          if (isExemptAttempted(node)) return;
+          checkFunctionBody(context, decl.body, name);
+        }
+
+        if (decl.type === "VariableDeclaration") {
+          for (const declarator of decl.declarations) {
+            if (
+              declarator.id.type === "Identifier" &&
+              MUTATION_METHODS.includes(declarator.id.name)
+            ) {
+              if (isExemptAttempted(node)) continue;
+              checkInitializer(context, declarator.init, declarator.id.name);
+            }
+          }
+        }
+      },
+    };
   },
 };

--- a/packages/web/eslint-rules/require-audit-log.js
+++ b/packages/web/eslint-rules/require-audit-log.js
@@ -46,24 +46,34 @@ module.exports = {
     const sourceCode = context.sourceCode || context.getSourceCode();
     const MUTATION_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 
-    // Only a comment whose trimmed text starts with "audit-exempt", followed
-    // immediately by a colon, whitespace, or the end of the comment, counts as
-    // an attempt at the marker. This keeps prose that merely MENTIONS the
-    // phrase mid-sentence (e.g. "deliberately carries NO audit-exempt:
-    // marker") — or a different word that happens to share the prefix (e.g.
-    // "audit-exemptions:") — from being misread as one.
+    // A marker is a comment that OPENS with "audit-exempt", followed
+    // immediately by a colon, whitespace, or the end of the comment. The
+    // anchoring is what has always kept prose that merely mentions the phrase
+    // from counting; the boundary is what stops a different word sharing the
+    // prefix (e.g. "audit-exemptions:") from being misread as one.
     const EXEMPT_ATTEMPT = /^audit-exempt(?::|\s|$)/;
     const EXEMPT_WITH_REASON = /^audit-exempt:\s*\S/;
 
+    // A comment trailing another statement belongs to that statement, not to
+    // whatever follows it: `const X = 1; // audit-exempt: …` reads as the
+    // const's note, and getCommentsBefore would otherwise hand it to the next
+    // handler as if it had been written above it.
+    function isOwnLineComment(comment) {
+      const before = sourceCode.getTokenBefore(comment, { includeComments: true });
+      return !before || before.loc.end.line < comment.loc.start.line;
+    }
+
     function findExemptAttempt(comments) {
-      return comments.find((c) => EXEMPT_ATTEMPT.test(c.value.trim())) ?? null;
+      return (
+        comments.find((c) => EXEMPT_ATTEMPT.test(c.value.trim()) && isOwnLineComment(c)) ?? null
+      );
     }
 
     // Validates format and reports missingExemptReason if malformed. Caches by
-    // comment identity so a comment consulted from more than one code path
-    // (the file-wide check and a per-handler check can resolve to the very
-    // same physical comment, e.g. in a file with no imports whose only
-    // statement is the exempted handler) is only ever reported once.
+    // comment identity so a comment consulted more than once — one
+    // `export const POST = …, DELETE = …` statement is visited per declarator,
+    // and each visit re-reads the same leading comment — is only ever reported
+    // once.
     const exemptValidationCache = new Map();
     function validateExempt(comment) {
       if (exemptValidationCache.has(comment)) {
@@ -77,16 +87,18 @@ module.exports = {
       return valid;
     }
 
-    // A single marker before the file's first import — or, if the file has no
-    // imports, before its first statement — covers every handler in the file.
-    // This is the only place one comment can exempt more than the handler
-    // it's directly attached to.
+    // A single marker in the file's header — above its first import — covers
+    // every handler in the file. This is the only place one comment can exempt
+    // more than the handler it's directly attached to.
+    //
+    // A file with no imports has no header to sit in: "before the first
+    // statement" is just that statement's own leading comment, and reading it
+    // as file-wide would leave the dead switch this rule closed — a marker
+    // above an unrelated `const` silently waiving the handler below it.
     function findFileWideExemptComment(program) {
-      const body = program.body;
-      if (body.length === 0) return null;
-      const firstImport = body.find((n) => n.type === "ImportDeclaration");
-      const boundary = firstImport ?? body[0];
-      return findExemptAttempt(sourceCode.getCommentsBefore(boundary));
+      const firstImport = program.body.find((n) => n.type === "ImportDeclaration");
+      if (!firstImport) return null;
+      return findExemptAttempt(sourceCode.getCommentsBefore(firstImport));
     }
 
     let hasFileWideExemptAttempt = false;

--- a/packages/web/eslint-rules/require-parse-request-body.js
+++ b/packages/web/eslint-rules/require-parse-request-body.js
@@ -25,6 +25,43 @@ module.exports = {
       return {};
     }
 
+    // Historically-known names, used as a conservative fallback whenever the
+    // first parameter's actual name can't be resolved (no enclosing function
+    // has params, or the nearest one that does destructures its first
+    // parameter instead of naming it plainly). Better a false positive here
+    // than silently skipping the check.
+    const FALLBACK_NAMES = new Set(["request", "req"]);
+
+    function isFunctionNode(node) {
+      return (
+        node.type === "FunctionDeclaration" ||
+        node.type === "FunctionExpression" ||
+        node.type === "ArrowFunctionExpression"
+      );
+    }
+
+    // Resolve the identifier that names "the request" for a given `.json()`
+    // call: walk up to the nearest enclosing function that actually declares a
+    // first parameter (skipping functions with none — a nested closure with no
+    // params of its own inherits the name from its enclosing handler via
+    // closure). A plain Identifier first parameter names it exactly; anything
+    // else (destructuring, defaults, ...) can't be resolved, so fall back to
+    // the historically-known names rather than skipping the call entirely.
+    function resolveExpectedNames(node) {
+      let current = node.parent;
+      while (current) {
+        if (isFunctionNode(current) && current.params.length > 0) {
+          const first = current.params[0];
+          if (first.type === "Identifier") {
+            return new Set([first.name]);
+          }
+          return FALLBACK_NAMES;
+        }
+        current = current.parent;
+      }
+      return FALLBACK_NAMES;
+    }
+
     return {
       CallExpression(node) {
         if (
@@ -33,8 +70,8 @@ module.exports = {
           node.callee.property.type === "Identifier" &&
           node.callee.property.name === "json" &&
           node.callee.object.type === "Identifier" &&
-          (node.callee.object.name === "request" || node.callee.object.name === "req") &&
-          node.arguments.length === 0
+          node.arguments.length === 0 &&
+          resolveExpectedNames(node).has(node.callee.object.name)
         ) {
           context.report({
             node,

--- a/packages/web/eslint-rules/require-parse-request-body.js
+++ b/packages/web/eslint-rules/require-parse-request-body.js
@@ -1,8 +1,17 @@
 /**
- * Forbid `request.json()` / `req.json()` in API route handlers — every state-mutating
- * route must go through `parseRequestBody()` from `@/lib/api-validation`. Catches
- * regressions where a new route would skip Zod validation, return 500 on malformed
- * JSON, or drift away from the shared error contract.
+ * Forbid reading the incoming request body directly in API route handlers —
+ * every state-mutating route must go through `parseRequestBody()` from
+ * `@/lib/api-validation`. Catches regressions where a new route would skip Zod
+ * validation, return 500 on malformed JSON, or drift away from the shared error
+ * contract.
+ *
+ * "The incoming request" is whatever the route handler's first parameter binds,
+ * whatever it is called, plus the historical `request` / `req` names for the
+ * cases scope cannot resolve. It is deliberately NOT "the first parameter of
+ * the nearest enclosing function": reading an upstream `Response` inside a
+ * route — `fetch(url).then((res) => res.json())` — is ordinary work, and a rule
+ * that reports it would be telling the author to run a Zod schema over someone
+ * else's reply.
  *
  * @type {import('eslint').Rule.RuleModule}
  */
@@ -25,12 +34,24 @@ module.exports = {
       return {};
     }
 
-    // Historically-known names, used as a conservative fallback whenever the
-    // first parameter's actual name can't be resolved (no enclosing function
-    // has params, or the nearest one that does destructures its first
-    // parameter instead of naming it plainly). Better a false positive here
-    // than silently skipping the check.
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    // The names a Next.js request has carried here since the rule was written.
+    // Matching on the name alone is crude, but it is the half of the check that
+    // needs no resolution at all, so it still fires when the request reaches
+    // the call as a free variable — a handler that destructures its first
+    // parameter, a helper that takes the request as an argument.
     const FALLBACK_NAMES = new Set(["request", "req"]);
+
+    const HANDLER_EXPORT_NAMES = new Set([
+      "GET",
+      "POST",
+      "PUT",
+      "PATCH",
+      "DELETE",
+      "HEAD",
+      "OPTIONS",
+    ]);
 
     function isFunctionNode(node) {
       return (
@@ -40,26 +61,77 @@ module.exports = {
       );
     }
 
-    // Resolve the identifier that names "the request" for a given `.json()`
-    // call: walk up to the nearest enclosing function that actually declares a
-    // first parameter (skipping functions with none — a nested closure with no
-    // params of its own inherits the name from its enclosing handler via
-    // closure). A plain Identifier first parameter names it exactly; anything
-    // else (destructuring, defaults, ...) can't be resolved, so fall back to
-    // the historically-known names rather than skipping the call entirely.
-    function resolveExpectedNames(node) {
-      let current = node.parent;
-      while (current) {
-        if (isFunctionNode(current) && current.params.length > 0) {
-          const first = current.params[0];
-          if (first.type === "Identifier") {
-            return new Set([first.name]);
-          }
-          return FALLBACK_NAMES;
-        }
-        current = current.parent;
+    function addFirstParam(fn, params) {
+      const first = fn.params[0];
+      if (first && first.type === "Identifier") params.add(first);
+    }
+
+    // `export const POST = withAdmin(async (request, ctx, session) => …)` — the
+    // request is the first parameter of the callback a wrapper receives, however
+    // many wrappers deep it sits.
+    function collectFromInitializer(init, params, depth) {
+      if (!init || depth > 4) return;
+      if (isFunctionNode(init)) {
+        addFirstParam(init, params);
+        return;
       }
-      return FALLBACK_NAMES;
+      if (init.type === "TSAsExpression" || init.type === "TSSatisfiesExpression") {
+        collectFromInitializer(init.expression, params, depth + 1);
+        return;
+      }
+      if (init.type === "CallExpression") {
+        for (const arg of init.arguments) collectFromInitializer(arg, params, depth + 1);
+      }
+    }
+
+    // The parameter bindings that ARE the incoming request: the first parameter
+    // of every exported route handler in this file. Anything else — a callback
+    // in a `.map()`, a local helper, an upstream `Response` — is not.
+    let handlerRequestParams = null;
+    function getHandlerRequestParams() {
+      if (handlerRequestParams) return handlerRequestParams;
+      handlerRequestParams = new Set();
+      for (const stmt of sourceCode.ast.body) {
+        if (stmt.type !== "ExportNamedDeclaration" || !stmt.declaration) continue;
+        const decl = stmt.declaration;
+        if (
+          decl.type === "FunctionDeclaration" &&
+          decl.id &&
+          HANDLER_EXPORT_NAMES.has(decl.id.name)
+        ) {
+          addFirstParam(decl, handlerRequestParams);
+          continue;
+        }
+        if (decl.type === "VariableDeclaration") {
+          for (const declarator of decl.declarations) {
+            if (declarator.id.type === "Identifier" && HANDLER_EXPORT_NAMES.has(declarator.id.name))
+              collectFromInitializer(declarator.init, handlerRequestParams, 0);
+          }
+        }
+      }
+      return handlerRequestParams;
+    }
+
+    function resolveVariable(identifier) {
+      let scope = sourceCode.getScope(identifier);
+      while (scope) {
+        const variable = scope.set.get(identifier.name);
+        if (variable) return variable;
+        scope = scope.upper;
+      }
+      return null;
+    }
+
+    // Resolution runs through scope, not through the call's position in the
+    // tree: a handler's request stays the request inside a `.map()` callback
+    // that has parameters of its own, and that callback's parameter never
+    // becomes the request just by being the nearest one.
+    function isHandlerRequest(identifier) {
+      const requestParams = getHandlerRequestParams();
+      if (requestParams.size === 0) return false;
+      const variable = resolveVariable(identifier);
+      if (!variable) return false;
+      return variable.defs.some((def) => def.type === "Parameter" && requestParams.has(def.name));
     }
 
     return {
@@ -71,7 +143,7 @@ module.exports = {
           node.callee.property.name === "json" &&
           node.callee.object.type === "Identifier" &&
           node.arguments.length === 0 &&
-          resolveExpectedNames(node).has(node.callee.object.name)
+          (FALLBACK_NAMES.has(node.callee.object.name) || isHandlerRequest(node.callee.object))
         ) {
           context.report({
             node,

--- a/packages/web/src/__tests__/eslint/require-audit-log.test.ts
+++ b/packages/web/src/__tests__/eslint/require-audit-log.test.ts
@@ -38,6 +38,17 @@ tester.run("require-audit-log", rule, {
       code: `export async function POST(req) { deferAuditLog({ eventType: "test" }); }`,
       filename: "/app/api/groups/route.ts",
     },
+    // A file-top exempt (before the first import) covers every handler in the file.
+    {
+      code: `// audit-exempt: nothing here mutates persisted state\nimport { NextResponse } from "next/server";\nexport async function POST(req) { return "ok"; }\nexport async function DELETE(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+    },
+    // A per-handler exempt covers only the handler it's directly attached to,
+    // and a sibling handler with a real audit call is independently fine.
+    {
+      code: `import { NextResponse } from "next/server";\n// audit-exempt: read-only forwarding, no persisted state change\nexport async function PUT(req) { return "ok"; }\nexport async function DELETE(req) { appendAuditLog({ eventType: "test" }); }`,
+      filename: "/app/api/groups/route.ts",
+    },
   ],
   invalid: [
     {
@@ -84,6 +95,34 @@ tester.run("require-audit-log", rule, {
       code: `export const PATCH = async (req) => { appendAuditLog({ eventType: "test" }).catch(console.error); }`,
       filename: "/app/api/groups/route.ts",
       errors: [{ messageId: "noFireAndForgetAudit" }],
+    },
+    // An exempt comment attached to GET must not exempt a mutation handler
+    // elsewhere in the same file — the exemption is per-handler, not file-wide.
+    {
+      code: `import { NextResponse } from "next/server";\n// audit-exempt: read-only listing\nexport async function GET(req) { return "ok"; }\nexport async function POST(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "missingAuditLog" }],
+    },
+    // A comment that merely MENTIONS "audit-exempt:" inside a sentence is not
+    // a marker — only a comment that starts with it counts.
+    {
+      code: `import { NextResponse } from "next/server";\n// This route deliberately carries NO audit-exempt: marker, unlike its sibling.\nexport async function POST(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "missingAuditLog" }],
+    },
+    // A different word sharing the "audit-exempt" prefix must not match.
+    {
+      code: `import { NextResponse } from "next/server";\n// audit-exemptions: this is a different marker entirely\nexport async function POST(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "missingAuditLog" }],
+    },
+    // An exempt comment separated from its handler by an intervening
+    // declaration does not attach to that handler (it must sit directly above
+    // the export, with nothing in between).
+    {
+      code: `import { NextResponse } from "next/server";\n// audit-exempt: dev-only endpoint\nconst SOME_CONST = 1;\nexport async function POST(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "missingAuditLog" }],
     },
   ],
 });

--- a/packages/web/src/__tests__/eslint/require-audit-log.test.ts
+++ b/packages/web/src/__tests__/eslint/require-audit-log.test.ts
@@ -49,6 +49,12 @@ tester.run("require-audit-log", rule, {
       code: `import { NextResponse } from "next/server";\n// audit-exempt: read-only forwarding, no persisted state change\nexport async function PUT(req) { return "ok"; }\nexport async function DELETE(req) { appendAuditLog({ eventType: "test" }); }`,
       filename: "/app/api/groups/route.ts",
     },
+    // A file with no imports has no header region, but a marker sitting
+    // directly above the handler still exempts that handler.
+    {
+      code: `// audit-exempt: dev-only endpoint\nexport async function POST(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+    },
   ],
   invalid: [
     {
@@ -121,6 +127,21 @@ tester.run("require-audit-log", rule, {
     // the export, with nothing in between).
     {
       code: `import { NextResponse } from "next/server";\n// audit-exempt: dev-only endpoint\nconst SOME_CONST = 1;\nexport async function POST(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "missingAuditLog" }],
+    },
+    // Same shape without imports: "before the file's first statement" is not a
+    // header region, it is just the comment on that statement. Treating it as
+    // file-wide would leave exactly the dead-switch this rule set out to close.
+    {
+      code: `// audit-exempt: dev-only endpoint\nconst SOME_CONST = 1;\nexport async function POST(req) { return "ok"; }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "missingAuditLog" }],
+    },
+    // A marker trailing another statement belongs to that statement, however
+    // close to the handler it lands.
+    {
+      code: `import { NextResponse } from "next/server";\nconst X = 1; // audit-exempt: reads as the handler's, belongs to the const\nexport async function POST(req) { return "ok"; }`,
       filename: "/app/api/groups/route.ts",
       errors: [{ messageId: "missingAuditLog" }],
     },

--- a/packages/web/src/__tests__/eslint/require-parse-request-body.test.ts
+++ b/packages/web/src/__tests__/eslint/require-parse-request-body.test.ts
@@ -35,6 +35,12 @@ tester.run("require-parse-request-body", rule, {
       code: `export async function POST() { const data = await response.json(); }`,
       filename: "/app/api/groups/route.ts",
     },
+    // A destructured first parameter is unresolvable, but names other than the
+    // conservative fallback ("request"/"req") still don't match.
+    {
+      code: `export async function POST({ headers }) { const data = await other.json(); }`,
+      filename: "/app/api/groups/route.ts",
+    },
   ],
   invalid: [
     {
@@ -52,6 +58,43 @@ tester.run("require-parse-request-body", rule, {
           const { name } = await request.json();
         }`,
       filename: "/app/api/agents/[id]/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    // A renamed first parameter must still be caught — the rule resolves the
+    // name from the enclosing handler's own signature rather than a fixed
+    // whitelist of "request"/"req".
+    {
+      code: `export async function POST(_req) { const body = await _req.json(); }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    {
+      code: `export async function POST(r) { const body = await r.json(); }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    {
+      code: `export const PUT = async (nextRequest) => { const body = await nextRequest.json(); }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    // A nested closure with no first parameter of its own inherits the name
+    // from the enclosing handler.
+    {
+      code: `export async function POST(_req) {
+          return withRetry(async () => {
+            const body = await _req.json();
+          });
+        }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    // A destructured first parameter can't be resolved to a name — conservative
+    // fallback still flags the historically-known "request"/"req" names rather
+    // than silently skipping the check.
+    {
+      code: `export async function POST({ headers }) { const body = await request.json(); }`,
+      filename: "/app/api/groups/route.ts",
       errors: [{ messageId: "directJsonCall" }],
     },
   ],

--- a/packages/web/src/__tests__/eslint/require-parse-request-body.test.ts
+++ b/packages/web/src/__tests__/eslint/require-parse-request-body.test.ts
@@ -41,6 +41,35 @@ tester.run("require-parse-request-body", rule, {
       code: `export async function POST({ headers }) { const data = await other.json(); }`,
       filename: "/app/api/groups/route.ts",
     },
+    // Reading an UPSTREAM response inside a route is ordinary work, not a
+    // skipped-validation bug. The callback parameter is a Response, and telling
+    // the author to `parseRequestBody(schema, res)` would be nonsense advice.
+    {
+      code: `export async function POST(request) {
+          const parsed = await parseRequestBody(schema, request);
+          return fetch(url).then((res) => res.json());
+        }`,
+      filename: "/app/api/groups/route.ts",
+    },
+    {
+      code: `export async function POST(request) {
+          const parsed = await parseRequestBody(schema, request);
+          return Promise.all(responses.map((r) => r.json()));
+        }`,
+      filename: "/app/api/groups/route.ts",
+    },
+    // A local helper in the same file is not a route handler, so its first
+    // parameter is not "the request" — even when it is called `response`.
+    {
+      code: `async function readUpstream(response) {
+          return response.json();
+        }
+        export async function POST(request) {
+          const parsed = await parseRequestBody(schema, request);
+          return readUpstream(await fetch(url));
+        }`,
+      filename: "/app/api/groups/route.ts",
+    },
   ],
   invalid: [
     {
@@ -61,7 +90,7 @@ tester.run("require-parse-request-body", rule, {
       errors: [{ messageId: "directJsonCall" }],
     },
     // A renamed first parameter must still be caught — the rule resolves the
-    // name from the enclosing handler's own signature rather than a fixed
+    // request from the ROUTE HANDLER's own signature rather than a fixed
     // whitelist of "request"/"req".
     {
       code: `export async function POST(_req) { const body = await _req.json(); }`,
@@ -78,13 +107,38 @@ tester.run("require-parse-request-body", rule, {
       filename: "/app/api/groups/route.ts",
       errors: [{ messageId: "directJsonCall" }],
     },
-    // A nested closure with no first parameter of its own inherits the name
-    // from the enclosing handler.
+    // The dominant shape in this codebase: the handler is a callback handed to
+    // an auth wrapper, so the request is that callback's first parameter.
+    {
+      code: `export const POST = withAdmin(async (rq, _ctx, session) => { const body = await rq.json(); });`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    // A nested closure with no first parameter of its own still sees the
+    // handler's request through the closure.
     {
       code: `export async function POST(_req) {
           return withRetry(async () => {
             const body = await _req.json();
           });
+        }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    // ...and so does a nested closure that HAS parameters of its own. Resolving
+    // only "the nearest enclosing function with parameters" loses this: the
+    // callback's own parameter shadows nothing, and the real request.json()
+    // slips through — the very call the rule exists to ban.
+    {
+      code: `export async function POST(_req) {
+          return items.map((item) => _req.json());
+        }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    {
+      code: `export async function POST(req) {
+          return upstream.then((res) => req.json());
         }`,
       filename: "/app/api/groups/route.ts",
       errors: [{ messageId: "directJsonCall" }],

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
@@ -199,7 +199,9 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
  *
  * Admin-only, like the reindex it reports on.
  */
-// audit-exempt: read-only status projection, no state change.
+// Read-only status projection, no state change — GET is outside
+// require-audit-log's scope (it only checks POST/PUT/PATCH/DELETE), so no
+// audit call is needed here.
 export const GET = withAdmin<RouteContext>(async (_request, { params }) => {
   const { agentId } = await params;
 

--- a/packages/web/src/app/api/dev/enterprise-toggle/route.ts
+++ b/packages/web/src/app/api/dev/enterprise-toggle/route.ts
@@ -3,11 +3,10 @@ import { requireAdmin } from "@/lib/api-auth";
 import { clearLicenseCache, isEnterprise } from "@/lib/enterprise";
 import { setSetting, deleteSetting } from "@/lib/settings";
 
-// audit-exempt: dev-only endpoint, not available in production
-
 const DEV_ENTERPRISE_KEY =
   "eyJhbGciOiJFUzI1NiJ9.eyJ0eXBlIjoicGFpZCIsImZlYXR1cmVzIjpbImVudGVycHJpc2UiXSwiaXNzIjoiaGV5cGluY2h5LmNvbSIsInN1YiI6InBpbmNoeS1kZXYiLCJpYXQiOjE3NzM0ODUyMzQsImV4cCI6MjA4ODg0NTIzNH0.h6stBWDrHP2LnXBv18RDk9_y71_b8FvFU6IodCBJkldlLoW6uxX6P7Hr_SL8OM-jhaNqUu7BIMaTYvbqW28buA";
 
+// audit-exempt: dev-only endpoint, not available in production
 export async function POST() {
   if (process.env.NODE_ENV === "production") {
     return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/packages/web/src/app/api/settings/api-keys/route.ts
+++ b/packages/web/src/app/api/settings/api-keys/route.ts
@@ -93,10 +93,14 @@ export const POST = withAdmin(async (request, _ctx, session) => {
  *
  * Read-only: no audit entry, and deliberately NO `audit-exempt:` marker. The
  * require-audit-log rule only asks for one on POST/PUT/PATCH/DELETE — a GET
- * never needed it — and the marker is FILE-scoped: any occurrence makes the
- * rule skip the whole file. So the one placed here for this GET was switching
- * off the guard on the POST above, the one that issues credentials. Verified:
- * with the marker present, stripping appendAuditLog out of POST lints clean.
+ * never needed it. The marker used to be FILE-scoped (any occurrence anywhere
+ * in the file made the rule skip every handler, so the one that used to sit
+ * here for this GET was silently switching off the guard on the POST above,
+ * the one that issues credentials — verified by stripping appendAuditLog out
+ * of POST and watching it lint clean). The rule is now per-handler: a marker
+ * only exempts the export it's directly attached to, or every handler when
+ * placed above the file's imports. This note stays as the reason a marker is
+ * still deliberately absent here, not as a live hazard.
  */
 export const GET = withAdmin(async () => {
   const rows = await db.select().from(apiKeys).orderBy(desc(apiKeys.createdAt));

--- a/packages/web/src/app/api/settings/providers/openai-compatible/route.ts
+++ b/packages/web/src/app/api/settings/providers/openai-compatible/route.ts
@@ -250,8 +250,10 @@ export const POST = withAdmin(async (request, _ctx, session) => {
  * `keyHint` (last 4 chars) and NEVER the decrypted key.
  */
 export const GET = withAdmin(async () => {
-  // audit-exempt: read-only list, no state change. Uses the admin accessor so
-  // each row carries a keyHint (the one decrypt path — see the module).
+  // Read-only list, no state change — GET is outside require-audit-log's scope
+  // (it only checks POST/PUT/PATCH/DELETE), so no audit call is needed here.
+  // Uses the admin accessor so each row carries a keyHint (the one decrypt
+  // path — see the module).
   const providers = await listOpenAiCompatibleProvidersForAdmin();
   return NextResponse.json(providers);
 });


### PR DESCRIPTION
## Summary

Two P2 fixes to the hand-written ESLint rules in `packages/web/eslint-rules/`.

**`require-audit-log.js` — file-wide exemption blind spot.**
The rule searched the whole file's comments for one `// audit-exempt:` marker and, if found, returned early — skipping the missing-audit-log check for **every** mutation handler (POST/PUT/PATCH/DELETE) in the file, not just the one the marker was meant for. An `audit-exempt` on a read-only GET silently disabled the check for a POST/DELETE in the same file.

A second matcher blind spot: `c.value.trim().startsWith("audit-exempt")` would treat a comment that only *mentions* the phrase mid-sentence as a marker attempt, with no word-boundary check (so `audit-exemptions:` would also match).

Fix:
- A marker now exempts only the handler export it's **directly** attached to (no other statement in between), unless it sits **before the file's first import** — the one place a single marker deliberately covers the whole file (e.g. `integrations/oauth/start/route.ts`, whose header comment says "Neither handler mutates persistent state").
- The attempt-detection regex now requires a word boundary right after `audit-exempt` (`:`, whitespace, or end-of-string), so prose mentions and similarly-prefixed words don't match.
- A bare `// audit-exempt` (no reason) is still caught and reported via `missingExemptReason`, same as before.

**`require-parse-request-body.js` — name whitelist blind spot.**
The rule only flagged `request.json()` / `req.json()` — a renamed first parameter (`_req`, `r`, a destructured param, `nextRequest`, ...) slipped through undetected. It now resolves the expected identifier from the nearest enclosing handler's actual first parameter (walking outward past closures with no params of their own), falling back to the historical `request`/`req` names when the parameter can't be resolved (destructuring) — conservatively flagging rather than silently skipping.

## Real finding surfaced by the stricter rule

`packages/web/src/app/api/dev/enterprise-toggle/route.ts` had its `// audit-exempt: dev-only endpoint...` comment sitting above an unrelated `const DEV_ENTERPRISE_KEY = ...` declaration instead of directly above `POST`. Under the old file-wide-dead-switch behavior this was masked; under the new per-handler rule it stopped attaching to the handler entirely (comment not adjacent). Relocated the comment directly above `export async function POST()` — no behavior change, still exempt (this is genuinely a dev-only, non-production endpoint).

All other `audit-exempt` markers repo-wide were audited by hand (checked each route file's HTTP methods, import position, and whether mutation handlers already call `appendAuditLog`/`deferAuditLog` directly in their body):
- `settings/providers/openai-compatible/route.ts` and `agents/[agentId]/knowledge/reindex/route.ts` — the markers named in the brief were attached to their `GET` handlers, which the rule never checked anyway (only POST/PUT/PATCH/DELETE). Their POST/DELETE handlers already call `appendAuditLog`/`deferAuditLog` directly and pass independently. Reworded the GET-side comments to plain prose (dropping the `audit-exempt:` prefix) so they don't read as a functioning marker that no longer does anything under the new semantics.
- `settings/api-keys/route.ts` — its own docstring already documented this exact file-wide bug (`"deliberately NO audit-exempt: marker... would switch off the guard on the POST above"`) as a *workaround*. Updated the comment to describe the fix instead of describing a still-live hazard.
- Every other `audit-exempt` marker in the repo is either on a GET-only file (irrelevant to this rule) or sits genuinely before the file's first import (correctly recognized as file-wide under the new rule, matching its original intent — e.g. `settings/context/route.ts`, `settings/telegram/route.ts`, `agents/[agentId]/files/[filename]/route.ts`, `users/me/context/route.ts`, all deliberately self-service/non-admin exemptions covering their PUT handlers).

## Test plan
- [x] TDD: extended both rule test files first, confirmed red (3 new failures in `require-audit-log.test.ts`, 4 in `require-parse-request-body.test.ts`), then implemented — both suites green (22 and 13 tests respectively).
- [x] `pnpm -C packages/web lint` (from repo root) — 0 errors, 981 warnings (identical pre-existing warning count verified via `git stash`/`git stash pop` against the unmodified tree; only the 1 real `dev/enterprise-toggle` error was fixed).
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm test:related` — 122 tests passed across 6 files.
- [x] `pnpm test` (full suite) — 10920 passed, 18 skipped (774 files passed, 4 skipped), no failures.
- [x] `pnpm test:scripts` — 894 passed, 0 failed.
- [x] `pnpm format:check` — clean.