### PR TITLE
fix(plugins): harden pinchy-audit's tool-audit retry against transient and 4xx failures

### DIFF
--- a/packages/plugins/pinchy-audit/index.test.ts
+++ b/packages/plugins/pinchy-audit/index.test.ts
@@ -599,5 +599,113 @@ describe("pinchy-audit plugin", () => {
       expect(timeoutSpy).toHaveBeenCalledWith(10_000);
       timeoutSpy.mockRestore();
     });
+
+    it("does not retry a definitive 4xx response and quotes the response body in the thrown error", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve(JSON.stringify({ error: "unknown toolName" })),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+      await expect(
+        beforeHook(
+          { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+          { toolName: "pinchy_read" }
+        )
+      ).rejects.toThrow(/400.*unknown toolName/);
+
+      // A definitive 4xx is our own bug and retrying it never helps — one
+      // attempt only.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      [429, "Too Many Requests"],
+      [408, "Request Timeout"],
+    ])(
+      "retries a %i despite it being a 4xx, because the status means 'try again'",
+      async (status) => {
+        // The 4xx shortcut above must not swallow the two statuses that ask for
+        // a retry by definition. Getting this wrong is worse here than in
+        // pinchy-transcript, which drops the message: this hook fails CLOSED, so
+        // classifying a load-shedding 429 as "our own bug" would abort the tool
+        // call of every agent for as long as the shedding lasts.
+        vi.useFakeTimers();
+        try {
+          const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce({ ok: false, status })
+            .mockResolvedValueOnce({ ok: true });
+          vi.stubGlobal("fetch", fetchMock);
+
+          const { default: plugin } = await import("./index");
+          plugin.register?.(
+            createMockApi({
+              apiBaseUrl: "http://pinchy:7777",
+              gatewayToken: "gw-token",
+            }) as any
+          );
+
+          const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+          const resultPromise = beforeHook(
+            { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+            { toolName: "pinchy_read" }
+          );
+
+          await vi.advanceTimersByTimeAsync(250);
+          expect(fetchMock).toHaveBeenCalledTimes(2);
+          await expect(resultPromise).resolves.toBeUndefined();
+        } finally {
+          vi.useRealTimers();
+        }
+      }
+    );
+
+    it("retries a 5xx response with backoff between attempts, then succeeds", async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce({ ok: false, status: 503 })
+          .mockResolvedValueOnce({ ok: false, status: 503 })
+          .mockResolvedValueOnce({ ok: true });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const { default: plugin } = await import("./index");
+        plugin.register?.(
+          createMockApi({
+            apiBaseUrl: "http://pinchy:7777",
+            gatewayToken: "gw-token",
+          }) as any
+        );
+
+        const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+        const resultPromise = beforeHook(
+          { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+          { toolName: "pinchy_read" }
+        );
+
+        // First retry waits 250ms * 1, second waits 250ms * 2 before succeeding.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(250);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        await vi.advanceTimersByTimeAsync(500);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+
+        await expect(resultPromise).resolves.toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -203,12 +203,77 @@ function toolStartKey(
 }
 
 const MAX_RETRIES = 2;
+// Deliberately short: this hook runs synchronously in the tool-call path, so
+// every millisecond here is a millisecond the agent's tool call is blocked.
+const RETRY_BACKOFF_MS = 250;
+
+// Longest reason string worth putting in a warning/error. Pinchy's own API
+// errors are a short `error` string, and anything longer than this is a
+// stack trace or an HTML error page, neither of which belongs in a one-line
+// message.
+const MAX_REASON_CHARS = 200;
+
+/**
+ * Best-effort read of a rejection body, for the error/log message only.
+ * Returns an empty string if the body is unreadable — diagnosing a failure
+ * must never cause a different one. Mirrors pinchy-transcript's
+ * readErrorBody (#599: a bare status code once sent a debugging session
+ * hunting the wrong layer, when the body already named the real cause), and
+ * pinned to it by read-error-body-drift.test.ts.
+ */
+async function readErrorBody(res: { text?: () => Promise<string> }): Promise<string> {
+  try {
+    // Collapse first: a proxy answers with a multi-line HTML document, and a
+    // warning that spans lines stops being one log entry — whatever ships
+    // these logs onward indexes the fragments separately.
+    const trimmed = ((await res.text?.()) ?? "").replace(/\s+/g, " ").trim();
+    if (!trimmed) return "";
+    // Pinchy's API errors are `{"error":"…"}`; unwrap so the reason reads as a
+    // sentence rather than as JSON.
+    try {
+      const parsed = JSON.parse(trimmed) as { error?: unknown };
+      if (typeof parsed?.error === "string" && parsed.error) {
+        return parsed.error.slice(0, MAX_REASON_CHARS);
+      }
+    } catch {
+      // Not JSON (a proxy's HTML error page, say) — fall through to raw text.
+    }
+    return trimmed.slice(0, MAX_REASON_CHARS);
+  } catch {
+    return "";
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Is this status one the server will answer the same way for an identical
+ * retry? True for most of 4xx — a bad payload stays bad, a revoked token stays
+ * revoked — but NOT for the two statuses whose whole meaning is "try again":
+ *
+ *   408 Request Timeout    the server gave up waiting, not a claim about us
+ *   429 Too Many Requests  load shedding, and by definition temporary
+ *
+ * The carve-out matters more here than in pinchy-transcript, which the 4xx
+ * shortcut is modelled on: transcript drops the message, this hook fails
+ * CLOSED. Calling a 429 definitive would abort the tool call of every agent
+ * for as long as Pinchy is shedding load — turning a self-healing overload
+ * into a platform-wide outage. `/api/internal/usage/record` already answers
+ * 429 from a pre-auth rate limiter, so this is one sibling route away from
+ * being live rather than hypothetical.
+ */
+function isDefinitiveRejection(status: number): boolean {
+  if (status === 408 || status === 429) return false;
+  return status >= 400 && status < 500;
+}
 
 // Bounds every attempt against a hung Pinchy container / network blackhole.
 // This hook runs before EVERY tool call of EVERY agent, so an unbounded fetch
 // here blocks all tool dispatch indefinitely. Note the worst case is this
-// times MAX_RETRIES + 1 — there is no backoff between attempts, so an
-// unreachable Pinchy costs ~30s per tool call before the hook fails closed.
+// times MAX_RETRIES + 1, plus the backoff spent between those attempts — an
+// unreachable Pinchy costs ~30.75s per tool call before the hook fails closed.
 const FETCH_TIMEOUT_MS = 10_000;
 
 async function postToolAuditEvent(
@@ -220,6 +285,8 @@ async function postToolAuditEvent(
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let nonRetryable = false;
+
     try {
       const res = await fetch(endpoint, {
         method: "POST",
@@ -233,20 +300,52 @@ async function postToolAuditEvent(
 
       if (res.ok) return;
 
-      lastError = new Error(
-        `[pinchy-audit] audit endpoint returned ${res.status} for ${payload.phase} ${payload.toolName}`
-      );
+      // A definitive 4xx is our own bug (bad payload, revoked token, ...), not
+      // a transient fault — the server will reject an identical retry the same
+      // way, so retrying only spends this hook's tool-call-blocking window
+      // for nothing. Quote the body so the eventual error names the real
+      // reason instead of a bare status code.
+      if (isDefinitiveRejection(res.status)) {
+        const reason = await readErrorBody(res);
+        lastError = new Error(
+          `[pinchy-audit] audit endpoint rejected ${payload.phase} ${payload.toolName} (${res.status}${reason ? `: ${reason}` : ""})`
+        );
+        nonRetryable = true;
+      } else {
+        lastError = new Error(
+          `[pinchy-audit] audit endpoint returned ${res.status} for ${payload.phase} ${payload.toolName}`
+        );
+      }
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
     }
+
+    if (nonRetryable) break;
 
     if (attempt < MAX_RETRIES) {
       logger?.warn?.(
         `[pinchy-audit] audit failed (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying: ${lastError?.message}`
       );
+      await sleep(RETRY_BACKOFF_MS * (attempt + 1));
     }
   }
 
+  // Every attempt failed (or landed on a definitive rejection above). Throwing
+  // is deliberate, not an oversight: audit is a product feature — see AGENTS.md
+  // § "API Routes And Audit Trail" — not a best-effort side channel, so a
+  // failure to record must surface rather than be swallowed.
+  //
+  // What the throw buys differs per hook, and only one of the two is genuinely
+  // fail-closed. Do not read the stronger guarantee onto both:
+  //
+  //   before_tool_call  the tool has NOT run yet, so raising here is what stops
+  //                     an un-auditable action from happening at all.
+  //   after_tool_call   the tool has ALREADY run. Nothing here can undo it; the
+  //                     throw only reports the missing end-of-call record.
+  //
+  // The tests in index.test.ts assert that this function rejects — they say
+  // nothing about how OpenClaw handles a rejecting hook, which is the runtime's
+  // contract and not ours to claim from here.
   throw lastError;
 }
 

--- a/packages/web/src/__tests__/lib/read-error-body-drift.test.ts
+++ b/packages/web/src/__tests__/lib/read-error-body-drift.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Drift-guard: the rejection-body reader is duplicated across
+ * `packages/plugins/pinchy-transcript/index.ts::readErrorBody` and
+ * `packages/plugins/pinchy-audit/index.ts::readErrorBody`.
+ *
+ * The duplication is intentional: plugins are separate packages with no shared
+ * lib between them, so the alternative to copying is a new workspace package
+ * in the OpenClaw container's dependency graph. Same trade-off, same remedy as
+ * `normalize-docx-table-html-drift.test.ts` — copy, then pin.
+ *
+ * What drift would cost is #599 spelled twice. That incident's lesson was
+ * "when a client gives up on a response, it must say why": the plugin logged
+ * `capture rejected (403)` and dropped the message while the body it already
+ * held said the domain lock had refused the Host header. Both copies exist to
+ * quote that body. A fix applied to one — a truncation bound, an unwrap of a
+ * new error shape, a swallowed throw — silently leaves the other reporting the
+ * bare status code that sent a debugging session hunting the wrong layer.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const TRANSCRIPT_FILE = resolve(
+  import.meta.dirname,
+  "../../../../plugins/pinchy-transcript/index.ts"
+);
+const AUDIT_FILE = resolve(import.meta.dirname, "../../../../plugins/pinchy-audit/index.ts");
+
+function extractFunctionBody(source: string, fnName: string): string {
+  const marker = `function ${fnName}(`;
+  const fnStart = source.indexOf(marker);
+  if (fnStart === -1) {
+    throw new Error(`function ${fnName} not found in source`);
+  }
+
+  // Walk past the parameter list before looking for the body's brace. Both
+  // copies annotate their parameter with an inline object type
+  // (`{ text?: () => Promise<string> }`), so "first { after the name" — which
+  // is what normalize-docx-table-html-drift.test.ts can afford, its subject
+  // taking a plain `string` — lands on that annotation instead. Two identical
+  // annotations compare equal, and the guard passes having read no body at
+  // all. A canary found that, reading the code did not.
+  let i = fnStart + marker.length;
+  let parenDepth = 1;
+  while (i < source.length && parenDepth > 0) {
+    const ch = source[i];
+    if (ch === "(") parenDepth++;
+    else if (ch === ")") parenDepth--;
+    i++;
+  }
+
+  const braceStart = source.indexOf("{", i);
+  if (braceStart === -1) {
+    throw new Error(`body of ${fnName} not found in source`);
+  }
+
+  let depth = 1;
+  i = braceStart + 1;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    i++;
+  }
+  return source.slice(braceStart + 1, i - 1);
+}
+
+function extractNumericConstant(source: string, name: string): string {
+  const match = new RegExp(`const ${name}\\s*=\\s*([^;]+);`).exec(source);
+  if (!match) throw new Error(`const ${name} not found in source`);
+  return match[1].trim();
+}
+
+function canonicalize(body: string): string {
+  return body
+    .replace(/\/\/.*$/gm, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+describe("readErrorBody drift guard", () => {
+  const transcriptSource = readFileSync(TRANSCRIPT_FILE, "utf-8");
+  const auditSource = readFileSync(AUDIT_FILE, "utf-8");
+
+  it("extracts real function bodies, not the parameter annotation", () => {
+    // The comparison below is only worth anything if both sides are bodies.
+    // An extractor that slides off one returns a string that still compares
+    // equal to the other's — a guard passing on an empty comparison, which is
+    // how a coverage gate turns into decoration. Anchor on something only the
+    // body contains.
+    for (const [label, source] of [
+      ["pinchy-transcript", transcriptSource],
+      ["pinchy-audit", auditSource],
+    ] as const) {
+      const body = extractFunctionBody(source, "readErrorBody");
+      expect(body, `${label}: extracted no function body`).toContain("MAX_REASON_CHARS");
+      expect(body, `${label}: extracted no function body`).toContain("JSON.parse");
+    }
+  });
+
+  it("transcript and audit implementations have identical normalized function bodies", () => {
+    const transcriptBody = canonicalize(extractFunctionBody(transcriptSource, "readErrorBody"));
+    const auditBody = canonicalize(extractFunctionBody(auditSource, "readErrorBody"));
+
+    expect(auditBody).toBe(transcriptBody);
+  });
+
+  it("both copies truncate at the same bound", () => {
+    // The bodies reference MAX_REASON_CHARS by name, so a divergent value is
+    // invisible to the body comparison above while still producing two
+    // different messages for the same rejection.
+    expect(extractNumericConstant(auditSource, "MAX_REASON_CHARS")).toBe(
+      extractNumericConstant(transcriptSource, "MAX_REASON_CHARS")
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`postToolAuditEvent` in `packages/plugins/pinchy-audit/index.ts` retried every audit-post failure identically: three attempts, back-to-back, no delay.

- A 4xx (our own bug — bad payload, revoked token) was retried 3x even though the server rejects the identical retry the same way every time. `pinchy-transcript` already has the drop-and-quote-the-body logic for exactly this case (#599 lesson); `pinchy-audit` did not.
- No backoff between attempts, so the retry loop survives no real transient fault.
- The throw after exhausting retries was undocumented as intentional fail-closed behavior.

## Changes

- **Classify the failure instead of retrying everything.** A *definitive* rejection stops after one attempt, reads the response body (mirroring `pinchy-transcript`'s `readErrorBody`), and quotes it in the thrown error.
- **408 and 429 stay retryable despite being 4xx**, because their whole meaning is "try again". This carve-out matters more here than in `pinchy-transcript`, which drops the message: this hook fails **closed**, so calling a load-shedding 429 definitive would abort the tool call of *every* agent for as long as the shedding lasts. `/api/internal/usage/record` already answers 429 from a pre-auth rate limiter, so that is one sibling route away rather than hypothetical.
- **`250ms * attempt` backoff** between retries of a genuinely transient failure (5xx or network) — deliberately short, since this hook blocks the tool call synchronously. `FETCH_TIMEOUT_MS`'s comment, which stated "there is no backoff between attempts" and a ~30s worst case, is corrected to ~30.75s in the same change.
- **Drift-guard for the duplicated `readErrorBody`** (`packages/web/src/__tests__/lib/read-error-body-drift.test.ts`), pinning the `pinchy-audit` and `pinchy-transcript` copies together the way `normalize-docx-table-html-drift.test.ts` pins its duplication. Plugins are separate packages with no shared lib, so copy-then-pin is the established pattern.
- **Honest fail-closed documentation.** The throw is genuinely fail-closed only in `before_tool_call`, where the tool has not run yet. In `after_tool_call` the action already happened and the throw merely reports the missing end-of-call record — the comment no longer claims the stronger guarantee for both.

Retry count (`MAX_RETRIES = 2`, 3 total attempts) is unchanged.

## Note on the drift-guard's extractor

`normalize-docx-table-html-drift.test.ts`'s `extractFunctionBody` could **not** be reused verbatim. It takes the first `{` after the function name, which works for its subject (`normalizeTableHtml(html: string)`) but not here: both `readErrorBody` copies annotate their parameter with an inline object type (`{ text?: () => Promise<string> }`), so that `{` opens the *annotation*. Two identical annotations compare equal, and the guard passes green having read no function body at all.

Found by canary, not by reading — the first version of this guard was written that way and stayed green through a deliberately introduced divergence. The extractor now walks past the parameter list, and a separate test anchors on content only a real body contains.

## Tests added (`packages/plugins/pinchy-audit/index.test.ts`)

- `does not retry a definitive 4xx response and quotes the response body in the thrown error` — fetch called exactly once, thrown error matches `/400.*unknown toolName/`.
- `retries a %i despite it being a 4xx, because the status means 'try again'` — `it.each` over 429 and 408.
- `retries a 5xx response with backoff between attempts, then succeeds` — fake timers confirm attempt 2 waits 250ms and attempt 3 a further 500ms.

Both canaries verified by reproduction: reverting the 408/429 carve-out reds exactly the two new status tests; diverging the audit copy of `readErrorBody` reds the drift guard.

## Test plan

- [x] `pnpm test:plugins` — all 9 plugin packages pass (pinchy-audit 23)
- [x] `pnpm typecheck:plugins` — all 9 packages typecheck cleanly
- [x] `pnpm test` — 776 files passed / 4 skipped, 10947 tests passed / 18 skipped
- [x] `pnpm test:scripts` — 913 passed, 0 failed
- [x] `pnpm format:check` — clean

Rebased onto current `main` (#1048 has since merged); the fetch call keeps its `signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)` and `plugin-fetch-timeout-coverage.test.ts` stays green.

Docs-not-needed: internal retry hardening, no reader-facing change
