### PR TITLE
fix(plugins): post-filter Brave search results by allowed/excluded domain

### DIFF
--- a/packages/plugins/pinchy-web/brave-search.test.ts
+++ b/packages/plugins/pinchy-web/brave-search.test.ts
@@ -205,4 +205,82 @@ describe("braveSearch", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(30_000);
     timeoutSpy.mockRestore();
   });
+
+  describe("result-side domain post-filtering", () => {
+    // The `site:` operator concatenated into the query above is only a
+    // best-effort hint to Brave. The model controls the free-text part of the
+    // query and can inject its own `site:`/`-site:` operators, whose
+    // interaction with ours under multiple competing site: groups is
+    // unspecified — so a result outside the configured domains can still come
+    // back. These results are filtered by hostname before being handed to the
+    // model, using the same allow/exclude semantics as pinchy_web_fetch.
+
+    it("drops a result outside the allowed domains even though the query used site:", async () => {
+      mockSuccessResponse([
+        { title: "Good", url: "https://github.com/foo", description: "d1" },
+        { title: "Bad", url: "https://evil.com/bar", description: "d2" },
+      ]);
+
+      const { results } = await braveSearch("original query", {
+        apiKey: "key",
+        allowedDomains: ["github.com"],
+      });
+
+      expect(results.map((r) => r.url)).toEqual(["https://github.com/foo"]);
+    });
+
+    it("drops a result from an excluded domain", async () => {
+      mockSuccessResponse([
+        { title: "Reddit", url: "https://reddit.com/r/foo", description: "d1" },
+        { title: "Other", url: "https://example.com/bar", description: "d2" },
+      ]);
+
+      const { results } = await braveSearch("query", {
+        apiKey: "key",
+        excludedDomains: ["reddit.com"],
+      });
+
+      expect(results.map((r) => r.url)).toEqual(["https://example.com/bar"]);
+    });
+
+    it("keeps a result on a subdomain of an allowed domain", async () => {
+      mockSuccessResponse([
+        { title: "Sub", url: "https://docs.github.com/foo", description: "d1" },
+      ]);
+
+      const { results } = await braveSearch("query", {
+        apiKey: "key",
+        allowedDomains: ["github.com"],
+      });
+
+      expect(results.map((r) => r.url)).toEqual(["https://docs.github.com/foo"]);
+    });
+
+    it("reports how many results were filtered out", async () => {
+      mockSuccessResponse([
+        { title: "Good", url: "https://github.com/foo", description: "d1" },
+        { title: "Bad1", url: "https://evil.com/bar", description: "d2" },
+        { title: "Bad2", url: "https://evil2.com/bar", description: "d3" },
+      ]);
+
+      const { filteredCount } = await braveSearch("query", {
+        apiKey: "key",
+        allowedDomains: ["github.com"],
+      });
+
+      expect(filteredCount).toBe(2);
+    });
+
+    it("leaves results and filteredCount untouched when no domain filters are configured", async () => {
+      mockSuccessResponse([
+        { title: "A", url: "https://any.com/1", description: "d1" },
+        { title: "B", url: "https://other.com/2", description: "d2" },
+      ]);
+
+      const { results, filteredCount } = await braveSearch("query", { apiKey: "key" });
+
+      expect(results).toHaveLength(2);
+      expect(filteredCount).toBeUndefined();
+    });
+  });
 });

--- a/packages/plugins/pinchy-web/brave-search.test.ts
+++ b/packages/plugins/pinchy-web/brave-search.test.ts
@@ -256,6 +256,41 @@ describe("braveSearch", () => {
       expect(results.map((r) => r.url)).toEqual(["https://docs.github.com/foo"]);
     });
 
+    it("drops a result whose URL cannot be parsed", async () => {
+      mockSuccessResponse([
+        { title: "Good", url: "https://github.com/foo", description: "d1" },
+        { title: "Broken", url: "not a url", description: "d2" },
+      ]);
+
+      const { results, filteredCount } = await braveSearch("query", {
+        apiKey: "key",
+        allowedDomains: ["github.com"],
+      });
+
+      // An unverifiable URL is dropped rather than waved through — we cannot
+      // say it is in scope, and "unknown" must not read as "allowed".
+      expect(results.map((r) => r.url)).toEqual(["https://github.com/foo"]);
+      expect(filteredCount).toBe(1);
+    });
+
+    it("drops a non-HTTP result URL that no exclude list could ever match", async () => {
+      // `new URL("data:...").hostname` is the empty string, so an exclude-only
+      // config matches nothing and would keep it — while pinchy_web_fetch
+      // refuses the same URL on its scheme check. Both tools answer alike.
+      mockSuccessResponse([
+        { title: "Inline", url: "data:text/html,<h1>hi</h1>", description: "d1" },
+        { title: "Fine", url: "https://example.com/ok", description: "d2" },
+      ]);
+
+      const { results, filteredCount } = await braveSearch("query", {
+        apiKey: "key",
+        excludedDomains: ["reddit.com"],
+      });
+
+      expect(results.map((r) => r.url)).toEqual(["https://example.com/ok"]);
+      expect(filteredCount).toBe(1);
+    });
+
     it("reports how many results were filtered out", async () => {
       mockSuccessResponse([
         { title: "Good", url: "https://github.com/foo", description: "d1" },

--- a/packages/plugins/pinchy-web/brave-search.ts
+++ b/packages/plugins/pinchy-web/brave-search.ts
@@ -1,4 +1,4 @@
-import { checkDomainAllowed } from "./web-fetch.js";
+import { domainDenialReason } from "./web-fetch.js";
 
 // External API call — bounds a hung Brave endpoint / network blackhole.
 // Matches web-fetch.ts's external-call timeout.
@@ -97,15 +97,23 @@ export async function braveSearch(
 
   let filteredCount = 0;
   const results = rawResults.filter((r) => {
-    let hostname: string;
+    let parsed: URL;
     try {
-      hostname = new URL(r.url).hostname;
+      parsed = new URL(r.url);
     } catch {
       // Unparseable URL — can't verify it's in scope, so drop it.
       filteredCount++;
       return false;
     }
-    if (checkDomainAllowed(hostname, config)) {
+    // pinchy_web_fetch gates on the scheme before it gates on the hostname,
+    // and a non-HTTP URL carries an empty hostname that no exclude list can
+    // ever match — so an exclude-only config would wave `data:`/`javascript:`
+    // through here while web_fetch refuses it. Ask the same question in both.
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      filteredCount++;
+      return false;
+    }
+    if (domainDenialReason(parsed.hostname, config)) {
       filteredCount++;
       return false;
     }

--- a/packages/plugins/pinchy-web/brave-search.ts
+++ b/packages/plugins/pinchy-web/brave-search.ts
@@ -1,3 +1,5 @@
+import { checkDomainAllowed } from "./web-fetch.js";
+
 // External API call — bounds a hung Brave endpoint / network blackhole.
 // Matches web-fetch.ts's external-call timeout.
 const FETCH_TIMEOUT_MS = 30_000;
@@ -21,7 +23,7 @@ export interface BraveSearchResult {
 export async function braveSearch(
   query: string,
   config: BraveSearchConfig
-): Promise<{ results: BraveSearchResult[] }> {
+): Promise<{ results: BraveSearchResult[]; filteredCount?: number }> {
   if (!config.apiKey) {
     throw new Error(
       "Brave Search API key is required. Configure it in Pinchy integration settings."
@@ -73,12 +75,42 @@ export async function braveSearch(
   }
 
   const data = await res.json();
-  const results = (data.web?.results ?? []).map((r: Record<string, unknown>) => ({
-    title: r.title as string,
-    url: r.url as string,
-    description: r.description as string,
-    extra_snippets: r.extra_snippets as string[] | undefined,
-  }));
+  const rawResults: BraveSearchResult[] = (data.web?.results ?? []).map(
+    (r: Record<string, unknown>) => ({
+      title: r.title as string,
+      url: r.url as string,
+      description: r.description as string,
+      extra_snippets: r.extra_snippets as string[] | undefined,
+    })
+  );
 
-  return { results };
+  // The `site:`/`-site:` operators concatenated into the query above are a
+  // best-effort hint to Brave, not enforcement: the model controls the
+  // free-text part of the query and can append its own site: operators, and
+  // Brave's behavior with multiple competing site: groups in one query is
+  // unspecified. So filter results by hostname here too, using the exact
+  // same allow/exclude + subdomain semantics as pinchy_web_fetch, before
+  // handing anything to the model.
+  if (!config.allowedDomains?.length && !config.excludedDomains?.length) {
+    return { results: rawResults };
+  }
+
+  let filteredCount = 0;
+  const results = rawResults.filter((r) => {
+    let hostname: string;
+    try {
+      hostname = new URL(r.url).hostname;
+    } catch {
+      // Unparseable URL — can't verify it's in scope, so drop it.
+      filteredCount++;
+      return false;
+    }
+    if (checkDomainAllowed(hostname, config)) {
+      filteredCount++;
+      return false;
+    }
+    return true;
+  });
+
+  return { results, filteredCount: filteredCount || undefined };
 }

--- a/packages/plugins/pinchy-web/index.test.ts
+++ b/packages/plugins/pinchy-web/index.test.ts
@@ -445,8 +445,55 @@ describe("pinchy-web plugin", () => {
 
       expect(result.isError).toBeUndefined();
       expect(result.content[0].text).toContain(
-        "2 results outside the allowed domains were filtered"
+        "(2 results were filtered out by this agent's domain restrictions.)"
       );
+    });
+
+    it("uses singular agreement in the note when exactly one result was filtered", async () => {
+      // The note is prose the model reads back to the user. "1 result … were
+      // filtered out" is the shape a `${n === 1 ? "" : "s"}` suffix leaves
+      // behind when the verb is not pluralised alongside the noun.
+      braveSearchMock.mockResolvedValue({
+        results: [{ title: "Result 1", url: "https://github.com/1", description: "Desc 1" }],
+        filteredCount: 1,
+      });
+      stubCredentialsFetch("brave-key-123");
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"], allowedDomains: ["github.com"] },
+        })
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      const result = await tool.execute("call-1", { query: "test query" });
+
+      expect(result.content[0].text).toContain(
+        "(1 result was filtered out by this agent's domain restrictions.)"
+      );
+    });
+
+    it("names the restriction rather than the allow-list, so an exclude-only agent reads true prose", async () => {
+      // An agent configured with only an exclude list has no allowed domains
+      // to be "outside" of — the earlier wording asserted a config that does
+      // not exist.
+      braveSearchMock.mockResolvedValue({
+        results: [{ title: "Result 1", url: "https://example.com/1", description: "Desc 1" }],
+        filteredCount: 3,
+      });
+      stubCredentialsFetch("brave-key-123");
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"], excludedDomains: ["reddit.com"] },
+        })
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      const result = await tool.execute("call-1", { query: "test query" });
+
+      expect(result.content[0].text).not.toContain("allowed domains");
+      expect(result.content[0].text).toContain("domain restrictions");
     });
 
     it("does not append a filtering note when nothing was filtered", async () => {

--- a/packages/plugins/pinchy-web/index.test.ts
+++ b/packages/plugins/pinchy-web/index.test.ts
@@ -427,6 +427,48 @@ describe("pinchy-web plugin", () => {
       expect(reportCalls).toHaveLength(0);
     });
 
+    it("appends a note to the tool result when results were filtered by domain", async () => {
+      const mockResults = [
+        { title: "Result 1", url: "https://github.com/1", description: "Desc 1" },
+      ];
+      braveSearchMock.mockResolvedValue({ results: mockResults, filteredCount: 2 });
+      stubCredentialsFetch("brave-key-123");
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"], allowedDomains: ["github.com"] },
+        })
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      const result = await tool.execute("call-1", { query: "test query" });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain(
+        "2 results outside the allowed domains were filtered"
+      );
+    });
+
+    it("does not append a filtering note when nothing was filtered", async () => {
+      const mockResults = [
+        { title: "Result 1", url: "https://example.com", description: "Desc 1" },
+      ];
+      braveSearchMock.mockResolvedValue({ results: mockResults });
+      stubCredentialsFetch("brave-key-123");
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"] },
+        })
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      const result = await tool.execute("call-1", { query: "test query" });
+
+      expect(result.content[0].text).not.toContain("filtered");
+      expect(JSON.parse(result.content[0].text)).toEqual(mockResults);
+    });
+
     it("handles non-Error throws from braveSearch", async () => {
       braveSearchMock.mockRejectedValue("string error");
       stubCredentialsFetch("brave-key-123");

--- a/packages/plugins/pinchy-web/index.ts
+++ b/packages/plugins/pinchy-web/index.ts
@@ -251,9 +251,18 @@ const plugin = {
                 };
                 return braveSearch(params.query as string, searchConfig);
               });
-              const filterNote = result.filteredCount
-                ? `\n\n(${result.filteredCount} result${result.filteredCount === 1 ? "" : "s"} outside the allowed domains were filtered out.)`
-                : "";
+              // Name the *restriction*, not the allow-list: a result is also
+              // dropped when it lands on an excluded domain, or when its URL
+              // can't be parsed at all, and "outside the allowed domains" is
+              // plainly false in both of those cases — an agent configured
+              // with only an exclude list has no allowed domains to be
+              // outside of.
+              const filterNote =
+                result.filteredCount === 1
+                  ? "\n\n(1 result was filtered out by this agent's domain restrictions.)"
+                  : result.filteredCount
+                    ? `\n\n(${result.filteredCount} results were filtered out by this agent's domain restrictions.)`
+                    : "";
               return {
                 content: [
                   {

--- a/packages/plugins/pinchy-web/index.ts
+++ b/packages/plugins/pinchy-web/index.ts
@@ -251,11 +251,14 @@ const plugin = {
                 };
                 return braveSearch(params.query as string, searchConfig);
               });
+              const filterNote = result.filteredCount
+                ? `\n\n(${result.filteredCount} result${result.filteredCount === 1 ? "" : "s"} outside the allowed domains were filtered out.)`
+                : "";
               return {
                 content: [
                   {
                     type: "text",
-                    text: JSON.stringify(result.results, null, 2),
+                    text: JSON.stringify(result.results, null, 2) + filterNote,
                   },
                 ],
               };

--- a/packages/plugins/pinchy-web/web-fetch.ts
+++ b/packages/plugins/pinchy-web/web-fetch.ts
@@ -167,7 +167,11 @@ function normalizeHostname(hostname: string): string {
   return hostname.toLowerCase().replace(/\.$/, "");
 }
 
-function checkDomainAllowed(
+// Exported for reuse by brave-search.ts, which post-filters search results by
+// hostname against the same allowedDomains/excludedDomains config (the
+// `site:` operator concatenated into the search query is only a best-effort
+// hint to Brave, not enforcement — see the comment in braveSearch()).
+export function checkDomainAllowed(
   hostname: string,
   config: Pick<WebFetchConfig, "allowedDomains" | "excludedDomains">
 ): string | null {

--- a/packages/plugins/pinchy-web/web-fetch.ts
+++ b/packages/plugins/pinchy-web/web-fetch.ts
@@ -167,11 +167,17 @@ function normalizeHostname(hostname: string): string {
   return hostname.toLowerCase().replace(/\.$/, "");
 }
 
-// Exported for reuse by brave-search.ts, which post-filters search results by
-// hostname against the same allowedDomains/excludedDomains config (the
-// `site:` operator concatenated into the search query is only a best-effort
-// hint to Brave, not enforcement — see the comment in braveSearch()).
-export function checkDomainAllowed(
+// Returns a human-readable reason when `hostname` is NOT allowed, and null when
+// it is — so the truthy branch is the *denial* branch, the opposite of how a
+// name like `checkDomainAllowed` reads. Named for what it returns now that
+// brave-search.ts shares it: an inverted read of a security gate is the
+// expensive kind of typo, and a second call site doubles the chance of one.
+//
+// brave-search.ts post-filters search results by hostname against the same
+// allowedDomains/excludedDomains config, because the `site:` operator
+// concatenated into the search query is only a best-effort hint to Brave, not
+// enforcement — see the comment in braveSearch().
+export function domainDenialReason(
   hostname: string,
   config: Pick<WebFetchConfig, "allowedDomains" | "excludedDomains">
 ): string | null {
@@ -340,7 +346,7 @@ export async function webFetch(
 
   // Domain filtering
   const hostname = parsed.hostname;
-  const domainError = checkDomainAllowed(hostname, config);
+  const domainError = domainDenialReason(hostname, config);
   if (domainError) {
     return { content: domainError, isError: true };
   }
@@ -392,7 +398,7 @@ export async function webFetch(
       }
 
       // Domain filtering on redirect target
-      const redirectDomainError = checkDomainAllowed(redirectUrl.hostname, config);
+      const redirectDomainError = domainDenialReason(redirectUrl.hostname, config);
       if (redirectDomainError) {
         return { content: redirectDomainError, isError: true };
       }


### PR DESCRIPTION
## Summary
- `braveSearch()` concatenates `allowedDomains`/`excludedDomains` into the Brave query as `site:`/`-site:` operators, but that's only a hint: the model controls the free-text part of the query and can append its own `site:` operators, and Brave's behavior with multiple competing `site:` groups in one query is unspecified. A result outside the configured domains could still reach the model as a title/snippet, even though `pinchy_web_fetch` already enforces the same restriction hard on fetch.
- Post-filter Brave's results by hostname after the API call, reusing `checkDomainAllowed` from `web-fetch.ts` (now exported) so `pinchy_web_search` and `pinchy_web_fetch` share identical allow/exclude and subdomain semantics.
- When results are dropped, append a short note to the tool result (`"N results outside the allowed domains were filtered out."`) so the model doesn't hallucinate about a sparse result set.
- The `site:` concatenation on the query itself is left in place — it's a useful pre-filter that saves Brave API results; the new post-filter is the actual enforcement.

## Test plan
- [x] Added failing tests first (red), then implemented (green): `brave-search.test.ts` → `result-side domain post-filtering` describe block: drops out-of-scope result despite `site:` query, drops excluded-domain result, keeps subdomain match, reports `filteredCount`, leaves results untouched when no filters configured.
- [x] `index.test.ts`: asserts the tool-result text includes the filtering note when `filteredCount` is set, and omits it (staying valid JSON) when nothing was filtered.
- [x] `pnpm test:plugins` — 9 plugin packages, all pass (pinchy-web: 105/105).
- [x] `pnpm typecheck:plugins` — all 9 plugin packages typecheck cleanly.
- [x] `pnpm test:scripts` — 894/894 pass.
- [x] `pnpm test` (full suite, machine-wide lock) — 10924 passed, 18 skipped (pre-existing, unrelated).
- [x] `pnpm format:check` — clean.

`docs/src/content/docs/guides/web-search-setup.mdx` already documents "the agent may only access these domains" for both Search and Fetch — this fix makes that existing promise true rather than changing what's promised, so `Docs-not-needed` trailer is on the commit.