### PR TITLE
fix(security): bind test/dev overlay host ports to 127.0.0.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,6 +420,18 @@ The compose defaults are unchanged (`7777`/`5434`/`8443`), so a checkout without
 
 Two guards in `scripts/lib/dev-stack-port-isolation.test.mjs` hold that line: one fails if a generated key is read outside the dev overlay or a dev-layered stack stops pinning, the other fails if a hard-coded host port anywhere in the repo lands inside an allocation band without being listed in `RESERVED_PORTS`. The reserved list matters because a probe only sees what is bound _right now_ while allocation is sticky: a worktree allocated while the integration stack was down would take `7779` and keep it.
 
+### Every published port binds loopback
+
+A `ports:` entry with no host IP — `"5434:5432"` — publishes on `0.0.0.0`. Every test overlay was written that way, so on a shared dev box or a CI runner with a routable address the test Postgres instances, each suite's Pinchy override and all eight mock servers answered the whole network: the odoo mock accepts writes, greenmail hands out mail, and the databases hold seeded credentials. Nothing was red, because reaching them over loopback works identically either way.
+
+The prefix (`"127.0.0.1:5434:5432"`) is one token per line across nine files with no locally visible failure mode — the shape of every drift this repo has already paid for. `scripts/lib/compose-port-bindings.test.mjs` (pure logic in `compose-port-bindings.mjs`, run by `pnpm test:scripts`) is the tripwire. Three things worth knowing before editing it:
+
+- **There is no list of accepted exceptions, deliberately.** A stack that genuinely needs a routable bind writes it the way `docker-compose.yml` does — `"${PINCHY_PORT:-127.0.0.1:7777}:7777"` — so the _default_ is loopback and an operator who wants more says so in their own environment. A checkout binds what its files say; nobody is exposed by omission.
+- **The parser throws on input it cannot read** rather than skipping the line. The long syntax (`- target: 9001` / `published:`) also binds every interface when `host_ip` is omitted, and a guard that silently ignores it reports on the lines it happens to understand instead of on what the stack binds.
+- **`docker-compose.dev.yml` spells the prefix two different ways, three lines apart.** `DEV_PINCHY_PORT` carries `127.0.0.1:` _inside_ the value (`managedValues` in `scripts/lib/env-file.mjs` writes it); `DEV_DB_PORT` and `DEV_CADDY_PORT` are bare numbers whose prefix the compose file supplies. Both halves are needed and neither can be "harmonised": adding the prefix to `DEV_DB_PORT` resolves to `127.0.0.1:127.0.0.1:5444:5432`, and removing it from `DEV_PINCHY_PORT` puts every already-allocated worktree back on `0.0.0.0` — a break that appears only in a worktree that has run `pnpm worktree:env`, never in CI and never in a fresh clone. The guard resolves the dev overlay against the values `managedValues` really writes, so it fails in both directions.
+
+Verify a change to it by reproduction, not by reading: drop a `127.0.0.1:` from any overlay and watch that exact line come back in the failure.
+
 Common host commands from the repository root:
 
 ```bash

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -88,13 +88,15 @@ services:
     environment:
       - POSTGRES_PASSWORD=pinchy_dev
     ports:
-      # Overridable so two worktrees can run a dev stack at once.
-      # `pnpm worktree:env` writes a free block into .env.
-      - "${DEV_DB_PORT:-5434}:5432"
+      # Overridable so two worktrees can run a dev stack at once. Host IP is
+      # hard-coded (not part of the variable) because DEV_DB_PORT is written
+      # as a bare number by `pnpm worktree:env` (scripts/worktree-env.mjs);
+      # binding all interfaces would expose the dev DB on the network.
+      - "127.0.0.1:${DEV_DB_PORT:-5434}:5432"
   caddy:
     image: caddy:2
     ports:
-      - "${DEV_CADDY_PORT:-8443}:443"
+      - "127.0.0.1:${DEV_CADDY_PORT:-8443}:443"
     volumes:
       - ./Caddyfile.dev:/etc/caddy/Caddyfile:ro
       - caddy_data_dev:/data

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -38,6 +38,7 @@ services:
   db:
     # Expose Postgres to the host for direct seeding from Playwright helpers
     # (seedSetup, createAgent). Production compose deliberately keeps the DB
-    # network-internal; tests need a back door.
+    # network-internal; tests need a back door. Bound to loopback only — the
+    # CI runner and Playwright always reach it via localhost.
     ports:
-      - "5434:5432"
+      - "127.0.0.1:5434:5432"

--- a/docker-compose.email-test.yml
+++ b/docker-compose.email-test.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: config/gmail-mock
     ports:
-      - "9004:9004"
+      - "127.0.0.1:9004:9004"
     healthcheck:
       test:
         [
@@ -28,7 +28,7 @@ services:
     build:
       context: config/graph-mock
     ports:
-      - "9005:9005"
+      - "127.0.0.1:9005:9005"
     healthcheck:
       test:
         [

--- a/docker-compose.eval.yml
+++ b/docker-compose.eval.yml
@@ -28,9 +28,9 @@ services:
   pinchy:
     # Override the default :7777 mapping so the eval stack (port 7781)
     # doesn't conflict with the integration suite (7779) or other E2E jobs
-    # (7777/7778).
+    # (7777/7778). Loopback-only: the harness reaches it via localhost.
     ports: !override
-      - "7781:7777"
+      - "127.0.0.1:7781:7777"
     environment:
       - AUDIT_HMAC_SECRET=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
       # Fixed test-only secrets (throwaway eval stack, mock data only — same
@@ -93,7 +93,7 @@ services:
   db:
     ports:
       !override # Playwright/setup helpers read/seed the DB directly from the host.
-      - "5437:5432"
+      - "127.0.0.1:5437:5432"
     tmpfs:
       - /var/lib/postgresql/data
     volumes: !reset []
@@ -102,8 +102,8 @@ services:
     build:
       context: config/odoo-mock
     ports:
-      - "9502:9002"
-      - "8169:8069"
+      - "127.0.0.1:9502:9002"
+      - "127.0.0.1:8169:8069"
     healthcheck:
       test:
         [
@@ -120,7 +120,7 @@ services:
     build:
       context: config/graph-mock
     ports:
-      - "9505:9005"
+      - "127.0.0.1:9505:9005"
     healthcheck:
       test:
         [

--- a/docker-compose.imap-test.yml
+++ b/docker-compose.imap-test.yml
@@ -18,9 +18,9 @@ services:
       # override both rely on this so no user provisioning step is needed.
       - GREENMAIL_OPTS=-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled
     ports:
-      - "3025:3025"
-      - "3143:3143"
-      - "8080:8080"
+      - "127.0.0.1:3025:3025"
+      - "127.0.0.1:3143:3143"
+      - "127.0.0.1:8080:8080"
     healthcheck:
       # Both listeners must be bound before dependents start: SMTP (3025) for
       # seeding and IMAP (3143) for listing/purging. Plain start-order isn't
@@ -46,7 +46,7 @@ services:
       - GREENMAIL_SMTP_PORT=3025
       - GREENMAIL_IMAP_PORT=3143
     ports:
-      - "9006:9006"
+      - "127.0.0.1:9006:9006"
     healthcheck:
       test:
         [

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -21,9 +21,10 @@
 services:
   pinchy:
     # Override the default :7777 mapping so the integration suite (port 7779)
-    # doesn't conflict with other E2E jobs that bind 7778/7777.
+    # doesn't conflict with other E2E jobs that bind 7778/7777. Loopback-only:
+    # the CI runner and Playwright reach it via localhost.
     ports: !override
-      - "7779:7777"
+      - "127.0.0.1:7779:7777"
     environment:
       # Exercises Pinchy's audit HMAC code path. Bare-bones non-empty 64-byte hex.
       - AUDIT_HMAC_SECRET=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
@@ -71,8 +72,8 @@ services:
     ports: !override
       # Playwright tests read/seed the DB directly from the host (see
       # global-setup.ts settings INSERT). Production compose keeps the DB
-      # network-internal; tests need a back door.
-      - "5435:5432"
+      # network-internal; tests need a back door. Loopback-only.
+      - "127.0.0.1:5435:5432"
     # Overrides docker-compose.yml's `pgdata` named volume with an in-memory
     # tmpfs — integration tests start from a fresh DB each run, no persistence
     # required and tmpfs is faster.

--- a/docker-compose.odoo-test.yml
+++ b/docker-compose.odoo-test.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: config/odoo-mock
     ports:
-      - "9002:9002"
-      - "8069:8069"
+      - "127.0.0.1:9002:9002"
+      - "127.0.0.1:8069:8069"
     healthcheck:
       test:
         [
@@ -43,4 +43,4 @@ services:
   db:
     # Same reason as pinchy above: pin the port the specs seed through.
     ports: !override
-      - "5434:5432"
+      - "127.0.0.1:5434:5432"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
     build:
       context: config/telegram-mock
     ports:
-      - "9001:9001"
+      - "127.0.0.1:9001:9001"
     networks:
       default:
         ipv4_address: 172.28.0.10

--- a/docker-compose.web-test.yml
+++ b/docker-compose.web-test.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: config/brave-mock
     ports:
-      - "9003:9003"
+      - "127.0.0.1:9003:9003"
     healthcheck:
       test:
         [

--- a/scripts/lib/compose-port-bindings.mjs
+++ b/scripts/lib/compose-port-bindings.mjs
@@ -1,0 +1,217 @@
+/**
+ * Which host interfaces a compose file's `ports:` entries publish on.
+ *
+ * A short-form entry with no host IP — `"5434:5432"` — binds `0.0.0.0`. Every
+ * test overlay was written that way, so on any shared dev or CI host the test
+ * Postgres instances, each suite's Pinchy override and all eight mock servers
+ * answered the whole network. The fix is one token per line
+ * (`"127.0.0.1:5434:5432"`), which is exactly the kind of convention that holds
+ * until the next overlay is added and nobody remembers it. Hence a parser
+ * rather than a habit.
+ *
+ * Two readings matter and they are deliberately the same one:
+ *
+ * - `${VAR:-default}` resolves to its default, because that is what a checkout
+ *   without a `.env` actually binds. `dev-stack-port-isolation.test.mjs` was
+ *   already reading compose ports that way with its own copy of this logic;
+ *   both now share this module, so the two questions ("which port" and "which
+ *   interface") cannot come apart.
+ * - Passing an `env` resolves against a concrete `.env` instead — how the dev
+ *   overlay behaves once `pnpm worktree:env` has run, which is a different
+ *   binding from the default one and has to be checked separately.
+ *
+ * The scan is scoped to `ports:` blocks and **throws** on an entry it cannot
+ * read, rather than skipping it. A guard that silently ignores the long syntax
+ * (`- target: 9001` / `published: 9001`, which also binds every interface when
+ * `host_ip` is omitted) reports on the lines it happens to understand, not on
+ * what the stack binds.
+ */
+
+/**
+ * Host IPs that reach no further than the machine itself. `localhost` is
+ * accepted because Docker resolves it, though nothing here uses it.
+ */
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+/** Anything in 127.0.0.0/8 is loopback, not just .0.1. */
+export function isLoopbackHost(host) {
+  if (host === null || host === undefined) return false;
+  return LOOPBACK_HOSTS.has(host) || /^127\.\d+\.\d+\.\d+$/.test(host);
+}
+
+/**
+ * Substitute `${VAR}` and `${VAR:-default}`. A name present in `env` wins over
+ * the default — that is the whole difference between "what a fresh checkout
+ * binds" and "what this worktree binds".
+ *
+ * @param {string} value
+ * @param {Record<string, string>} env
+ */
+export function expandComposeVars(value, env = {}) {
+  return value.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g,
+    (_, name, fallback) => env[name] ?? fallback ?? "",
+  );
+}
+
+/** A port number or a `3000-3005` range, as Compose writes them. */
+const PORT_OR_RANGE = /^\d+(-\d+)?$/;
+
+/**
+ * Split one resolved short-form entry into its parts.
+ *
+ * @param {string} resolved
+ * @returns {{hostIp: string|null, hostPort: string|null, containerPort: string}}
+ */
+function parseShortForm(resolved) {
+  const proto = /\/(tcp|udp|sctp)$/i.exec(resolved);
+  const bare = proto ? resolved.slice(0, -proto[0].length) : resolved;
+
+  // An IPv6 host IP is bracketed: "[::1]:8080:80".
+  const bracketed = /^(\[[^\]]+\]):(.*)$/.exec(bare);
+  const head = bracketed ? bracketed[1] : null;
+  const parts = (bracketed ? bracketed[2] : bare).split(":");
+
+  const shape = `${head ? "ip+" : ""}${parts.length}`;
+  const [hostIp, hostPort, containerPort] = {
+    // "[::1]:8080:80"
+    "ip+2": [head, parts[0], parts[1]],
+    // "9100" — a random host port on every interface.
+    1: [null, null, parts[0]],
+    // "5434:5432"
+    2: [null, parts[0], parts[1]],
+    // "127.0.0.1:5434:5432"
+    3: [parts[0], parts[1], parts[2]],
+  }[shape] ?? [undefined, undefined, undefined];
+
+  if (containerPort === undefined) {
+    throw new Error(
+      `cannot read the port entry "${resolved}": ${parts.length + (head ? 1 : 0)} ` +
+        `colon-separated fields. A doubled host IP ` +
+        `("127.0.0.1:127.0.0.1:5434:5432") looks exactly like this — check ` +
+        `whether a variable already carries the prefix the compose file adds.`,
+    );
+  }
+  if (!PORT_OR_RANGE.test(containerPort)) {
+    throw new Error(
+      `cannot read the port entry "${resolved}": "${containerPort}" is not a ` +
+        `container port.`,
+    );
+  }
+  if (hostPort !== null && !PORT_OR_RANGE.test(hostPort)) {
+    throw new Error(
+      `cannot read the port entry "${resolved}": "${hostPort}" is not a host port.`,
+    );
+  }
+  return { hostIp, hostPort, containerPort };
+}
+
+/** Lines belonging to each `ports:` block, keyed by the block's start line. */
+function portsBlocks(text) {
+  const lines = text.split("\n");
+  const blocks = [];
+  for (let i = 0; i < lines.length; i++) {
+    const header = /^(\s*)ports:(.*)$/.exec(lines[i]);
+    if (!header) continue;
+    const indent = header[1].length;
+    const body = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (line.trim() === "") continue;
+      const lineIndent = line.length - line.trimStart().length;
+      if (lineIndent <= indent) break;
+      body.push({ line, number: j + 1 });
+    }
+    blocks.push({ body, number: i + 1 });
+  }
+  return blocks;
+}
+
+/**
+ * Every host-port publish a compose file declares.
+ *
+ * @param {string} text compose file contents
+ * @param {Record<string, string>} env values from a `.env`, overriding defaults
+ * @returns {{raw: string, resolved: string, hostIp: string|null, hostPort: string|null, containerPort: string, line: number}[]}
+ */
+export function publishedPortEntries(text, env = {}) {
+  const entries = [];
+  for (const block of portsBlocks(text)) {
+    for (const { line, number } of block.body) {
+      const trimmed = line.trim().replace(/\s+#.*$/, "");
+      // The `!override` / `!reset` tag may sit on its own line under the key,
+      // and a comment line carries nothing.
+      if (trimmed.startsWith("#") || /^![a-z]+$/.test(trimmed)) continue;
+
+      const item = /^-\s*(.*)$/.exec(trimmed);
+      if (!item) {
+        throw new Error(
+          `line ${number}: ${JSON.stringify(line.trim())} is not a short-form ` +
+            `port entry. The long syntax (target:/published:) publishes on ` +
+            `every interface when host_ip is omitted — teach this parser to ` +
+            `read it rather than letting it pass unread.`,
+        );
+      }
+      const raw = item[1].replace(/^(["'])(.*)\1$/, "$2");
+      if (raw.startsWith("target:") || raw.startsWith("published:")) {
+        throw new Error(
+          `line ${number}: ${JSON.stringify(raw)} is the long port syntax, ` +
+            `which this parser cannot read. It publishes on every interface ` +
+            `unless host_ip is set.`,
+        );
+      }
+      const resolved = expandComposeVars(raw, env);
+      try {
+        entries.push({
+          raw,
+          resolved,
+          line: number,
+          ...parseShortForm(resolved),
+        });
+      } catch (err) {
+        throw new Error(`line ${number}: ${err.message}`);
+      }
+    }
+  }
+  return entries;
+}
+
+/**
+ * Host ports a compose file publishes, as numbers. `${VAR:-default}` resolves
+ * to its default — what a checkout without `.env` binds. A random-port entry
+ * ("9100") is not a claim on any particular port and is left out.
+ *
+ * @param {string} text
+ * @returns {number[]}
+ */
+export function publishedHostPorts(text) {
+  return publishedPortEntries(text)
+    .map((entry) => Number(entry.hostPort))
+    .filter((port) => Number.isInteger(port));
+}
+
+/**
+ * Entries that publish beyond the machine, each with the reason.
+ *
+ * @param {string} text
+ * @param {Record<string, string>} env
+ */
+export function nonLoopbackPublishes(text, env = {}) {
+  const offenders = [];
+  for (const entry of publishedPortEntries(text, env)) {
+    if (entry.hostPort === null) {
+      offenders.push({
+        ...entry,
+        why: "publishes a random host port on every interface",
+      });
+    } else if (!isLoopbackHost(entry.hostIp)) {
+      offenders.push({
+        ...entry,
+        why: entry.hostIp
+          ? `binds ${entry.hostIp}`
+          : "has no host IP, so Docker binds 0.0.0.0",
+      });
+    }
+  }
+  return offenders;
+}

--- a/scripts/lib/compose-port-bindings.test.mjs
+++ b/scripts/lib/compose-port-bindings.test.mjs
@@ -1,0 +1,282 @@
+/**
+ * Keeps every compose stack in this repo bound to the machine it runs on.
+ *
+ * The defect this exists for: every `ports:` entry in the test and dev overlays
+ * was written host-IP-less ("5434:5432"), which Docker publishes on 0.0.0.0. On
+ * a shared dev box or a CI runner with a routable address that made the test
+ * Postgres instances, each suite's Pinchy override and all eight mock servers
+ * answerable from the network — the odoo mock accepts writes, greenmail hands
+ * out mail, and the databases hold seeded credentials.
+ *
+ * Prefixing each entry fixes today. It does not fix the next overlay: the
+ * convention lives in nine files, is one token wide, and has no failure mode
+ * that anyone would notice locally. That is the shape of every drift this repo
+ * has already paid for, so it gets a tripwire rather than a habit — the same
+ * argument as `contracts.tools` in AGENTS.md.
+ *
+ * The escape hatch is deliberately not a list of accepted exceptions. A stack
+ * that genuinely needs a routable bind writes it the way `docker-compose.yml`
+ * does — `"${PINCHY_PORT:-127.0.0.1:7777}:7777"` — so the DEFAULT is loopback
+ * and an operator who wants more has to say so in their own environment. A
+ * checkout binds what its files say; nobody is exposed by omission.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  expandComposeVars,
+  isLoopbackHost,
+  nonLoopbackPublishes,
+  publishedHostPorts,
+  publishedPortEntries,
+} from "./compose-port-bindings.mjs";
+import { MANAGED_KEYS, managedValues } from "./env-file.mjs";
+import { allocatePorts, projectSlug } from "./worktree-ports.mjs";
+import { trackedFilesIn } from "./tracked-files.mjs";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const read = (...parts) => readFileSync(join(ROOT, ...parts), "utf8");
+
+// git, not readdir: an untracked `docker-compose.local.yml` is a developer's
+// own business, and this guard asserts about what the repo publishes. Falls
+// back to the listing when git cannot answer — a guard may check too much,
+// never too little.
+const composeFiles = (trackedFilesIn(ROOT) ?? readdirSync(ROOT)).filter(
+  (f) => f.startsWith("docker-compose") && f.endsWith(".yml"),
+);
+
+// ---------------------------------------------------------------------------
+// The corpus
+// ---------------------------------------------------------------------------
+
+test("every compose file in the repo publishes on loopback only", () => {
+  const offenders = [];
+  let entries = 0;
+  for (const file of composeFiles) {
+    const found = publishedPortEntries(read(file));
+    entries += found.length;
+    for (const bad of nonLoopbackPublishes(read(file))) {
+      offenders.push(`${file}:${bad.line} "${bad.raw}" — ${bad.why}`);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `These entries publish beyond this machine:\n  ${offenders.join("\n  ")}\n` +
+      `Prefix the host port with 127.0.0.1 ("127.0.0.1:5434:5432"). If the ` +
+      `bind address must stay operator-controlled, put it in the variable's ` +
+      `default the way docker-compose.yml does: "\${PINCHY_PORT:-127.0.0.1:7777}:7777".`,
+  );
+
+  // A walker that finds nothing passes cheerfully. Both floors are well under
+  // today's numbers (12 files, 24 entries) and well over zero.
+  assert.ok(
+    composeFiles.length >= 8,
+    `Only found ${composeFiles.length} compose files — the walker is broken.`,
+  );
+  assert.ok(
+    entries >= 20,
+    `Only read ${entries} port entries across ${composeFiles.length} compose ` +
+      `files — the parser is reading past them.`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The dev overlay, resolved against a real allocation
+// ---------------------------------------------------------------------------
+
+/**
+ * The corpus test reads what a fresh checkout binds — the `${VAR:-default}`
+ * side. A worktree that has run `pnpm worktree:env` binds something else
+ * entirely, and the two halves of that value are written in two different
+ * places: `127.0.0.1:` is inside DEV_PINCHY_PORT but outside DEV_DB_PORT and
+ * DEV_CADDY_PORT, where the compose file supplies it.
+ *
+ * Nothing about either file says so, which is how the next person "harmonises"
+ * them and produces `127.0.0.1:127.0.0.1:5444:5432` — a compose error that only
+ * appears in an allocated worktree, never in CI, never in a fresh clone.
+ */
+test("the dev overlay binds loopback for a worktree that ran `pnpm worktree:env`", () => {
+  const slug = projectSlug("/tmp/some-worktree");
+  const ports = allocatePorts(slug, () => true);
+  const env = managedValues({ slug, ports });
+
+  const entries = publishedPortEntries(read("docker-compose.dev.yml"), env);
+
+  assert.equal(
+    entries.length,
+    3,
+    `Expected the dev overlay to publish pinchy, db and caddy; got ${entries.length}.`,
+  );
+  for (const entry of entries) {
+    assert.ok(
+      isLoopbackHost(entry.hostIp),
+      `docker-compose.dev.yml:${entry.line} resolves to "${entry.resolved}" ` +
+        `once .env exists, which binds ${entry.hostIp ?? "0.0.0.0"}.`,
+    );
+  }
+  assert.deepEqual(
+    entries.map((e) => Number(e.hostPort)).sort((a, b) => a - b),
+    [ports.pinchyPort, ports.dbPort, ports.caddyPort].sort((a, b) => a - b),
+    `The dev overlay does not bind the ports the allocator handed out.`,
+  );
+});
+
+test("the generated block writes exactly the keys it declares", () => {
+  const values = managedValues({
+    slug: "x",
+    ports: { pinchyPort: 7777, dbPort: 5434, caddyPort: 8443 },
+  });
+  assert.deepEqual(Object.keys(values).sort(), [...MANAGED_KEYS].sort());
+});
+
+// ---------------------------------------------------------------------------
+// The parser
+// ---------------------------------------------------------------------------
+
+const wrap = (...entries) =>
+  [
+    "services:",
+    "  svc:",
+    "    ports:",
+    ...entries.map((e) => `      - ${e}`),
+  ].join("\n");
+
+test("reads the short-form shapes compose actually accepts", () => {
+  assert.deepEqual(
+    publishedPortEntries(wrap('"127.0.0.1:5434:5432"')).map((e) => [
+      e.hostIp,
+      e.hostPort,
+      e.containerPort,
+    ]),
+    [["127.0.0.1", "5434", "5432"]],
+  );
+  assert.deepEqual(
+    publishedPortEntries(wrap('"5434:5432"')).map((e) => e.hostIp),
+    [null],
+  );
+  assert.deepEqual(
+    publishedPortEntries(wrap('"9100"')).map((e) => [
+      e.hostPort,
+      e.containerPort,
+    ]),
+    [[null, "9100"]],
+  );
+  assert.deepEqual(
+    publishedPortEntries(wrap('"[::1]:8080:80"')).map((e) => e.hostIp),
+    ["[::1]"],
+  );
+  assert.deepEqual(
+    publishedPortEntries(wrap('"127.0.0.1:5434:5432/udp"')).map(
+      (e) => e.hostPort,
+    ),
+    ["5434"],
+  );
+});
+
+test("resolves ${VAR:-default} both ways round", () => {
+  // The IP inside the variable's default (docker-compose.yml's shape) …
+  assert.deepEqual(
+    publishedPortEntries(wrap('"${PINCHY_PORT:-127.0.0.1:7777}:7777"')).map(
+      (e) => [e.hostIp, e.hostPort],
+    ),
+    [["127.0.0.1", "7777"]],
+  );
+  // … and the IP outside it (docker-compose.dev.yml's shape for db/caddy).
+  assert.deepEqual(
+    publishedPortEntries(wrap('"127.0.0.1:${DEV_DB_PORT:-5434}:5432"')).map(
+      (e) => [e.hostIp, e.hostPort],
+    ),
+    [["127.0.0.1", "5434"]],
+  );
+  // A supplied value wins over the default.
+  assert.deepEqual(
+    publishedPortEntries(wrap('"127.0.0.1:${DEV_DB_PORT:-5434}:5432"'), {
+      DEV_DB_PORT: "5444",
+    }).map((e) => e.hostPort),
+    ["5444"],
+  );
+  assert.equal(expandComposeVars("${NOPE}x"), "x");
+});
+
+test("flags every way an entry reaches past this machine", () => {
+  const cases = [
+    ['"5434:5432"', "no host IP"],
+    ['"0.0.0.0:9001:9001"', "explicit 0.0.0.0"],
+    ['"192.168.1.5:9001:9001"', "a LAN address"],
+    ['"9100"', "a random host port"],
+    ['"${DEV_DB_PORT:-5434}:5432"', "a variable default with no IP"],
+  ];
+  for (const [entry, why] of cases) {
+    assert.equal(
+      nonLoopbackPublishes(wrap(entry)).length,
+      1,
+      `${entry} (${why}) should be flagged.`,
+    );
+  }
+  assert.deepEqual(nonLoopbackPublishes(wrap('"127.0.0.1:5434:5432"')), []);
+  // 127.0.0.0/8 is all loopback, not just .0.1.
+  assert.deepEqual(nonLoopbackPublishes(wrap('"127.0.0.2:5434:5432"')), []);
+});
+
+test("throws on a doubled host IP instead of reading past it", () => {
+  // The exact shape a "harmonised" DEV_DB_PORT produces.
+  assert.throws(
+    () =>
+      publishedPortEntries(wrap('"127.0.0.1:${DEV_DB_PORT:-5434}:5432"'), {
+        DEV_DB_PORT: "127.0.0.1:5444",
+      }),
+    /doubled host IP|colon-separated fields/,
+  );
+});
+
+test("throws on the long port syntax rather than reporting on the lines it understands", () => {
+  const long = [
+    "services:",
+    "  svc:",
+    "    ports:",
+    "      - target: 9001",
+    "        published: 9001",
+  ].join("\n");
+  assert.throws(
+    () => publishedPortEntries(long),
+    /long port syntax|short-form/,
+  );
+});
+
+test("reads only ports blocks, so volumes, env and extra_hosts cannot be mistaken for binds", () => {
+  const noise = [
+    "services:",
+    "  svc:",
+    "    environment:",
+    "      - OPENCLAW_WS_URL=ws://openclaw:18789",
+    "      - BRAVE_API_BASE_URL=http://brave-mock:9003",
+    "    extra_hosts:",
+    '      - "api.telegram.org:172.28.0.10"',
+    "    volumes:",
+    "      - ./Caddyfile.dev:/etc/caddy/Caddyfile:ro",
+    "      - caddy_data_dev:/data",
+    "    ports:",
+    '      - "127.0.0.1:9003:9003"',
+  ].join("\n");
+  assert.deepEqual(publishedHostPorts(noise), [9003]);
+});
+
+test("tolerates the tag and comment shapes the overlays already use", () => {
+  const tagged = [
+    "services:",
+    "  db:",
+    "    ports:",
+    "      !override # Playwright/setup helpers read/seed the DB from the host.",
+    '      - "127.0.0.1:5437:5432"',
+    "  pinchy:",
+    "    ports: !override",
+    "      # the eval stack sits on 7781",
+    '      - "127.0.0.1:7781:7777"',
+  ].join("\n");
+  assert.deepEqual(publishedHostPorts(tagged), [5437, 7781]);
+});

--- a/scripts/lib/dev-stack-port-isolation.test.mjs
+++ b/scripts/lib/dev-stack-port-isolation.test.mjs
@@ -32,6 +32,7 @@ import { fileURLToPath } from "node:url";
 import { unreservedBandConflicts } from "./worktree-ports.mjs";
 import { MANAGED_KEYS } from "./env-file.mjs";
 import { trackedFilesIn } from "./tracked-files.mjs";
+import { publishedHostPorts } from "./compose-port-bindings.mjs";
 
 const ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const WEB = join(ROOT, "packages", "web");
@@ -61,25 +62,10 @@ const playwrightConfigs = [
   join("packages", "web", "eval", "playwright.eval.config.ts"),
 ];
 
-/**
- * Host ports a compose file publishes. `${VAR:-default}` resolves to its
- * default — that is what a checkout without `.env` actually binds. A
- * single-element entry ("9100") publishes on a random host port and is not a
- * claim on anything.
- */
-function publishedHostPorts(text) {
-  const ports = [];
-  for (const line of text.split("\n")) {
-    const entry = /^\s*-\s*"?([^"#\s]+)"?\s*$/.exec(line);
-    if (!entry) continue;
-    const resolved = entry[1].replace(/\$\{[^:}]+:-([^}]*)\}/g, "$1");
-    const parts = resolved.split(":");
-    if (parts.length < 2) continue;
-    const host = parts.length >= 3 ? parts[1] : parts[0];
-    if (/^\d+$/.test(host)) ports.push(Number(host));
-  }
-  return ports;
-}
+// `publishedHostPorts` is imported rather than defined here: which host port a
+// compose entry claims and which interface it binds are the same reading of the
+// same line, and two copies of it would eventually answer differently. See
+// compose-port-bindings.mjs.
 
 /** Ports a Playwright config or package script expects to talk to. */
 function expectedPorts(text) {

--- a/scripts/lib/env-file.mjs
+++ b/scripts/lib/env-file.mjs
@@ -16,6 +16,31 @@ export const MANAGED_KEYS = [
 ];
 
 /**
+ * The values `scripts/worktree-env.mjs` writes into the generated block.
+ *
+ * Note the asymmetry, which is load-bearing rather than untidy: DEV_PINCHY_PORT
+ * carries `127.0.0.1:` INSIDE the value, while DEV_DB_PORT and DEV_CADDY_PORT
+ * are bare numbers whose prefix is hard-coded in `docker-compose.dev.yml`.
+ * Every already-generated `.env` has that shape, so "harmonising" either half
+ * breaks the other: give DEV_DB_PORT the prefix too and the overlay resolves to
+ * `127.0.0.1:127.0.0.1:5444:5432`; drop it from DEV_PINCHY_PORT and every
+ * existing worktree publishes its dev stack on 0.0.0.0. The pairing is pinned
+ * by `compose-port-bindings.test.mjs`, which resolves the dev overlay against
+ * exactly these values.
+ *
+ * @param {{slug: string, ports: {pinchyPort: number, dbPort: number, caddyPort: number}}} allocation
+ * @returns {Record<string, string>}
+ */
+export function managedValues({ slug, ports }) {
+  return {
+    COMPOSE_PROJECT_NAME: slug,
+    DEV_PINCHY_PORT: `127.0.0.1:${ports.pinchyPort}`,
+    DEV_DB_PORT: String(ports.dbPort),
+    DEV_CADDY_PORT: String(ports.caddyPort),
+  };
+}
+
+/**
  * Key names the FIRST version of this script wrote. They were renamed because
  * `PINCHY_PORT`, `DB_PORT` and `CADDY_PORT` are read by `docker-compose.yml`
  * itself, so a dev-stack allocation leaked into every E2E stack layered on it

--- a/scripts/worktree-env.mjs
+++ b/scripts/worktree-env.mjs
@@ -33,6 +33,7 @@ import {
 } from "./lib/worktree-ports.mjs";
 import {
   MANAGED_KEYS,
+  managedValues,
   parseEnvFile,
   writeManagedBlock,
 } from "./lib/env-file.mjs";
@@ -85,12 +86,7 @@ const ports = allocatePorts(slug, (port) => free.has(port));
 // everything the developer put in .env themselves is preserved in place.
 writeFileSync(
   envPath,
-  writeManagedBlock(existing, {
-    COMPOSE_PROJECT_NAME: slug,
-    DEV_PINCHY_PORT: `127.0.0.1:${ports.pinchyPort}`,
-    DEV_DB_PORT: String(ports.dbPort),
-    DEV_CADDY_PORT: String(ports.caddyPort),
-  }),
+  writeManagedBlock(existing, managedValues({ slug, ports })),
 );
 
 console.log(`Allocated block +${ports.offset} for "${slug}":`);


### PR DESCRIPTION
## Summary

- Every test/dev compose overlay's `ports:` entries published on `0.0.0.0` by default (no host-IP prefix), so on a shared dev/CI host the test Postgres DBs, the per-suite Pinchy port overrides, and every mock server (telegram, brave, gmail, graph, odoo, greenmail/imap, fake-ollama db, dev caddy) were reachable from the network, not just from localhost.
- Prefixed every affected host-port binding with `127.0.0.1:` in: `docker-compose.dev.yml`, `docker-compose.e2e.yml`, `docker-compose.integration.yml`, `docker-compose.eval.yml`, `docker-compose.odoo-test.yml`, `docker-compose.email-test.yml`, `docker-compose.imap-test.yml`, `docker-compose.test.yml`, `docker-compose.web-test.yml`.
- Every consumer of these ports (Playwright configs, `e2e/**/helpers.ts`, eval harness, vitest integration DB URL) already addresses them via `localhost:PORT`, so this is purely a bind-address hardening with no functional change.
- `docker-compose.dev.yml`'s DB/Caddy ports use worktree-allocated env vars (`DEV_DB_PORT`, `DEV_CADDY_PORT`) that are written as bare port numbers by `scripts/worktree-env.mjs`; the `127.0.0.1:` prefix is hard-coded in the compose file itself (not inside the variable) so it applies regardless of whether `.env` was ever generated, without touching the allocator.
- Left alone deliberately:
  - `docker-compose.yml` (production) — already binds `127.0.0.1:7777` per prior review, untouched.
  - `docker-compose.screenshots.yml` / `docker-compose.setup-wizard-test.yml` — their mock services use `expose:` only (container-network only, no host port published), so nothing to harden.
  - `GREENMAIL_OPTS=-Dgreenmail.hostname=0.0.0.0` in `docker-compose.imap-test.yml` — this binds the process *inside* the container to all its own interfaces so other containers on the compose network can reach it by service name; unrelated to the host-port publish, which is now loopback-only.

## Test plan

- [x] `pnpm test:scripts` — 894 passed, 0 failed (includes `dev-stack-port-isolation.test.mjs`, which still parses the new `127.0.0.1:PORT:PORT` triplets correctly and enforces the DEV_* isolation invariants).
- [x] `pnpm format:check` — clean, no diffs.
- [x] Verified by grep that every `ports:` list entry across all `docker-compose*.yml` now carries a `127.0.0.1:` (or variable-embedded) host-IP prefix, except the untouched production file (already compliant) and the two `expose:`-only overlays.
- [x] Verified every host port changed here is addressed by test/CI tooling exclusively via `localhost:PORT` (grepped Playwright configs, `e2e/**/helpers.ts`, eval harness, vitest integration DB URL resolvers) — no cross-host access pattern found that would require a non-loopback bind.

Docs-not-needed: test/dev compose hardening, no reader-facing surface