### PR TITLE
test(kb): cover the LIKE-escaping boundary in buildPathFilter

### DIFF
--- a/packages/web/src/__tests__/lib/knowledge/path-filter.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/path-filter.test.ts
@@ -9,92 +9,66 @@
  * prefix-bleed and deny-by-default, but no allowed path containing `_`, `%`,
  * or `\`.
  *
- * `escapeLikePattern` itself is a private, unexported implementation detail
- * of buildPathFilter() — deliberately not exported for this test file, since
- * the brief for this PR is test-only. These tests instead exercise it through
- * buildPathFilter()'s public SQL output, by walking the drizzle-orm `SQL`
- * object's `queryChunks` to read the raw LIKE-pattern parameter that was
- * interpolated into the query. This is exactly the value Postgres receives
- * on the wire, so it is at least as strong a check as calling the private
- * function directly — and it also lets these tests catch a regression where
- * the escaping is dropped entirely, moved to the wrong operand, or applied
- * in the wrong order (see the "order matters" test below).
+ * `escapeLikePattern` is a private, unexported implementation detail of
+ * buildPathFilter(), and stays that way — the question worth asking is not
+ * what that function returns but what Postgres is finally asked to match. So
+ * these tests compile buildPathFilter()'s `SQL` with drizzle's own
+ * `PgDialect.sqlToQuery()` — the public API the driver itself calls on the
+ * way to the wire — and assert the resulting `{ sql, params }`: the
+ * parameterized query text and the exact bytes bound into it.
  *
- * Mutation check performed while writing this file (not committed): with the
- * three `.replace(...)` calls in `escapeLikePattern` removed (or reordered),
- * every test below goes red. See the PR description for the exact diff and
- * failure output.
+ * Reading the compiled query rather than the `SQL` object's internal
+ * `queryChunks` is what lets the ESCAPE-clause test below exist at all: the
+ * clause is query TEXT, not a parameter, so no assertion on the pattern
+ * string can see it.
+ *
+ * Mutation evidence, measured while writing this file (nothing committed —
+ * `git diff` on path-filter.ts is empty):
+ *
+ *   - `escapeLikePattern` reduced to `return value`: 6 of 10 red. Listing the
+ *     four survivors is the honest half of this note — they are the two that
+ *     assert an ABSENCE of escaping (the plain-path case and the `=`-operand
+ *     case), the determinism check, and the compiled-predicate check. None of
+ *     them depends on a metacharacter being rewritten, so "every test goes
+ *     red" would be a claim this file does not support.
+ *   - the `.replace()` calls reordered so `%`/`_` are escaped before `\`:
+ *     5 of 10 red. The one metacharacter case that survives is the
+ *     backslash-only path, which contains no `%` or `_` for the reordering to
+ *     act on — every other metacharacter case comes out with the backslash
+ *     doubled around a now-unescaped wildcard.
+ *   - `ESCAPE '\\'` changed to `ESCAPE '!'` in path-filter.ts: 2 red, and
+ *     both are the tests that read the compiled query TEXT. Every assertion
+ *     on a bound pattern stays green and byte-identical while Postgres reads
+ *     the emitted `\_` as two literal characters and the wildcard is back.
+ *     That mutant is the reason this file compiles the query instead of
+ *     inspecting the escaping in isolation.
  */
-import { sql, type SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 
 import { buildPathFilter } from "@/lib/knowledge/path-filter";
 
-/**
- * Recursively walks a drizzle-orm SQL object's `queryChunks` (which nest —
- * `buildPathFilter` builds one `SQL` fragment per allowed path and joins them
- * with `sql\` OR \``, so a multi-path call's chunks contain child `SQL`
- * objects rather than one flat array) and collects every raw string
- * parameter that was interpolated immediately after a ` LIKE ` operator
- * chunk, in encounter order. That parameter is exactly what
- * `escapeLikePattern` produced (plus the trailing `%` buildPathFilter
- * appends), i.e. the literal bytes Postgres receives for the LIKE pattern.
- */
-function collectLikePatterns(node: unknown, out: string[] = []): string[] {
-  if (Array.isArray(node)) {
-    for (let i = 0; i < node.length; i++) {
-      const chunk = node[i];
-      if (
-        typeof chunk === "object" &&
-        chunk !== null &&
-        Array.isArray((chunk as { value?: unknown[] }).value) &&
-        (chunk as { value: unknown[] }).value[0] === " LIKE "
-      ) {
-        const next = node[i + 1];
-        if (typeof next === "string") out.push(next);
-      }
-      collectLikePatterns(chunk, out);
-    }
-    return out;
-  }
-  if (typeof node === "object" && node !== null && "queryChunks" in node) {
-    collectLikePatterns((node as { queryChunks: unknown[] }).queryChunks, out);
-  }
-  return out;
-}
-
-/** Same walk, but for the raw parameter following the ` = ` equality operator. */
-function collectEqualsValues(node: unknown, out: string[] = []): string[] {
-  if (Array.isArray(node)) {
-    for (let i = 0; i < node.length; i++) {
-      const chunk = node[i];
-      if (
-        typeof chunk === "object" &&
-        chunk !== null &&
-        Array.isArray((chunk as { value?: unknown[] }).value) &&
-        (chunk as { value: unknown[] }).value[0] === " = "
-      ) {
-        const next = node[i + 1];
-        if (typeof next === "string") out.push(next);
-      }
-      collectEqualsValues(chunk, out);
-    }
-    return out;
-  }
-  if (typeof node === "object" && node !== null && "queryChunks" in node) {
-    collectEqualsValues((node as { queryChunks: unknown[] }).queryChunks, out);
-  }
-  return out;
-}
-
 const COLUMN = sql`c.source_path`;
 
-/** buildPathFilter() for a single allowed path, returning its LIKE pattern. */
+/**
+ * Compiles buildPathFilter()'s fragment the way the pg driver does, yielding
+ * the parameterized SQL text plus the ordered parameter values. Per allowed
+ * path the template binds two, in this order: the `=` operand (the raw
+ * allowed path) and then the LIKE pattern (escaped, with the trailing `%`).
+ */
+function compile(allowedPaths: readonly string[]): { text: string; params: unknown[] } {
+  const { sql: text, params } = new PgDialect().sqlToQuery(buildPathFilter(allowedPaths, COLUMN));
+  return { text, params };
+}
+
+/** The LIKE pattern buildPathFilter() binds for a single allowed path. */
 function likePatternFor(allowedPath: string): string {
-  const condition = buildPathFilter([allowedPath], COLUMN);
-  const patterns = collectLikePatterns(condition);
-  expect(patterns).toHaveLength(1);
-  return patterns[0];
+  const { params } = compile([allowedPath]);
+  expect(params).toHaveLength(2);
+  const pattern = params[1];
+  expect(typeof pattern).toBe("string");
+  return pattern as string;
 }
 
 describe("buildPathFilter — LIKE pattern escaping (escapeLikePattern boundary)", () => {
@@ -147,10 +121,38 @@ describe("buildPathFilter — LIKE pattern escaping (escapeLikePattern boundary)
     expect(second).toBe(first);
   });
 
+  it("compiles to an equality-or-prefix predicate that declares backslash as the LIKE ESCAPE character", () => {
+    // Two things no assertion on a bound parameter can reach.
+    //
+    // The ESCAPE character: it is what makes the emitted `\_` an escaped
+    // literal underscore rather than two characters. Change it to anything
+    // else and every pattern assertion in this file is still byte-identical
+    // and still green, while Postgres reads the `_` as a wildcard again.
+    // (Backslash also happens to be Postgres's default, so DROPPING the
+    // clause is harmless — replacing it is not, and that is the mutant.)
+    //
+    // The parameter order: the tests above read params[1] as the LIKE
+    // pattern and params[0] as the `=` operand. This is where that reading
+    // is pinned, so a restructured predicate fails here by name instead of
+    // making the others quietly compare the wrong operand.
+    expect(compile(["/data/my_folder"]).text).toBe(
+      "(c.source_path = $1 OR c.source_path LIKE $2 ESCAPE '\\')"
+    );
+  });
+
   it("escapes each allowed path independently when buildPathFilter is given several", () => {
-    const condition = buildPathFilter(["/data/my_folder", "/data/50%off"], COLUMN);
-    const patterns = collectLikePatterns(condition);
-    expect(patterns).toEqual(["/data/my\\_folder/%", "/data/50\\%off/%"]);
+    const { text, params } = compile(["/data/my_folder", "/data/50%off"]);
+
+    expect(text).toBe(
+      "(c.source_path = $1 OR c.source_path LIKE $2 ESCAPE '\\') OR " +
+        "(c.source_path = $3 OR c.source_path LIKE $4 ESCAPE '\\')"
+    );
+    expect(params).toEqual([
+      "/data/my_folder",
+      "/data/my\\_folder/%",
+      "/data/50%off",
+      "/data/50\\%off/%",
+    ]);
   });
 
   it("does NOT escape the exact-match (=) operand — escaping is scoped to the LIKE pattern only", () => {
@@ -159,8 +161,6 @@ describe("buildPathFilter — LIKE pattern escaping (escapeLikePattern boundary)
     // that escaped everywhere (not just the prefix pattern) would break an
     // agent whose allowedPaths entry is an exact file path containing `_`
     // or `%` — it would stop matching itself.
-    const condition = buildPathFilter(["/data/my_folder"], COLUMN);
-    const equalsValues = collectEqualsValues(condition);
-    expect(equalsValues).toEqual(["/data/my_folder"]);
+    expect(compile(["/data/my_folder"]).params[0]).toBe("/data/my_folder");
   });
 });

--- a/packages/web/src/__tests__/lib/knowledge/path-filter.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/path-filter.test.ts
@@ -1,0 +1,166 @@
+/**
+ * `escapeLikePattern` (packages/web/src/lib/knowledge/path-filter.ts) is a
+ * "security-relevant boundary bypass" guard per its own doc comment: without
+ * it, an allowed path containing a literal `_` or `%` — both real Postgres
+ * LIKE metacharacters, and `_` is common in real folder names like
+ * "my_folder" — would silently widen an agent's allow-listed knowledge-base
+ * path into a wildcard, letting the agent read documents outside its grant.
+ * Nothing exercised this before: retrieve.integration.test.ts covers
+ * prefix-bleed and deny-by-default, but no allowed path containing `_`, `%`,
+ * or `\`.
+ *
+ * `escapeLikePattern` itself is a private, unexported implementation detail
+ * of buildPathFilter() — deliberately not exported for this test file, since
+ * the brief for this PR is test-only. These tests instead exercise it through
+ * buildPathFilter()'s public SQL output, by walking the drizzle-orm `SQL`
+ * object's `queryChunks` to read the raw LIKE-pattern parameter that was
+ * interpolated into the query. This is exactly the value Postgres receives
+ * on the wire, so it is at least as strong a check as calling the private
+ * function directly — and it also lets these tests catch a regression where
+ * the escaping is dropped entirely, moved to the wrong operand, or applied
+ * in the wrong order (see the "order matters" test below).
+ *
+ * Mutation check performed while writing this file (not committed): with the
+ * three `.replace(...)` calls in `escapeLikePattern` removed (or reordered),
+ * every test below goes red. See the PR description for the exact diff and
+ * failure output.
+ */
+import { sql, type SQL } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { buildPathFilter } from "@/lib/knowledge/path-filter";
+
+/**
+ * Recursively walks a drizzle-orm SQL object's `queryChunks` (which nest —
+ * `buildPathFilter` builds one `SQL` fragment per allowed path and joins them
+ * with `sql\` OR \``, so a multi-path call's chunks contain child `SQL`
+ * objects rather than one flat array) and collects every raw string
+ * parameter that was interpolated immediately after a ` LIKE ` operator
+ * chunk, in encounter order. That parameter is exactly what
+ * `escapeLikePattern` produced (plus the trailing `%` buildPathFilter
+ * appends), i.e. the literal bytes Postgres receives for the LIKE pattern.
+ */
+function collectLikePatterns(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      const chunk = node[i];
+      if (
+        typeof chunk === "object" &&
+        chunk !== null &&
+        Array.isArray((chunk as { value?: unknown[] }).value) &&
+        (chunk as { value: unknown[] }).value[0] === " LIKE "
+      ) {
+        const next = node[i + 1];
+        if (typeof next === "string") out.push(next);
+      }
+      collectLikePatterns(chunk, out);
+    }
+    return out;
+  }
+  if (typeof node === "object" && node !== null && "queryChunks" in node) {
+    collectLikePatterns((node as { queryChunks: unknown[] }).queryChunks, out);
+  }
+  return out;
+}
+
+/** Same walk, but for the raw parameter following the ` = ` equality operator. */
+function collectEqualsValues(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      const chunk = node[i];
+      if (
+        typeof chunk === "object" &&
+        chunk !== null &&
+        Array.isArray((chunk as { value?: unknown[] }).value) &&
+        (chunk as { value: unknown[] }).value[0] === " = "
+      ) {
+        const next = node[i + 1];
+        if (typeof next === "string") out.push(next);
+      }
+      collectEqualsValues(chunk, out);
+    }
+    return out;
+  }
+  if (typeof node === "object" && node !== null && "queryChunks" in node) {
+    collectEqualsValues((node as { queryChunks: unknown[] }).queryChunks, out);
+  }
+  return out;
+}
+
+const COLUMN = sql`c.source_path`;
+
+/** buildPathFilter() for a single allowed path, returning its LIKE pattern. */
+function likePatternFor(allowedPath: string): string {
+  const condition = buildPathFilter([allowedPath], COLUMN);
+  const patterns = collectLikePatterns(condition);
+  expect(patterns).toHaveLength(1);
+  return patterns[0];
+}
+
+describe("buildPathFilter — LIKE pattern escaping (escapeLikePattern boundary)", () => {
+  it("escapes a literal underscore so it is not read as a single-character wildcard", () => {
+    // Unescaped, `/data/my_folder/%` as a LIKE pattern would ALSO match
+    // "/data/myXfolder/…" for any X — exactly the bypass this guards against.
+    expect(likePatternFor("/data/my_folder")).toBe("/data/my\\_folder/%");
+  });
+
+  it("escapes a literal percent sign so it is not read as a multi-character wildcard", () => {
+    // Unescaped, `%` in the allowed path would make the LIKE pattern match
+    // an arbitrary run of characters at that position.
+    expect(likePatternFor("/data/50%off")).toBe("/data/50\\%off/%");
+  });
+
+  it("escapes a literal backslash by doubling it, so it is not read as an escape character itself", () => {
+    // Input path contains one literal backslash: /data/foo\bar
+    expect(likePatternFor("/data/foo\\bar")).toBe("/data/foo\\\\bar/%");
+  });
+
+  it("escapes backslash, percent, and underscore together in one path", () => {
+    // Input: /data/50%_off\thing
+    expect(likePatternFor("/data/50%_off\\thing")).toBe("/data/50\\%\\_off\\\\thing/%");
+  });
+
+  it("escapes backslash BEFORE percent/underscore, so a literal backslash immediately followed by an underscore does not collapse into an unescaped wildcard", () => {
+    // Order matters here. Input: /data/foo\_bar (one literal backslash, then
+    // an underscore). escapeLikePattern must escape the backslash first
+    // (\ -> \\), THEN escape the underscore (_ -> \_) on the ALREADY-escaped
+    // string — giving three backslashes then the underscore: \\\_.
+    //
+    // If the implementation instead escaped `_` before `\` (the wrong
+    // order), the underscore would become `\_` first and the subsequent
+    // backslash-escaping step would double BOTH backslashes in that pair,
+    // producing `\\\\_` (four backslashes) instead of `\\\_` (three) — a
+    // different but still-technically-escaped string, so this case is a
+    // weaker way to catch an order bug than the raw wildcard bypass tests
+    // above. It's included anyway because it pins the exact algorithm the
+    // code comment promises (escape `\\` first).
+    expect(likePatternFor("/data/foo\\_bar")).toBe("/data/foo\\\\\\_bar/%");
+  });
+
+  it("does not escape a path with no LIKE metacharacters (no spurious backslashes)", () => {
+    expect(likePatternFor("/data/plain-folder")).toBe("/data/plain-folder/%");
+  });
+
+  it("is deterministic: the same allowed path always produces the same escaped LIKE pattern", () => {
+    const first = likePatternFor("/data/my_folder");
+    const second = likePatternFor("/data/my_folder");
+    expect(second).toBe(first);
+  });
+
+  it("escapes each allowed path independently when buildPathFilter is given several", () => {
+    const condition = buildPathFilter(["/data/my_folder", "/data/50%off"], COLUMN);
+    const patterns = collectLikePatterns(condition);
+    expect(patterns).toEqual(["/data/my\\_folder/%", "/data/50\\%off/%"]);
+  });
+
+  it("does NOT escape the exact-match (=) operand — escaping is scoped to the LIKE pattern only", () => {
+    // The `=` branch compares the raw allowedPath directly (not a LIKE
+    // pattern), so it must never be touched by escapeLikePattern. A mutant
+    // that escaped everywhere (not just the prefix pattern) would break an
+    // agent whose allowedPaths entry is an exact file path containing `_`
+    // or `%` — it would stop matching itself.
+    const condition = buildPathFilter(["/data/my_folder"], COLUMN);
+    const equalsValues = collectEqualsValues(condition);
+    expect(equalsValues).toEqual(["/data/my_folder"]);
+  });
+});

--- a/packages/web/src/__tests__/lib/knowledge/retrieve.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/retrieve.integration.test.ts
@@ -141,6 +141,55 @@ it("respects the allowedPaths directory boundary without prefix bleed (/data/foo
   expect(ids).not.toContain(outside.chunkId);
 });
 
+it("escapes a literal underscore in allowedPaths so it isn't read as a LIKE single-character wildcard (/data/my_folder must not match /data/myXfolder)", async () => {
+  // path-filter.ts's escapeLikePattern() exists exactly for this: `_` is a
+  // real LIKE metacharacter AND a common real folder-name character (e.g.
+  // "my_folder"). Without escaping, the prefix pattern "/data/my_folder/%"
+  // would also match "/data/myXfolder/..." for any X — silently widening an
+  // agent's allow-listed path into a sibling directory it was never granted.
+  const inside = await seedChunk({
+    sourcePath: "/data/my_folder/manual.pdf",
+    text: "The vacation policy allows unlimited PTO.",
+    embedding: oneHot(0),
+  });
+  const sibling = await seedChunk({
+    sourcePath: "/data/myXfolder/other.pdf",
+    text: "The vacation policy allows unlimited PTO.",
+    embedding: oneHot(0),
+  });
+
+  const { deps } = fakeDeps();
+  const results = await retrieve(ORG_ID, ["/data/my_folder"], "vacation policy", deps);
+
+  const ids = results.map((r) => r.chunkId);
+  expect(ids).toContain(inside.chunkId);
+  expect(ids).not.toContain(sibling.chunkId);
+});
+
+it("escapes a literal percent sign in allowedPaths so it isn't read as a LIKE multi-character wildcard (/data/50%off must not match /data/50XXXoff)", async () => {
+  // Same boundary as the underscore case above, for the OTHER LIKE
+  // metacharacter escapeLikePattern() handles. Without escaping,
+  // "/data/50%off/%" would also match "/data/50XXXoff/..." for any run of
+  // characters in place of the literal `%`.
+  const inside = await seedChunk({
+    sourcePath: "/data/50%off/manual.pdf",
+    text: "The vacation policy allows unlimited PTO.",
+    embedding: oneHot(0),
+  });
+  const sibling = await seedChunk({
+    sourcePath: "/data/50XXXoff/other.pdf",
+    text: "The vacation policy allows unlimited PTO.",
+    embedding: oneHot(0),
+  });
+
+  const { deps } = fakeDeps();
+  const results = await retrieve(ORG_ID, ["/data/50%off"], "vacation policy", deps);
+
+  const ids = results.map((r) => r.chunkId);
+  expect(ids).toContain(inside.chunkId);
+  expect(ids).not.toContain(sibling.chunkId);
+});
+
 it("matches an allowedPaths entry that is an exact file, without matching a sibling whose name is a superstring", async () => {
   const exact = await seedChunk({
     sourcePath: "/data/exact-file.pdf",


### PR DESCRIPTION
## Summary

`escapeLikePattern` in `packages/web/src/lib/knowledge/path-filter.ts` escapes `\`, `%`, and `_` before an allowed path is used as a LIKE prefix pattern. Its own doc comment calls it a "security-relevant boundary bypass" guard: without it, an allowed path containing a literal `_` (common in real folder names, e.g. `my_folder`) would silently widen an agent's knowledge-base path grant into unrelated sibling paths via LIKE's single-character wildcard.

No test exercised this. `retrieve.integration.test.ts` covers prefix-bleed (`/data/foo` vs `/data/foobar`) and deny-by-default, but no allowed path containing `_`, `%`, or `\` — so a refactor that dropped the escaping would stay green.

- Adds `packages/web/src/__tests__/lib/knowledge/path-filter.test.ts` (new file, 10 tests). `escapeLikePattern` is a private, unexported implementation detail and stays that way; the tests exercise it through `buildPathFilter()`'s public output, compiled with drizzle's own `PgDialect.sqlToQuery()` — the same public API the pg driver calls on the way to the wire. That yields both halves of what Postgres actually receives: the parameterized query text and the exact bytes bound into it. Covers: underscore, percent, backslash, the backslash-before-`%`/`_` ordering, no spurious escaping on a plain path, determinism across calls, independent escaping per path in a multi-path call, that the `=` exact-match operand is left unescaped, and that the predicate declares backslash as the LIKE `ESCAPE` character.
- Extends `packages/web/src/__tests__/lib/knowledge/retrieve.integration.test.ts` (+2 tests, real Postgres DB): an agent scoped to `/data/my_folder` must not see a sibling document at `/data/myXfolder` (the `_`-as-wildcard bypass), and likewise for a literal `%` in the allowed path.

Pure test addition, no production code changed.

## Mutation-testing evidence (red→green proof)

Since the code under test already has the escaping (this is a coverage-only PR), the red→green proof is inverted: three mutants were applied to `path-filter.ts` locally, one at a time, and reverted after each measurement. `git diff` on the production file is empty.

**Mutant 1 — escaping removed** (`escapeLikePattern` reduced to `return value`):

- Unit: **6 of 10 red.** The four survivors are the two that assert an *absence* of escaping (plain path, `=` operand), the determinism check, and the compiled-predicate check — none of them depends on a metacharacter being rewritten. This is stated rather than rounded up to "everything goes red", which would be a claim the file does not support.
- Integration: **both new tests red**, and only those two of 14. The sibling assertions (`expect(ids).not.toContain(sibling.chunkId)`) flipped to include the sibling's id — i.e. the boundary bypass actually happened against a real DB.

**Mutant 2 — escape order reversed** (`%`/`_` escaped before `\`):

- Unit: **5 of 10 red.** The one metacharacter case that survives is the backslash-only path, which contains no `%` or `_` for the reordering to act on. Every other metacharacter case comes out with the backslash doubled around a now-unescaped wildcard.

**Mutant 3 — `ESCAPE '\'` changed to `ESCAPE '!'`:**

- Unit: **2 red**, and both are the tests that read the compiled query *text*. Every assertion on a bound pattern stays green and byte-identical, while Postgres reads the emitted `\_` as two literal characters and the wildcard is back.
- Integration: **both new tests red** (the `toContain(inside)` half — the escaped pattern stops matching its own directory).

Mutant 3 is why the tests compile the query rather than inspecting the escaping in isolation: the `ESCAPE` clause is query text, not a parameter, so no assertion on the pattern string can see it.

## Test plan

- [x] `path-filter.test.ts` — 10/10 passing (`pnpm -C packages/web exec vitest run src/__tests__/lib/knowledge/path-filter.test.ts`)
- [x] `retrieve.integration.test.ts` — 14/14 passing against a real local Postgres (`pnpm -C packages/web test:db src/__tests__/lib/knowledge/retrieve.integration.test.ts`)
- [x] `pnpm test` — full suite green
- [x] `pnpm format:check` — clean
- [x] `pnpm -C packages/web typecheck` — clean
