### PR TITLE
docs: document the amd64-only requirement for Pinchy's images

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -9,6 +9,7 @@ This guide walks you through getting Pinchy up and running — from downloading 
 
 ## Prerequisites
 
+- A 64-bit x86 (amd64) machine — Pinchy's images are built for `linux/amd64` only, so Arm64 hosts are [not yet supported](/installation/#system-requirements) ([#1081](https://github.com/heypinchy/pinchy/issues/1081))
 - [Docker](https://docs.docker.com/get-docker/) (includes Docker Compose v2)
 - An API key from an LLM provider (Anthropic, OpenAI, Google, or Ollama)
 

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -42,11 +42,12 @@ Hetzner Cloud is an excellent choice for running Pinchy. Their servers run in EU
     Under **Shared Resources**, select **Cost-Optimized**, then pick **x86 (Intel/AMD)** as the architecture — not **Arm64**.
 
     <Aside type="caution">
-      Hetzner's cheapest Shared vCPU line, **CAX**, runs on Arm64 CPUs. Pinchy's
-      Docker images are built for x86 (amd64) only
-      ([#1081](https://github.com/heypinchy/pinchy/issues/1081)), so a CAX
-      server can't run them — the containers fail to start with `exec format
-      error`. Double-check **x86 (Intel/AMD)** is selected before you continue.
+      Hetzner's **CAX** servers run on Arm64 CPUs, and Pinchy's Docker images
+      are built for x86 (amd64) only
+      ([#1081](https://github.com/heypinchy/pinchy/issues/1081)). On a CAX
+      server the stack never starts: pulling the images fails with a "no
+      matching manifest for linux/arm64/v8" error. Double-check **x86
+      (Intel/AMD)** is selected before you continue.
     </Aside>
 
     Scroll down to the server sizes and select the smallest option with **at least 4 GB RAM** and **2 vCPUs**. This is the minimum for Pinchy.

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -39,7 +39,15 @@ Hetzner Cloud is an excellent choice for running Pinchy. Their servers run in EU
 
 4.  **Choose server type**
 
-    Under **Shared Resources**, select **Cost-Optimized**, then pick **x86 (Intel/AMD)** as the architecture.
+    Under **Shared Resources**, select **Cost-Optimized**, then pick **x86 (Intel/AMD)** as the architecture — not **Arm64**.
+
+    <Aside type="caution">
+      Hetzner's cheapest Shared vCPU line, **CAX**, runs on Arm64 CPUs. Pinchy's
+      Docker images are built for x86 (amd64) only
+      ([#1081](https://github.com/heypinchy/pinchy/issues/1081)), so a CAX
+      server can't run them — the containers fail to start with `exec format
+      error`. Double-check **x86 (Intel/AMD)** is selected before you continue.
+    </Aside>
 
     Scroll down to the server sizes and select the smallest option with **at least 4 GB RAM** and **2 vCPUs**. This is the minimum for Pinchy.
 

--- a/docs/src/content/docs/guides/vps-deployment.mdx
+++ b/docs/src/content/docs/guides/vps-deployment.mdx
@@ -5,18 +5,21 @@ description: Step-by-step guide for deploying Pinchy on a virtual private server
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-This guide walks you through deploying Pinchy on a fresh Linux VPS. It has been tested on Ubuntu 24.04, but any Linux distribution with Docker support will work.
+This guide walks you through deploying Pinchy on a fresh Linux VPS. It has been tested on Ubuntu 24.04, but any x86 (amd64) Linux distribution with Docker support will work.
 
 If you're coming from a provider-specific guide ([Hetzner](/guides/deploy-hetzner/), [DigitalOcean](/guides/deploy-digitalocean/)), you should already be connected to your server via SSH. All commands below run **on the server**, not on your local machine.
 
 ## Requirements
 
-| Resource | Minimum       | Recommended  |
-| -------- | ------------- | ------------ |
-| RAM      | 4 GB          | 8 GB         |
-| CPU      | 2 vCPUs       | 4 vCPUs      |
-| Disk     | 20 GB         | 40 GB        |
-| OS       | Ubuntu 22.04+ | Ubuntu 24.04 |
+| Resource     | Minimum       | Recommended  |
+| ------------ | ------------- | ------------ |
+| Architecture | x86 (amd64)   | x86 (amd64)  |
+| RAM          | 4 GB          | 8 GB         |
+| CPU          | 2 vCPUs       | 4 vCPUs      |
+| Disk         | 20 GB         | 40 GB        |
+| OS           | Ubuntu 22.04+ | Ubuntu 24.04 |
+
+Arm64 VPS offerings — Hetzner CAX, Oracle Ampere, AWS Graviton, Scaleway COPARM — are not yet supported: Pinchy's images are built for `linux/amd64` only, and on Arm64 `docker compose pull` fails with `no matching manifest for linux/arm64/v8 in the manifest list entries`. We're tracking Arm64 images in [#1081](https://github.com/heypinchy/pinchy/issues/1081).
 
 You also need:
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -13,6 +13,7 @@ import { Aside } from "@astrojs/starlight/components";
 
 ## System requirements
 
+- A 64-bit x86 (amd64) host — Pinchy's Docker images are built for `linux/amd64` only. Arm64 hosts (Hetzner's CAX line, Raspberry Pi, Apple Silicon servers) are not yet supported and fail to start with `exec format error`; we're tracking Arm64 images in [#1081](https://github.com/heypinchy/pinchy/issues/1081).
 - Docker Engine 20.10+ and Docker Compose v2+
 - 4 GB RAM minimum (for Pinchy + OpenClaw + PostgreSQL)
 - An LLM provider: API key (Anthropic, OpenAI, Google, Ollama Cloud), a [local Ollama instance](/guides/ollama-setup/), or [any OpenAI-compatible endpoint](/guides/llm-providers/#openai-compatible-providers)

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -13,7 +13,7 @@ import { Aside } from "@astrojs/starlight/components";
 
 ## System requirements
 
-- A 64-bit x86 (amd64) host — Pinchy's Docker images are built for `linux/amd64` only. Arm64 hosts (Hetzner's CAX line, Raspberry Pi, Apple Silicon servers) are not yet supported and fail to start with `exec format error`; we're tracking Arm64 images in [#1081](https://github.com/heypinchy/pinchy/issues/1081).
+- A 64-bit x86 (amd64) host — Pinchy's Docker images are built for `linux/amd64` only. Arm64 hosts (Hetzner's CAX line, Raspberry Pi, Apple Silicon servers) are not yet supported: `docker compose pull` fails with `no matching manifest for linux/arm64/v8 in the manifest list entries`. We're tracking Arm64 images in [#1081](https://github.com/heypinchy/pinchy/issues/1081).
 - Docker Engine 20.10+ and Docker Compose v2+
 - 4 GB RAM minimum (for Pinchy + OpenClaw + PostgreSQL)
 - An LLM provider: API key (Anthropic, OpenAI, Google, Ollama Cloud), a [local Ollama instance](/guides/ollama-setup/), or [any OpenAI-compatible endpoint](/guides/llm-providers/#openai-compatible-providers)


### PR DESCRIPTION
## Summary
- Pinchy's release images are built for `linux/amd64` only (`release.yml` / `pre-release.yml` pin `platforms: linux/amd64`), but the docs never said so.
- `installation.mdx` never mentioned an architecture requirement; the Hetzner guide only said "pick x86 (Intel/AMD)" in passing, with no explanation.
- Hetzner's cheapest Shared vCPU line (**CAX**) is Arm64 — a price-sensitive self-hoster following the guide can land on it and get a bare `exec format error` with nothing pointing back at the cause.
- Added a system-requirements bullet to `installation.mdx` naming the amd64 requirement and the unsupported Arm64 hosts (Hetzner CAX, Raspberry Pi, Apple Silicon servers), citing #1081 (tracked arm64-image work).
- Turned the Hetzner guide's incidental "pick x86" into an explicit `<Aside type="caution">` explaining why (CAX = Arm64, images are amd64-only) and the failure symptom.

## Test plan
- [x] `cd docs && pnpm build` — 67 pages built successfully
- [x] `pnpm -C docs check:anchors` — 70 pages checked, no broken internal links
- [x] `pnpm -C docs check:rendered` — 70 pages checked, every table rendered
- [x] `pnpm -C docs check:tables` — no indented tables found
- [x] `pnpm -C docs test` — 42/42 passed
- [x] `pnpm test:scripts` (repo root, incl. docs-consistency forward-looking-claim guard and docs-coverage) — 894/894 passed
- [x] `pnpm format:check` — clean