### PR TITLE
test(ci): pin Playwright's retries: 0 / workers: 1 as a drift guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,13 @@ Three details worth knowing before editing the guard:
 
 Every Playwright config here pins `retries: 0, workers: 1` on purpose: a flake is a signal, not something a rerun hides. A fixed sleep quietly trades that away. It is green on a fast host and red on a loaded runner, and when it does fail it says "timeout" instead of naming what was slow.
 
+That pin is itself guarded now, by `scripts/lib/playwright-config-pins.mjs` (`pnpm test:scripts`). It reads all nine `playwright*.config.ts` files under `packages/web` and requires `retries: 0`, `workers: 1`, and no `fullyParallel: true` — the third because `workers: 1` alone still lets tests _within one file_ race, against a stack that `resetStack()` specs assume is exclusively theirs. `retries` and `fullyParallel` are checked at every nesting depth: Playwright honours a per-project override, so `projects: [{ retries: 3 }]` defeats the top-level pin while leaving it visibly intact.
+
+Two things it does deliberately, both for reasons AGENTS.md keeps re-learning elsewhere:
+
+- **It tokenizes rather than greps.** A first-match regex reads `// retries: 0 — see AGENTS.md` sitting above a real `retries: 2` as compliance, and reads a comment left behind after the pin was _deleted_ as the pin. That is the "reports on the presence of a string" failure again, and the guard's own error messages are what prompt a developer to write that comment. Skipping string literals is not optional either — `baseURL: "http://localhost:7778"` would otherwise start a comment.
+- **The walk is recursive, and the corpus check is a cross-reference, not a floor.** A package-root `readdir` — the obvious implementation — misses `packages/web/eval/playwright.eval.config.ts`, a ninth config that CI really runs. So `configsReferencedByScripts` parses `packages/web/package.json` and fails if any config a script invokes was not discovered. A floor of 8 would have stayed green through exactly that gap.
+
 The ESLint rule `pinchy/no-untracked-sleeps` bans `page.waitForTimeout(...)` across `e2e/**` (unit tests in `src/__tests__/eslint/no-untracked-sleeps.test.ts`). Wait on a real signal instead — a web-first assertion, `expect.poll(...)`, `page.waitForURL(...)`, `page.waitForResponse(...)`, or the shared `pollAuditForEvent` / `pollAuditForTool` helpers in `e2e/shared/dispatch-probe.ts`. When you replace a sleep in a retry loop, **the poll's exit condition must be the same condition the final assertion checks** — a weaker "something arrived" exit races the assertion and reintroduces the flake it was meant to remove.
 
 The exemption is the same contract as the skip policy: a comment carrying `#NNN` (or the issue URL). Two differences worth knowing:

--- a/scripts/lib/playwright-config-pins.mjs
+++ b/scripts/lib/playwright-config-pins.mjs
@@ -1,0 +1,109 @@
+/**
+ * Drift guard for the Playwright flake-signal pins.
+ *
+ * AGENTS.md § "No Untracked Sleeps In E2E" states the property in passing:
+ * every Playwright config here pins `retries: 0, workers: 1` on purpose — a
+ * flake is a signal, not something a rerun hides. Nothing pinned that claim
+ * itself. A well-meaning `retries: 2` landing in one of the eight
+ * `packages/web/playwright*.config.ts` files would quietly turn a real flake
+ * into an intermittent pass, and CI would stay green while doing so.
+ *
+ * The property is not just "retries: 0, workers: 1 literally appear" — a
+ * config could set `workers: 1` and still race two specs against one stack
+ * via `fullyParallel: true` (Playwright's own default when neither is set is
+ * `workers` scaled off CPU count and `fullyParallel: false`, but an explicit
+ * `true` overrides `workers: 1` for tests *within* one file). Every config
+ * here that states the field spells it out as `false`; this guard forbids
+ * `true` for the same reason it forbids `retries` above 0: specs in this repo
+ * call `resetStack()` (truncates the DB, restarts containers) or share one
+ * OpenClaw session, so two specs running concurrently inside one stack wipe
+ * each other's state.
+ *
+ * Text analysis, not `require()`/dynamic import: these are Playwright
+ * `defineConfig()` modules meant to run under Playwright's own loader, and
+ * importing them here would need every mock server and DB env var they
+ * reference (see the `webServer.command` block in playwright.config.ts).
+ * Reading the source text is what the analogous *-gate guards in this
+ * directory already do (see node-version-pin.mjs's Dockerfile/workflow
+ * readers). It is also a legitimate reading of AGENTS.md's own contract:
+ * `AGENTS.md` states the property in prose, so a text-level check of the
+ * config source is the natural read-side sibling — the same shape as
+ * upgrading-released-sections.mjs reading a doc section as text.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// Matches every `packages/web/playwright*.config.ts` file: the bare
+// `playwright.config.ts` and every suffixed variant
+// (`playwright.odoo.config.ts`, `playwright.email.config.ts`, ...).
+const CONFIG_FILE_PATTERN = /^playwright.*\.config\.ts$/;
+
+/**
+ * Discover every Playwright config file directly under a web package root.
+ * @param {string} webRoot absolute path to packages/web
+ * @returns {string[]} sorted absolute file paths
+ */
+export function discoverPlaywrightConfigs(webRoot) {
+  return readdirSync(webRoot)
+    .filter((name) => CONFIG_FILE_PATTERN.test(name))
+    .map((name) => join(webRoot, name))
+    .sort();
+}
+
+/**
+ * Find a top-level `key: value` assignment inside a `defineConfig({...})`
+ * object literal. Deliberately shallow — it looks for the key anywhere at
+ * the top indentation level Playwright configs use, not a real parser, which
+ * is the same tradeoff the sibling text-based guards in this directory make.
+ * @param {string} text
+ * @param {string} key
+ * @returns {string | null} the raw value text, or null if the key is absent
+ */
+function findTopLevelValue(text, key) {
+  const pattern = new RegExp(`(?:^|[\\s,{])${key}\\s*:\\s*([^,\\n}]+)`);
+  const match = pattern.exec(text);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Validate one Playwright config's *source text* against the flake-signal
+ * pins: `retries: 0`, `workers: 1`, and no `fullyParallel: true`.
+ * @param {string} text raw config file contents
+ * @returns {string[]} one message per problem; empty means correctly pinned
+ */
+export function validatePlaywrightConfigText(text) {
+  const problems = [];
+  const source = String(text ?? "");
+
+  const retries = findTopLevelValue(source, "retries");
+  if (retries === null) {
+    problems.push(
+      "missing retries: 0 — without it Playwright's own default reruns a failing test, hiding the flake this pin exists to surface.",
+    );
+  } else if (retries !== "0") {
+    problems.push(
+      `retries is ${JSON.stringify(retries)}, expected 0 — a retry can pass by re-running against DB state (or an OpenClaw session) the first attempt already mutated, silently hiding the flake instead of reporting it.`,
+    );
+  }
+
+  const workers = findTopLevelValue(source, "workers");
+  if (workers === null) {
+    problems.push(
+      "missing workers: 1 — without it Playwright sizes the worker pool off CPU count, and specs here truncate the DB / restart containers, so two workers can wipe each other's state.",
+    );
+  } else if (workers !== "1") {
+    problems.push(
+      `workers is ${JSON.stringify(workers)}, expected 1 — specs here truncate the DB / restart containers or share one OpenClaw session, so more than one worker can wipe another spec's state.`,
+    );
+  }
+
+  const fullyParallel = findTopLevelValue(source, "fullyParallel");
+  if (fullyParallel === "true") {
+    problems.push(
+      "fullyParallel is true, expected false (or absent) — it races tests within one file against a stack that resetStack()/shared-session specs assume is exclusively theirs.",
+    );
+  }
+
+  return problems;
+}

--- a/scripts/lib/playwright-config-pins.mjs
+++ b/scripts/lib/playwright-config-pins.mjs
@@ -4,20 +4,27 @@
  * AGENTS.md § "No Untracked Sleeps In E2E" states the property in passing:
  * every Playwright config here pins `retries: 0, workers: 1` on purpose — a
  * flake is a signal, not something a rerun hides. Nothing pinned that claim
- * itself. A well-meaning `retries: 2` landing in one of the eight
- * `packages/web/playwright*.config.ts` files would quietly turn a real flake
- * into an intermittent pass, and CI would stay green while doing so.
+ * itself. A well-meaning `retries: 2` landing in one of the nine
+ * `playwright*.config.ts` files under `packages/web` would quietly turn a
+ * real flake into an intermittent pass, and CI would stay green while doing
+ * so.
  *
  * The property is not just "retries: 0, workers: 1 literally appear" — a
  * config could set `workers: 1` and still race two specs against one stack
- * via `fullyParallel: true` (Playwright's own default when neither is set is
- * `workers` scaled off CPU count and `fullyParallel: false`, but an explicit
- * `true` overrides `workers: 1` for tests *within* one file). Every config
- * here that states the field spells it out as `false`; this guard forbids
- * `true` for the same reason it forbids `retries` above 0: specs in this repo
- * call `resetStack()` (truncates the DB, restarts containers) or share one
- * OpenClaw session, so two specs running concurrently inside one stack wipe
- * each other's state.
+ * via `fullyParallel: true` (`workers` bounds concurrent worker *processes*,
+ * while `fullyParallel: true` additionally lets tests *within* one file run
+ * against each other). Every config here that states the field spells it out
+ * as `false`; this guard forbids `true` for the same reason it forbids
+ * `retries` above 0: specs in this repo call `resetStack()` (truncates the
+ * DB, restarts containers) or share one OpenClaw session, so two specs
+ * running concurrently inside one stack wipe each other's state.
+ *
+ * `retries` and `fullyParallel` are checked at **every** nesting depth, not
+ * only the top level, because Playwright honours a per-project override:
+ * `projects: [{ name: "chromium", retries: 3 }]` defeats a top-level
+ * `retries: 0` for that project while leaving the top-level pin visibly
+ * intact. `workers` has no project-level form, so it is required (and
+ * checked) at the top level only.
  *
  * Text analysis, not `require()`/dynamic import: these are Playwright
  * `defineConfig()` modules meant to run under Playwright's own loader, and
@@ -25,45 +32,251 @@
  * reference (see the `webServer.command` block in playwright.config.ts).
  * Reading the source text is what the analogous *-gate guards in this
  * directory already do (see node-version-pin.mjs's Dockerfile/workflow
- * readers). It is also a legitimate reading of AGENTS.md's own contract:
- * `AGENTS.md` states the property in prose, so a text-level check of the
- * config source is the natural read-side sibling — the same shape as
- * upgrading-released-sections.mjs reading a doc section as text.
+ * readers).
+ *
+ * But a *regex* over that text is not good enough, and the reason is the
+ * one AGENTS.md keeps naming: a check that reports on the presence of a
+ * string reports on the presence of a string. A first-match regex reads
+ *
+ *     // retries: 0 — a flake is a signal, see AGENTS.md
+ *     retries: 2,
+ *
+ * as a compliant config, because the comment matches first — and that
+ * comment is exactly what a developer writes next to the pin, or leaves
+ * behind after deleting it. `node-version-pin.mjs` makes the same point
+ * about Dockerfiles ("the guard reads FROM lines only, never prose"). So
+ * this one tokenizes: `extractConfigEntries` skips comments and string
+ * literals and tracks brace depth, so only real object entries are read.
+ * The `//` in `baseURL: "http://localhost:7778"` is why the string-skipping
+ * half is not optional either.
  */
 
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
-// Matches every `packages/web/playwright*.config.ts` file: the bare
-// `playwright.config.ts` and every suffixed variant
-// (`playwright.odoo.config.ts`, `playwright.email.config.ts`, ...).
+// Matches every `playwright*.config.ts` file: the bare `playwright.config.ts`
+// and every suffixed variant (`playwright.odoo.config.ts`,
+// `playwright.email.config.ts`, `playwright.eval.config.ts`, ...).
 const CONFIG_FILE_PATTERN = /^playwright.*\.config\.ts$/;
 
+// Directories a source-tree walk must not descend into: installed packages
+// ship their own Playwright configs, and build output is generated.
+const SKIPPED_DIRS = new Set([
+  "node_modules",
+  ".next",
+  "dist",
+  "build",
+  "coverage",
+  "playwright-report",
+  "test-results",
+]);
+
+const QUOTES = new Set(['"', "'", "`"]);
+const IDENT_START = /[A-Za-z_$]/;
+const IDENT_PART = /[\w$]/;
+
 /**
- * Discover every Playwright config file directly under a web package root.
+ * Discover every Playwright config file under a web package root.
+ *
+ * The walk is **recursive**, and that is not incidental tidiness. A
+ * top-level-only readdir misses `packages/web/eval/playwright.eval.config.ts`
+ * — a ninth config, run by `pnpm eval:selftest` in CI, that a package-root
+ * glob leaves entirely unguarded. Same lesson as AGENTS.md § "A
+ * Hand-Maintained List That Mirrors Code Will Be Wrong": a guard whose scope
+ * is narrower than the thing it claims to cover reports on what it looks at,
+ * not on what it should.
  * @param {string} webRoot absolute path to packages/web
  * @returns {string[]} sorted absolute file paths
  */
 export function discoverPlaywrightConfigs(webRoot) {
-  return readdirSync(webRoot)
-    .filter((name) => CONFIG_FILE_PATTERN.test(name))
-    .map((name) => join(webRoot, name))
-    .sort();
+  /** @type {string[]} */
+  const found = [];
+  /** @param {string} dir */
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith(".") || SKIPPED_DIRS.has(entry.name))
+          continue;
+        walk(join(dir, entry.name));
+      } else if (entry.isFile() && CONFIG_FILE_PATTERN.test(entry.name)) {
+        found.push(join(dir, entry.name));
+      }
+    }
+  };
+  walk(webRoot);
+  return found.sort();
 }
 
 /**
- * Find a top-level `key: value` assignment inside a `defineConfig({...})`
- * object literal. Deliberately shallow — it looks for the key anywhere at
- * the top indentation level Playwright configs use, not a real parser, which
- * is the same tradeoff the sibling text-based guards in this directory make.
- * @param {string} text
- * @param {string} key
- * @returns {string | null} the raw value text, or null if the key is absent
+ * Every Playwright config a `packages/web/package.json` script actually runs.
+ *
+ * The corpus floor below is a backstop against a discovery glob that finds
+ * nothing; this is the sharper question — a config the scripts run but the
+ * glob misses (a differently named file, or one moved into a subdirectory)
+ * would be unguarded while the floor stayed satisfied by its siblings. A
+ * bare `playwright test` resolves `playwright.config.ts` in the package
+ * root, so it contributes that name implicitly.
+ * @param {string} packageJsonText raw packages/web/package.json contents
+ * @returns {string[]} sorted, de-duplicated config file names
  */
-function findTopLevelValue(text, key) {
-  const pattern = new RegExp(`(?:^|[\\s,{])${key}\\s*:\\s*([^,\\n}]+)`);
-  const match = pattern.exec(text);
-  return match ? match[1].trim() : null;
+export function configsReferencedByScripts(packageJsonText) {
+  const scripts = JSON.parse(packageJsonText).scripts ?? {};
+  const referenced = new Set();
+  for (const command of Object.values(scripts)) {
+    if (typeof command !== "string" || !/\bplaywright test\b/.test(command)) {
+      continue;
+    }
+    const explicit = [...command.matchAll(/--config[=\s]+(\S+)/g)];
+    if (explicit.length === 0) {
+      referenced.add("playwright.config.ts");
+      continue;
+    }
+    for (const [, path] of explicit) {
+      referenced.add(path.replace(/^\.\//, ""));
+    }
+  }
+  return [...referenced].sort();
+}
+
+/**
+ * Skip a string literal starting at `i`. Returns the index just past it.
+ * @param {string} src
+ * @param {number} i index of the opening quote
+ * @returns {number}
+ */
+function skipString(src, i) {
+  const quote = src[i];
+  let j = i + 1;
+  while (j < src.length) {
+    if (src[j] === "\\") {
+      j += 2;
+      continue;
+    }
+    if (src[j] === quote) return j + 1;
+    j += 1;
+  }
+  return j;
+}
+
+/**
+ * Skip a `//` or block comment starting at `i`.
+ * @param {string} src
+ * @param {number} i
+ * @returns {number} index just past the comment, or -1 if `i` starts none
+ */
+function skipComment(src, i) {
+  if (src[i] !== "/") return -1;
+  if (src[i + 1] === "/") {
+    let j = i + 2;
+    while (j < src.length && src[j] !== "\n") j += 1;
+    return j;
+  }
+  if (src[i + 1] === "*") {
+    let j = i + 2;
+    while (j < src.length && !(src[j] === "*" && src[j + 1] === "/")) j += 1;
+    return Math.min(j + 2, src.length);
+  }
+  return -1;
+}
+
+/**
+ * Read the raw text of a value starting just after its `:`, stopping at the
+ * `,` or closing bracket that ends it. Nested brackets, strings and comments
+ * are consumed rather than treated as terminators, so `use: { a: "x, y" }`
+ * reads as one value and `retries: 0, // pin` reads as `0`.
+ * @param {string} src
+ * @param {number} start index just past the colon
+ * @returns {string} the value text, comments removed, trimmed
+ */
+function readRawValue(src, start) {
+  const chunks = [];
+  let depth = 0;
+  let i = start;
+  while (i < src.length) {
+    const pastComment = skipComment(src, i);
+    if (pastComment !== -1) {
+      i = pastComment;
+      continue;
+    }
+    const ch = src[i];
+    if (QUOTES.has(ch)) {
+      const end = skipString(src, i);
+      chunks.push(src.slice(i, end));
+      i = end;
+      continue;
+    }
+    if (ch === "{" || ch === "[" || ch === "(") {
+      depth += 1;
+    } else if (ch === "}" || ch === "]" || ch === ")") {
+      if (depth === 0) break;
+      depth -= 1;
+    } else if (ch === "," && depth === 0) {
+      break;
+    }
+    chunks.push(ch);
+    i += 1;
+  }
+  return chunks.join("").trim();
+}
+
+/**
+ * Tokenize a config's source into its `key: value` entries.
+ *
+ * Comments and string literals are skipped, so neither a commented-out pin
+ * nor a `//` inside a URL is mistaken for configuration. `depth` counts
+ * `{`/`[` nesting: the entries of the object passed to `defineConfig({...})`
+ * sit at depth 1, a `projects: [{ ... }]` member's entries at depth 3.
+ * @param {string} text raw config file contents
+ * @returns {{ key: string, value: string, depth: number }[]}
+ */
+export function extractConfigEntries(text) {
+  const src = String(text ?? "");
+  const entries = [];
+  let depth = 0;
+  let i = 0;
+  while (i < src.length) {
+    const pastComment = skipComment(src, i);
+    if (pastComment !== -1) {
+      i = pastComment;
+      continue;
+    }
+    const ch = src[i];
+    if (QUOTES.has(ch)) {
+      i = skipString(src, i);
+      continue;
+    }
+    if (ch === "{" || ch === "[") {
+      depth += 1;
+      i += 1;
+      continue;
+    }
+    if (ch === "}" || ch === "]") {
+      depth = Math.max(0, depth - 1);
+      i += 1;
+      continue;
+    }
+    if (IDENT_START.test(ch)) {
+      let end = i;
+      while (end < src.length && IDENT_PART.test(src[end])) end += 1;
+      let afterKey = end;
+      while (afterKey < src.length && /\s/.test(src[afterKey])) afterKey += 1;
+      if (src[afterKey] === ":" && src[afterKey + 1] !== ":") {
+        entries.push({
+          key: src.slice(i, end),
+          value: readRawValue(src, afterKey + 1),
+          depth,
+        });
+        // Resume just past the colon rather than past the value, so entries
+        // nested inside it (a project-level `retries`) are seen too.
+        i = afterKey + 1;
+        continue;
+      }
+      i = end;
+      continue;
+    }
+    i += 1;
+  }
+  return entries;
 }
 
 /**
@@ -74,34 +287,41 @@ function findTopLevelValue(text, key) {
  */
 export function validatePlaywrightConfigText(text) {
   const problems = [];
-  const source = String(text ?? "");
+  const entries = extractConfigEntries(text);
+  const where = (entry) =>
+    entry.depth === 1 ? "" : ` (nested at depth ${entry.depth})`;
 
-  const retries = findTopLevelValue(source, "retries");
-  if (retries === null) {
+  const retries = entries.filter((entry) => entry.key === "retries");
+  if (!retries.some((entry) => entry.depth === 1)) {
     problems.push(
-      "missing retries: 0 — without it Playwright's own default reruns a failing test, hiding the flake this pin exists to surface.",
+      "missing retries: 0 — the pin is what makes a later `retries: 2` a deliberate, reviewable edit rather than a default nobody stated.",
     );
-  } else if (retries !== "0") {
+  }
+  for (const entry of retries.filter((e) => e.value !== "0")) {
     problems.push(
-      `retries is ${JSON.stringify(retries)}, expected 0 — a retry can pass by re-running against DB state (or an OpenClaw session) the first attempt already mutated, silently hiding the flake instead of reporting it.`,
+      `retries is ${JSON.stringify(entry.value)}${where(entry)}, expected 0 — a retry can pass by re-running against DB state (or an OpenClaw session) the first attempt already mutated, silently hiding the flake instead of reporting it.`,
     );
   }
 
-  const workers = findTopLevelValue(source, "workers");
-  if (workers === null) {
+  const workers = entries.filter(
+    (entry) => entry.key === "workers" && entry.depth === 1,
+  );
+  if (workers.length === 0) {
     problems.push(
       "missing workers: 1 — without it Playwright sizes the worker pool off CPU count, and specs here truncate the DB / restart containers, so two workers can wipe each other's state.",
     );
-  } else if (workers !== "1") {
+  }
+  for (const entry of workers.filter((e) => e.value !== "1")) {
     problems.push(
-      `workers is ${JSON.stringify(workers)}, expected 1 — specs here truncate the DB / restart containers or share one OpenClaw session, so more than one worker can wipe another spec's state.`,
+      `workers is ${JSON.stringify(entry.value)}, expected 1 — specs here truncate the DB / restart containers or share one OpenClaw session, so more than one worker can wipe another spec's state.`,
     );
   }
 
-  const fullyParallel = findTopLevelValue(source, "fullyParallel");
-  if (fullyParallel === "true") {
+  for (const entry of entries.filter(
+    (e) => e.key === "fullyParallel" && e.value === "true",
+  )) {
     problems.push(
-      "fullyParallel is true, expected false (or absent) — it races tests within one file against a stack that resetStack()/shared-session specs assume is exclusively theirs.",
+      `fullyParallel is true${where(entry)}, expected false (or absent) — it races tests within one file against a stack that resetStack()/shared-session specs assume is exclusively theirs.`,
     );
   }
 

--- a/scripts/lib/playwright-config-pins.test.mjs
+++ b/scripts/lib/playwright-config-pins.test.mjs
@@ -2,9 +2,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join, resolve, basename } from "node:path";
+import { dirname, join, resolve, basename, relative } from "node:path";
 import {
+  configsReferencedByScripts,
   discoverPlaywrightConfigs,
+  extractConfigEntries,
   validatePlaywrightConfigText,
 } from "./playwright-config-pins.mjs";
 
@@ -81,6 +83,176 @@ test("validatePlaywrightConfigText reports every problem in one pass, not just t
   assert.ok(problems.some((p) => /fullyParallel/.test(p)));
 });
 
+test('validatePlaywrightConfigText flags a non-numeric workers such as "50%"', () => {
+  const text = GOOD.replace("workers: 1", 'workers: "50%"');
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /workers/.test(p)),
+    `expected a workers problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+// --- The comment blind spot -------------------------------------------------
+//
+// A first-match regex over the source reads a comment as configuration, which
+// makes the guard report on the presence of a string rather than on the
+// config. That is not a theoretical shape: the guard's own failure messages
+// tell a developer to write `retries: 0`, so a comment carrying the literal
+// pin next to (or instead of) the real one is the likeliest next commit.
+
+test("a comment stating the pin does not excuse a violating value", () => {
+  const text = `export default defineConfig({
+  // retries: 0
+  // workers: 1
+  retries: 2,
+  workers: 4,
+});
+`;
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /retries/.test(p)),
+    `expected a retries problem, got ${JSON.stringify(problems)}`,
+  );
+  assert.ok(
+    problems.some((p) => /workers/.test(p)),
+    `expected a workers problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("a comment left behind after deleting the pin does not count as the pin", () => {
+  const text = `export default defineConfig({
+  // retries: 0
+  // workers: 1
+  reporter: "list",
+});
+`;
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /missing retries/.test(p)),
+    `expected a missing-retries problem, got ${JSON.stringify(problems)}`,
+  );
+  assert.ok(
+    problems.some((p) => /missing workers/.test(p)),
+    `expected a missing-workers problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("a block comment describing the pins is not read as configuration", () => {
+  const text = `/**
+ * This suite pins retries: 0 and workers: 1 (AGENTS.md).
+ */
+export default defineConfig({
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+});
+`;
+  assert.deepEqual(validatePlaywrightConfigText(text), []);
+});
+
+test("a // inside a string (baseURL) does not start a comment", () => {
+  // playwright.config.ts really does carry `baseURL: "http://localhost:7778"`.
+  // A comment stripper that is not string-aware would blank the rest of that
+  // line — and, in a config where the URL precedes the pins, everything after.
+  const text = `export default defineConfig({
+  use: { baseURL: "http://localhost:7778" },
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+});
+`;
+  assert.deepEqual(validatePlaywrightConfigText(text), []);
+});
+
+// --- Project-level overrides ------------------------------------------------
+
+test("a project-level retries override is flagged even when the top level pins 0", () => {
+  // Playwright honours `retries` per project, so this really does re-run
+  // failing tests while the top-level pin sits there looking intact.
+  const text = `export default defineConfig({
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  projects: [{ name: "chromium", retries: 3 }],
+});
+`;
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /retries is "3"/.test(p)),
+    `expected a nested retries problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("a project-level fullyParallel: true is flagged", () => {
+  const text = `export default defineConfig({
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  projects: [{ name: "chromium", fullyParallel: true }],
+});
+`;
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /fullyParallel/.test(p)),
+    `expected a fullyParallel problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("extractConfigEntries reports the nesting depth of each entry", () => {
+  const entries = extractConfigEntries(`export default defineConfig({
+  retries: 0,
+  projects: [{ name: "chromium", retries: 3 }],
+});
+`);
+  const retries = entries.filter((e) => e.key === "retries");
+  assert.deepEqual(
+    retries.map((e) => ({ value: e.value, depth: e.depth })),
+    [
+      { value: "0", depth: 1 },
+      { value: "3", depth: 3 },
+    ],
+  );
+});
+
+// --- Canaries against the real config shape ---------------------------------
+//
+// The fixtures above are toys. AGENTS.md asks for verification by
+// reproduction, so these mutate the real playwright.config.ts — comments, a
+// testIgnore array, a webServer.command megastring, a baseURL containing `//`
+// — and require the guard to catch drift in that shape, not just in a
+// hand-written five-line object.
+
+const REAL_CONFIG = readFileSync(
+  join(WEB_ROOT, "playwright.config.ts"),
+  "utf8",
+);
+
+test("canary: the real playwright.config.ts passes unmutated", () => {
+  assert.deepEqual(validatePlaywrightConfigText(REAL_CONFIG), []);
+});
+
+test("canary: retries: 2 in the real config is caught", () => {
+  const mutated = REAL_CONFIG.replace("retries: 0,", "retries: 2,");
+  assert.notEqual(mutated, REAL_CONFIG, "mutation did not apply");
+  const problems = validatePlaywrightConfigText(mutated);
+  assert.ok(
+    problems.some((p) => /retries is "2"/.test(p)),
+    `expected a retries problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("canary: deleting workers: 1 from the real config is caught", () => {
+  const mutated = REAL_CONFIG.replace("  workers: 1,\n", "");
+  assert.notEqual(mutated, REAL_CONFIG, "mutation did not apply");
+  const problems = validatePlaywrightConfigText(mutated);
+  assert.ok(
+    problems.some((p) => /missing workers/.test(p)),
+    `expected a missing-workers problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+// --- Discovery --------------------------------------------------------------
+
 test("discoverPlaywrightConfigs finds every packages/web/playwright*.config.ts", () => {
   const files = discoverPlaywrightConfigs(WEB_ROOT);
   assert.ok(
@@ -90,17 +262,70 @@ test("discoverPlaywrightConfigs finds every packages/web/playwright*.config.ts",
 });
 
 // Corpus floor (AGENTS.md): a guard that discovers nothing checks nothing. The
-// repo has 8 Playwright configs today under packages/web; require at least 6
-// so the guard fails loudly if the discovery glob breaks rather than passing
+// repo has 9 Playwright configs today under packages/web; require at least 8
+// so the guard fails loudly if the discovery walk breaks rather than passing
 // vacuously.
-test("discoverPlaywrightConfigs finds at least 6 configs (corpus floor)", () => {
+test("discoverPlaywrightConfigs finds at least 8 configs (corpus floor)", () => {
   const files = discoverPlaywrightConfigs(WEB_ROOT);
   assert.ok(
-    files.length >= 6,
-    `expected to discover at least 6 playwright configs, found ${files.length}: ${JSON.stringify(
-      files.map((f) => basename(f)),
+    files.length >= 8,
+    `expected to discover at least 8 playwright configs, found ${files.length}: ${JSON.stringify(
+      files.map((f) => relative(WEB_ROOT, f)),
     )}`,
   );
+});
+
+test("discoverPlaywrightConfigs reaches configs in subdirectories", () => {
+  // packages/web/eval/playwright.eval.config.ts is run by `pnpm eval:selftest`
+  // in CI and sits one directory down. A package-root-only readdir — the
+  // obvious implementation — leaves it entirely unguarded.
+  const relatives = discoverPlaywrightConfigs(WEB_ROOT).map((f) =>
+    relative(WEB_ROOT, f),
+  );
+  assert.ok(
+    relatives.includes(join("eval", "playwright.eval.config.ts")),
+    `expected the nested eval config to be discovered, got ${JSON.stringify(relatives)}`,
+  );
+});
+
+// The floor only catches a walk that finds *nothing*. This catches the sharper
+// case: a config the scripts really run that discovery does not reach — which
+// is how the nested eval config went unguarded in the first place.
+test("every config a packages/web script runs is discovered", () => {
+  const referenced = configsReferencedByScripts(
+    readFileSync(join(WEB_ROOT, "package.json"), "utf8"),
+  );
+  const discovered = new Set(
+    discoverPlaywrightConfigs(WEB_ROOT).map((f) => relative(WEB_ROOT, f)),
+  );
+  const missing = referenced.filter((name) => !discovered.has(name));
+  assert.ok(
+    referenced.length >= 6,
+    `expected the e2e scripts to reference configs, got ${JSON.stringify(referenced)}`,
+  );
+  assert.deepEqual(
+    missing,
+    [],
+    `run by a packages/web script but never checked by this guard: ${JSON.stringify(missing)}`,
+  );
+});
+
+test("configsReferencedByScripts reads --config and the implicit bare invocation", () => {
+  const referenced = configsReferencedByScripts(
+    JSON.stringify({
+      scripts: {
+        "test:e2e": "playwright test",
+        "test:e2e:odoo": "playwright test --config playwright.odoo.config.ts",
+        "test:e2e:web": "playwright test --config=./playwright.web.config.ts",
+        lint: "eslint .",
+      },
+    }),
+  );
+  assert.deepEqual(referenced, [
+    "playwright.config.ts",
+    "playwright.odoo.config.ts",
+    "playwright.web.config.ts",
+  ]);
 });
 
 // Real-repo assertion: every actual packages/web/playwright*.config.ts must

--- a/scripts/lib/playwright-config-pins.test.mjs
+++ b/scripts/lib/playwright-config-pins.test.mjs
@@ -1,0 +1,123 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve, basename } from "node:path";
+import {
+  discoverPlaywrightConfigs,
+  validatePlaywrightConfigText,
+} from "./playwright-config-pins.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const WEB_ROOT = join(REPO_ROOT, "packages", "web");
+
+// A config text that satisfies every rule this guard enforces: retries: 0,
+// workers: 1, and no fullyParallel: true.
+const GOOD = `import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/odoo",
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+});
+`;
+
+test("validatePlaywrightConfigText accepts a config pinning retries: 0 and workers: 1", () => {
+  assert.deepEqual(validatePlaywrightConfigText(GOOD), []);
+});
+
+test("validatePlaywrightConfigText flags retries: 2", () => {
+  // A well-meaning "let's rerun flaky tests" edit is exactly the drift this
+  // guard exists to catch: specs here truncate the DB / share an OpenClaw
+  // session, so a retry can pass by re-running against state the first
+  // attempt already mutated, silently hiding the flake instead of reporting it.
+  const text = GOOD.replace("retries: 0", "retries: 2");
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /retries/.test(p)),
+    `expected a retries problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validatePlaywrightConfigText flags fullyParallel: true", () => {
+  // Specs in this suite call resetStack() (truncates the DB, restarts
+  // containers) or share one OpenClaw session; two specs running in parallel
+  // inside one stack would wipe each other's state.
+  const text = GOOD.replace("fullyParallel: false", "fullyParallel: true");
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /fullyParallel/.test(p)),
+    `expected a fullyParallel problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validatePlaywrightConfigText flags a missing workers: 1", () => {
+  const text = GOOD.replace("  workers: 1,\n", "");
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /workers/.test(p)),
+    `expected a workers problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validatePlaywrightConfigText flags a missing retries: 0", () => {
+  const text = GOOD.replace("  retries: 0,\n", "");
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(
+    problems.some((p) => /retries/.test(p)),
+    `expected a retries problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validatePlaywrightConfigText reports every problem in one pass, not just the first", () => {
+  const text = GOOD.replace("retries: 0", "retries: 2").replace(
+    "fullyParallel: false",
+    "fullyParallel: true",
+  );
+  const problems = validatePlaywrightConfigText(text);
+  assert.ok(problems.some((p) => /retries/.test(p)));
+  assert.ok(problems.some((p) => /fullyParallel/.test(p)));
+});
+
+test("discoverPlaywrightConfigs finds every packages/web/playwright*.config.ts", () => {
+  const files = discoverPlaywrightConfigs(WEB_ROOT);
+  assert.ok(
+    files.every((f) => /playwright.*\.config\.ts$/.test(basename(f))),
+    `expected only playwright*.config.ts files, got ${JSON.stringify(files.map((f) => basename(f)))}`,
+  );
+});
+
+// Corpus floor (AGENTS.md): a guard that discovers nothing checks nothing. The
+// repo has 8 Playwright configs today under packages/web; require at least 6
+// so the guard fails loudly if the discovery glob breaks rather than passing
+// vacuously.
+test("discoverPlaywrightConfigs finds at least 6 configs (corpus floor)", () => {
+  const files = discoverPlaywrightConfigs(WEB_ROOT);
+  assert.ok(
+    files.length >= 6,
+    `expected to discover at least 6 playwright configs, found ${files.length}: ${JSON.stringify(
+      files.map((f) => basename(f)),
+    )}`,
+  );
+});
+
+// Real-repo assertion: every actual packages/web/playwright*.config.ts must
+// pin retries: 0, workers: 1, and must not set fullyParallel: true.
+test("every real packages/web/playwright*.config.ts is pinned correctly", () => {
+  const files = discoverPlaywrightConfigs(WEB_ROOT);
+  const offenders = files
+    .map((file) => ({
+      file: file.replace(REPO_ROOT + "/", ""),
+      problems: validatePlaywrightConfigText(readFileSync(file, "utf8")),
+    }))
+    .filter((r) => r.problems.length > 0);
+  assert.deepEqual(
+    offenders,
+    [],
+    `playwright configs not pinned:\n${offenders
+      .map((o) => `  ${o.file}: ${o.problems.join("; ")}`)
+      .join("\n")}`,
+  );
+});


### PR DESCRIPTION
## Summary

- AGENTS.md § "No Untracked Sleeps In E2E" states in passing that every Playwright config here pins `retries: 0, workers: 1` on purpose — specs truncate the DB (`resetStack()`) or share one OpenClaw session, so a flake is a signal and a retry/extra worker would silently hide it. Nothing enforced that claim: a well-meaning `retries: 2` in one of the configs would turn the flake signal off while CI stayed green.
- New `scripts/lib/playwright-config-pins.mjs` discovers every `playwright*.config.ts` under `packages/web` and checks each pins `retries: 0` and `workers: 1`, and does not set `fullyParallel: true` (which would race specs within one file against a stack they assume is exclusively theirs).
- **All 9 real configs already comply** — no config file is changed by this PR.

## Review fixes (2nd commit)

The first commit implemented the check as a first-match regex over the config source. Review found that reads a comment as configuration, in both directions, reproducibly:

```
// retries: 0
retries: 2,        -> no problem reported

// retries: 0
(pin deleted)      -> no problem reported
```

That is the "reports on the presence of a string" failure AGENTS.md keeps naming — and the likeliest next commit here, since the guard's own error messages tell a developer to write `retries: 0`.

- **Tokenizer instead of regex.** `extractConfigEntries` skips comments and string literals and tracks brace depth. String skipping is load-bearing too: `baseURL: "http://localhost:7778"` in the real `playwright.config.ts` would otherwise start a comment.
- **Per-project overrides.** Playwright honours `retries`/`fullyParallel` per project, so `projects: [{ retries: 3 }]` defeated the top-level pin while leaving it visibly intact. Both keys are now checked at every nesting depth; `workers` has no project-level form and stays top-level.
- **Scope was wrong — and it mattered.** Discovery was a package-root `readdir`, and there is a **ninth** config one directory down: `packages/web/eval/playwright.eval.config.ts`, run by `pnpm eval:selftest` in CI. It was never checked. The walk is recursive now, and `configsReferencedByScripts` cross-checks every config a `packages/web` script actually invokes against what discovery reached — a corpus floor structurally cannot see that gap, so it stays only as a found-nothing backstop.
- **Dropped a false claim** from a failure message: Playwright's own `retries` default is 0, so an absent pin does not by itself cause reruns. The pin is what makes a later `retries: 2` a reviewable edit.
- **Documented the guard in AGENTS.md** § "No Untracked Sleeps In E2E", where the claim it enforces already lived.

## Test plan

- [x] TDD: `node --test scripts/lib/playwright-config-pins.test.mjs` written first against fixtures — confirmed red (module not found), then implemented — confirmed green.
- [x] The four comment/scope regression tests were run **against the previous implementation first** and passed vacuously there, so each one is a real reproduction rather than a restatement of the code.
- [x] Canaries mutate the *real* `playwright.config.ts` (comments, `testIgnore` array, `webServer.command` megastring, a `baseURL` containing `//`) rather than only a five-line fixture.
- [x] `pnpm test:scripts` — 917 passed, 0 failed.
- [x] `pnpm format:check` — clean.