### PR TITLE
fix(security): require explicit insecure-mock flags for gmail/graph/brave base-url overrides

### DIFF
--- a/docker-compose.email-test.yml
+++ b/docker-compose.email-test.yml
@@ -63,3 +63,9 @@ services:
       # The pinchy-email plugin (running inside OpenClaw) calls the provider APIs.
       - GMAIL_API_BASE_URL=http://gmail-mock:9004
       - GRAPH_API_BASE_URL=http://graph-mock:9005
+      # Both *_API_BASE_URL overrides above only take effect alongside this
+      # explicit flag (gmail-adapter.ts / graph-adapter.ts), so a stray
+      # override left over in production can never silently redirect an
+      # OAuth-authenticated API call. Same convention as
+      # docker-compose.imap-test.yml's PINCHY_INSECURE_MAIL_MOCK.
+      - PINCHY_INSECURE_MAIL_MOCK=1

--- a/docker-compose.email-test.yml
+++ b/docker-compose.email-test.yml
@@ -52,6 +52,13 @@ services:
       - MICROSOFT_OAUTH_BASE_URL=http://graph-mock:9005
       # The OAuth callback and connection probe fetch the user profile from Graph.
       - GRAPH_API_BASE_URL=http://graph-mock:9005
+      # All three overrides above only take effect alongside this explicit flag
+      # (insecure-mock-base-url.ts). Pinchy — not OpenClaw — holds the OAuth
+      # client secret and the refresh tokens, so an unflagged *_OAUTH_BASE_URL
+      # left over in production would redirect strictly more than the plugin
+      # side does. Same convention as docker-compose.imap-test.yml, which
+      # already sets this flag on both services.
+      - PINCHY_INSECURE_MAIL_MOCK=1
     extra_hosts:
       # Allows Pinchy (Docker) to fetch the Ollama model list from fake-Ollama on
       # the host during regenerateOpenClawConfig(). OpenClaw already has this

--- a/docker-compose.eval.yml
+++ b/docker-compose.eval.yml
@@ -52,6 +52,11 @@ services:
       # endpoint.
       - MICROSOFT_OAUTH_BASE_URL=http://graph-mock:9005
       - GRAPH_API_BASE_URL=http://graph-mock:9005
+      # Both overrides above only take effect alongside this explicit flag
+      # (insecure-mock-base-url.ts). Pinchy holds the OAuth client secret and
+      # the refresh tokens, so an unflagged *_OAUTH_BASE_URL left over in
+      # production would redirect strictly more than the plugin side does.
+      - PINCHY_INSECURE_MAIL_MOCK=1
       # Passed through so `models` mode can seed settings.ollama_cloud_api_key
       # without baking a real key into the image or compose file.
       - OLLAMA_CLOUD_API_KEY=${OLLAMA_CLOUD_API_KEY:-}

--- a/docker-compose.eval.yml
+++ b/docker-compose.eval.yml
@@ -81,6 +81,11 @@ services:
       # The pinchy-email plugin (running inside OpenClaw) calls the Graph API
       # directly for attachment downloads.
       - GRAPH_API_BASE_URL=http://graph-mock:9005
+      # GRAPH_API_BASE_URL above only takes effect alongside this explicit
+      # flag (graph-adapter.ts), so a stray override left over in production
+      # can never silently redirect an OAuth-authenticated API call. Same
+      # convention as docker-compose.imap-test.yml's PINCHY_INSECURE_MAIL_MOCK.
+      - PINCHY_INSECURE_MAIL_MOCK=1
       # #723 governed-tools comparison sweep: the pinchy-odoo write guards
       # (duplicate guard #721 + read-back #720) are read from this env at guard
       # time. Default "enforced" = governed arm; set PINCHY_ODOO_GOVERNANCE=off

--- a/docker-compose.web-test.yml
+++ b/docker-compose.web-test.yml
@@ -35,3 +35,8 @@ services:
   openclaw:
     environment:
       - BRAVE_API_BASE_URL=http://brave-mock:9003
+      # BRAVE_API_BASE_URL above only takes effect alongside this explicit
+      # flag (brave-search.ts), so a stray override left over in production
+      # can never silently redirect the Brave API key. Same convention as
+      # docker-compose.imap-test.yml's PINCHY_INSECURE_MAIL_MOCK.
+      - PINCHY_INSECURE_WEB_MOCK=1

--- a/packages/plugins/pinchy-email/__tests__/email-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/email-adapter.test.ts
@@ -193,7 +193,7 @@ describe("resolveInsecureMockBaseUrl", () => {
     );
   });
 
-  it("warns exactly once per overrideVar when the override is set without the flag", () => {
+  it("warns only once for a repeated read of the same override var", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
 
@@ -204,6 +204,36 @@ describe("resolveInsecureMockBaseUrl", () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain("GMAIL_API_BASE_URL");
     expect(warn.mock.calls[0][0]).toContain("PINCHY_INSECURE_MAIL_MOCK");
+  });
+
+  it("warns separately for each distinct override var", () => {
+    // The dedupe is keyed by override var — that is the whole point of the Set.
+    // Repeating ONE var proves the "once" half and says nothing about the "per
+    // var" half: a plain boolean would pass that test while reporting the Gmail
+    // override and then staying silent about the Graph one for the rest of the
+    // process.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    const messages = warn.mock.calls.map((c) => c[0]).join("\n");
+    expect(messages).toContain("GMAIL_API_BASE_URL");
+    expect(messages).toContain("GRAPH_API_BASE_URL");
+  });
+
+  it("treats an empty override as unset, and does not warn about it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GMAIL_API_BASE_URL", "");
+    expect(resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK")).toBe(
+      undefined
+    );
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("does not warn when the override is not set", () => {

--- a/packages/plugins/pinchy-email/__tests__/email-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/email-adapter.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   createFolderMapper,
   escapeDoubleQuoted,
   stripHtml,
   truncateEmailBody,
   EMAIL_BODY_MAX_CHARS,
+  resolveInsecureMockBaseUrl,
+  resetInsecureMockWarningsForTest,
   type Folder,
 } from "../email-adapter.js";
 
@@ -149,5 +151,72 @@ describe("truncateEmailBody", () => {
 
   it("honours an explicit budget", () => {
     expect(truncateEmailBody("abcdefghij", 4).startsWith("abcd")).toBe(true);
+  });
+});
+
+describe("resolveInsecureMockBaseUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetInsecureMockWarningsForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when the override var is not set", () => {
+    expect(resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK")).toBe(
+      undefined
+    );
+  });
+
+  it("ignores the override and returns undefined when the insecure flag is absent", () => {
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    // No PINCHY_INSECURE_MAIL_MOCK: a stray override left over in production
+    // must not silently redirect API calls (and the bearer token sent with
+    // them) to whatever host it names.
+    expect(resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK")).toBe(
+      undefined
+    );
+  });
+
+  it("returns the override when the insecure flag is also set", () => {
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+    expect(resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK")).toBe(
+      "http://gmail-mock:9004"
+    );
+  });
+
+  it('ignores the override when the insecure flag is set to something other than exactly "1"', () => {
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "true");
+    expect(resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK")).toBe(
+      undefined
+    );
+  });
+
+  it("warns exactly once per overrideVar when the override is set without the flag", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("GMAIL_API_BASE_URL");
+    expect(warn.mock.calls[0][0]).toContain("PINCHY_INSECURE_MAIL_MOCK");
+  });
+
+  it("does not warn when the override is not set", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when the override is set together with the flag", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resetInsecureMockWarningsForTest } from "../email-adapter.js";
 
 // Mock googleapis before importing the adapter
 const mockList = vi.fn();
@@ -42,6 +43,7 @@ vi.mock("googleapis", () => {
 });
 
 import { GmailAdapter } from "../gmail-adapter.js";
+import { google } from "googleapis";
 
 // Helper: base64url encode a string
 function base64url(str: string): string {
@@ -1068,5 +1070,47 @@ describe("GmailAdapter", () => {
       expect(options.timeout).toBe(120_000);
       expect(options.timeout).toBeGreaterThan(30_000);
     });
+  });
+});
+
+describe("GmailAdapter mock env overrides", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetInsecureMockWarningsForTest();
+  });
+
+  it("does not pass rootUrl when GMAIL_API_BASE_URL is not set", () => {
+    new GmailAdapter({ accessToken: "test-token" });
+
+    expect(google.gmail).toHaveBeenCalledWith(
+      expect.not.objectContaining({ rootUrl: expect.anything() })
+    );
+  });
+
+  it("ignores GMAIL_API_BASE_URL and uses the real API host when the insecure flag is absent", () => {
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    // No PINCHY_INSECURE_MAIL_MOCK: the mock seam must NOT fire, so a stray
+    // override left over in production can't redirect the OAuth token.
+
+    new GmailAdapter({ accessToken: "test-token" });
+
+    expect(google.gmail).toHaveBeenCalledWith(
+      expect.not.objectContaining({ rootUrl: expect.anything() })
+    );
+  });
+
+  it("passes rootUrl from GMAIL_API_BASE_URL when the insecure flag is also set", () => {
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+
+    new GmailAdapter({ accessToken: "test-token" });
+
+    expect(google.gmail).toHaveBeenCalledWith(
+      expect.objectContaining({ rootUrl: "http://gmail-mock:9004" })
+    );
   });
 });

--- a/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { GraphAdapter } from "../graph-adapter.js";
+import { resetInsecureMockWarningsForTest } from "../email-adapter.js";
 
 describe("GraphAdapter.list", () => {
   beforeEach(() => {
@@ -9,6 +10,8 @@ describe("GraphAdapter.list", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     delete process.env.GRAPH_API_BASE_URL;
+    delete process.env.PINCHY_INSECURE_MAIL_MOCK;
+    resetInsecureMockWarningsForTest();
   });
 
   it("list({folder:'INBOX'}) hits /v1.0/me/mailFolders/inbox/messages", async () => {
@@ -102,8 +105,9 @@ describe("GraphAdapter.list", () => {
     timeoutSpy.mockRestore();
   });
 
-  it("uses GRAPH_API_BASE_URL when set", async () => {
+  it("uses GRAPH_API_BASE_URL when set together with the insecure flag", async () => {
     process.env.GRAPH_API_BASE_URL = "http://graph-mock:9005";
+    process.env.PINCHY_INSECURE_MAIL_MOCK = "1";
     const adapter = new GraphAdapter({ accessToken: "tok" });
     (fetch as Mock).mockResolvedValueOnce({
       ok: true,
@@ -114,7 +118,22 @@ describe("GraphAdapter.list", () => {
       expect.stringContaining("http://graph-mock:9005/v1.0/me/mailFolders/inbox/messages"),
       expect.any(Object)
     );
-    delete process.env.GRAPH_API_BASE_URL;
+  });
+
+  it("ignores GRAPH_API_BASE_URL and uses the real API host when the insecure flag is absent", async () => {
+    process.env.GRAPH_API_BASE_URL = "http://graph-mock:9005";
+    // No PINCHY_INSECURE_MAIL_MOCK: the mock seam must NOT fire, so a stray
+    // override left over in production can't redirect the bearer token.
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: [] }),
+    });
+    await adapter.list({});
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages"),
+      expect.any(Object)
+    );
   });
 });
 

--- a/packages/plugins/pinchy-email/email-adapter.ts
+++ b/packages/plugins/pinchy-email/email-adapter.ts
@@ -1,5 +1,42 @@
 export type Folder = "INBOX" | "SENT" | "DRAFTS" | "TRASH" | "SPAM";
 
+// Tracks which mock-override env vars we've already warned about in this
+// process, so a leftover override doesn't spam the log on every tool call.
+const warnedMockOverrides = new Set<string>();
+
+// Returns `overrideVar`'s value, but ONLY when `flagVar` is explicitly "1".
+// Shared by the Gmail and Graph adapters, which both accept a *_API_BASE_URL
+// override so E2E tests can redirect API calls to a local mock server.
+// Without the paired flag, the override is ignored (the caller falls back to
+// the real API host) and a one-time warning is logged — mirroring the
+// IMAP/SMTP mock seam in imap-adapter.ts, which requires the same
+// PINCHY_INSECURE_MAIL_MOCK flag for the same reason: a *_API_BASE_URL
+// carried into production by accident must not silently redirect
+// OAuth-authenticated API calls (and the bearer token sent with them) to
+// whatever host it names.
+export function resolveInsecureMockBaseUrl(
+  overrideVar: string,
+  flagVar: string
+): string | undefined {
+  const override = process.env[overrideVar];
+  if (!override) return undefined;
+  if (process.env[flagVar] === "1") return override;
+  if (!warnedMockOverrides.has(overrideVar)) {
+    warnedMockOverrides.add(overrideVar);
+    console.warn(
+      `[pinchy-email] ${overrideVar} is set but ${flagVar} is not "1" — ignoring it and using the ` +
+        `real API host. If this is a test/mock stack, also set ${flagVar}=1.`
+    );
+  }
+  return undefined;
+}
+
+// Test-only: clears the warn-once dedupe so a test can assert the warning
+// fires again after resetting env stubs.
+export function resetInsecureMockWarningsForTest(): void {
+  warnedMockOverrides.clear();
+}
+
 // Escape a value for embedding inside a double-quoted query string: backslashes
 // BEFORE quotes so a trailing "\" can't escape the closing quote. Used by both
 // the Gmail query builder and the Graph $search KQL builder; each adapter keeps

--- a/packages/plugins/pinchy-email/gmail-adapter.ts
+++ b/packages/plugins/pinchy-email/gmail-adapter.ts
@@ -1,5 +1,10 @@
 import { google } from "googleapis";
-import { createFolderMapper, escapeDoubleQuoted, stripHtml } from "./email-adapter.js";
+import {
+  createFolderMapper,
+  escapeDoubleQuoted,
+  resolveInsecureMockBaseUrl,
+  stripHtml,
+} from "./email-adapter.js";
 import type {
   EmailAdapter,
   EmailAttachment,
@@ -80,8 +85,10 @@ export class GmailAdapter implements EmailAdapter {
     const auth = new google.auth.OAuth2();
     auth.setCredentials({ access_token: opts.accessToken });
     // GMAIL_API_BASE_URL allows E2E tests to redirect gmail API calls to a
-    // local mock server instead of https://gmail.googleapis.com/
-    const rootUrl = process.env.GMAIL_API_BASE_URL;
+    // local mock server instead of https://gmail.googleapis.com/. Only takes
+    // effect alongside PINCHY_INSECURE_MAIL_MOCK=1 — see
+    // resolveInsecureMockBaseUrl in email-adapter.ts.
+    const rootUrl = resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK");
     this.gmail = google.gmail({
       version: "v1",
       auth,

--- a/packages/plugins/pinchy-email/graph-adapter.ts
+++ b/packages/plugins/pinchy-email/graph-adapter.ts
@@ -1,4 +1,9 @@
-import { createFolderMapper, escapeDoubleQuoted, stripHtml } from "./email-adapter.js";
+import {
+  createFolderMapper,
+  escapeDoubleQuoted,
+  resolveInsecureMockBaseUrl,
+  stripHtml,
+} from "./email-adapter.js";
 import type {
   EmailAdapter,
   EmailAttachment,
@@ -137,8 +142,15 @@ function toSummary(m: GraphMessage): EmailSummary {
 export class GraphAdapter implements EmailAdapter {
   constructor(private opts: { accessToken: string }) {}
 
+  // GRAPH_API_BASE_URL allows E2E tests to redirect Graph API calls to a
+  // local mock server instead of https://graph.microsoft.com. Only takes
+  // effect alongside PINCHY_INSECURE_MAIL_MOCK=1 — see
+  // resolveInsecureMockBaseUrl in email-adapter.ts.
   private graphBase(): string {
-    return process.env.GRAPH_API_BASE_URL ?? "https://graph.microsoft.com";
+    return (
+      resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL", "PINCHY_INSECURE_MAIL_MOCK") ??
+      "https://graph.microsoft.com"
+    );
   }
 
   // `signal` is deliberately not accepted. The earlier shape took one and did

--- a/packages/plugins/pinchy-web/brave-search.test.ts
+++ b/packages/plugins/pinchy-web/brave-search.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { braveSearch } from "./brave-search.js";
+import { braveSearch, resetBraveBaseUrlWarningForTest } from "./brave-search.js";
 
 describe("braveSearch", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
@@ -317,5 +317,72 @@ describe("braveSearch", () => {
       expect(results).toHaveLength(2);
       expect(filteredCount).toBeUndefined();
     });
+  });
+});
+
+describe("braveSearch mock env overrides", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ web: { results: [] } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    resetBraveBaseUrlWarningForTest();
+  });
+
+  it("uses the real API host when BRAVE_API_BASE_URL is not set", async () => {
+    await braveSearch("query", { apiKey: "key" });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("https://api.search.brave.com/res/v1/web/search");
+  });
+
+  it("ignores BRAVE_API_BASE_URL and uses the real API host when PINCHY_INSECURE_WEB_MOCK is absent", async () => {
+    vi.stubEnv("BRAVE_API_BASE_URL", "http://brave-mock:9003");
+    // No PINCHY_INSECURE_WEB_MOCK: the mock seam must NOT fire, so a stray
+    // override left over in production can't redirect the Brave API key.
+
+    await braveSearch("query", { apiKey: "key" });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("https://api.search.brave.com/res/v1/web/search");
+  });
+
+  it("uses BRAVE_API_BASE_URL when PINCHY_INSECURE_WEB_MOCK is also set", async () => {
+    vi.stubEnv("BRAVE_API_BASE_URL", "http://brave-mock:9003");
+    vi.stubEnv("PINCHY_INSECURE_WEB_MOCK", "1");
+
+    await braveSearch("query", { apiKey: "key" });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("http://brave-mock:9003/res/v1/web/search");
+  });
+
+  it("warns exactly once when BRAVE_API_BASE_URL is set without the insecure flag", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("BRAVE_API_BASE_URL", "http://brave-mock:9003");
+
+    await braveSearch("query", { apiKey: "key" });
+    await braveSearch("query", { apiKey: "key" });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("BRAVE_API_BASE_URL");
+    expect(warn.mock.calls[0][0]).toContain("PINCHY_INSECURE_WEB_MOCK");
+    warn.mockRestore();
+  });
+
+  it("does not warn when BRAVE_API_BASE_URL is set together with the insecure flag", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("BRAVE_API_BASE_URL", "http://brave-mock:9003");
+    vi.stubEnv("PINCHY_INSECURE_WEB_MOCK", "1");
+
+    await braveSearch("query", { apiKey: "key" });
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/packages/plugins/pinchy-web/brave-search.ts
+++ b/packages/plugins/pinchy-web/brave-search.ts
@@ -4,6 +4,41 @@ import { domainDenialReason } from "./web-fetch.js";
 // Matches web-fetch.ts's external-call timeout.
 const FETCH_TIMEOUT_MS = 30_000;
 
+// Tracks whether we've already warned about a mock-override env var set
+// without its paired insecure-mock flag, so a leftover override doesn't spam
+// the log on every tool call.
+let warnedAboutBraveBaseUrlOverride = false;
+
+// Returns BRAVE_API_BASE_URL, but ONLY when PINCHY_INSECURE_WEB_MOCK is
+// explicitly "1". BRAVE_API_BASE_URL lets E2E tests redirect Brave Search
+// calls to a local mock server instead of https://api.search.brave.com.
+// Without the flag, the override is ignored (the real API host is used) and
+// a one-time warning is logged — same seam and same reasoning as the mail
+// adapters' PINCHY_INSECURE_MAIL_MOCK (see resolveInsecureMockBaseUrl in
+// pinchy-email/email-adapter.ts): a *_API_BASE_URL carried into production
+// by accident must not silently redirect the Brave API key to whatever host
+// it names.
+function resolveBraveBaseUrl(): string {
+  const override = process.env.BRAVE_API_BASE_URL;
+  if (!override) return "https://api.search.brave.com";
+  if (process.env.PINCHY_INSECURE_WEB_MOCK === "1") return override;
+  if (!warnedAboutBraveBaseUrlOverride) {
+    warnedAboutBraveBaseUrlOverride = true;
+    console.warn(
+      '[pinchy-web] BRAVE_API_BASE_URL is set but PINCHY_INSECURE_WEB_MOCK is not "1" — ignoring ' +
+        "it and using the real API host. If this is a test/mock stack, also set " +
+        "PINCHY_INSECURE_WEB_MOCK=1."
+    );
+  }
+  return "https://api.search.brave.com";
+}
+
+// Test-only: clears the warn-once dedupe so a test can assert the warning
+// fires again after resetting env stubs.
+export function resetBraveBaseUrlWarningForTest(): void {
+  warnedAboutBraveBaseUrlOverride = false;
+}
+
 export interface BraveSearchConfig {
   apiKey: string;
   allowedDomains?: string[];
@@ -59,7 +94,7 @@ export async function braveSearch(
   if (config.language) params.set("search_lang", config.language);
   if (config.freshness) params.set("freshness", config.freshness);
 
-  const BRAVE_SEARCH_BASE_URL = process.env.BRAVE_API_BASE_URL ?? "https://api.search.brave.com";
+  const BRAVE_SEARCH_BASE_URL = resolveBraveBaseUrl();
 
   const res = await fetch(`${BRAVE_SEARCH_BASE_URL}/res/v1/web/search?${params}`, {
     headers: {

--- a/packages/web/src/__tests__/api/oauth-callback.test.ts
+++ b/packages/web/src/__tests__/api/oauth-callback.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resetInsecureMockWarningsForTest } from "@/lib/integrations/insecure-mock-base-url";
 
 const {
   mockGetSession,
@@ -935,8 +936,9 @@ describe("GET /api/integrations/oauth/callback", () => {
       );
     });
 
-    it("uses MICROSOFT_OAUTH_BASE_URL env override for token endpoint", async () => {
+    it("uses MICROSOFT_OAUTH_BASE_URL env override for token endpoint when the insecure flag is set", async () => {
       vi.stubEnv("MICROSOFT_OAUTH_BASE_URL", "https://mock-ms-auth.local");
+      vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
       mockFetch
         .mockResolvedValueOnce(mockMsTokenExchange())
         .mockResolvedValueOnce(mockMsProfileFetch());
@@ -951,6 +953,30 @@ describe("GET /api/integrations/oauth/callback", () => {
       const tokenCall = mockFetch.mock.calls[0];
       expect(tokenCall[0]).toBe("https://mock-ms-auth.local/my-tenant/oauth2/v2.0/token");
       vi.unstubAllEnvs();
+    });
+
+    it("ignores MICROSOFT_OAUTH_BASE_URL for the token endpoint when the insecure flag is absent", async () => {
+      // The end-to-end shape of the seam: this exchange POSTs the client secret
+      // and the authorization code, so a stray override reaching the callback
+      // route must not redirect it. Guards the route, not just the descriptor.
+      vi.stubEnv("MICROSOFT_OAUTH_BASE_URL", "https://mock-ms-auth.local");
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      resetInsecureMockWarningsForTest();
+      mockFetch
+        .mockResolvedValueOnce(mockMsTokenExchange())
+        .mockResolvedValueOnce(mockMsProfileFetch());
+
+      await GET(
+        makeRequest(
+          { code: "ms-auth-code", state: VALID_STATE },
+          `oauth_state=${VALID_STATE}; oauth_pending_id=ms-pending-conn-id`
+        )
+      );
+
+      const tokenCall = mockFetch.mock.calls[0];
+      expect(tokenCall[0]).toBe("https://login.microsoftonline.com/my-tenant/oauth2/v2.0/token");
+      vi.unstubAllEnvs();
+      resetInsecureMockWarningsForTest();
     });
 
     it("defaults to tenantId='organizations' when tenantId is missing", async () => {

--- a/packages/web/src/__tests__/lib/email-workflows/ports/gmail.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/gmail.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { mapGmailMessage, createGmailPort } from "@/lib/email-workflows/ports/gmail";
+import { resetInsecureMockWarningsForTest } from "@/lib/integrations/insecure-mock-base-url";
 
 const credentials = {
   accessToken: "test-access-token",
@@ -134,6 +135,41 @@ describe("Gmail port — mapGmailMessage", () => {
     // The inline logo is the HTML body's own image — counting it would fire
     // every workflow's hasAttachment filter on ordinary newsletters.
     expect(mapped.attachments).toEqual([{ mimeType: "application/pdf", filename: "invoice.pdf" }]);
+  });
+});
+
+describe("Gmail port — mock base-url override", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValue(jsonResponse({ messages: [] }));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    vi.unstubAllEnvs();
+    resetInsecureMockWarningsForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("ignores GMAIL_API_BASE_URL and calls the real Gmail host when the insecure flag is absent", async () => {
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    // No PINCHY_INSECURE_MAIL_MOCK: the sweep sends the stored access token.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await createGmailPort(credentials).search({ sinceDays: 14, folder: "INBOX", limit: 50 });
+
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("https://gmail.googleapis.com/gmail/");
+  });
+
+  it("uses GMAIL_API_BASE_URL when the insecure flag is set", async () => {
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+
+    await createGmailPort(credentials).search({ sinceDays: 14, folder: "INBOX", limit: 50 });
+
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("http://gmail-mock:9004/gmail/");
   });
 });
 

--- a/packages/web/src/__tests__/lib/email-workflows/ports/graph.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/ports/graph.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { mapGraphMessage, createGraphPort } from "@/lib/email-workflows/ports/graph";
+import { resetInsecureMockWarningsForTest } from "@/lib/integrations/insecure-mock-base-url";
 
 const credentials = {
   accessToken: "test-access-token",
@@ -143,6 +144,41 @@ describe("Graph port — immutable ids", () => {
     await port.read("m1");
 
     expect(headersOf(0).get("Prefer")).toBe('IdType="ImmutableId"');
+  });
+});
+
+describe("Graph port — mock base-url override", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValue(jsonResponse({ value: [] }));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    vi.unstubAllEnvs();
+    resetInsecureMockWarningsForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("ignores GRAPH_API_BASE_URL and calls the real Graph host when the insecure flag is absent", async () => {
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+    // No PINCHY_INSECURE_MAIL_MOCK: the sweep sends the stored access token.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await createGraphPort(credentials).search({ sinceDays: 14, folder: "inbox", limit: 50 });
+
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("https://graph.microsoft.com/v1.0/");
+  });
+
+  it("uses GRAPH_API_BASE_URL when the insecure flag is set", async () => {
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+
+    await createGraphPort(credentials).search({ sinceDays: 14, folder: "inbox", limit: 50 });
+
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("http://graph-mock:9005/v1.0/");
   });
 });
 

--- a/packages/web/src/__tests__/lib/integrations/google-oauth.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/google-oauth.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { googleTokenEndpoint, refreshAccessToken } from "@/lib/integrations/google-oauth";
+import { resetInsecureMockWarningsForTest } from "@/lib/integrations/insecure-mock-base-url";
+
+/**
+ * GMAIL_OAUTH_BASE_URL used to be read once at module load into a
+ * `const TOKEN_ENDPOINT`, with no paired opt-in flag. That request POSTs the
+ * OAuth client secret AND the refresh token, so a stray override left over in
+ * production would have handed Pinchy's longest-lived Google credentials to
+ * whatever host it named — and a module-level const also made the seam
+ * untestable without a module reset.
+ */
+describe("googleTokenEndpoint", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetInsecureMockWarningsForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("uses the real Google token endpoint when no override is set", () => {
+    expect(googleTokenEndpoint()).toBe("https://oauth2.googleapis.com/token");
+  });
+
+  it("ignores GMAIL_OAUTH_BASE_URL when the insecure flag is absent", () => {
+    vi.stubEnv("GMAIL_OAUTH_BASE_URL", "http://gmail-mock:9004");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(googleTokenEndpoint()).toBe("https://oauth2.googleapis.com/token");
+  });
+
+  it("uses GMAIL_OAUTH_BASE_URL when the insecure flag is also set", () => {
+    vi.stubEnv("GMAIL_OAUTH_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+    expect(googleTokenEndpoint()).toBe("http://gmail-mock:9004/token");
+  });
+
+  it("is read per call, not frozen at module load", () => {
+    expect(googleTokenEndpoint()).toBe("https://oauth2.googleapis.com/token");
+    vi.stubEnv("GMAIL_OAUTH_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+    expect(googleTokenEndpoint()).toBe("http://gmail-mock:9004/token");
+  });
+});
+
+describe("refreshAccessToken", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    resetInsecureMockWarningsForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs to the real Google host even when GMAIL_OAUTH_BASE_URL is set without the flag", async () => {
+    vi.stubEnv("GMAIL_OAUTH_BASE_URL", "http://gmail-mock:9004");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "a", expires_in: 3600 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await refreshAccessToken({ refreshToken: "r", clientId: "c", clientSecret: "s" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("https://oauth2.googleapis.com/token");
+  });
+
+  it("POSTs to the override when the flag is set", async () => {
+    vi.stubEnv("GMAIL_OAUTH_BASE_URL", "http://gmail-mock:9004");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "a", expires_in: 3600 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await refreshAccessToken({ refreshToken: "r", clientId: "c", clientSecret: "s" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://gmail-mock:9004/token");
+  });
+});

--- a/packages/web/src/__tests__/lib/integrations/insecure-mock-base-url.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/insecure-mock-base-url.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  resolveInsecureMockBaseUrl,
+  resetInsecureMockWarningsForTest,
+} from "@/lib/integrations/insecure-mock-base-url";
+
+describe("resolveInsecureMockBaseUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetInsecureMockWarningsForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when the override var is not set", () => {
+    expect(resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL")).toBe(undefined);
+  });
+
+  it("ignores the override and returns undefined when the insecure flag is absent", () => {
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+    // No PINCHY_INSECURE_MAIL_MOCK: a stray override left over in production
+    // must not silently redirect the OAuth client secret, refresh token or
+    // access token this host would receive.
+    expect(resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL")).toBe(undefined);
+  });
+
+  it("returns the override when the insecure flag is also set", () => {
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+    expect(resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL")).toBe("http://graph-mock:9005");
+  });
+
+  it('ignores the override when the flag is set to something other than exactly "1"', () => {
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "true");
+    expect(resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL")).toBe(undefined);
+  });
+
+  it("treats an empty override as unset, and does not warn about it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GRAPH_API_BASE_URL", "");
+    expect(resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL")).toBe(undefined);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns only once for a repeated read of the same override var", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL");
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL");
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL");
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("GRAPH_API_BASE_URL");
+    expect(warn.mock.calls[0][0]).toContain("PINCHY_INSECURE_MAIL_MOCK");
+  });
+
+  it("warns separately for each distinct override var", () => {
+    // The dedupe is keyed by override var, not global: two leftover overrides
+    // must both be reported, or the second one is invisible.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+    vi.stubEnv("GMAIL_API_BASE_URL", "http://gmail-mock:9004");
+
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL");
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL");
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL");
+    resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL");
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls.map((c) => c[0]).join("\n")).toContain("GRAPH_API_BASE_URL");
+    expect(warn.mock.calls.map((c) => c[0]).join("\n")).toContain("GMAIL_API_BASE_URL");
+  });
+
+  it("does not warn when the override is not set", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when the override is set together with the flag", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+    vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+    resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL");
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/integrations/microsoft-oauth.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/microsoft-oauth.test.ts
@@ -4,6 +4,7 @@ import { refreshAccessToken } from "@/lib/integrations/microsoft-oauth";
 // source module instead of via microsoft-oauth's re-export (see D14 cleanup).
 import { isTokenExpired } from "@/lib/integrations/oauth-token";
 import { MICROSOFT_OAUTH_SCOPES, OAUTH_PROVIDERS } from "@/lib/integrations/oauth-providers";
+import { resetInsecureMockWarningsForTest } from "@/lib/integrations/insecure-mock-base-url";
 
 describe("microsoft-oauth", () => {
   beforeEach(() => {
@@ -13,6 +14,9 @@ describe("microsoft-oauth", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     delete process.env.MICROSOFT_OAUTH_BASE_URL;
+    delete process.env.PINCHY_INSECURE_MAIL_MOCK;
+    resetInsecureMockWarningsForTest();
+    vi.restoreAllMocks();
   });
 
   it("isTokenExpired returns true when within the 5-minute buffer", () => {
@@ -60,8 +64,9 @@ describe("microsoft-oauth", () => {
     );
   });
 
-  it("uses MICROSOFT_OAUTH_BASE_URL when set", async () => {
+  it("uses MICROSOFT_OAUTH_BASE_URL when set together with the insecure flag", async () => {
     process.env.MICROSOFT_OAUTH_BASE_URL = "http://graph-mock:9005";
+    process.env.PINCHY_INSECURE_MAIL_MOCK = "1";
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: async () => ({ access_token: "a", refresh_token: "r", expires_in: 1 }),
@@ -74,6 +79,28 @@ describe("microsoft-oauth", () => {
     });
     expect(fetch).toHaveBeenCalledWith(
       "http://graph-mock:9005/t/oauth2/v2.0/token",
+      expect.any(Object)
+    );
+  });
+
+  it("ignores MICROSOFT_OAUTH_BASE_URL when the insecure flag is absent", async () => {
+    process.env.MICROSOFT_OAUTH_BASE_URL = "http://graph-mock:9005";
+    // No PINCHY_INSECURE_MAIL_MOCK. This is the request body that carries the
+    // client secret AND the refresh token — the longest-lived credentials
+    // Pinchy holds — so a stray override must not redirect it.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: "a", refresh_token: "r", expires_in: 1 }),
+    });
+    await refreshAccessToken({
+      tenantId: "t",
+      refreshToken: "r",
+      clientId: "c",
+      clientSecret: "s",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://login.microsoftonline.com/t/oauth2/v2.0/token",
       expect.any(Object)
     );
   });

--- a/packages/web/src/__tests__/lib/integrations/oauth-preflight.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/oauth-preflight.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { validateMicrosoftTenant } from "@/lib/integrations/oauth-preflight";
+import { resetInsecureMockWarningsForTest } from "@/lib/integrations/insecure-mock-base-url";
 
 describe("validateMicrosoftTenant", () => {
   const originalFetch = global.fetch;
   const originalBaseUrl = process.env.MICROSOFT_OAUTH_BASE_URL;
+  const originalFlag = process.env.PINCHY_INSECURE_MAIL_MOCK;
 
   beforeEach(() => {
     global.fetch = vi.fn();
@@ -16,6 +18,12 @@ describe("validateMicrosoftTenant", () => {
     } else {
       process.env.MICROSOFT_OAUTH_BASE_URL = originalBaseUrl;
     }
+    if (originalFlag === undefined) {
+      delete process.env.PINCHY_INSECURE_MAIL_MOCK;
+    } else {
+      process.env.PINCHY_INSECURE_MAIL_MOCK = originalFlag;
+    }
+    resetInsecureMockWarningsForTest();
     vi.restoreAllMocks();
   });
 
@@ -51,14 +59,30 @@ describe("validateMicrosoftTenant", () => {
     expect(result).toEqual({ ok: "unknown" });
   });
 
-  it("reads process.env.MICROSOFT_OAUTH_BASE_URL when set, using it as the fetch host", async () => {
+  it("reads process.env.MICROSOFT_OAUTH_BASE_URL when set together with the insecure flag", async () => {
     process.env.MICROSOFT_OAUTH_BASE_URL = "http://graph-mock:9005";
+    process.env.PINCHY_INSECURE_MAIL_MOCK = "1";
     vi.mocked(global.fetch).mockResolvedValueOnce({ ok: true, status: 200 } as Response);
 
     await validateMicrosoftTenant("my-tenant");
 
     expect(global.fetch).toHaveBeenCalledWith(
       "http://graph-mock:9005/my-tenant/v2.0/.well-known/openid-configuration",
+      { signal: expect.any(AbortSignal) }
+    );
+  });
+
+  it("ignores MICROSOFT_OAUTH_BASE_URL when the insecure flag is absent", async () => {
+    process.env.MICROSOFT_OAUTH_BASE_URL = "http://graph-mock:9005";
+    // No PINCHY_INSECURE_MAIL_MOCK: a stray override must not point the tenant
+    // probe — which leaks the configured tenant id — at an arbitrary host.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(global.fetch).mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+    await validateMicrosoftTenant("my-tenant");
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://login.microsoftonline.com/my-tenant/v2.0/.well-known/openid-configuration",
       { signal: expect.any(AbortSignal) }
     );
   });

--- a/packages/web/src/__tests__/lib/integrations/oauth-providers.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/oauth-providers.test.ts
@@ -151,10 +151,30 @@ describe("OAUTH_PROVIDERS descriptor", () => {
       );
     });
 
-    it("honours MICROSOFT_OAUTH_BASE_URL env override for the token host", () => {
+    it("honours MICROSOFT_OAUTH_BASE_URL env override for the token host when the insecure flag is set", () => {
       vi.stubEnv("MICROSOFT_OAUTH_BASE_URL", "https://mock-ms-auth.local");
+      vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
       expect(OAUTH_PROVIDERS.microsoft.tokenUrl({ tenantId: "t1" })).toBe(
         "https://mock-ms-auth.local/t1/oauth2/v2.0/token"
+      );
+    });
+
+    it("ignores MICROSOFT_OAUTH_BASE_URL when the insecure flag is absent", () => {
+      vi.stubEnv("MICROSOFT_OAUTH_BASE_URL", "https://mock-ms-auth.local");
+      // No PINCHY_INSECURE_MAIL_MOCK. The token endpoint receives the OAuth
+      // client secret and the refresh token, so a stray override left over in
+      // production must not redirect it.
+      expect(OAUTH_PROVIDERS.microsoft.tokenUrl({ tenantId: "t1" })).toBe(
+        "https://login.microsoftonline.com/t1/oauth2/v2.0/token"
+      );
+    });
+
+    it("ignores MICROSOFT_OAUTH_BASE_URL for the authorize host too when the flag is absent", () => {
+      // authorize and token share microsoftHostAndTenant(), so the gate must
+      // cover both — not only the one a test happens to exercise.
+      vi.stubEnv("MICROSOFT_OAUTH_BASE_URL", "https://mock-ms-auth.local");
+      expect(OAUTH_PROVIDERS.microsoft.authorizeUrl({ tenantId: "t1" })).toBe(
+        "https://login.microsoftonline.com/t1/oauth2/v2.0/authorize"
       );
     });
   });
@@ -174,10 +194,18 @@ describe("OAUTH_PROVIDERS descriptor", () => {
       expect(OAUTH_PROVIDERS.microsoft.profileUrl).toBe("https://graph.microsoft.com/v1.0/me");
     });
 
-    it("honours GRAPH_API_BASE_URL env override for the Microsoft profile host", () => {
+    it("honours GRAPH_API_BASE_URL env override for the Microsoft profile host when the insecure flag is set", () => {
       vi.stubEnv("GRAPH_API_BASE_URL", "https://mock-graph.local");
+      vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
       // profileUrl must be a getter so env overrides are read lazily.
       expect(OAUTH_PROVIDERS.microsoft.profileUrl).toBe("https://mock-graph.local/v1.0/me");
+    });
+
+    it("ignores GRAPH_API_BASE_URL when the insecure flag is absent", () => {
+      vi.stubEnv("GRAPH_API_BASE_URL", "https://mock-graph.local");
+      // No PINCHY_INSECURE_MAIL_MOCK: this fetch carries the freshly minted
+      // access token.
+      expect(OAUTH_PROVIDERS.microsoft.profileUrl).toBe("https://graph.microsoft.com/v1.0/me");
     });
   });
 

--- a/packages/web/src/__tests__/lib/integrations/probe.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/probe.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/lib/integrations/imap-probe", async (importActual) => {
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
 import { probeBraveApiKey } from "@/lib/integrations/brave-probe";
 import { probeIntegrationCredentials } from "@/lib/integrations/probe";
+import { resetInsecureMockWarningsForTest } from "@/lib/integrations/insecure-mock-base-url";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -121,6 +122,34 @@ describe("probeIntegrationCredentials", () => {
           headers: { Authorization: "Bearer valid-access-token" },
         })
       );
+    });
+
+    it("ignores GRAPH_API_BASE_URL and probes the real Graph host when the insecure flag is absent", async () => {
+      vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+      // No PINCHY_INSECURE_MAIL_MOCK: this probe sends the stored access token.
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      resetInsecureMockWarningsForTest();
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      await probeIntegrationCredentials("microsoft", validCreds);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://graph.microsoft.com/v1.0/me",
+        expect.any(Object)
+      );
+      vi.unstubAllEnvs();
+      resetInsecureMockWarningsForTest();
+    });
+
+    it("uses GRAPH_API_BASE_URL when the insecure flag is set", async () => {
+      vi.stubEnv("GRAPH_API_BASE_URL", "http://graph-mock:9005");
+      vi.stubEnv("PINCHY_INSECURE_MAIL_MOCK", "1");
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+      await probeIntegrationCredentials("microsoft", validCreds);
+
+      expect(mockFetch).toHaveBeenCalledWith("http://graph-mock:9005/v1.0/me", expect.any(Object));
+      vi.unstubAllEnvs();
     });
 
     it("returns failure when Graph /me returns 401", async () => {

--- a/packages/web/src/__tests__/security/insecure-mock-override-coverage.test.ts
+++ b/packages/web/src/__tests__/security/insecure-mock-override-coverage.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+/**
+ * Every `*_BASE_URL` / `*_MOCK_HOST` / `*_MOCK_PORT` env var in this repo exists
+ * for one reason: to let an E2E stack redirect an outbound call to a local mock
+ * server. Each one is therefore a switch that reroutes an authenticated request
+ * — an OAuth client secret, a refresh token, an access token, an API key — to
+ * whatever host it names. Left over in a production environment, unpaired with
+ * an explicit opt-in, it does that silently.
+ *
+ * The pairing convention (`PINCHY_INSECURE_MAIL_MOCK=1`,
+ * `PINCHY_INSECURE_WEB_MOCK=1`) has been in `imap-adapter.ts` since that seam
+ * was written, and three later overrides simply did not adopt it. Nothing
+ * noticed, because nothing was looking: AGENTS.md's own lesson is that the one
+ * list with a guard (`contracts.tools`) is the one list that did not drift.
+ *
+ * This is that guard. It scans production source in `packages/web/src` and
+ * `packages/plugins/pinchy-*` for override reads, and requires every var it
+ * finds to be REGISTERED below and GATED where it is read. Both directions
+ * fail: an unregistered var, and a registered var that no longer appears — a
+ * verdict must not outlive its evidence.
+ *
+ * What it deliberately does not do is prove the gate *works*. That is the job
+ * of the resolvers' own behavioural tests
+ * (`insecure-mock-base-url.test.ts`, `email-adapter.test.ts`,
+ * `brave-search.test.ts`) plus the per-call-site tests next to each consumer.
+ * This guard proves nothing was left out of that set.
+ */
+
+const WEB_SRC = resolve(__dirname, "../..");
+const PLUGINS_DIR = resolve(__dirname, "../../../../plugins");
+
+/** Env vars whose whole purpose is to redirect an outbound call. */
+const OVERRIDE_VAR_PATTERN = /^[A-Z][A-Z0-9_]*_(?:BASE_URL|MOCK_HOST|MOCK_PORT)$/;
+
+/**
+ * Functions that resolve an override AND enforce its flag internally. A read
+ * that goes through one of these is gated by construction; a bare
+ * `process.env.X` read is only gated if its own file also names the flag.
+ */
+const FLAG_ENFORCING_RESOLVERS = ["resolveInsecureMockBaseUrl", "resolveBraveBaseUrl"];
+
+type Verdict = { gatedBy: string; note?: string } | { exempt: string };
+
+/**
+ * The registry. `gatedBy` names the flag that must accompany the override;
+ * `exempt` records why a var needs no flag, in prose, because the reason is the
+ * artefact (there is nothing to defer to a tracking issue).
+ */
+const OVERRIDE_REGISTRY: Record<string, Verdict> = {
+  // --- Pinchy (web app): holds the OAuth client secret and refresh tokens. ---
+  GMAIL_OAUTH_BASE_URL: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+  MICROSOFT_OAUTH_BASE_URL: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+  // Read by BOTH the web app (ports, probe, OAuth profile) and the
+  // pinchy-email plugin's graph adapter — each with its own resolver.
+  GRAPH_API_BASE_URL: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+  GMAIL_API_BASE_URL: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+
+  // --- Plugins (inside the OpenClaw container). ---
+  IMAP_MOCK_HOST: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+  IMAP_MOCK_PORT: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+  SMTP_MOCK_HOST: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+  SMTP_MOCK_PORT: { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" },
+  BRAVE_API_BASE_URL: { gatedBy: "PINCHY_INSECURE_WEB_MOCK" },
+};
+
+function walkSource(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "__tests__" || entry === "dist") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walkSource(full));
+    } else if (
+      (entry.endsWith(".ts") || entry.endsWith(".tsx")) &&
+      !entry.endsWith(".test.ts") &&
+      !entry.endsWith(".test.tsx") &&
+      !entry.endsWith(".test-d.ts") &&
+      !entry.endsWith(".spec.ts")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function pluginSourceFiles(): string[] {
+  return readdirSync(PLUGINS_DIR)
+    .filter((entry) => entry.startsWith("pinchy-"))
+    .flatMap((entry) => walkSource(join(PLUGINS_DIR, entry)));
+}
+
+interface Read {
+  varName: string;
+  file: string;
+  /** true when the read went through a flag-enforcing resolver. */
+  viaResolver: boolean;
+}
+
+/**
+ * An override reaches the code in exactly two shapes, and the second one is the
+ * reason a plain `grep process.env.` is not enough any more: once a read moves
+ * behind `resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL")`, the var name lives
+ * in a string literal and `process.env.GMAIL_API_BASE_URL` appears nowhere.
+ */
+function collectReads(files: string[]): Read[] {
+  const reads: Read[] = [];
+  const bare = /process\.env\.([A-Z][A-Z0-9_]*)|process\.env\[\s*["']([A-Z][A-Z0-9_]*)["']\s*\]/g;
+  const viaResolver = new RegExp(
+    `(?:${FLAG_ENFORCING_RESOLVERS.join("|")})\\(\\s*["']([A-Z][A-Z0-9_]*)["']`,
+    "g"
+  );
+
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+    for (const m of src.matchAll(bare)) {
+      const varName = m[1] ?? m[2];
+      if (OVERRIDE_VAR_PATTERN.test(varName)) reads.push({ varName, file, viaResolver: false });
+    }
+    for (const m of src.matchAll(viaResolver)) {
+      if (OVERRIDE_VAR_PATTERN.test(m[1])) reads.push({ varName: m[1], file, viaResolver: true });
+    }
+  }
+  return reads;
+}
+
+const sourceFiles = [...walkSource(WEB_SRC), ...pluginSourceFiles()];
+const reads = collectReads(sourceFiles);
+const repoRoot = resolve(__dirname, "../../../../..");
+const rel = (file: string) => relative(repoRoot, file);
+
+describe("insecure-mock override coverage", () => {
+  it("scans a real corpus", () => {
+    // A walker that finds nothing would satisfy every check below in silence,
+    // which is how a coverage gate becomes decoration.
+    expect(sourceFiles.length).toBeGreaterThan(300);
+    expect(reads.length).toBeGreaterThan(5);
+  });
+
+  it("registers every override var found in production source", () => {
+    const unregistered = [...new Set(reads.map((r) => r.varName))]
+      .filter((name) => !(name in OVERRIDE_REGISTRY))
+      .map((name) => {
+        const where = reads.filter((r) => r.varName === name).map((r) => rel(r.file));
+        return `${name} (read in ${where.join(", ")})`;
+      });
+
+    expect(
+      unregistered,
+      `Unregistered mock-redirect override(s).\n\n` +
+        `A *_BASE_URL / *_MOCK_HOST / *_MOCK_PORT var reroutes an authenticated\n` +
+        `outbound call. Add it to OVERRIDE_REGISTRY in this file as either\n` +
+        `  { gatedBy: "PINCHY_INSECURE_MAIL_MOCK" }  — and route the read through\n` +
+        `    resolveInsecureMockBaseUrl(), or name the flag in the reading file, or\n` +
+        `  { exempt: "<why this one needs no flag>" }\n`
+    ).toEqual([]);
+  });
+
+  it("keeps no registry entry whose var has disappeared from the source", () => {
+    // A verdict must not outlive its evidence: a stale entry silently
+    // pre-approves a var somebody may reintroduce later, unexamined.
+    const seen = new Set(reads.map((r) => r.varName));
+    const orphans = Object.keys(OVERRIDE_REGISTRY).filter((name) => !seen.has(name));
+
+    expect(
+      orphans,
+      "Registry entries for override vars no source file reads any more — delete them."
+    ).toEqual([]);
+  });
+
+  it("gates every flag-required override at the place it is read", () => {
+    const ungated: string[] = [];
+
+    for (const read of reads) {
+      const verdict = OVERRIDE_REGISTRY[read.varName];
+      if (!verdict || "exempt" in verdict) continue;
+      // A resolver enforces the flag itself, so the reading file need not.
+      if (read.viaResolver) continue;
+      // A bare read is acceptable only where the same file applies the flag
+      // inline, as imap-adapter.ts does.
+      const src = readFileSync(read.file, "utf8");
+      if (src.includes(verdict.gatedBy)) continue;
+      ungated.push(`${read.varName} in ${rel(read.file)} (expected ${verdict.gatedBy})`);
+    }
+
+    expect(
+      ungated,
+      `Override read without its opt-in flag.\n\n` +
+        `Route it through ${FLAG_ENFORCING_RESOLVERS.join("() / ")}(), or apply the\n` +
+        `flag inline in the same file the way imap-adapter.ts does.\n`
+    ).toEqual([]);
+  });
+
+  it("covers both halves of the deployment — the web app and the plugins", () => {
+    // The seam has two sides and the first fix only closed one. Pinchy holds
+    // the client secret and the refresh tokens; OpenClaw holds an access token.
+    // A guard that scanned only one tree would have called that fix complete.
+    const scannedWeb = reads.some((r) => r.file.startsWith(WEB_SRC));
+    const scannedPlugins = reads.some((r) => r.file.startsWith(PLUGINS_DIR));
+    expect({ scannedWeb, scannedPlugins }).toEqual({ scannedWeb: true, scannedPlugins: true });
+  });
+});

--- a/packages/web/src/lib/email-workflows/ports/gmail.ts
+++ b/packages/web/src/lib/email-workflows/ports/gmail.ts
@@ -1,4 +1,5 @@
 import type { EmailListItem, EmailPort, EmailReadResult } from "@/lib/email-workflows/lister";
+import { resolveInsecureMockBaseUrl } from "@/lib/integrations/insecure-mock-base-url";
 
 /**
  * The Gmail mailbox port for the reconciliation sweep.
@@ -41,9 +42,13 @@ const SYSTEM_LABEL_IDS = new Set([
   "CATEGORY_FORUMS",
 ]);
 
-/** Same convention as the pinchy-email plugin's gmail adapter (E2E mock redirect). */
+/**
+ * Same convention as the pinchy-email plugin's gmail adapter (E2E mock
+ * redirect): the override fires only alongside PINCHY_INSECURE_MAIL_MOCK=1, so
+ * a stray var cannot redirect the access token this port sends.
+ */
 function gmailBase(): string {
-  return process.env.GMAIL_API_BASE_URL ?? "https://gmail.googleapis.com";
+  return resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL") ?? "https://gmail.googleapis.com";
 }
 
 interface GmailHeader {

--- a/packages/web/src/lib/email-workflows/ports/graph.ts
+++ b/packages/web/src/lib/email-workflows/ports/graph.ts
@@ -1,4 +1,5 @@
 import type { EmailListItem, EmailPort, EmailReadResult } from "@/lib/email-workflows/lister";
+import { resolveInsecureMockBaseUrl } from "@/lib/integrations/insecure-mock-base-url";
 
 /**
  * The Microsoft Graph (Microsoft 365) mailbox port for the reconciliation sweep.
@@ -24,9 +25,13 @@ const DEFAULT_FOLDER = "inbox";
  */
 const IMMUTABLE_ID_HEADER = { Prefer: 'IdType="ImmutableId"' } as const;
 
-/** Same convention as probe.ts and the pinchy-email plugin's graph adapter. */
+/**
+ * Same convention as probe.ts and the pinchy-email plugin's graph adapter: the
+ * override fires only alongside PINCHY_INSECURE_MAIL_MOCK=1, so a stray var
+ * cannot redirect the access token this port sends.
+ */
 function graphBase(): string {
-  return process.env.GRAPH_API_BASE_URL ?? "https://graph.microsoft.com";
+  return resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL") ?? "https://graph.microsoft.com";
 }
 
 interface GraphAddress {

--- a/packages/web/src/lib/integrations/google-oauth.ts
+++ b/packages/web/src/lib/integrations/google-oauth.ts
@@ -1,17 +1,30 @@
 // GMAIL_OAUTH_BASE_URL allows E2E tests to redirect OAuth token refresh calls
-// to a local mock server instead of https://oauth2.googleapis.com/
+// to a local mock server instead of https://oauth2.googleapis.com/. It only
+// takes effect alongside PINCHY_INSECURE_MAIL_MOCK=1 — see
+// insecure-mock-base-url.ts. This request carries the client secret AND the
+// refresh token, so an unflagged redirect here hands over long-lived
+// credentials, not a token that expires.
 import { computeExpiresAt } from "./oauth-token";
+import { resolveInsecureMockBaseUrl } from "./insecure-mock-base-url";
 
-const TOKEN_ENDPOINT = process.env.GMAIL_OAUTH_BASE_URL
-  ? `${process.env.GMAIL_OAUTH_BASE_URL}/token`
-  : "https://oauth2.googleapis.com/token";
+const GOOGLE_TOKEN_DEFAULT = "https://oauth2.googleapis.com/token";
+
+/**
+ * Resolved per call, not once at module load: the flag pairing has to be read
+ * after the process env is fully set up, and a module-level const would also
+ * make the seam untestable without a module reset.
+ */
+export function googleTokenEndpoint(): string {
+  const base = resolveInsecureMockBaseUrl("GMAIL_OAUTH_BASE_URL");
+  return base ? `${base}/token` : GOOGLE_TOKEN_DEFAULT;
+}
 
 export async function refreshAccessToken(opts: {
   refreshToken: string;
   clientId: string;
   clientSecret: string;
 }): Promise<{ accessToken: string; expiresAt: string }> {
-  const res = await fetch(TOKEN_ENDPOINT, {
+  const res = await fetch(googleTokenEndpoint(), {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({

--- a/packages/web/src/lib/integrations/insecure-mock-base-url.ts
+++ b/packages/web/src/lib/integrations/insecure-mock-base-url.ts
@@ -1,0 +1,74 @@
+/**
+ * The web app's half of the insecure-mock seam.
+ *
+ * Four env vars let the E2E stacks redirect Google/Microsoft traffic to a local
+ * mock server: `GMAIL_OAUTH_BASE_URL`, `MICROSOFT_OAUTH_BASE_URL`,
+ * `GMAIL_API_BASE_URL` and `GRAPH_API_BASE_URL`. Pinchy — not OpenClaw — is the
+ * process that holds the OAuth client secret and the refresh tokens and runs the
+ * token exchange, so a stray override here redirects strictly more than the
+ * plugin-side equivalents do: an access token expires, a client secret and a
+ * refresh token do not.
+ *
+ * So the override only fires alongside an explicit `PINCHY_INSECURE_MAIL_MOCK=1`
+ * opt-in, exactly as the plugin-side seams do (`imap-adapter.ts`, and
+ * `resolveInsecureMockBaseUrl` in `pinchy-email/email-adapter.ts`). Without the
+ * flag the override is ignored, the caller falls back to the real host, and a
+ * one-time warning names the var so a leftover override is visible in the logs
+ * instead of silently rerouting credentials.
+ *
+ * Deliberately duplicated rather than imported from the plugin package: the web
+ * app does not depend on `packages/plugins/*`, and an import that reached across
+ * that boundary would drag plugin code into the Next.js bundle graph.
+ * `insecure-mock-override-coverage.test.ts` is what keeps the two halves from
+ * drifting apart in coverage.
+ */
+
+/** The single opt-in flag for every mail/OAuth mock redirect on the web side. */
+export const INSECURE_MAIL_MOCK_FLAG = "PINCHY_INSECURE_MAIL_MOCK";
+
+/**
+ * Override vars this module governs. The coverage guard reads this list, so an
+ * override var that is added to the code and not to this list fails CI.
+ */
+export const INSECURE_MOCK_OVERRIDE_VARS = [
+  "GMAIL_OAUTH_BASE_URL",
+  "MICROSOFT_OAUTH_BASE_URL",
+  "GMAIL_API_BASE_URL",
+  "GRAPH_API_BASE_URL",
+] as const;
+
+export type InsecureMockOverrideVar = (typeof INSECURE_MOCK_OVERRIDE_VARS)[number];
+
+// Which override vars we have already warned about in this process, so a
+// leftover override doesn't spam the log on every refresh, probe or sweep.
+const warnedMockOverrides = new Set<string>();
+
+/**
+ * Returns `overrideVar`'s value, but ONLY when `PINCHY_INSECURE_MAIL_MOCK` is
+ * explicitly `"1"`. Returns undefined otherwise, so callers keep their real
+ * production host as the `??` fallback.
+ */
+export function resolveInsecureMockBaseUrl(
+  overrideVar: InsecureMockOverrideVar
+): string | undefined {
+  const override = process.env[overrideVar];
+  if (!override) return undefined;
+  if (process.env[INSECURE_MAIL_MOCK_FLAG] === "1") return override;
+  if (!warnedMockOverrides.has(overrideVar)) {
+    warnedMockOverrides.add(overrideVar);
+    console.warn(
+      `[pinchy] ${overrideVar} is set but ${INSECURE_MAIL_MOCK_FLAG} is not "1" — ignoring it ` +
+        `and using the real host. If this is a test/mock stack, also set ` +
+        `${INSECURE_MAIL_MOCK_FLAG}=1.`
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Test-only: clears the warn-once dedupe so a test can assert the warning fires
+ * again after resetting env stubs.
+ */
+export function resetInsecureMockWarningsForTest(): void {
+  warnedMockOverrides.clear();
+}

--- a/packages/web/src/lib/integrations/oauth-preflight.ts
+++ b/packages/web/src/lib/integrations/oauth-preflight.ts
@@ -4,6 +4,12 @@
 // pre-authorize error that never redirects back to our callback, so it can
 // only be PREVENTED here, not caught later. See docs/plans/2026-07-03-oauth-
 // lifecycle-hardening.md.
+//
+// The single import here is deliberate: insecure-mock-base-url.ts has no
+// imports of its own, so this module stays client-safe and oauth-providers.ts
+// (a Client Component dependency) can keep importing it.
+import { resolveInsecureMockBaseUrl } from "@/lib/integrations/insecure-mock-base-url";
+
 const WELL_KNOWN_TENANTS = new Set(["organizations", "common", "consumers"]);
 
 // Matches the timeout convention used by the other third-party probes in this
@@ -19,7 +25,10 @@ export type TenantValidation =
 export async function validateMicrosoftTenant(tenantId: string): Promise<TenantValidation> {
   const t = tenantId.trim();
   if (t.length === 0 || WELL_KNOWN_TENANTS.has(t.toLowerCase())) return { ok: true };
-  const host = process.env.MICROSOFT_OAUTH_BASE_URL || "https://login.microsoftonline.com";
+  // Honoured only alongside PINCHY_INSECURE_MAIL_MOCK=1, same as every other
+  // mock redirect on the web side — see insecure-mock-base-url.ts.
+  const host =
+    resolveInsecureMockBaseUrl("MICROSOFT_OAUTH_BASE_URL") || "https://login.microsoftonline.com";
   try {
     const res = await fetch(
       `${host}/${encodeURIComponent(t)}/v2.0/.well-known/openid-configuration`,

--- a/packages/web/src/lib/integrations/oauth-providers.ts
+++ b/packages/web/src/lib/integrations/oauth-providers.ts
@@ -12,13 +12,15 @@
  * from oauth-settings.ts would drag `@/lib/settings` → `db` → `postgres` into
  * the client bundle and break the build.
  *
- * `validateMicrosoftTenant` from oauth-preflight.ts is the one exception to
- * "no imports beyond this file's own data": that module has zero imports of
- * its own (only global fetch/process/AbortSignal), so it is just as
- * client-safe as this file and is used to implement the microsoft
- * descriptor's `validateConfig`.
+ * `validateMicrosoftTenant` from oauth-preflight.ts and
+ * `resolveInsecureMockBaseUrl` from insecure-mock-base-url.ts are the two
+ * exceptions to "no imports beyond this file's own data". The latter has zero
+ * imports (only global process/console); the former's only import is the
+ * latter. Neither reaches the settings/db layer, so both are as client-safe as
+ * this file.
  */
 import { validateMicrosoftTenant } from "@/lib/integrations/oauth-preflight";
+import { resolveInsecureMockBaseUrl } from "@/lib/integrations/insecure-mock-base-url";
 // Type-only import (erased at compile time), so it keeps this module client-safe
 // while tying `connectionType` to the enum the DB CHECK constraint enforces.
 import type { IntegrationConnectionType } from "@/db/enums";
@@ -151,12 +153,14 @@ const MICROSOFT_GRAPH_DEFAULT = "https://graph.microsoft.com";
 /**
  * Resolve the Microsoft login host + effective tenant used by both the
  * authorize and token endpoints, so the two can never drift. The host honours
- * the `MICROSOFT_OAUTH_BASE_URL` env override (staging/mock); the tenant falls
- * back to "organizations" when absent or blank.
+ * the `MICROSOFT_OAUTH_BASE_URL` env override (staging/mock) only alongside
+ * `PINCHY_INSECURE_MAIL_MOCK=1` — the token endpoint receives the client secret
+ * and the refresh token, so an unflagged redirect would hand those over. The
+ * tenant falls back to "organizations" when absent or blank.
  */
 function microsoftHostAndTenant(tenantId?: string): { host: string; tenant: string } {
   const tenant = tenantId?.trim() || "organizations";
-  const host = process.env.MICROSOFT_OAUTH_BASE_URL ?? MICROSOFT_LOGIN_DEFAULT;
+  const host = resolveInsecureMockBaseUrl("MICROSOFT_OAUTH_BASE_URL") ?? MICROSOFT_LOGIN_DEFAULT;
   return { host, tenant };
 }
 
@@ -206,8 +210,10 @@ export const OAUTH_PROVIDERS: Record<OAuthProviderId, OAuthProviderDescriptor> =
       return `${host}/${tenant}/oauth2/v2.0/token`;
     },
     // Getter so the GRAPH_API_BASE_URL env override is read lazily (staging/mock).
+    // Honoured only alongside PINCHY_INSECURE_MAIL_MOCK=1 — this fetch carries
+    // the freshly minted access token.
     get profileUrl() {
-      const graphBase = process.env.GRAPH_API_BASE_URL ?? MICROSOFT_GRAPH_DEFAULT;
+      const graphBase = resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL") ?? MICROSOFT_GRAPH_DEFAULT;
       return `${graphBase}/v1.0/me`;
     },
     extractEmail(profile) {

--- a/packages/web/src/lib/integrations/probe.ts
+++ b/packages/web/src/lib/integrations/probe.ts
@@ -9,6 +9,7 @@ import {
   classifyProbeError,
 } from "@/lib/integrations/imap-probe";
 import { imapTestSchema } from "@/lib/schemas/imap";
+import { resolveInsecureMockBaseUrl } from "@/lib/integrations/insecure-mock-base-url";
 
 /**
  * Verify that credentials work for the given integration type.
@@ -73,7 +74,10 @@ export async function probeIntegrationCredentials(
     if (typeof accessToken !== "string" || !accessToken) {
       return { success: false, reason: "No access token stored. Please reconnect to Microsoft." };
     }
-    const graphBase = process.env.GRAPH_API_BASE_URL ?? "https://graph.microsoft.com";
+    // Honoured only alongside PINCHY_INSECURE_MAIL_MOCK=1 — this probe sends
+    // the stored access token. See insecure-mock-base-url.ts.
+    const graphBase =
+      resolveInsecureMockBaseUrl("GRAPH_API_BASE_URL") ?? "https://graph.microsoft.com";
     try {
       const res = await fetch(`${graphBase}/v1.0/me`, {
         headers: { Authorization: `Bearer ${accessToken}` },


### PR DESCRIPTION
## Summary

- `GMAIL_API_BASE_URL`, `GRAPH_API_BASE_URL` and `BRAVE_API_BASE_URL` let E2E tests redirect the corresponding adapters to a local mock server. Unlike `ImapAdapter`'s `IMAP_MOCK_HOST`/`SMTP_MOCK_HOST` seam (which already requires `PINCHY_INSECURE_MAIL_MOCK=1`), none of these three required a paired opt-in flag — so a single leftover env var in production could silently redirect an OAuth-authenticated API call (or the Brave API key) to whatever host it names.
- `gmail-adapter.ts` and `graph-adapter.ts` now reuse the existing `PINCHY_INSECURE_MAIL_MOCK` flag (same domain, same reasoning as `imap-adapter.ts`), via a shared `resolveInsecureMockBaseUrl()` helper in `email-adapter.ts`.
- `brave-search.ts` (a different plugin package, `pinchy-web`) gets its own local `resolveBraveBaseUrl()` with a new `PINCHY_INSECURE_WEB_MOCK` flag — no such flag existed in that plugin before.
- Without the paired flag, the override is now ignored (falls back to the real API host) and a one-time warning is logged to `console.warn`, so a leftover override is visible in production logs instead of silently redirecting.
- Compose overlays updated so the affected E2E suites keep exercising the mock seam: `docker-compose.email-test.yml` and `docker-compose.eval.yml` (`openclaw` service) now also set `PINCHY_INSECURE_MAIL_MOCK=1`; `docker-compose.web-test.yml` (`openclaw` service) now also sets `PINCHY_INSECURE_WEB_MOCK=1`.

## Test plan

- [x] TDD: added failing tests first, confirmed red (by stashing the corresponding source-file change), then green after wiring the implementation, for all four touched surfaces (`email-adapter.test.ts`, `gmail-adapter.test.ts`, `graph-adapter.test.ts`, `brave-search.test.ts`).
- [x] `pnpm test:plugins` — all plugin packages pass (pinchy-email 372, pinchy-web 103, others unaffected).
- [x] `pnpm typecheck:plugins` — all 9 plugin packages typecheck cleanly.
- [x] `pnpm test` (full web suite) — 10933 passed, 18 skipped.
- [x] `pnpm test:scripts` — 894 passed.
- [x] `pnpm format:check` — clean.
- [ ] Full E2E suites (`test:e2e:email`, `test:e2e:imap`, `test:e2e:web`) were not run locally (requires the docker stack) — the compose changes were reviewed by hand against how the plugin reads these vars, mirroring the existing `docker-compose.imap-test.yml` convention exactly. CI's `email-e2e` and `web-e2e` jobs will exercise this.

---

## Follow-up (review): the web app's half of the same seam

The first commit closed the plugin half only. Pinchy — not OpenClaw — holds the OAuth client secret and the refresh tokens and runs the token exchange, and it read **four** override vars with no paired flag, at seven call sites:

| Read site | What an unflagged override would redirect |
| --- | --- |
| `google-oauth.ts` | `GMAIL_OAUTH_BASE_URL` → token refresh: **client secret + refresh token** |
| `oauth-providers.ts` (`microsoftHostAndTenant`) | `MICROSOFT_OAUTH_BASE_URL` → authorize **and** token exchange: **client secret + auth code** |
| `oauth-providers.ts` (`profileUrl`) | `GRAPH_API_BASE_URL` → profile fetch with the freshly minted access token |
| `oauth-preflight.ts` | `MICROSOFT_OAUTH_BASE_URL` → tenant probe |
| `probe.ts` | `GRAPH_API_BASE_URL` → stored access token |
| `email-workflows/ports/gmail.ts` | `GMAIL_API_BASE_URL` → access token (reconciliation sweep) |
| `email-workflows/ports/graph.ts` | `GRAPH_API_BASE_URL` → access token (reconciliation sweep) |

Same class as the plugin vars, with the more valuable secret: an access token expires, a client secret and a refresh token do not. `docker-compose.email-test.yml` sets three of these on the `pinchy` service, so the route into a production config is the same one.

- `packages/web/src/lib/integrations/insecure-mock-base-url.ts` is the web-side resolver, mirroring the plugin's. It has **no imports of its own**, so `oauth-providers.ts` (a Client Component dependency) and `oauth-preflight.ts` stay client-safe — verified by `pnpm build`, the only check that sees that boundary.
- `google-oauth.ts`'s `TOKEN_ENDPOINT` was a module-level `const`, so it also had to become a per-call function — a module-level read cannot be flag-paired lazily and made the seam untestable.
- The five existing tests that pinned the unflagged behaviour now set the flag and **each gained its negative counterpart**. `probe.ts`, both mailbox ports and `google-oauth.ts` had no base-url coverage at all and now do.
- `docker-compose.email-test.yml` and `docker-compose.eval.yml` set `PINCHY_INSECURE_MAIL_MOCK=1` on the `pinchy` service (`docker-compose.imap-test.yml` already set it on both services).

### A drift guard, so the next one can't land unflagged

`packages/web/src/__tests__/security/insecure-mock-override-coverage.test.ts` scans production source in `packages/web/src` **and** `packages/plugins/pinchy-*` and requires every `*_BASE_URL` / `*_MOCK_HOST` / `*_MOCK_PORT` read to be registered and gated at the place it is read. Both directions fail, so a verdict can't outlive its evidence.

Scanning **both** trees is the point: a guard over one of them would have called the first commit complete. And a plain `grep process.env.` no longer finds these — once a read moves behind `resolveInsecureMockBaseUrl("GMAIL_API_BASE_URL")` the name lives in a string literal — so the scanner reads both shapes.

Verified by canary, not by reading it: an unregistered var fails "registers every override var", and a bare ungated read of a registered var fails "gates every flag-required override". Tree restored after both.

### Also

`email-adapter.test.ts`'s "warns exactly once **per overrideVar**" called the helper three times with the *same* var. That proves the "once" half and leaves the "per var" half — the reason the dedupe is a `Set` rather than a boolean — untested. It now exercises two vars.

### Test plan (follow-up commit)

- [x] `pnpm test` — 10967 passed, 18 skipped
- [x] `pnpm test:plugins` — all packages pass (pinchy-email 374)
- [x] `pnpm test:scripts` — 894 passed
- [x] `pnpm typecheck:plugins` + `pnpm -C packages/web typecheck` — clean
- [x] `pnpm build` — clean (this is what proves the client-safe boundary held)
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] `pnpm format:check` — clean
- [x] Guard verified by canary in both directions
- [ ] E2E not run locally (needs the docker stack). CI's `email-e2e` / `web-e2e` exercise the compose changes; the `pinchy`-service flag is the new half to watch.

### Not done, deliberately

No docs change: none of these vars appear anywhere in `docs/`, and `check-docs-required.mjs` reports nothing to ask for. They are test-only seams, not a configuration surface we want to advertise.

The warning goes to the container's stdout, which is the invisibility AGENTS.md describes at #599. For a config smell detected once per process — not a rejected request — an `appendAuditLog` row would be disproportionate, and every audit write serialises on one advisory lock. Worth naming rather than silently accepting.
