### PR TITLE
test(api): cover POST /api/integrations/sync-preview

### DIFF
--- a/packages/web/src/__tests__/api/integrations-sync-preview.test.ts
+++ b/packages/web/src/__tests__/api/integrations-sync-preview.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  auth: { api: { getSession: (...args: unknown[]) => mockGetSession(...args) } },
+}));
+
+const mockValidateExternalUrl = vi.fn();
+vi.mock("@/lib/integrations/url-validation", () => ({
+  validateExternalUrl: (...args: unknown[]) => mockValidateExternalUrl(...args),
+}));
+
+const mockFetchOdooSchema = vi.fn();
+vi.mock("@/lib/integrations/odoo-sync", () => ({
+  fetchOdooSchema: (...args: unknown[]) => mockFetchOdooSchema(...args),
+}));
+
+import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
+
+function makeRequest(path: string, options?: ConstructorParameters<typeof NextRequest>[1]) {
+  return new NextRequest(`http://localhost:7777${path}`, options);
+}
+
+const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
+const memberSession = { user: { id: "user-2", email: "member@test.com", role: "member" } };
+
+const validCredentials = {
+  url: "https://odoo.example.com",
+  db: "prod",
+  login: "admin",
+  apiKey: "secret-key",
+  uid: 2,
+};
+
+const validSyncResult = {
+  success: true,
+  models: 2,
+  lastSyncAt: "2026-01-01T00:00:00.000Z",
+  categories: [{ category: "sales", count: 1 }],
+  data: {
+    models: [
+      {
+        model: "sale.order",
+        name: "Sales Order",
+        fields: [],
+        access: { read: true, create: false, write: false, delete: false },
+      },
+    ],
+    lastSyncAt: "2026-01-01T00:00:00.000Z",
+  },
+};
+
+describe("POST /api/integrations/sync-preview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+    mockValidateExternalUrl.mockReturnValue({ valid: true, url: "https://odoo.example.com" });
+    mockFetchOdooSchema.mockResolvedValue(validSyncResult);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/integrations/sync-preview/route");
+
+    const request = makeRequest("/api/integrations/sync-preview", {
+      method: "POST",
+      body: JSON.stringify({ type: "odoo", credentials: validCredentials }),
+    });
+    const response = await POST(request, routeContext());
+
+    expect(response.status).toBe(401);
+    expect(mockFetchOdooSchema).not.toHaveBeenCalled();
+  });
+
+  it("should return 403 for non-admin users", async () => {
+    mockGetSession.mockResolvedValueOnce(memberSession);
+    const { POST } = await import("@/app/api/integrations/sync-preview/route");
+
+    const request = makeRequest("/api/integrations/sync-preview", {
+      method: "POST",
+      body: JSON.stringify({ type: "odoo", credentials: validCredentials }),
+    });
+    const response = await POST(request, routeContext());
+
+    expect(response.status).toBe(403);
+    expect(mockFetchOdooSchema).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when required credential fields are missing", async () => {
+    const { POST } = await import("@/app/api/integrations/sync-preview/route");
+
+    const request = makeRequest("/api/integrations/sync-preview", {
+      method: "POST",
+      body: JSON.stringify({
+        type: "odoo",
+        credentials: { url: "https://odoo.example.com" },
+      }),
+    });
+    const response = await POST(request, routeContext());
+
+    expect(response.status).toBe(400);
+    expect(mockFetchOdooSchema).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 for an invalid url", async () => {
+    const { POST } = await import("@/app/api/integrations/sync-preview/route");
+
+    const request = makeRequest("/api/integrations/sync-preview", {
+      method: "POST",
+      body: JSON.stringify({
+        type: "odoo",
+        credentials: { ...validCredentials, url: "not-a-url" },
+      }),
+    });
+    const response = await POST(request, routeContext());
+
+    expect(response.status).toBe(400);
+    expect(mockFetchOdooSchema).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 for a non-odoo type", async () => {
+    const { POST } = await import("@/app/api/integrations/sync-preview/route");
+
+    const request = makeRequest("/api/integrations/sync-preview", {
+      method: "POST",
+      body: JSON.stringify({ type: "web-search", credentials: { apiKey: "x" } }),
+    });
+    const response = await POST(request, routeContext());
+
+    expect(response.status).toBe(400);
+    expect(mockFetchOdooSchema).not.toHaveBeenCalled();
+  });
+
+  it("rejects the request when validateExternalUrl refuses the target and never calls fetchOdooSchema", async () => {
+    // Pins the SSRF ordering: validation must run BEFORE the outbound fetch,
+    // and a rejection must short-circuit the route entirely.
+    mockValidateExternalUrl.mockReturnValue({
+      valid: false,
+      error: "URLs targeting private or internal networks are not allowed",
+    });
+    const { POST } = await import("@/app/api/integrations/sync-preview/route");
+
+    const request = makeRequest("/api/integrations/sync-preview", {
+      method: "POST",
+      body: JSON.stringify({
+        type: "odoo",
+        credentials: { ...validCredentials, url: "http://169.254.169.254/" },
+      }),
+    });
+    const response = await POST(request, routeContext());
+    const body = await response.json();
+
+    expect(mockValidateExternalUrl).toHaveBeenCalledWith("http://169.254.169.254/");
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("URLs targeting private or internal networks are not allowed");
+    expect(mockFetchOdooSchema).not.toHaveBeenCalled();
+  });
+
+  it("returns the schema from fetchOdooSchema when the url passes SSRF validation", async () => {
+    const { POST } = await import("@/app/api/integrations/sync-preview/route");
+
+    const request = makeRequest("/api/integrations/sync-preview", {
+      method: "POST",
+      body: JSON.stringify({ type: "odoo", credentials: validCredentials }),
+    });
+    const response = await POST(request, routeContext());
+    const body = await response.json();
+
+    expect(mockValidateExternalUrl).toHaveBeenCalledWith(validCredentials.url);
+    expect(mockFetchOdooSchema).toHaveBeenCalledWith(validCredentials);
+    expect(response.status).toBe(200);
+    expect(body).toEqual(validSyncResult);
+  });
+});

--- a/packages/web/src/__tests__/api/integrations-sync-preview.test.ts
+++ b/packages/web/src/__tests__/api/integrations-sync-preview.test.ts
@@ -20,23 +20,34 @@ vi.mock("@/lib/integrations/odoo-sync", () => ({
   fetchOdooSchema: (...args: unknown[]) => mockFetchOdooSchema(...args),
 }));
 
-import { NextRequest } from "next/server";
-import { routeContext } from "@/test-helpers/route";
+import { mockSession } from "@/test-helpers/auth";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
-function makeRequest(path: string, options?: ConstructorParameters<typeof NextRequest>[1]) {
-  return new NextRequest(`http://localhost:7777${path}`, options);
+const ROUTE_URL = "http://localhost:7777/api/integrations/sync-preview";
+
+function postSyncPreview(body: unknown) {
+  return makeNextRequest(ROUTE_URL, { method: "POST", body: JSON.stringify(body) });
 }
 
-const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
-const memberSession = { user: { id: "user-2", email: "member@test.com", role: "member" } };
+const adminSession = mockSession();
+const memberSession = mockSession({
+  user: { id: "user-2", email: "member@test.com", name: "Test Member", role: "member" },
+});
 
+// The url deliberately carries a path. `validateExternalUrl` answers with a
+// NORMALIZED origin (scheme + host + port, no path), so a fixture whose input
+// already IS its own origin makes "the route fetched what it validated"
+// indistinguishable from "the route fetched something else" — both assertions
+// would compare the same string. With a path the two differ, and the happy-path
+// test below can tell them apart.
 const validCredentials = {
-  url: "https://odoo.example.com",
+  url: "https://odoo.example.com/erp",
   db: "prod",
   login: "admin",
   apiKey: "secret-key",
   uid: 2,
 };
+const validatedOrigin = "https://odoo.example.com";
 
 const validSyncResult = {
   success: true,
@@ -60,7 +71,7 @@ describe("POST /api/integrations/sync-preview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
-    mockValidateExternalUrl.mockReturnValue({ valid: true, url: "https://odoo.example.com" });
+    mockValidateExternalUrl.mockReturnValue({ valid: true, url: validatedOrigin });
     mockFetchOdooSchema.mockResolvedValue(validSyncResult);
   });
 
@@ -68,13 +79,14 @@ describe("POST /api/integrations/sync-preview", () => {
     mockGetSession.mockResolvedValueOnce(null);
     const { POST } = await import("@/app/api/integrations/sync-preview/route");
 
-    const request = makeRequest("/api/integrations/sync-preview", {
-      method: "POST",
-      body: JSON.stringify({ type: "odoo", credentials: validCredentials }),
-    });
-    const response = await POST(request, routeContext());
+    const response = await POST(
+      postSyncPreview({ type: "odoo", credentials: validCredentials }),
+      routeContext()
+    );
 
     expect(response.status).toBe(401);
+    // The credentials must not leave the process before the caller is known.
+    expect(mockValidateExternalUrl).not.toHaveBeenCalled();
     expect(mockFetchOdooSchema).not.toHaveBeenCalled();
   });
 
@@ -82,58 +94,72 @@ describe("POST /api/integrations/sync-preview", () => {
     mockGetSession.mockResolvedValueOnce(memberSession);
     const { POST } = await import("@/app/api/integrations/sync-preview/route");
 
-    const request = makeRequest("/api/integrations/sync-preview", {
-      method: "POST",
-      body: JSON.stringify({ type: "odoo", credentials: validCredentials }),
-    });
-    const response = await POST(request, routeContext());
+    const response = await POST(
+      postSyncPreview({ type: "odoo", credentials: validCredentials }),
+      routeContext()
+    );
 
     expect(response.status).toBe(403);
+    expect(mockValidateExternalUrl).not.toHaveBeenCalled();
     expect(mockFetchOdooSchema).not.toHaveBeenCalled();
   });
 
   it("should return 400 when required credential fields are missing", async () => {
     const { POST } = await import("@/app/api/integrations/sync-preview/route");
 
-    const request = makeRequest("/api/integrations/sync-preview", {
-      method: "POST",
-      body: JSON.stringify({
-        type: "odoo",
-        credentials: { url: "https://odoo.example.com" },
-      }),
-    });
-    const response = await POST(request, routeContext());
+    const response = await POST(
+      postSyncPreview({ type: "odoo", credentials: { url: validCredentials.url } }),
+      routeContext()
+    );
+    const body = await response.json();
 
     expect(response.status).toBe(400);
+    // Assert WHICH check refused. `parseRequestBody` answers 400 for a failed
+    // schema AND for an unparseable body, so a bare status assertion passes
+    // even when the route rejected for a reason the test never intended.
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.credentials).toBeDefined();
+    expect(mockValidateExternalUrl).not.toHaveBeenCalled();
     expect(mockFetchOdooSchema).not.toHaveBeenCalled();
   });
 
   it("should return 400 for an invalid url", async () => {
     const { POST } = await import("@/app/api/integrations/sync-preview/route");
 
-    const request = makeRequest("/api/integrations/sync-preview", {
-      method: "POST",
-      body: JSON.stringify({
+    const response = await POST(
+      postSyncPreview({
         type: "odoo",
         credentials: { ...validCredentials, url: "not-a-url" },
       }),
-    });
-    const response = await POST(request, routeContext());
+      routeContext()
+    );
+    const body = await response.json();
 
     expect(response.status).toBe(400);
+    expect(body.error).toBe("Validation failed");
+    // Every other credential field is valid, so the url is the only thing that
+    // can have failed — name it, otherwise this passes on any credential error.
+    expect(body.details.fieldErrors.credentials).toContain("Invalid URL");
+    expect(mockValidateExternalUrl).not.toHaveBeenCalled();
     expect(mockFetchOdooSchema).not.toHaveBeenCalled();
   });
 
   it("should return 400 for a non-odoo type", async () => {
     const { POST } = await import("@/app/api/integrations/sync-preview/route");
 
-    const request = makeRequest("/api/integrations/sync-preview", {
-      method: "POST",
-      body: JSON.stringify({ type: "web-search", credentials: { apiKey: "x" } }),
-    });
-    const response = await POST(request, routeContext());
+    // The credentials are deliberately VALID: with an invalid `credentials`
+    // block alongside, this test goes green even if `type` stops being a
+    // literal, and then pins nothing about the only value the route handles.
+    const response = await POST(
+      postSyncPreview({ type: "web-search", credentials: validCredentials }),
+      routeContext()
+    );
+    const body = await response.json();
 
     expect(response.status).toBe(400);
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.type).toBeDefined();
+    expect(body.details.fieldErrors.credentials).toBeUndefined();
     expect(mockFetchOdooSchema).not.toHaveBeenCalled();
   });
 
@@ -146,14 +172,13 @@ describe("POST /api/integrations/sync-preview", () => {
     });
     const { POST } = await import("@/app/api/integrations/sync-preview/route");
 
-    const request = makeRequest("/api/integrations/sync-preview", {
-      method: "POST",
-      body: JSON.stringify({
+    const response = await POST(
+      postSyncPreview({
         type: "odoo",
         credentials: { ...validCredentials, url: "http://169.254.169.254/" },
       }),
-    });
-    const response = await POST(request, routeContext());
+      routeContext()
+    );
     const body = await response.json();
 
     expect(mockValidateExternalUrl).toHaveBeenCalledWith("http://169.254.169.254/");
@@ -165,16 +190,23 @@ describe("POST /api/integrations/sync-preview", () => {
   it("returns the schema from fetchOdooSchema when the url passes SSRF validation", async () => {
     const { POST } = await import("@/app/api/integrations/sync-preview/route");
 
-    const request = makeRequest("/api/integrations/sync-preview", {
-      method: "POST",
-      body: JSON.stringify({ type: "odoo", credentials: validCredentials }),
-    });
-    const response = await POST(request, routeContext());
+    const response = await POST(
+      postSyncPreview({ type: "odoo", credentials: validCredentials }),
+      routeContext()
+    );
     const body = await response.json();
 
     expect(mockValidateExternalUrl).toHaveBeenCalledWith(validCredentials.url);
     expect(mockFetchOdooSchema).toHaveBeenCalledWith(validCredentials);
     expect(response.status).toBe(200);
     expect(body).toEqual(validSyncResult);
+
+    // The invariant SSRF actually rests on: the string that was checked is the
+    // string that gets fetched. Asserted as an identity between the two calls
+    // rather than against a literal, so a route that swapped in the normalized
+    // origin (or any other rewrite) between check and fetch fails here.
+    const [validatedUrl] = mockValidateExternalUrl.mock.calls[0] as [string];
+    const [forwarded] = mockFetchOdooSchema.mock.calls[0] as [typeof validCredentials];
+    expect(forwarded.url).toBe(validatedUrl);
   });
 });


### PR DESCRIPTION
## Summary
- `POST /api/integrations/sync-preview` was the only one of 101 API routes with zero test coverage (route accepts plaintext Odoo credentials and calls `fetchOdooSchema`).
- Adds `packages/web/src/__tests__/api/integrations-sync-preview.test.ts` covering: admin gate (401/403), Zod schema validation (400 on missing fields / invalid url / wrong `type`), SSRF wiring (`validateExternalUrl` rejects → route returns 400 and never calls `fetchOdooSchema`, pinning validation-before-fetch ordering), and the happy path (200 with the schema returned by `fetchOdooSchema`).
- Test-only change; verified against current `origin/main`, where `validateExternalUrl` is still synchronous (PR #1051's async/DNS-resolving signature has not landed).

## Test plan
- [x] `pnpm test:related packages/web/src/app/api/integrations/sync-preview/route.ts` — 7 passed
- [x] Red→green check: temporarily reordered the route (fetch before validateExternalUrl) to confirm the SSRF-ordering test fails, then reverted — diff after revert is empty
- [x] `pnpm test` — 775 test files passed / 4 skipped, 10924 tests passed / 18 skipped
- [x] `pnpm -C packages/web typecheck` — clean
- [x] `pnpm format:check` — clean