### PR TITLE
test: rewrite env-gated describe skips to describe.skipIf, and let a guard see the form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Status: early development. The core is working: setup wizard, authentication, pr
 
 ## No Untracked Test Skips
 
-Permanent test skips need a tracking issue. The ESLint rule `pinchy/no-untracked-skips` and the vitest drift-guard `src/__tests__/lib/no-untracked-skips.test.ts` both enforce this — they fire on `test.skip`, `it.skip`, `describe.skip`, `.todo`, `.fixme`, `xit`, `xdescribe` unless the immediately surrounding 40 lines contain a tracking-issue reference (`#NNN` or a github.com/.../issues/NNN URL). A third guard, `no-untracked-skips-parity.test.ts`, pins the two checkers together: if you teach one a new skip syntax and forget the other, the parity fixtures will flag the drift.
+Permanent test skips need a tracking issue. The ESLint rule `pinchy/no-untracked-skips` and the vitest drift-guard `src/__tests__/lib/no-untracked-skips.test.ts` both enforce this — they fire on `test.skip`, `it.skip`, `describe.skip`, `.todo`, `.fixme`, `xit`, `xdescribe` unless the immediately surrounding 40 lines contain a tracking-issue reference (`#NNN` or a github.com/.../issues/NNN URL) — whether the skip is called directly or hidden behind an alias, see below. A third guard, `no-untracked-skips-parity.test.ts`, pins the two checkers together: if you teach one a new skip syntax and forget the other, the parity fixtures will flag the drift.
 
 Two patterns are explicitly allowed:
 
@@ -62,6 +62,26 @@ Two patterns are explicitly allowed:
 - **Any banned form (`.skip`, `.todo`, `.fixme`, `xit`, `xdescribe`) with `#NNN` in the leading comment block** — the issue is the contract. "Tracked separately" / "follow-up" / inline TODO without a number is not enough. `it.todo("…")` is treated exactly like `.skip` — it silently turns green in CI but never runs, which is precisely the failure mode this policy exists to stop.
 
 If a check is in your way and you can't fix it in scope, **file the issue first**, link the number, then skip. Don't ship the skip with a promise to file the issue later — the 2026-05-22 audit found five clusters where exactly that happened, one of them hiding a production password-reset bug.
+
+### A skip must be called, not aliased
+
+Both checkers matched the **call** form only, so putting the skip behind an identifier made it invisible to both:
+
+```ts
+const describeIf = url ? describe : describe.skip; // seen by nothing
+describeIf("getSeatUsage", () => { … });
+```
+
+Two of these sat in the tree and were found by reading, not by a check (#1071). The conditional spelling above is harmless in effect — it is a gate, and the fix is to write it as one — but the same blind spot swallows `const d = describe.skip`, which is a permanent untracked skip with no condition anywhere near it. That is the case worth a guard.
+
+The ESLint rule now reports a skip that is **referenced rather than called** (`aliasedSkip`), and the drift-guard matches the assignment/ternary form. Same escape hatch as any other skip: a `#NNN` nearby. For a conditional gate, don't reach for the escape hatch — write `describe.skipIf(!url)`. The chained `test.skip.each(...)` is a call, not an alias, and is reported as an ordinary untracked skip.
+
+Two limits are documented rather than closed, because both cost more to catch than they are worth:
+
+- **Aliasing the test object instead of the skip** (`const d = describe;` then `d.skip(...)`) needs scope analysis. Neither checker follows it.
+- **The drift-guard's anchor must be on the skip's own line**, so a wrapped `const d =\n  describe.skip;` is missed there. The ESLint rule walks the AST and catches it — the text scan is the weaker of the two by design.
+
+The anchor is not fussiness: an unanchored text match for `test.skip` reports three lines in this repo that are a block comment, a test name and a string literal, one of them untracked — a red CI over prose. Verify a change to either checker by reproduction, not by reading: the fixtures in `no-untracked-skips-parity.test.ts` feed the same snippets through both and fail on any disagreement.
 
 ## No Untracked Test Removal
 

--- a/packages/web/eslint-rules/no-untracked-skips.js
+++ b/packages/web/eslint-rules/no-untracked-skips.js
@@ -16,9 +16,22 @@
 // pins them together — it feeds the same fixtures through both and asserts
 // matching verdicts, so if you only update one, CI will tell you.
 //
-// Known false-negative window: the leading-comment scan reaches 40 lines
-// above the skip call. An unrelated `#NNN` inside that window will pass
-// the check. Documented limitation; a code review will catch it.
+// A skip must be CALLED, not aliased. `const d = cond ? describe : describe.skip`
+// and the plain `const d = describe.skip` both put the skip behind an
+// identifier, and every checker here — plus the drift-guard's text scan —
+// matches the call form only. So the alias form was invisible to both, which
+// is how two of them sat in the tree until #1071 rewrote them by hand. The
+// unconditional `const d = describe.skip` is the case that matters: a permanent,
+// untracked skip that no guard could see. Aliases are reported separately
+// (`aliasedSkip`) because the fix differs — a conditional gate wants
+// `describe.skipIf(cond)`, not an issue number.
+//
+// Known false-negative windows, both documented rather than closed:
+//   - The leading-comment scan reaches 40 lines above the skip call. An
+//     unrelated `#NNN` inside that window will pass the check.
+//   - Aliasing the test object instead of the skip (`const d = describe;`
+//     then `d.skip(...)`) needs scope analysis to follow and is not reported.
+// A code review owns both.
 //
 // Background: the 2026-05-22 audit found five separate skip clusters that
 // all followed the same pattern (quick fix → honest "tracked separately"
@@ -41,6 +54,8 @@ module.exports = {
     messages: {
       untrackedSkip:
         '{{call}} needs a tracking issue. Add a comment with `#<issue-number>` (or the issue URL) above the call, or remove the skip. See AGENTS.md § "No untracked test skips".',
+      aliasedSkip:
+        '{{call}} is referenced instead of called, which hides it from both skip guards (they match the call form). For a conditional gate use `{{object}}.skipIf(<condition>)`; for a permanent skip call it directly with a `#<issue-number>` comment. See AGENTS.md § "No untracked test skips".',
     },
     schema: [],
   },
@@ -73,37 +88,51 @@ module.exports = {
       });
     }
 
+    /**
+     * Describe a skip member expression, or return null if the node isn't one.
+     *
+     * Two accepted shapes:
+     *   - `test.skip` / `it.todo` / `describe.fixme`  (object is an Identifier)
+     *   - `test.describe.skip`                        (chained member)
+     *
+     * `describe.skipIf` is deliberately not one of them: `skipIf` isn't in
+     * SKIP_MEMBERS, so a conditional gate never reaches this function.
+     */
+    function skipMember(node) {
+      if (node.type !== "MemberExpression" || node.computed) return null;
+      if (node.property.type !== "Identifier") return null;
+      if (!SKIP_MEMBERS.has(node.property.name)) return null;
+
+      // Shape 1: `describe.skip`
+      if (node.object.type === "Identifier" && TEST_OBJECTS.has(node.object.name)) {
+        return { path: `${node.object.name}.${node.property.name}`, object: node.object.name };
+      }
+
+      // Shape 2: `test.describe.skip`
+      const obj = node.object;
+      if (
+        obj.type === "MemberExpression" &&
+        !obj.computed &&
+        obj.object.type === "Identifier" &&
+        obj.property.type === "Identifier" &&
+        TEST_OBJECTS.has(obj.object.name)
+      ) {
+        const objectPath = `${obj.object.name}.${obj.property.name}`;
+        return { path: `${objectPath}.${node.property.name}`, object: objectPath };
+      }
+
+      return null;
+    }
+
     return {
       CallExpression(node) {
         const callee = node.callee;
 
-        // Pattern 1: `test.skip(...)`, `it.todo(...)`, `describe.fixme(...)`
-        if (
-          callee.type === "MemberExpression" &&
-          !callee.computed &&
-          callee.object.type === "Identifier" &&
-          callee.property.type === "Identifier" &&
-          TEST_OBJECTS.has(callee.object.name) &&
-          SKIP_MEMBERS.has(callee.property.name)
-        ) {
-          report(node, `${callee.object.name}.${callee.property.name}(...)`);
-          return;
-        }
-
-        // Pattern 2: `test.describe.skip(...)` — chained member.
-        if (
-          callee.type === "MemberExpression" &&
-          !callee.computed &&
-          callee.property.type === "Identifier" &&
-          SKIP_MEMBERS.has(callee.property.name) &&
-          callee.object.type === "MemberExpression" &&
-          !callee.object.computed &&
-          callee.object.object.type === "Identifier" &&
-          callee.object.property.type === "Identifier" &&
-          TEST_OBJECTS.has(callee.object.object.name)
-        ) {
-          const desc = `${callee.object.object.name}.${callee.object.property.name}.${callee.property.name}(...)`;
-          report(node, desc);
+        // Patterns 1 & 2: `test.skip(...)`, `it.todo(...)`, `describe.fixme(...)`
+        // and the chained `test.describe.skip(...)`.
+        const member = skipMember(callee);
+        if (member) {
+          report(node, `${member.path}(...)`);
           return;
         }
 
@@ -112,6 +141,38 @@ module.exports = {
           report(node, `${callee.name}(...)`);
           return;
         }
+      },
+
+      // Pattern 4: a skip that is referenced rather than called.
+      //
+      //   const d = cond ? describe : describe.skip;   // conditional gate
+      //   const d = describe.skip;                     // permanent skip, hidden
+      //   test.skip.each([...])("name", fn)            // chained off the skip
+      //
+      // The CallExpression visitor above sees none of these, because in all
+      // three the skip member is not the thing being called.
+      MemberExpression(node) {
+        const member = skipMember(node);
+        if (!member) return;
+
+        const parent = node.parent;
+
+        // `describe.skip(...)` — the CallExpression visitor owns this one.
+        if (parent && parent.type === "CallExpression" && parent.callee === node) return;
+
+        // `test.skip.each([...])(...)` — still a skip being invoked, just
+        // through a chain. Report it as the skip it is, not as an alias.
+        if (parent && parent.type === "MemberExpression" && parent.object === node) {
+          report(node, `${member.path}(...)`);
+          return;
+        }
+
+        if (hasNearbyIssueRef(node)) return;
+        context.report({
+          node,
+          messageId: "aliasedSkip",
+          data: { call: member.path, object: member.object },
+        });
       },
     };
   },

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -75,7 +75,9 @@ const eslintConfig = defineConfig([
   //   tracking-issue reference (`#NNN` or a github.com issue URL). The
   //   companion vitest drift-guard in
   //   src/__tests__/lib/no-untracked-skips.test.ts enforces the same
-  //   contract at test time. `.skipIf(...)` is always allowed.
+  //   contract at test time. `.skipIf(...)` is always allowed. A skip that is
+  //   aliased rather than called (`const d = describe.skip`) is reported too —
+  //   that form was invisible to both checkers until #1071.
   {
     files: [
       "src/**/*.{test,spec}.{ts,tsx,js,jsx}",

--- a/packages/web/src/__tests__/eslint/no-untracked-skips.test.ts
+++ b/packages/web/src/__tests__/eslint/no-untracked-skips.test.ts
@@ -46,6 +46,16 @@ tester.run("no-untracked-skips", rule, {
       code: `test("foo", () => {});\nit("bar", () => {});\ndescribe("baz", () => {});`,
       filename: "/x.test.ts",
     },
+    // An aliased skip with a tracking issue is allowed, like a called one
+    {
+      code: `// tracked in #1071\nconst d = describe.skip;\nd("g", () => {});`,
+      filename: "/x.test.ts",
+    },
+    // Aliasing a non-skip member is ordinary code
+    {
+      code: `const d = describe.skipIf(!process.env.RUN);\nd("g", () => {});`,
+      filename: "/x.test.ts",
+    },
   ],
   invalid: [
     // Plain skip, no comment
@@ -88,6 +98,30 @@ tester.run("no-untracked-skips", rule, {
     {
       code: `test.describe.skip("group", () => {});`,
       filename: "/e2e/x.spec.ts",
+      errors: [{ messageId: "untrackedSkip" }],
+    },
+    // Aliased skip: the ternary gate #1071 had to find by hand
+    {
+      code: `const d = process.env.X ? describe : describe.skip;\nd("g", () => {});`,
+      filename: "/x.test.ts",
+      errors: [{ messageId: "aliasedSkip" }],
+    },
+    // Aliased skip: unconditional, i.e. a permanent skip no guard could see
+    {
+      code: `const d = describe.skip;\nd("g", () => {});`,
+      filename: "/x.test.ts",
+      errors: [{ messageId: "aliasedSkip" }],
+    },
+    // Aliased chained skip
+    {
+      code: `const d = test.describe.skip;\nd("g", () => {});`,
+      filename: "/e2e/x.spec.ts",
+      errors: [{ messageId: "aliasedSkip" }],
+    },
+    // A skip invoked through `.each` is a call, not an alias
+    {
+      code: `test.skip.each([1])("g", () => {});`,
+      filename: "/x.test.ts",
       errors: [{ messageId: "untrackedSkip" }],
     },
     // Issue ref too far away (>40 lines)

--- a/packages/web/src/__tests__/integration/ollama-provider.test.ts
+++ b/packages/web/src/__tests__/integration/ollama-provider.test.ts
@@ -3,9 +3,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 const OLLAMA_URL = process.env.OLLAMA_URL;
 
 // Skip all tests when Ollama is not available (normal unit test runs)
-const describeOllama = OLLAMA_URL ? describe : describe.skip;
-
-describeOllama("Ollama integration (requires running Ollama)", () => {
+describe.skipIf(!OLLAMA_URL)("Ollama integration (requires running Ollama)", () => {
   beforeAll(async () => {
     // Verify Ollama is reachable
     const response = await fetch(`${OLLAMA_URL}/api/tags`);

--- a/packages/web/src/__tests__/lib/no-untracked-skips-parity.test.ts
+++ b/packages/web/src/__tests__/lib/no-untracked-skips-parity.test.ts
@@ -17,8 +17,9 @@ const rule = require("../../../eslint-rules/no-untracked-skips.js");
 // Keep these regex constants in lockstep with packages/web/src/__tests__/lib/no-untracked-skips.test.ts.
 // (Drift-guard's regex is the canonical text-scan; this copy is what we
 // use to simulate the drift-guard's behaviour over a single snippet.)
-const SKIP_RE = /\b(?:test|it|describe)\.(?:skip|todo|fixme)\s*\(/;
+const SKIP_RE = /\b(?:test|it|describe)\.(?:skip|todo|fixme)\s*[.(]/;
 const X_RE = /^\s*(?:xit|xdescribe)\s*\(/;
+const ALIAS_RE = /[=?:]\s*(?:test\.describe|test|it|describe)\.(?:skip|todo|fixme)\b(?!\s*[.(])/;
 const ISSUE_REF_RE = /#\d+|github\.com\/[^/]+\/[^/]+\/issues\/\d+/;
 
 function eslintFlags(code: string): boolean {
@@ -36,7 +37,7 @@ function driftGuardFlags(code: string): boolean {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const codeOnly = line.replace(/\/\/.*$/, "").replace(/\/\*[\s\S]*?\*\//g, "");
-    if (!SKIP_RE.test(codeOnly) && !X_RE.test(codeOnly)) continue;
+    if (!SKIP_RE.test(codeOnly) && !X_RE.test(codeOnly) && !ALIAS_RE.test(codeOnly)) continue;
     if (/\b(?:test|it|describe)\.skipIf\s*\(/.test(codeOnly)) continue;
     const start = Math.max(0, i - 40);
     const leading = lines.slice(start, i).join("\n");
@@ -79,6 +80,41 @@ const FIXTURES: Array<{ name: string; code: string; shouldFlag: boolean }> = [
   {
     name: "issue ref one block up",
     code: `// (tracked in #99)\ndescribe("group", () => {\n  test.skip("a", () => {});\n});`,
+    shouldFlag: false,
+  },
+  // ── Aliased skips: referenced instead of called ────────────────────
+  // Both checkers were blind to every one of these until #1071 — which is
+  // why that PR had to rewrite two of them by hand instead of being told.
+  {
+    name: "ternary alias (the form #1071 rewrote)",
+    code: `const d = process.env.X ? describe : describe.skip;\nd("g", () => {});`,
+    shouldFlag: true,
+  },
+  {
+    name: "unconditional alias (a permanent skip in disguise)",
+    code: `const d = describe.skip;\nd("g", () => {});`,
+    shouldFlag: true,
+  },
+  {
+    name: "chained test.describe.skip alias",
+    code: `const d = test.describe.skip;\nd("g", () => {});`,
+    shouldFlag: true,
+  },
+  {
+    name: "skip invoked through .each",
+    code: `test.skip.each([1])("g", () => {});`,
+    shouldFlag: true,
+  },
+  {
+    name: "aliased skip with tracking issue",
+    code: `// tracked in #1071\nconst d = describe.skip;\nd("g", () => {});`,
+    shouldFlag: false,
+  },
+  // Prose and string literals that merely mention a skip must stay silent —
+  // an unanchored text scan reports three such lines in this repo alone.
+  {
+    name: "skip named inside a string literal",
+    code: `const msg = "a probe inside a test.skip does not count";`,
     shouldFlag: false,
   },
   // ── Conditional skipIf is always allowed ───────────────────────────

--- a/packages/web/src/__tests__/lib/no-untracked-skips.test.ts
+++ b/packages/web/src/__tests__/lib/no-untracked-skips.test.ts
@@ -55,9 +55,25 @@ const SELF_EXCLUSIONS = {
 
 // Permanent-skip patterns we forbid without an issue link. We do NOT match
 // `.skipIf(` here — that's an explicit conditional gate, not a "we'll fix
-// this later" suppression.
-const SKIP_RE = /\b(?:test|it|describe)\.(?:skip|todo|fixme)\s*\(/;
+// this later" suppression. The trailing `[.(]` also covers the chained
+// `test.skip.each(...)`, which is a skip invoked one link down.
+const SKIP_RE = /\b(?:test|it|describe)\.(?:skip|todo|fixme)\s*[.(]/;
 const X_RE = /^\s*(?:xit|xdescribe)\s*\(/;
+// An ALIASED skip: the member is assigned, or handed to a ternary branch,
+// instead of being called — `const d = describe.skip`, or the
+// `cond ? describe : describe.skip` form that #1071 had to rewrite by hand
+// because no checker saw it. The unconditional spelling is a permanent
+// untracked skip wearing a different hat, so it belongs here.
+//
+// Anchored on the `=`/`?`/`:` deliberately: an unanchored `test.skip` text
+// match cannot tell code from prose, and measured against this repo it
+// reports three lines that are a block comment, a test name and a string
+// literal — one of them untracked, i.e. an instantly red CI over nothing.
+//
+// Known limit: the anchor has to be on the skip's own line, so a wrapped
+// `const d =\n  describe.skip;` is missed here. The ESLint rule walks the
+// AST and catches it; this is the weaker of the two checkers by design.
+const ALIAS_RE = /[=?:]\s*(?:test\.describe|test|it|describe)\.(?:skip|todo|fixme)\b(?!\s*[.(])/;
 // Token a passing skip-comment must contain. Either a bare issue number (#42),
 // a fully-qualified GitHub URL, or any of these escape hatches that have a
 // dedicated, separately-tracked policy doc.
@@ -128,7 +144,7 @@ function findUntrackedSkips(file: string): Finding[] {
     // Strip line-comments so we don't match `.skip(` references in
     // documentation about the rule itself.
     const codeOnly = line.replace(/\/\/.*$/, "").replace(/\/\*[\s\S]*?\*\//g, "");
-    if (!SKIP_RE.test(codeOnly) && !X_RE.test(codeOnly)) continue;
+    if (!SKIP_RE.test(codeOnly) && !X_RE.test(codeOnly) && !ALIAS_RE.test(codeOnly)) continue;
 
     // `.skipIf(` is a conditional gate, not a permanent skip — allow.
     if (/\b(?:test|it|describe)\.skipIf\s*\(/.test(codeOnly)) continue;
@@ -173,6 +189,10 @@ describe("no-untracked-skips", () => {
           "leading comment. Either add an issue link or remove the skip:",
           "",
           ...findings.map((f) => `  ${relative(REPO_ROOT, f.file)}:${f.line}  →  ${f.match}`),
+          "",
+          "A skip assigned to a variable (`const d = describe.skip`, or the",
+          "`cond ? describe : describe.skip` form) counts too — aliasing it hides",
+          "it from every checker. Write `describe.skipIf(<condition>)` instead.",
           "",
           'Conditional gates (`.skipIf(...)`) are exempt. See AGENTS.md § "No untracked test skips".',
         ].join("\n")

--- a/packages/web/src/__tests__/lib/seat-usage.test.ts
+++ b/packages/web/src/__tests__/lib/seat-usage.test.ts
@@ -5,7 +5,6 @@ import { users, invites } from "@/db/schema";
 import { makeLicense } from "../helpers/license-fixtures";
 
 const url = process.env.DATABASE_URL;
-const describeIf = url ? describe : describe.skip;
 
 async function clearTables() {
   await db.delete(invites);
@@ -42,7 +41,7 @@ async function seedInvite(opts: {
   });
 }
 
-describeIf("getSeatUsage", () => {
+describe.skipIf(!url)("getSeatUsage", () => {
   beforeEach(clearTables);
 
   it("returns unlimited when license has maxUsers=0", async () => {


### PR DESCRIPTION
## Summary

Two commits: the rewrite, and the guard that makes it stick.

**1. `test:` rewrite the two call sites.** The `cond ? describe : describe.skip` env-gate pattern in two files becomes the blessed `describe.skipIf(!cond)`. Negation preserved exactly (`url ? describe : describe.skip` ⟺ `describe.skipIf(!url)`), no behaviour change.

- `packages/web/src/__tests__/integration/ollama-provider.test.ts:6` — gated on `OLLAMA_URL`.
- `packages/web/src/__tests__/lib/seat-usage.test.ts:8` — gated on `DATABASE_URL`.

**2. `fix(lint):` catch a skip that is aliased instead of called.** The first commit originally shipped alone, with the guard change declared out of scope. Review found that this left the PR with no enforcement consequence at all: **both checkers were silent before the rewrite and silent after it.** A canary through the ESLint rule and the drift-guard reports `blind blind` for the ternary form — and for `const d = describe.skip`, which is a permanent untracked skip with no condition anywhere near it.

That second form is why this is worth a guard rather than a grep. The ESLint rule only visited `CallExpression`; the drift-guard's regex requires a `(` after `.skip`. Now:

- The rule visits `MemberExpression` too, and separates the verdicts: a skip reached through a chain (`test.skip.each(...)`) is an ordinary `untrackedSkip`; a skip merely referenced is an `aliasedSkip` whose message names `skipIf` as the fix rather than an issue number.
- The drift-guard matches the assignment/ternary form, anchored on the `=`/`?`/`:`.
- The parity guard gets fixtures for all of it, so the two checkers cannot drift apart on aliases.

**The anchor is load-bearing.** An unanchored `test.skip` text match reports three lines in this repo that are a block comment, a test name and a string literal — one of them untracked, i.e. CI red over prose.

Two limits stay open and are written down rather than papered over: aliasing the test object (`const d = describe;` then `d.skip(...)`) needs scope analysis, and the drift-guard's anchor must sit on the skip's own line, so a wrapped assignment is caught by the AST rule alone.

## Verification

Guard changes verified by reproduction, not by reading:

- **Canary, both checkers, 10 cases** — ternary alias, unconditional alias, chained alias, `.each` chain, tracked alias, `skipIf`, aliased `skipIf`, prose-in-a-string, plain tests, control. All 10 agree between the two checkers and match the expected verdict.
- **Reverse canary** — run against the two files *as they stood before this PR*, the extended drift-guard names both lines (`ollama-provider.test.ts:6`, `seat-usage.test.ts:8`). It would have caught what this PR fixed by hand.
- **Blast radius** — anchored, the scan finds nothing across 911 test files; unanchored it reports the three prose lines above.

Gates:

- [x] `pnpm test` — 774 passed | 4 skipped (778 files), 10929 passed | 18 skipped (10947 tests). Net +12 tests, no removals.
- [x] `pnpm test:scripts` — 894/894.
- [x] `pnpm -C packages/web typecheck` — clean.
- [x] `pnpm -C packages/web lint` on the changed files — 0 errors (5 pre-existing warnings).
- [x] `pnpm format:check` — clean.
- [x] Both gated suites still report as skipped with env vars unset (2 files, 12 tests).

Docs-not-needed: test-syntax normalization plus lint-guard behaviour; the policy is recorded in AGENTS.md § "No Untracked Test Skips".