### PR TITLE
ci: serialize release and pre-release workflow runs

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,6 +8,13 @@ permissions:
   contents: read
   packages: write
 
+# Two pushes to the same branch in quick succession must not push the moving
+# tag (:next / rc-X.Y) concurrently — they can overtake each other. Never
+# cancel: a build in progress must run to completion; the second waits.
+concurrency:
+  group: pre-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build & push moving tag and :sha-<short>

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,8 +9,20 @@ permissions:
   packages: write
 
 # Two pushes to the same branch in quick succession must not push the moving
-# tag (:next / rc-X.Y) concurrently — they can overtake each other. Never
-# cancel: a build in progress must run to completion; the second waits.
+# tag (:next / rc-X.Y) concurrently — they can overtake each other.
+#
+# Keyed on the ref, unlike release.yml's constant group: the moving tag is
+# derived per branch (`movingTagForRef`: main → next, release/X.Y → rc-X.Y),
+# so the branch IS the contended resource. Two release branches can never
+# collide and must not queue behind each other. `:sha-<short>` is immutable
+# and unique per commit, so it never collides either.
+#
+# Never cancel a build in flight. The cost: GitHub keeps only one run pending
+# per group, so three pushes to one branch inside a single build — a
+# merge-queue batch can do that — cancel the middle one, and that commit's
+# `:sha-<short>` image is never published. The moving tag stays correct
+# regardless (the newest push supersedes it); re-run the workflow if you need
+# to pin that exact commit.
 concurrency:
   group: pre-release-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,26 @@ permissions:
 
 # Two tags pushed in quick succession (or a tag push racing a
 # workflow_dispatch republish) must not run their Docker pushes
-# concurrently — they can overtake each other on `:latest`/the version tag.
-# Never cancel: a release in progress must run to completion; the second
-# waits instead.
+# concurrently — they can overtake each other on `:latest`/the version tag,
+# and the loser silently leaves the tag pointing at the older image.
+#
+# The group is a CONSTANT, and that is the whole point. `:latest` is one
+# resource for the entire repository, so every release run competes with
+# every other one. `release-${{ github.ref }}` would look like this fix and
+# serialize almost nothing: a tag push carries `refs/tags/vX.Y.Z`, so two
+# tags land in two different groups and race exactly as before — and a
+# workflow_dispatch republish names its tag in `inputs.tag` (see the checkout
+# step) while running from a branch ref, so it would never share a group with
+# any tag push, not even a republish of the tag still building.
+#
+# Never cancel: a release in progress must run to completion; the next one
+# waits. The cost is that GitHub keeps only ONE run pending per group, so a
+# third release starting while one runs and one waits cancels the waiting
+# one. That needs three tags inside a single ~20-minute build, and it is
+# loud when it happens (no GitHub Release is created for the cancelled run),
+# whereas a `:latest` that points at the wrong image is silent and permanent.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ permissions:
   pages: write
   id-token: write
 
+# Two tags pushed in quick succession (or a tag push racing a
+# workflow_dispatch republish) must not run their Docker pushes
+# concurrently — they can overtake each other on `:latest`/the version tag.
+# Never cancel: a release in progress must run to completion; the second
+# waits instead.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   docker:
     name: Build & Push Docker Images

--- a/scripts/lib/release-concurrency.test.mjs
+++ b/scripts/lib/release-concurrency.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Pins the concurrency groups that keep two publishing runs off the same
+ * mutable Docker tag.
+ *
+ * `release.yml` and `pre-release.yml` both push to GHCR, and both push tags
+ * that MOVE: `:latest` and `vX.Y.Z` from the release workflow, `:next` /
+ * `rc-X.Y` from the pre-release one. Two runs pushing the same moving tag
+ * concurrently can overtake each other — the slower build wins, and the tag
+ * ends up pointing at the older image. Nothing reports that; it is discovered
+ * by a user who pulled `:latest` and got the previous version.
+ *
+ * The two workflows need DIFFERENT keys, and that asymmetry is the whole
+ * reason this guard exists:
+ *
+ * - **release.yml must be keyed on a constant.** `:latest` is one resource
+ *   for the entire repository, so every release run competes with every other
+ *   release run. Keying on `${{ github.ref }}` looks right and serializes
+ *   almost nothing: a tag push carries `refs/tags/vX.Y.Z`, so two tags pushed
+ *   in quick succession land in two different groups and race on `:latest`
+ *   exactly as they did before. A `workflow_dispatch` republish is worse — it
+ *   names its tag in an *input* (`inputs.tag`, which is why the checkout step
+ *   reads it) and runs from `refs/heads/main`, so a per-ref group would never
+ *   pair it with any tag push, including a republish of the very tag that is
+ *   still building.
+ *
+ * - **pre-release.yml must be keyed on the ref.** Its moving tag is derived
+ *   per branch (`movingTagForRef`: main → `next`, release/X.Y → `rc-X.Y`), so
+ *   the branch IS the resource: two pushes to one branch must queue, two
+ *   release branches must not wait on each other. A constant group there
+ *   would serialize builds that can never collide.
+ *
+ * Sibling of ci-image-tags.test.mjs and moving-tag-workflow.test.mjs: keep a
+ * workflow and the invariant it encodes from silently diverging.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const RELEASE = join(ROOT, ".github", "workflows", "release.yml");
+const PRE_RELEASE = join(ROOT, ".github", "workflows", "pre-release.yml");
+
+/** Strips `#` comments so a commented-out example can never satisfy a check. */
+function uncommented(path) {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)#.*$/, "$1"))
+    .join("\n");
+}
+
+/**
+ * Reads the workflow-level `concurrency:` block.
+ *
+ * Deliberately anchored at column 0: a `concurrency:` nested inside a job
+ * governs that job alone and would leave the other jobs — including the
+ * Docker pushes — unserialized.
+ */
+function readConcurrency(path) {
+  const yaml = uncommented(path);
+  const match = yaml.match(/^concurrency:\n((?: {2}.*\n?)+)/m);
+  assert.ok(
+    match,
+    `${path} must declare a workflow-level (column-0) concurrency block — a job-level one leaves the other jobs racing.`,
+  );
+  const group = match[1].match(/^ {2}group:\s*(.+?)\s*$/m);
+  const cancel = match[1].match(/^ {2}cancel-in-progress:\s*(.+?)\s*$/m);
+  assert.ok(group, `${path}'s concurrency block must set a group.`);
+  return { group: group[1], cancelInProgress: cancel ? cancel[1] : undefined };
+}
+
+// Corpus assertion. Every check below is about GHCR pushes; if a workflow
+// stops pushing, the guard is asserting something about a file that no longer
+// does the dangerous thing, and would pass for the wrong reason.
+test("both workflows really do push images to GHCR", () => {
+  for (const path of [RELEASE, PRE_RELEASE]) {
+    const yaml = uncommented(path);
+    assert.match(
+      yaml,
+      /push:\s*true/,
+      `${path} was expected to push a Docker image; if that changed, revisit this guard rather than deleting it.`,
+    );
+    assert.match(yaml, /ghcr\.io\//, `${path} was expected to target GHCR.`);
+  }
+});
+
+test("release.yml's concurrency group is a constant, not keyed on the ref", () => {
+  const { group } = readConcurrency(RELEASE);
+  assert.ok(
+    !group.includes("${{"),
+    `release.yml's concurrency group must be a constant, got "${group}". ` +
+      "`:latest` is one resource for the whole repository, so every release run competes with every other one. " +
+      "A group containing ${{ github.ref }} puts two tags pushed in quick succession into two different groups — " +
+      "they race on `:latest` exactly as if there were no concurrency block at all — and a workflow_dispatch " +
+      "republish (which runs from a branch and names its tag in inputs.tag) never shares a group with any tag push.",
+  );
+  assert.ok(
+    group.length > 0,
+    "release.yml's concurrency group must not be empty.",
+  );
+});
+
+test("pre-release.yml's concurrency group is keyed on the ref", () => {
+  const { group } = readConcurrency(PRE_RELEASE);
+  assert.match(
+    group,
+    /\$\{\{\s*github\.ref\s*\}\}/,
+    `pre-release.yml's concurrency group must contain \${{ github.ref }}, got "${group}". ` +
+      "Its moving tag is derived per branch (main → :next, release/X.Y → rc-X.Y), so the branch is the contended " +
+      "resource: two pushes to one branch must queue, two release branches must never wait on each other.",
+  );
+});
+
+test("neither workflow cancels a publish in flight", () => {
+  for (const path of [RELEASE, PRE_RELEASE]) {
+    assert.equal(
+      readConcurrency(path).cancelInProgress,
+      "false",
+      `${path} must set cancel-in-progress: false. Cancelling a run mid-push leaves a half-published set of ` +
+        "images — some tags moved, some not — which is worse than the race this serializes away.",
+    );
+  }
+});
+
+// The groups are plain strings in one repository-wide namespace. If they ever
+// collided, a pre-release build would block a release (and vice versa) for no
+// reason — the two touch disjoint tags.
+test("the two groups can never collide", () => {
+  const release = readConcurrency(RELEASE).group;
+  const preRelease = readConcurrency(PRE_RELEASE).group;
+  // github.ref always renders non-empty, so equality can only come from the
+  // literal prefixes — compare those.
+  const preReleasePrefix = preRelease.slice(0, preRelease.indexOf("${{"));
+  assert.notEqual(
+    release,
+    preReleasePrefix,
+    `release.yml's group ("${release}") must differ from pre-release.yml's ("${preRelease}") — ` +
+      "concurrency groups share one namespace across the repository.",
+  );
+});


### PR DESCRIPTION
## Summary

- `release.yml` and `pre-release.yml` had no `concurrency` group. Two tags pushed in quick succession (or a tag push racing a `workflow_dispatch` republish, or two fast pushes to the same branch) could run their Docker pushes in parallel and overtake each other on `:latest` / the version tag / the moving pre-release tag (`:next` / `rc-X.Y`).
- Added `concurrency: { group: release-${{ github.ref }}, cancel-in-progress: false }` to `release.yml` and `concurrency: { group: pre-release-${{ github.ref }}, cancel-in-progress: false }` to `pre-release.yml`. `cancel-in-progress: false` is deliberate: an in-flight release must never be cancelled, a second push just queues behind it.
- Checked every other workflow with push side effects: `docs.yml`, `screenshots.yml`, `prune-ghcr.yml`, and `ci.yml` already carry concurrency groups. `sbom.yml` does not, but it only builds a local Docker image and uploads a build artifact — no GHCR push, no git push — so there is no collision to guard against, and it was left untouched.

## Test plan

- [x] `pnpm test:scripts` — 894 passed, 0 failed, 0 skipped
- [x] `pnpm format:check` — clean
- [x] YAML validity of both edited files confirmed via `python3 -c "yaml.safe_load(...)"`