### PR TITLE
fix(plugins): bound odoo_aggregate and Graph email_read against blind truncation

### DIFF
--- a/packages/plugins/pinchy-email/__tests__/email-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/email-adapter.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { createFolderMapper, escapeDoubleQuoted, type Folder } from "../email-adapter.js";
+import {
+  createFolderMapper,
+  escapeDoubleQuoted,
+  stripHtml,
+  truncateEmailBody,
+  EMAIL_BODY_MAX_CHARS,
+  type Folder,
+} from "../email-adapter.js";
 
 describe("escapeDoubleQuoted", () => {
   it("passes a plain value through unchanged", () => {
@@ -58,5 +65,89 @@ describe("createFolderMapper", () => {
     expect(() => mapFolder("archive" as Folder)).toThrow(
       "unknown folder: archive. Valid: INBOX, SENT, DRAFTS, TRASH, SPAM."
     );
+  });
+});
+
+// stripHtml is a rare fallback for IMAP (mailparser derives text from html
+// first) but the PRIMARY path for Graph and for Gmail's html-only messages.
+// These assert the properties that matter when a model, not a renderer, is
+// the reader.
+describe("stripHtml", () => {
+  it("removes tags and their attributes", () => {
+    expect(stripHtml('<p class="x">Hello <b>Bob</b></p>')).toBe("Hello Bob");
+  });
+
+  it("drops script and style bodies rather than reading them as text", () => {
+    const html = "<style>.a{color:red}</style><script>alert(1)</script><p>Real text</p>";
+    const out = stripHtml(html);
+    expect(out).toBe("Real text");
+  });
+
+  // Collapsing every block boundary to a space turns a whole email into one
+  // endless line — which is what the model then has to reason over.
+  it("keeps paragraph and list structure as line breaks", () => {
+    const html = "<p>First para</p><p>Second para</p><ul><li>one</li><li>two</li></ul>";
+    const out = stripHtml(html);
+    expect(out.split("\n").filter(Boolean)).toEqual(["First para", "Second para", "one", "two"]);
+  });
+
+  it("collapses runs of blank lines instead of emitting a wall of them", () => {
+    expect(stripHtml("<div><div><div><p>Only text</p></div></div></div>")).toBe("Only text");
+  });
+
+  it("decodes the entities that actually appear in mail bodies", () => {
+    expect(stripHtml("<p>Tom &amp; Jerry &quot;quoted&quot; 3 &lt; 4&nbsp;always</p>")).toBe(
+      'Tom & Jerry "quoted" 3 < 4 always'
+    );
+  });
+
+  // Decoding after tag removal, not before: otherwise an escaped tag in the
+  // source becomes a real tag that nothing then strips.
+  it("does not let an escaped tag in the source survive as markup", () => {
+    expect(stripHtml("<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>")).toBe(
+      "<script>alert(1)</script>"
+    );
+  });
+
+  // Outlook conditional comments wrap a whole alternative rendering. Left in,
+  // their contents survive tag-stripping and the model reads the mail twice.
+  it("drops Outlook conditional-comment markup instead of reading it as content", () => {
+    const html =
+      "<p>Real</p><!--[if mso]><table><tr><td>MSO fallback</td></tr></table><![endif]-->";
+    expect(stripHtml(html)).not.toContain("MSO fallback");
+  });
+
+  it("leaves an unknown entity alone rather than silently eating it", () => {
+    expect(stripHtml("<p>caf&eacute;</p>")).toBe("caf&eacute;");
+  });
+});
+
+describe("truncateEmailBody", () => {
+  it("returns a body that fits unchanged, with no marker", () => {
+    const body = "Line one\n\nLine two.";
+    expect(truncateEmailBody(body)).toBe(body);
+  });
+
+  it("returns a body of exactly the budget unchanged (the boundary is inclusive)", () => {
+    const body = "z".repeat(EMAIL_BODY_MAX_CHARS);
+    expect(truncateEmailBody(body)).toBe(body);
+  });
+
+  // The marker has to be self-describing: a bare "[truncated]" reads as part
+  // of the message, and a model that cannot tell how much it is missing will
+  // answer as though it read the whole mail.
+  it("keeps the leading budget and states how much of the message it is", () => {
+    const body = "z".repeat(EMAIL_BODY_MAX_CHARS * 2);
+    const out = truncateEmailBody(body);
+
+    expect(out.startsWith("z".repeat(EMAIL_BODY_MAX_CHARS))).toBe(true);
+    expect(out).toContain(String(EMAIL_BODY_MAX_CHARS));
+    expect(out).toContain(String(body.length));
+    // Bounded overhead: the marker must not itself become a size problem.
+    expect(out.length).toBeLessThan(EMAIL_BODY_MAX_CHARS + 500);
+  });
+
+  it("honours an explicit budget", () => {
+    expect(truncateEmailBody("abcdefghij", 4).startsWith("abcd")).toBe(true);
   });
 });

--- a/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
@@ -280,7 +280,11 @@ describe("GmailAdapter", () => {
 
       const result = await adapter.read("msg3");
 
-      expect(result.body).toBe("<b>HTML only</b>");
+      // The fallback used to return raw markup — the same defect the Graph
+      // adapter had, and for the same reason: an html-only message is common
+      // for anything machine-generated, and its tags are noise the model has
+      // to read past.
+      expect(result.body).toBe("HTML only");
     });
 
     it("handles nested multipart/mixed with multipart/alternative", async () => {

--- a/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
-import { GraphAdapter } from "../graph-adapter.js";
+import { GraphAdapter, GRAPH_BODY_MAX_CHARS } from "../graph-adapter.js";
 
 describe("GraphAdapter.list", () => {
   beforeEach(() => {
@@ -117,6 +117,75 @@ describe("GraphAdapter.read", () => {
     expect(result.body).toBe("Hi there, full body");
     expect(result.cc).toBe("charlie@example.com");
     expect(result.unread).toBe(true);
+  });
+
+  // Unlike IMAP/Gmail (which prefer text/plain and only fall back to raw HTML
+  // when no plain-text part exists), Graph's `body.content` was serialized
+  // verbatim regardless of contentType, with no cap — a real HTML marketing
+  // email (~500 KB) hits OpenClaw's blind 64000-char mid-JSON truncation, the
+  // same production failure mode as the odoo_read/odoo_aggregate incidents.
+  it("strips HTML from the body when body.contentType is html", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "msg1",
+        subject: "Hello",
+        bodyPreview: "Hi",
+        receivedDateTime: "2024-01-01T10:00:00Z",
+        from: { emailAddress: { address: "alice@example.com" } },
+        toRecipients: [],
+        isRead: true,
+        body: { contentType: "html", content: "<p>Hello <b>Bob</b>, see attached.</p>" },
+      }),
+    });
+    const result = await adapter.read("msg1");
+    expect(result.body).not.toContain("<p>");
+    expect(result.body).not.toContain("<b>");
+    // Same tag-to-space collapsing as IMAP's shared stripHtml — a space is
+    // left where </b> was, ahead of the comma.
+    expect(result.body).toContain("Hello Bob , see attached.");
+  });
+
+  it("truncates an oversized body to GRAPH_BODY_MAX_CHARS with a [truncated] marker", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    const hugeHtml = `<p>${"x".repeat(GRAPH_BODY_MAX_CHARS * 2)}</p>`;
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "msg1",
+        subject: "Newsletter",
+        bodyPreview: "…",
+        receivedDateTime: "2024-01-01T10:00:00Z",
+        from: { emailAddress: { address: "marketing@example.com" } },
+        toRecipients: [],
+        isRead: true,
+        body: { contentType: "html", content: hugeHtml },
+      }),
+    });
+    const result = await adapter.read("msg1");
+    expect(result.body.length).toBeLessThanOrEqual(GRAPH_BODY_MAX_CHARS + "\n[truncated]".length);
+    expect(result.body).toContain("[truncated]");
+  });
+
+  it("does not truncate or mark a body that already fits under the budget", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "msg1",
+        subject: "Short",
+        bodyPreview: "short",
+        receivedDateTime: "2024-01-01T10:00:00Z",
+        from: { emailAddress: { address: "alice@example.com" } },
+        toRecipients: [],
+        isRead: true,
+        body: { contentType: "text", content: "A short plain-text body." },
+      }),
+    });
+    const result = await adapter.read("msg1");
+    expect(result.body).toBe("A short plain-text body.");
+    expect(result.body).not.toContain("[truncated]");
   });
 
   it("non-ok response throws a descriptive error", async () => {

--- a/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
-import { GraphAdapter, GRAPH_BODY_MAX_CHARS } from "../graph-adapter.js";
+import { GraphAdapter } from "../graph-adapter.js";
 
 describe("GraphAdapter.list", () => {
   beforeEach(() => {
@@ -119,11 +119,12 @@ describe("GraphAdapter.read", () => {
     expect(result.unread).toBe(true);
   });
 
-  // Unlike IMAP/Gmail (which prefer text/plain and only fall back to raw HTML
-  // when no plain-text part exists), Graph's `body.content` was serialized
-  // verbatim regardless of contentType, with no cap — a real HTML marketing
-  // email (~500 KB) hits OpenClaw's blind 64000-char mid-JSON truncation, the
-  // same production failure mode as the odoo_read/odoo_aggregate incidents.
+  // Graph returns `body.content` verbatim in whatever `body.contentType` the
+  // message was stored in, and most Outlook mail is stored as html — so this
+  // was handing the model raw markup where IMAP hands it text. The SIZE
+  // ceiling that keeps email_read out of OpenClaw's blind mid-JSON truncation
+  // is asserted at the tool boundary instead (see tools.test.ts), because it
+  // applies to every adapter's body and not just this one's.
   it("strips HTML from the body when body.contentType is html", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
     (fetch as Mock).mockResolvedValueOnce({
@@ -142,34 +143,42 @@ describe("GraphAdapter.read", () => {
     const result = await adapter.read("msg1");
     expect(result.body).not.toContain("<p>");
     expect(result.body).not.toContain("<b>");
-    // Same tag-to-space collapsing as IMAP's shared stripHtml — a space is
-    // left where </b> was, ahead of the comma.
+    // Inline tags collapse to a space, so one is left where </b> was, ahead of
+    // the comma.
     expect(result.body).toContain("Hello Bob , see attached.");
   });
 
-  it("truncates an oversized body to GRAPH_BODY_MAX_CHARS with a [truncated] marker", async () => {
+  // Graph documents the enum as lowercase, but a case-sensitive compare would
+  // silently take the "already plain text" branch on anything else and hand
+  // the model a body of pure markup — the exact defect above, one payload
+  // variation away.
+  it("strips HTML when contentType arrives in a different case", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
-    const hugeHtml = `<p>${"x".repeat(GRAPH_BODY_MAX_CHARS * 2)}</p>`;
     (fetch as Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         id: "msg1",
-        subject: "Newsletter",
-        bodyPreview: "…",
+        subject: "Hello",
+        bodyPreview: "Hi",
         receivedDateTime: "2024-01-01T10:00:00Z",
-        from: { emailAddress: { address: "marketing@example.com" } },
+        from: { emailAddress: { address: "alice@example.com" } },
         toRecipients: [],
         isRead: true,
-        body: { contentType: "html", content: hugeHtml },
+        body: { contentType: "HTML", content: "<p>Hello <b>Bob</b>.</p>" },
       }),
     });
     const result = await adapter.read("msg1");
-    expect(result.body.length).toBeLessThanOrEqual(GRAPH_BODY_MAX_CHARS + "\n[truncated]".length);
-    expect(result.body).toContain("[truncated]");
+    expect(result.body).not.toContain("<b>");
+    expect(result.body).toContain("Hello Bob");
   });
 
-  it("does not truncate or mark a body that already fits under the budget", async () => {
+  // The control that proves the html branch is a branch: a plain-text body
+  // must reach the model byte-for-byte. It carries a literal "<" and real line
+  // breaks precisely because stripHtml would eat both — an all-prose control
+  // would pass even if stripHtml were applied unconditionally.
+  it("leaves a plain-text body byte-for-byte intact, including line breaks and a literal <", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
+    const plain = "Line one\n\nLine two: 3 < 4 and a  double space.";
     (fetch as Mock).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -180,12 +189,11 @@ describe("GraphAdapter.read", () => {
         from: { emailAddress: { address: "alice@example.com" } },
         toRecipients: [],
         isRead: true,
-        body: { contentType: "text", content: "A short plain-text body." },
+        body: { contentType: "text", content: plain },
       }),
     });
     const result = await adapter.read("msg1");
-    expect(result.body).toBe("A short plain-text body.");
-    expect(result.body).not.toContain("[truncated]");
+    expect(result.body).toBe(plain);
   });
 
   it("non-ok response throws a descriptive error", async () => {

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -67,6 +67,7 @@ import { GraphAdapter } from "../graph-adapter";
 import { ImapAdapter } from "../imap-adapter";
 import plugin from "../index";
 import { MAX_ENTRIES_PER_AGENT, MSG_PREFIX, resolveHandle } from "../id-handle-store";
+import { EMAIL_BODY_MAX_CHARS } from "../email-adapter";
 
 interface AgentTool {
   name: string;
@@ -1007,6 +1008,92 @@ describe("email_read", () => {
     expect(guidance).not.toContain("msg-1");
     expect(guidance).not.toContain("att-1");
     expect(guidance).not.toContain("att-2");
+  });
+});
+
+// OpenClaw's runtime caps every tool result at 64000 chars and replaces the
+// overflow with a literal marker spliced MID-JSON, so the model gets corrupt
+// JSON and loops on it (the odoo_read incident, ODOO_READ_RESULT_BUDGET_CHARS
+// in pinchy-odoo/index.ts). The body is email_read's one unbounded field, and
+// it is unbounded for EVERY adapter — Graph's stored html, Gmail's decoded
+// part, IMAP's mailparser text. These assert the bound where all three meet,
+// so a fourth provider inherits it instead of having to remember it.
+describe("email_read body budget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCredentialResponse();
+  });
+
+  it("bounds an oversized body so the serialized result stays far under OpenClaw's 64000-char cap", async () => {
+    mockRead.mockResolvedValue({
+      id: "msg-1",
+      from: "marketing@test.com",
+      subject: "Newsletter",
+      body: "x".repeat(EMAIL_BODY_MAX_CHARS * 3),
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_read", agentId)!;
+
+    const result = await tool.execute("call-1", { id: "msg-1" });
+
+    // The payload is pretty-printed (JSON.stringify(..., null, 2)), so assert
+    // the shipped text, not the body in isolation.
+    expect(result.content[0].text.length).toBeLessThan(64000);
+    const data = JSON.parse(result.content[0].text);
+    expect(data.body.length).toBeLessThan(EMAIL_BODY_MAX_CHARS + 500);
+  });
+
+  // A bare "[truncated]" reads as part of the message. The marker has to say
+  // enough that the model reports a long email as long instead of treating
+  // the cut text as the whole thing.
+  it("names what was cut, in terms the model can act on", async () => {
+    const full = "y".repeat(EMAIL_BODY_MAX_CHARS * 2);
+    mockRead.mockResolvedValue({
+      id: "msg-1",
+      from: "marketing@test.com",
+      subject: "Newsletter",
+      body: full,
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_read", agentId)!;
+
+    const data = JSON.parse((await tool.execute("call-1", { id: "msg-1" })).content[0].text);
+
+    expect(data.body).toContain("truncated");
+    expect(data.body).toContain(String(EMAIL_BODY_MAX_CHARS));
+    expect(data.body).toContain(String(full.length));
+  });
+
+  it("leaves a body that already fits completely unchanged, with no marker", async () => {
+    mockRead.mockResolvedValue({
+      id: "msg-1",
+      from: "a@test.com",
+      subject: "Short",
+      body: "A short body.\n\nWith a second paragraph.",
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_read", agentId)!;
+
+    const data = JSON.parse((await tool.execute("call-1", { id: "msg-1" })).content[0].text);
+
+    expect(data.body).toBe("A short body.\n\nWith a second paragraph.");
+    expect(data.body).not.toContain("truncated");
+  });
+
+  // An adapter that returns no body at all must not gain an invented `body: ""`
+  // key on the way through — the cap normalizes size, not shape.
+  it("does not invent a body key when the adapter returned none", async () => {
+    mockRead.mockResolvedValue({ id: "msg-1", from: "a@test.com", subject: "No body" });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_read", agentId)!;
+
+    const data = JSON.parse((await tool.execute("call-1", { id: "msg-1" })).content[0].text);
+
+    expect(data).not.toHaveProperty("body");
   });
 });
 

--- a/packages/plugins/pinchy-email/email-adapter.ts
+++ b/packages/plugins/pinchy-email/email-adapter.ts
@@ -8,21 +8,87 @@ export function escapeDoubleQuoted(v: string): string {
   return v.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-// Very small HTML-to-text fallback. IMAP relies on mailparser's bundled
-// html-to-text for the common case and only reaches this when a message
-// genuinely has no text/plain part; Graph has no equivalent library in the
-// loop at all, since Graph's own `body.content` is returned verbatim in
-// whatever `body.contentType` the message was stored in. Shared here (rather
-// than duplicated per adapter) so both providers reduce HTML the same way.
-// Kept intentionally simple rather than pulling in another HTML-parsing
-// dependency for a fallback/normalization path.
+// Block-level tags mark a line break in the rendered message. Collapsing them
+// to a space along with everything else turns a whole email into one endless
+// line, which is exactly what the model then has to reason over.
+const HTML_BLOCK_BOUNDARY_RE =
+  /<\/?(?:p|div|br|tr|li|ul|ol|h[1-6]|table|thead|tbody|blockquote|section|article|pre|hr)\b[^>]*>/gi;
+
+const HTML_ENTITIES: Record<string, string> = {
+  nbsp: " ",
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  "#39": "'",
+};
+
+// Reduce an HTML body to readable plain text.
+//
+// This is a *fallback* for IMAP — mailparser's bundled html-to-text already
+// derives `ParsedMail.text` from the html in the common case, so IMAP only
+// reaches this when a message genuinely has no text/plain part. For Graph it
+// is the *primary* path (Graph hands back `body.content` verbatim in whatever
+// `body.contentType` the message was stored in, and most Outlook mail is
+// stored as html), and it is the html-only path for Gmail. So "good enough
+// for a rare fallback" is not the bar any more: block-level tags become line
+// breaks so paragraph and list structure survives, and the handful of
+// entities that actually appear in mail bodies are decoded.
+//
+// Still deliberately dependency-free. A real HTML parser buys correctness on
+// markup this never sees — the output is read by a model, not rendered.
 export function stripHtml(html: string): string {
-  return html
-    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return (
+    html
+      .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+      // Outlook's conditional comments (`<!--[if mso]> … <![endif]-->`) are
+      // markup, not content; without this their bodies survive tag-stripping
+      // and read as duplicated text.
+      .replace(/<!--[\s\S]*?-->/g, " ")
+      .replace(HTML_BLOCK_BOUNDARY_RE, "\n")
+      .replace(/<[^>]+>/g, " ")
+      // Decoded AFTER tag removal, so a `&lt;script&gt;` in the source can
+      // never become a tag this function then fails to strip.
+      .replace(/&(nbsp|amp|lt|gt|quot|apos|#39);/gi, (m, name: string) => {
+        return HTML_ENTITIES[name.toLowerCase()] ?? m;
+      })
+      // Horizontal whitespace only — `\s+` would eat the line breaks above.
+      .replace(/[^\S\n]+/g, " ")
+      .replace(/ ?\n ?/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
+}
+
+/**
+ * Ceiling for an email body handed to the model, in characters.
+ *
+ * OpenClaw's runtime caps every tool result at 64000 chars and replaces the
+ * overflow with a literal truncation marker spliced MID-JSON, so the model
+ * receives corrupt JSON and loops on it — the production failure documented on
+ * `ODOO_READ_RESULT_BUDGET_CHARS` in pinchy-odoo/index.ts. An email body is
+ * the one unbounded field in `email_read`'s payload: a real HTML marketing
+ * mail runs to hundreds of KB, and even stripped to text a newsletter clears
+ * 64000 easily. Bounding well under the cap keeps our JSON intact and leaves
+ * room for several reads inside OpenClaw's 256000-char aggregate budget.
+ */
+export const EMAIL_BODY_MAX_CHARS = 30000;
+
+/**
+ * Bound a body to {@link EMAIL_BODY_MAX_CHARS}. A body that already fits is
+ * returned unchanged (same string, no marker). An oversized one keeps its
+ * leading `EMAIL_BODY_MAX_CHARS` characters and says so in words the model can
+ * act on — a bare `[truncated]` reads as part of the message and leaves the
+ * model free to report the cut text as the whole email.
+ */
+export function truncateEmailBody(body: string, max: number = EMAIL_BODY_MAX_CHARS): string {
+  if (body.length <= max) return body;
+  return (
+    `${body.slice(0, max)}\n\n[Body truncated: this is the first ${max} of ${body.length} ` +
+    `characters. The rest was not read — say the message is longer rather than ` +
+    `treating this as its full text.]`
+  );
 }
 
 // Shared by every adapter: the canonical-name validation and error message are

--- a/packages/plugins/pinchy-email/email-adapter.ts
+++ b/packages/plugins/pinchy-email/email-adapter.ts
@@ -8,6 +8,23 @@ export function escapeDoubleQuoted(v: string): string {
   return v.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+// Very small HTML-to-text fallback. IMAP relies on mailparser's bundled
+// html-to-text for the common case and only reaches this when a message
+// genuinely has no text/plain part; Graph has no equivalent library in the
+// loop at all, since Graph's own `body.content` is returned verbatim in
+// whatever `body.contentType` the message was stored in. Shared here (rather
+// than duplicated per adapter) so both providers reduce HTML the same way.
+// Kept intentionally simple rather than pulling in another HTML-parsing
+// dependency for a fallback/normalization path.
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 // Shared by every adapter: the canonical-name validation and error message are
 // identical across providers, only the provider-specific value for each
 // folder differs (Gmail label IDs vs Graph well-known folder names). Sharing

--- a/packages/plugins/pinchy-email/gmail-adapter.ts
+++ b/packages/plugins/pinchy-email/gmail-adapter.ts
@@ -1,5 +1,5 @@
 import { google } from "googleapis";
-import { createFolderMapper, escapeDoubleQuoted } from "./email-adapter.js";
+import { createFolderMapper, escapeDoubleQuoted, stripHtml } from "./email-adapter.js";
 import type {
   EmailAdapter,
   EmailAttachment,
@@ -275,7 +275,8 @@ function findAttachmentPart(part: MimePart, attachmentId: string): MimePart | nu
 function extractBody(payload: MimePart): string {
   // Single-part message
   if (!payload.parts && payload.body?.data) {
-    return decodeBase64url(payload.body.data);
+    const decoded = decodeBase64url(payload.body.data);
+    return payload.mimeType === "text/html" ? stripHtml(decoded) : decoded;
   }
 
   // Multipart: recursively search for text/plain, fallback to text/html
@@ -284,9 +285,13 @@ function extractBody(payload: MimePart): string {
     return decodeBase64url(plain.body.data);
   }
 
+  // The html fallback used to be returned as raw markup. That is the same
+  // defect the Graph adapter had: an html-only message (common for anything
+  // machine-generated) reached the model as a wall of tags, and a marketing
+  // mail's markup is mostly styling the model then has to read past.
   const html = findPart(payload, "text/html");
   if (html?.body?.data) {
-    return decodeBase64url(html.body.data);
+    return stripHtml(decodeBase64url(html.body.data));
   }
 
   return "";

--- a/packages/plugins/pinchy-email/graph-adapter.ts
+++ b/packages/plugins/pinchy-email/graph-adapter.ts
@@ -96,27 +96,19 @@ function buildOrderedFilter(filters: string[]): string | undefined {
 }
 
 // Microsoft Graph returns `body.content` verbatim in whatever
-// `body.contentType` ("text" or "html") the message was stored in — unlike
-// IMAP/Gmail, which prefer the text/plain MIME part and only fall back to
-// raw (stripped) HTML when no plain-text part exists. Left unbounded, a
-// large HTML marketing email easily runs to hundreds of KB, and OpenClaw's
-// runtime caps every tool result at 64000 chars, replacing the overflow with
-// a literal truncation marker spliced MID-JSON — the model then receives
-// corrupt JSON and loops on it, the same production failure mode documented
-// on ODOO_READ_RESULT_BUDGET_CHARS in pinchy-odoo/index.ts. We strip HTML to
-// text (via the shared `stripHtml`) and bound the result well under 64000 so
-// email_read's output is never cut mid-structure.
-export const GRAPH_BODY_MAX_CHARS = 30000;
-
-function truncateBody(text: string): string {
-  if (text.length <= GRAPH_BODY_MAX_CHARS) return text;
-  return `${text.slice(0, GRAPH_BODY_MAX_CHARS)}\n[truncated]`;
-}
-
+// `body.contentType` ("text" or "html") the message was stored in, and most
+// Outlook mail is stored as html — so without this the model reads raw markup
+// where IMAP hands it text. The size ceiling that keeps `email_read` out of
+// OpenClaw's blind mid-JSON truncation is NOT here: it is applied once at the
+// tool boundary (`truncateEmailBody`, see index.ts) because every adapter's
+// body is equally unbounded, and a per-adapter cap is a list that goes stale
+// the first time a fourth provider lands.
 function extractBody(body: { contentType?: string; content?: string } | undefined): string {
   const raw = body?.content ?? "";
-  const plain = body?.contentType === "html" ? stripHtml(raw) : raw;
-  return truncateBody(plain);
+  // Graph documents the enum as lowercase `text`/`html`, but a case-sensitive
+  // compare is one unexpected payload away from handing the model a body of
+  // pure markup — cheap to not depend on.
+  return body?.contentType?.toLowerCase() === "html" ? stripHtml(raw) : raw;
 }
 
 function toSummary(m: GraphMessage): EmailSummary {

--- a/packages/plugins/pinchy-email/graph-adapter.ts
+++ b/packages/plugins/pinchy-email/graph-adapter.ts
@@ -1,4 +1,4 @@
-import { createFolderMapper, escapeDoubleQuoted } from "./email-adapter.js";
+import { createFolderMapper, escapeDoubleQuoted, stripHtml } from "./email-adapter.js";
 import type {
   EmailAdapter,
   EmailAttachment,
@@ -95,6 +95,30 @@ function buildOrderedFilter(filters: string[]): string | undefined {
   return ordered.join(" and ");
 }
 
+// Microsoft Graph returns `body.content` verbatim in whatever
+// `body.contentType` ("text" or "html") the message was stored in — unlike
+// IMAP/Gmail, which prefer the text/plain MIME part and only fall back to
+// raw (stripped) HTML when no plain-text part exists. Left unbounded, a
+// large HTML marketing email easily runs to hundreds of KB, and OpenClaw's
+// runtime caps every tool result at 64000 chars, replacing the overflow with
+// a literal truncation marker spliced MID-JSON — the model then receives
+// corrupt JSON and loops on it, the same production failure mode documented
+// on ODOO_READ_RESULT_BUDGET_CHARS in pinchy-odoo/index.ts. We strip HTML to
+// text (via the shared `stripHtml`) and bound the result well under 64000 so
+// email_read's output is never cut mid-structure.
+export const GRAPH_BODY_MAX_CHARS = 30000;
+
+function truncateBody(text: string): string {
+  if (text.length <= GRAPH_BODY_MAX_CHARS) return text;
+  return `${text.slice(0, GRAPH_BODY_MAX_CHARS)}\n[truncated]`;
+}
+
+function extractBody(body: { contentType?: string; content?: string } | undefined): string {
+  const raw = body?.content ?? "";
+  const plain = body?.contentType === "html" ? stripHtml(raw) : raw;
+  return truncateBody(plain);
+}
+
 function toSummary(m: GraphMessage): EmailSummary {
   return {
     id: m.id,
@@ -163,7 +187,7 @@ export class GraphAdapter implements EmailAdapter {
     return {
       ...toSummary(m),
       cc: m.ccRecipients?.map((r) => r.emailAddress?.address ?? "").join(", ") ?? "",
-      body: m.body?.content ?? "",
+      body: extractBody(m.body),
       // Only pay for the second round trip when the message actually has
       // attachments — the common no-attachment case stays a single request.
       attachments: m.hasAttachments ? await this.listAttachments(id) : [],

--- a/packages/plugins/pinchy-email/imap-adapter.ts
+++ b/packages/plugins/pinchy-email/imap-adapter.ts
@@ -4,6 +4,7 @@ import { simpleParser } from "mailparser";
 import type { AddressObject, ParsedMail } from "mailparser";
 import nodemailer from "nodemailer";
 import MailComposer from "nodemailer/lib/mail-composer/index.js";
+import { stripHtml } from "./email-adapter.js";
 import type {
   EmailAdapter,
   EmailAttachment,
@@ -169,20 +170,6 @@ const SNIPPET_LENGTH = 200;
 function addressText(addr: AddressObject | AddressObject[] | undefined): string {
   if (!addr) return "";
   return Array.isArray(addr) ? addr.map((a) => a.text).join(", ") : addr.text;
-}
-
-// Very small HTML-to-text fallback for when a message has no text/plain
-// part. mailparser already derives ParsedMail.text from html in the common
-// case (via its bundled html-to-text), so this only matters for the rare
-// case where text is genuinely absent — kept intentionally simple rather
-// than pulling in another HTML-parsing dependency for a fallback path.
-function stripHtml(html: string): string {
-  return html
-    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/\s+/g, " ")
-    .trim();
 }
 
 // First ~200 chars of the body, whitespace-collapsed onto a single line —

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile, access, chown } from "node:fs/promises";
 import { basename } from "node:path";
 import type { EmailAdapter, EmailSummary, Folder } from "./email-adapter.js";
+import { truncateEmailBody } from "./email-adapter.js";
 import { checkPermission, type Permissions } from "./permissions.js";
 import {
   putHandle,
@@ -985,9 +986,17 @@ const plugin = {
                 ...a,
                 id: putAttachmentHandle(agentId, a.id),
               }));
+              // The body is the one unbounded field in this payload, and every
+              // adapter's is unbounded in its own way (Graph's stored html,
+              // Gmail's decoded part, IMAP's mailparser text). Bounding it here
+              // rather than in each adapter means a future provider is covered
+              // the moment it exists, instead of the moment someone remembers.
+              const body =
+                typeof result.body === "string" ? truncateEmailBody(result.body) : result.body;
               const handleizedResult = {
                 ...result,
                 id: msgHandle,
+                body,
                 attachments: handleizedAttachments,
               };
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -54,6 +54,7 @@ import plugin, {
   enforceReadResultBudget,
   ODOO_READ_RESULT_BUDGET_CHARS,
   ODOO_READ_TRUNCATION_HINT,
+  ODOO_AGGREGATE_TRUNCATION_HINT,
 } from "../index";
 
 const MOVE_FIELDS: OdooField[] = [
@@ -1345,7 +1346,12 @@ describe("enforceReadResultBudget", () => {
   // is exactly the gap this closes.
   it("supports a custom key so it can also bound odoo_aggregate's `groups` result", () => {
     const result = { groups: bigRecords(200) };
-    const out = enforceReadResultBudget(result, ODOO_READ_RESULT_BUDGET_CHARS, "groups") as {
+    const out = enforceReadResultBudget(
+      result,
+      ODOO_READ_RESULT_BUDGET_CHARS,
+      "groups",
+      ODOO_AGGREGATE_TRUNCATION_HINT
+    ) as {
       groups: unknown[];
       total: number;
       returned: number;
@@ -1356,8 +1362,32 @@ describe("enforceReadResultBudget", () => {
     expect(out.groups.length).toBeLessThan(200);
     expect(out.groups.length).toBeGreaterThan(0);
     expect(out.returned).toBe(out.groups.length);
-    expect(out.hint).toBe(ODOO_READ_TRUNCATION_HINT);
+    expect(out.hint).toBe(ODOO_AGGREGATE_TRUNCATION_HINT);
     expect(JSON.stringify(out).length).toBeLessThanOrEqual(ODOO_READ_RESULT_BUDGET_CHARS);
+  });
+
+  it("still uses the read hint when no hint is passed, so odoo_read is unchanged", () => {
+    const out = enforceReadResultBudget({ records: bigRecords(200) }) as { hint: string };
+    expect(out.hint).toBe(ODOO_READ_TRUNCATION_HINT);
+  });
+});
+
+// The hint is the only thing the model has to recover from a cut result, so
+// its advice has to be executable for the tool that emitted it. Reusing the
+// read hint here told the model to "request fewer `fields` (drop heavy ones
+// like `description`)" — on an aggregation a field IS the aggregation, so
+// following that advice removes the answer rather than shrinking the result.
+describe("ODOO_AGGREGATE_TRUNCATION_HINT", () => {
+  it("names levers odoo_aggregate actually has", () => {
+    expect(ODOO_AGGREGATE_TRUNCATION_HINT).toContain("limit");
+    expect(ODOO_AGGREGATE_TRUNCATION_HINT).toContain("group by");
+    expect(ODOO_AGGREGATE_TRUNCATION_HINT).toContain("filters");
+    expect(ODOO_AGGREGATE_TRUNCATION_HINT).toContain("offset");
+  });
+
+  it("does not repeat the read hint's inapplicable advice", () => {
+    expect(ODOO_AGGREGATE_TRUNCATION_HINT).not.toContain("description");
+    expect(ODOO_AGGREGATE_TRUNCATION_HINT).not.toContain("records");
   });
 });
 
@@ -2224,6 +2254,9 @@ describe("odoo_aggregate", () => {
     expect(data.truncated).toBe(true);
     expect(data.groups.length).toBeGreaterThan(0);
     expect(data.groups.length).toBeLessThan(500);
+    // The recovery advice the model receives has to be the aggregate one —
+    // the read hint's "drop heavy `fields`" removes the aggregation itself.
+    expect(data.hint).toBe(ODOO_AGGREGATE_TRUNCATION_HINT);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1337,6 +1337,28 @@ describe("enforceReadResultBudget", () => {
     expect(out.returned).toBe(out.records.length);
     expect(JSON.stringify(out).length).toBeLessThanOrEqual(ODOO_READ_RESULT_BUDGET_CHARS);
   });
+
+  // odoo_aggregate's readGroup result nests its rows under `groups`, not
+  // `records` — the same shape difference odoo_read never has. A budget
+  // helper that only ever looks for `records` would report `records.length
+  // === 0` for a `{ groups: [...] }` payload and return it unbounded, which
+  // is exactly the gap this closes.
+  it("supports a custom key so it can also bound odoo_aggregate's `groups` result", () => {
+    const result = { groups: bigRecords(200) };
+    const out = enforceReadResultBudget(result, ODOO_READ_RESULT_BUDGET_CHARS, "groups") as {
+      groups: unknown[];
+      total: number;
+      returned: number;
+      truncated: boolean;
+      hint: string;
+    };
+    expect(out.truncated).toBe(true);
+    expect(out.groups.length).toBeLessThan(200);
+    expect(out.groups.length).toBeGreaterThan(0);
+    expect(out.returned).toBe(out.groups.length);
+    expect(out.hint).toBe(ODOO_READ_TRUNCATION_HINT);
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(ODOO_READ_RESULT_BUDGET_CHARS);
+  });
 });
 
 describe("odoo_read", () => {
@@ -2171,6 +2193,37 @@ describe("odoo_aggregate", () => {
 
     expect(result.content[0].text).toContain("Permission denied");
     expect(result.isError).toBe(true);
+  });
+
+  // Same production incident as odoo_read (see ODOO_READ_RESULT_BUDGET_CHARS):
+  // a wide `groupby` on a large table can return hundreds of groups, and the
+  // readGroup result was serialized verbatim with no budget at all. Without
+  // this, OpenClaw's blind 64000-char mid-JSON truncation corrupts the JSON
+  // and the model loops, exactly as with the original odoo_read incident.
+  it("truncates an oversized readGroup result into valid, self-describing JSON instead of letting OpenClaw cut it mid-JSON", async () => {
+    mockReadGroup.mockResolvedValue({
+      groups: Array.from({ length: 500 }, (_, i) => ({
+        partner_id: [i + 1, `Customer ${i + 1} ${"x".repeat(500)}`],
+        amount_total: 1500,
+        __count: 3,
+      })),
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+
+    const result = await tool.execute("call-budget", {
+      model: "sale.order",
+      filters: [],
+      fields: ["partner_id", "amount_total:sum"],
+      groupby: ["partner_id"],
+    });
+
+    expect(result.content[0].text.length).toBeLessThanOrEqual(ODOO_READ_RESULT_BUDGET_CHARS);
+    const data = JSON.parse(result.content[0].text);
+    expect(data.truncated).toBe(true);
+    expect(data.groups.length).toBeGreaterThan(0);
+    expect(data.groups.length).toBeLessThan(500);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2078,6 +2078,21 @@ export const ODOO_READ_TRUNCATION_HINT =
   "`returned`.";
 
 /**
+ * The aggregate hint is its own text, not a reuse of the read one. Truncation
+ * guidance is what the model acts on, and every lever the read hint names is
+ * either wrong or a no-op for `odoo_aggregate`: dropping a `field` removes an
+ * aggregation rather than a heavy column, and the rows are groups, not
+ * records. Wrong recovery advice on a truncated result is how the original
+ * incident's loop started.
+ */
+export const ODOO_AGGREGATE_TRUNCATION_HINT =
+  "Result truncated to fit the model's context budget: the first `returned` of " +
+  "`total` groups (in order) are included. To make the result smaller, set a " +
+  "`limit`, group by fewer or coarser fields (e.g. `date_order:month` instead of " +
+  "`date_order:day`), or narrow `filters`. To get the next page, re-run with " +
+  "`offset` set to this request's `offset` plus `returned`.";
+
+/**
  * Bound an `odoo_read` (or, via the `key` param, `odoo_aggregate`) result to
  * {@link ODOO_READ_RESULT_BUDGET_CHARS} so it can never trip OpenClaw's blind
  * mid-JSON truncation. A result that already fits is returned verbatim (same
@@ -2092,12 +2107,14 @@ export const ODOO_READ_TRUNCATION_HINT =
  *
  * `key` defaults to `"records"` (the `odoo_read`/`searchRead` shape).
  * `odoo_aggregate`'s `readGroup` result nests its rows under `groups` instead,
- * so it passes `key: "groups"`.
+ * so it passes `key: "groups"` — and its own `hint`, since the read hint's
+ * advice does not apply to an aggregation.
  */
 export function enforceReadResultBudget(
   result: unknown,
   budget: number = ODOO_READ_RESULT_BUDGET_CHARS,
-  key: string = "records"
+  key: string = "records",
+  hint: string = ODOO_READ_TRUNCATION_HINT
 ): unknown {
   const records = getSearchReadRecords(result, key);
   if (records.length === 0) return result;
@@ -2119,7 +2136,7 @@ export function enforceReadResultBudget(
     total,
     returned: kept.length,
     truncated: true,
-    hint: ODOO_READ_TRUNCATION_HINT,
+    hint,
   });
 
   // Grow the kept set while the *actual* serialized length stays within budget
@@ -3049,7 +3066,12 @@ const plugin = {
                   {
                     type: "text",
                     text: JSON.stringify(
-                      enforceReadResultBudget(result, ODOO_READ_RESULT_BUDGET_CHARS, "groups")
+                      enforceReadResultBudget(
+                        result,
+                        ODOO_READ_RESULT_BUDGET_CHARS,
+                        "groups",
+                        ODOO_AGGREGATE_TRUNCATION_HINT
+                      )
                     ),
                   },
                 ],

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -640,10 +640,10 @@ export function prepareAggregateFields(value: unknown, paramName: "fields" | "gr
   return stripped;
 }
 
-function getSearchReadRecords(result: unknown): OdooRecord[] {
+function getSearchReadRecords(result: unknown, key: string = "records"): OdooRecord[] {
   if (Array.isArray(result)) return result.filter(isRecord);
-  if (isRecord(result) && Array.isArray(result.records)) {
-    return result.records.filter(isRecord);
+  if (isRecord(result) && Array.isArray(result[key])) {
+    return (result[key] as unknown[]).filter(isRecord);
   }
   return [];
 }
@@ -2054,7 +2054,8 @@ function wrapReadResult(
 }
 
 /**
- * Serialized-size ceiling for an `odoo_read` result, in characters.
+ * Serialized-size ceiling for an `odoo_read` or `odoo_aggregate` result, in
+ * characters.
  *
  * OpenClaw's runtime caps every tool result at `maxChars=64000` and the whole
  * prompt history at `aggregateBudgetChars=256000`, replacing the overflow with a
@@ -2077,29 +2078,36 @@ export const ODOO_READ_TRUNCATION_HINT =
   "`returned`.";
 
 /**
- * Bound an `odoo_read` result to {@link ODOO_READ_RESULT_BUDGET_CHARS} so it can
- * never trip OpenClaw's blind mid-JSON truncation. A result that already fits is
- * returned verbatim (same reference, no added keys — existing callers/tests see
- * no change). An oversized result keeps the largest prefix of records that fits
+ * Bound an `odoo_read` (or, via the `key` param, `odoo_aggregate`) result to
+ * {@link ODOO_READ_RESULT_BUDGET_CHARS} so it can never trip OpenClaw's blind
+ * mid-JSON truncation. A result that already fits is returned verbatim (same
+ * reference, no added keys — existing callers/tests see no change). An
+ * oversized result keeps the largest prefix of `result[key]` entries that fits
  * and returns a self-describing object: the original `total` (full Odoo match
- * count) is preserved, `returned` gives the included count, `truncated: true`
- * flags the cut, and `hint` tells the model how to get the rest. At least one
- * record is always kept, even if that single record alone exceeds the budget, so
- * the model can still make progress (and see the hint to drop heavy `fields`).
+ * count, when the input carries one) is preserved, `returned` gives the
+ * included count, `truncated: true` flags the cut, and `hint` tells the model
+ * how to get the rest. At least one entry is always kept, even if that single
+ * entry alone exceeds the budget, so the model can still make progress (and
+ * see the hint to drop heavy `fields`).
+ *
+ * `key` defaults to `"records"` (the `odoo_read`/`searchRead` shape).
+ * `odoo_aggregate`'s `readGroup` result nests its rows under `groups` instead,
+ * so it passes `key: "groups"`.
  */
 export function enforceReadResultBudget(
   result: unknown,
-  budget: number = ODOO_READ_RESULT_BUDGET_CHARS
+  budget: number = ODOO_READ_RESULT_BUDGET_CHARS,
+  key: string = "records"
 ): unknown {
-  const records = getSearchReadRecords(result);
+  const records = getSearchReadRecords(result, key);
   if (records.length === 0) return result;
   if (JSON.stringify(result).length <= budget) return result;
 
-  const isObjectShape = isRecord(result) && Array.isArray(result.records);
+  const isObjectShape = isRecord(result) && Array.isArray(result[key]);
   const base: Record<string, unknown> = isObjectShape
     ? { ...(result as Record<string, unknown>) }
     : {};
-  delete base.records;
+  delete base[key];
   const total =
     isObjectShape && typeof (result as Record<string, unknown>).total === "number"
       ? ((result as Record<string, unknown>).total as number)
@@ -2107,7 +2115,7 @@ export function enforceReadResultBudget(
 
   const build = (kept: OdooRecord[]) => ({
     ...base,
-    records: kept,
+    [key]: kept,
     total,
     returned: kept.length,
     truncated: true,
@@ -3037,7 +3045,14 @@ const plugin = {
               );
 
               return {
-                content: [{ type: "text", text: JSON.stringify(result) }],
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(
+                      enforceReadResultBudget(result, ODOO_READ_RESULT_BUDGET_CHARS, "groups")
+                    ),
+                  },
+                ],
               };
             } catch (error) {
               return errorResult(error, {


### PR DESCRIPTION
## Summary

- OpenClaw's runtime caps every tool result at 64000 chars and replaces overflow with a literal marker spliced mid-JSON — a documented production incident for `odoo_read` (see `ODOO_READ_RESULT_BUDGET_CHARS` comment in `packages/plugins/pinchy-odoo/index.ts`). Two more paths shared the same unbounded shape and could hit the same failure (corrupt JSON → model loops):
  - `odoo_aggregate`'s `readGroup` result nests rows under `groups`, not `records`, so the existing `enforceReadResultBudget` silently found nothing to bound. Generalized the helper with a `key` param (defaults to `"records"`, unchanged for `odoo_read`) and wrapped the aggregate result with `key: "groups"`.
  - `pinchy-email`'s Microsoft Graph adapter returned `body.content` verbatim regardless of `contentType`, unlike IMAP/Gmail (which prefer `text/plain` and only fall back to stripped HTML). Moved the existing `stripHtml` helper to the shared `email-adapter.ts` module, route Graph's HTML bodies through it, and cap the result to a new `GRAPH_BODY_MAX_CHARS` (30000) with a `[truncated]` marker.

## Test plan

- [x] `packages/plugins/pinchy-odoo/__tests__/tools.test.ts`: added `enforceReadResultBudget` test for the `groups` key, and an `odoo_aggregate` test asserting an oversized `readGroup` result truncates into valid, budget-bound JSON — both red before the fix, green after.
- [x] `packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts`: added tests for HTML stripping, oversized-body truncation with the `[truncated]` marker, and a same-shape control asserting a short plain-text body is left unchanged — red before the fix, green after.
- [x] `pnpm test:related` — 750 passed.
- [x] `pnpm typecheck:plugins` — all 9 plugin packages clean.
- [x] `pnpm test:plugins` — 454 (pinchy-odoo) + 364 (pinchy-email) + others, all passed.
- [x] `pnpm format:check` — clean.
- [x] `pnpm test` (full suite) — 774 passed | 4 skipped test files, 10922 passed | 18 skipped tests.