### PR TITLE
test(ci): derive the email/imap Playwright partition from one source

### DIFF
--- a/packages/web/e2e/email/imap-spec-patterns.ts
+++ b/packages/web/e2e/email/imap-spec-patterns.ts
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for how e2e/email/ is partitioned between the two
+ * Playwright configs that share it:
+ *
+ * - playwright.imap.config.ts claims exactly these specs (testMatch) — they
+ *   need the GreenMail + imap-mock stack (docker-compose.imap-test.yml) that
+ *   the OAuth-provider job does not bring up.
+ * - playwright.email.config.ts ignores exactly these specs (testIgnore) and
+ *   runs everything else in e2e/email by default.
+ *
+ * A spec listed here is claimed by imap and ignored by email; a spec NOT
+ * listed here runs under email by default (the email config is a denylist).
+ * Both configs import from this module, so there is no second list to keep
+ * in sync by hand. See AGENTS.md, "A Hand-Maintained List That Mirrors Code
+ * Will Be Wrong".
+ */
+export const IMAP_ONLY_SPEC_FILES = ["email-imap.spec.ts", "inbox-sweep.spec.ts"] as const;
+
+/** RegExp form for playwright.imap.config.ts's testMatch, derived from the list above. */
+export const IMAP_ONLY_SPEC_MATCH = new RegExp(
+  `(${IMAP_ONLY_SPEC_FILES.map((f) => f.replace(/\.spec\.ts$/, "")).join("|")})\\.spec\\.ts`
+);

--- a/packages/web/e2e/email/imap-spec-patterns.ts
+++ b/packages/web/e2e/email/imap-spec-patterns.ts
@@ -16,7 +16,23 @@
  */
 export const IMAP_ONLY_SPEC_FILES = ["email-imap.spec.ts", "inbox-sweep.spec.ts"] as const;
 
-/** RegExp form for playwright.imap.config.ts's testMatch, derived from the list above. */
+/**
+ * Escape a literal file name for embedding in a RegExp. A derived pattern must
+ * escape what it derives from: an unescaped `.` matches any character, so a
+ * future `email-imap.v2.spec.ts` would silently widen the allowlist to specs
+ * nobody listed here — and a widened testMatch claims a spec the email config
+ * still runs, so it runs twice rather than nowhere.
+ */
+function escapeForRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * RegExp form for playwright.imap.config.ts's testMatch, derived from the list
+ * above. Playwright tests this against a file path, so the alternation is
+ * anchored to a whole path segment: it matches `<anything>/inbox-sweep.spec.ts`
+ * and nothing that merely contains that name.
+ */
 export const IMAP_ONLY_SPEC_MATCH = new RegExp(
-  `(${IMAP_ONLY_SPEC_FILES.map((f) => f.replace(/\.spec\.ts$/, "")).join("|")})\\.spec\\.ts`
+  `(?:^|/)(?:${IMAP_ONLY_SPEC_FILES.map(escapeForRegExp).join("|")})$`
 );

--- a/packages/web/playwright.email.config.ts
+++ b/packages/web/playwright.email.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+import { IMAP_ONLY_SPEC_FILES } from "./e2e/email/imap-spec-patterns";
+
 /**
  * Playwright config for pinchy-email (Gmail) E2E.
  * Assumes the full Docker stack with gmail-mock is already running:
@@ -8,15 +10,15 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e/email",
   // Run only the OAuth-provider specs here. e2e/email is shared with
-  // playwright.imap.config.ts, which claims exactly the specs listed below:
-  // they need the GreenMail + imap-mock stack (docker-compose.imap-test.yml)
-  // that this job does NOT bring up, so running them here fails with "IMAP
-  // mock not ready".
+  // playwright.imap.config.ts, which claims exactly the specs in
+  // IMAP_ONLY_SPEC_FILES (e2e/email/imap-spec-patterns.ts): they need the
+  // GreenMail + imap-mock stack (docker-compose.imap-test.yml) that this job
+  // does NOT bring up, so running them here fails with "IMAP mock not ready".
   //
-  // This is a denylist, so a NEW spec added to e2e/email runs here by default.
-  // Keep it in sync with playwright.imap.config.ts's testMatch — the two
-  // partition one directory, and a spec must appear in exactly one of them.
-  testIgnore: ["email-imap.spec.ts", "inbox-sweep.spec.ts"],
+  // This is a denylist, so a NEW spec added to e2e/email runs here by
+  // default. Both configs read from imap-spec-patterns.ts — there is nothing
+  // left to keep in sync by hand.
+  testIgnore: [...IMAP_ONLY_SPEC_FILES],
   fullyParallel: false,
   retries: 0,
   workers: 1,

--- a/packages/web/playwright.imap.config.ts
+++ b/packages/web/playwright.imap.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+import { IMAP_ONLY_SPEC_MATCH } from "./e2e/email/imap-spec-patterns";
+
 /**
  * Playwright config for pinchy-email (IMAP/SMTP) E2E.
  * Assumes the full Docker stack with greenmail + imap-mock is already running:
@@ -7,7 +9,9 @@ import { defineConfig } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./e2e/email",
-  testMatch: /(email-imap|inbox-sweep)\.spec\.ts/,
+  // See e2e/email/imap-spec-patterns.ts — this must claim exactly the specs
+  // playwright.email.config.ts ignores. Both configs read the same module.
+  testMatch: IMAP_ONLY_SPEC_MATCH,
   fullyParallel: false,
   retries: 0,
   workers: 1,

--- a/packages/web/src/__tests__/lib/e2e-email-config-partition.test.ts
+++ b/packages/web/src/__tests__/lib/e2e-email-config-partition.test.ts
@@ -22,6 +22,7 @@ import { join } from "path";
 
 import { describe, it, expect } from "vitest";
 
+import { IMAP_ONLY_SPEC_FILES, IMAP_ONLY_SPEC_MATCH } from "../../../e2e/email/imap-spec-patterns";
 import emailConfig from "../../../playwright.email.config";
 import imapConfig from "../../../playwright.imap.config";
 
@@ -96,5 +97,16 @@ describe("e2e/email is partitioned between the two Playwright configs", () => {
         `playwright.email.config.ts ignores "${ignored}", but playwright.imap.config.ts does not claim it — no job runs this spec`
       ).toBe(true);
     }
+  });
+
+  it("reads the partition from the shared e2e/email/imap-spec-patterns module, not two hand-maintained lists", () => {
+    // The two checks above prove the configs agree. This one proves *why* they
+    // agree: both derive testIgnore/testMatch from the same constants rather
+    // than two lists that happen to match today. Without this, a revert to a
+    // literal duplicate array would pass the checks above and reintroduce the
+    // mirror AGENTS.md's "A Hand-Maintained List That Mirrors Code Will Be
+    // Wrong" warns about.
+    expect(emailIgnoreList()).toEqual([...IMAP_ONLY_SPEC_FILES]);
+    expect((imapConfig.testMatch as RegExp).source).toBe(IMAP_ONLY_SPEC_MATCH.source);
   });
 });

--- a/packages/web/src/__tests__/lib/e2e-email-config-partition.test.ts
+++ b/packages/web/src/__tests__/lib/e2e-email-config-partition.test.ts
@@ -17,7 +17,7 @@
 // Nothing else checks this: each config is individually valid whatever the other
 // says, and CI runs them in separate jobs that never compare notes. A brand-new
 // spec that neither mentions is fine by construction — the denylist runs it.
-import { readdirSync } from "fs";
+import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 
 import { describe, it, expect } from "vitest";
@@ -26,7 +26,43 @@ import { IMAP_ONLY_SPEC_FILES, IMAP_ONLY_SPEC_MATCH } from "../../../e2e/email/i
 import emailConfig from "../../../playwright.email.config";
 import imapConfig from "../../../playwright.imap.config";
 
-const E2E_EMAIL_DIR = join(__dirname, "../../../e2e/email");
+const WEB_ROOT = join(__dirname, "../../..");
+const E2E_EMAIL_DIR = join(WEB_ROOT, "e2e/email");
+const SHARED_MODULE = "./e2e/email/imap-spec-patterns";
+const SHARED_MODULE_PATTERN = SHARED_MODULE.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
+
+const EMAIL_CONFIG_FILE = "playwright.email.config.ts";
+const IMAP_CONFIG_FILE = "playwright.imap.config.ts";
+
+function configSource(file: string): string {
+  return readFileSync(join(WEB_ROOT, file), "utf8");
+}
+
+/**
+ * Does `file` import `binding` from the shared partition module?
+ *
+ * Anchored at the start of a line, so a mention inside a comment cannot satisfy
+ * it — both configs name these constants in their prose, and a check that
+ * counted that would pass on a config that had been reverted to a literal.
+ */
+function importsFromSharedModule(file: string, binding: string): boolean {
+  const importLine = new RegExp(
+    String.raw`^import\s*\{[^}]*\b${binding}\b[^}]*\}\s*from\s*["']${SHARED_MODULE_PATTERN}["'];?$`,
+    "m"
+  );
+  return importLine.test(configSource(file));
+}
+
+/** The value of `option` exactly as written in the config source. */
+function optionExpression(file: string, option: "testIgnore" | "testMatch"): string {
+  const src = configSource(file);
+  const declaration = new RegExp(String.raw`^\s*${option}:\s*(.+?),?\s*$`, "m").exec(src);
+  expect(
+    declaration,
+    `${file} must declare ${option} on one line so this guard can read how it is written`
+  ).not.toBeNull();
+  return declaration![1];
+}
 
 function specFiles(): string[] {
   return readdirSync(E2E_EMAIL_DIR)
@@ -100,12 +136,38 @@ describe("e2e/email is partitioned between the two Playwright configs", () => {
   });
 
   it("reads the partition from the shared e2e/email/imap-spec-patterns module, not two hand-maintained lists", () => {
-    // The two checks above prove the configs agree. This one proves *why* they
+    // The checks above prove the configs AGREE. This one proves *why* they
     // agree: both derive testIgnore/testMatch from the same constants rather
-    // than two lists that happen to match today. Without this, a revert to a
-    // literal duplicate array would pass the checks above and reintroduce the
-    // mirror AGENTS.md's "A Hand-Maintained List That Mirrors Code Will Be
+    // than two lists that happen to match today. Without it, a revert to a
+    // literal duplicate would pass every check above and silently reintroduce
+    // the mirror AGENTS.md's "A Hand-Maintained List That Mirrors Code Will Be
     // Wrong" warns about.
+    //
+    // Provenance is only visible in the source text: two lists that agree
+    // produce byte-identical runtime values, so comparing the loaded config
+    // against the shared constants cannot tell a wired config from a copy of
+    // it. Verified by reproduction — revert both configs to literals and this
+    // test must go red while the other three stay green.
+    expect(
+      importsFromSharedModule(EMAIL_CONFIG_FILE, "IMAP_ONLY_SPEC_FILES"),
+      `${EMAIL_CONFIG_FILE} must import IMAP_ONLY_SPEC_FILES from "${SHARED_MODULE}" instead of spelling the list out again`
+    ).toBe(true);
+    expect(
+      optionExpression(EMAIL_CONFIG_FILE, "testIgnore"),
+      `${EMAIL_CONFIG_FILE}'s testIgnore must be derived from IMAP_ONLY_SPEC_FILES, not a literal array`
+    ).toContain("IMAP_ONLY_SPEC_FILES");
+
+    expect(
+      importsFromSharedModule(IMAP_CONFIG_FILE, "IMAP_ONLY_SPEC_MATCH"),
+      `${IMAP_CONFIG_FILE} must import IMAP_ONLY_SPEC_MATCH from "${SHARED_MODULE}" instead of spelling the pattern out again`
+    ).toBe(true);
+    expect(
+      optionExpression(IMAP_CONFIG_FILE, "testMatch"),
+      `${IMAP_CONFIG_FILE}'s testMatch must be derived from IMAP_ONLY_SPEC_MATCH, not a literal RegExp`
+    ).toContain("IMAP_ONLY_SPEC_MATCH");
+
+    // And the wiring must not be decorative: a config that imports the shared
+    // constants and then overrides them is back to two sources.
     expect(emailIgnoreList()).toEqual([...IMAP_ONLY_SPEC_FILES]);
     expect((imapConfig.testMatch as RegExp).source).toBe(IMAP_ONLY_SPEC_MATCH.source);
   });


### PR DESCRIPTION
## Summary
- `playwright.email.config.ts` (`testIgnore` denylist) and `playwright.imap.config.ts` (`testMatch` regex) partitioned `e2e/email/` as a hand-maintained mirror pair — the shape AGENTS.md's "A Hand-Maintained List That Mirrors Code Will Be Wrong" warns about.
- An existing guard (`e2e-email-config-partition.test.ts`, on `main` since #139) already catches drift between the two lists, but the mirror itself stayed: a new spec still had to be added to both lists by hand.
- Adds `packages/web/e2e/email/imap-spec-patterns.ts` as the single source (`IMAP_ONLY_SPEC_FILES` / `IMAP_ONLY_SPEC_MATCH`). Both configs now import from it instead of carrying their own copy.
- Extends the existing guard test to assert the configs are actually wired to the shared module — not just coincidentally in agreement — so a revert to a literal duplicate array fails loudly instead of silently reintroducing the mirror.
- Retries/workers pins in both configs are untouched (out of scope, and covered by a separate pin guard).

## Test plan
- [x] TDD: extended `e2e-email-config-partition.test.ts` with a wiring assertion first — red (`Cannot find module '../../../e2e/email/imap-spec-patterns'`), then green after adding the shared module and rewiring both configs (4/4 passed).
- [x] Canary (per repo convention of verifying by reproduction, not by reading code): temporarily added `inbox-sweep-canary.spec.ts` and confirmed both `playwright test --list` outputs flip consistently when the file is added to the shared list (email: 6→0 tests matching, imap: 0→6), with a single edit. Reverted before committing.
- [x] `pnpm exec playwright test --list --config playwright.email.config.ts` → 15 tests in 2 files (unchanged from before the refactor).
- [x] `pnpm exec playwright test --list --config playwright.imap.config.ts` → 6 tests in 2 files (unchanged).
- [x] `pnpm test:scripts` → 894 passed, 0 failed.
- [x] `pnpm format:check` → clean.
- [x] `pnpm -C packages/web typecheck` → clean.
- [x] `pnpm test` (full suite) → 774 passed | 4 skipped test files, 10918 passed | 18 skipped tests.