### PR TITLE
fix(plugins): precheck attachment size before download in email_get_attachment

### DIFF
--- a/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
@@ -44,6 +44,7 @@ vi.mock("googleapis", () => {
 
 import { GmailAdapter } from "../gmail-adapter.js";
 import { google } from "googleapis";
+import { MAX_ATTACHMENT_BYTES } from "../email-adapter.js";
 
 // Helper: base64url encode a string
 function base64url(str: string): string {
@@ -703,7 +704,10 @@ describe("GmailAdapter", () => {
       expect(mockAttachmentsGet).not.toHaveBeenCalled();
     });
 
-    it("does not reject a size right at the threshold", async () => {
+    // The pair below is the actual boundary. "size: 5 is allowed" says nothing
+    // about where the cut sits — a `>=` typo would pass it — so these pin the
+    // exact cap from both sides.
+    it("allows a part whose declared size is EXACTLY MAX_ATTACHMENT_BYTES", async () => {
       mockGet.mockResolvedValue({
         data: {
           id: "msg-ok",
@@ -715,7 +719,7 @@ describe("GmailAdapter", () => {
               {
                 mimeType: "text/plain",
                 filename: "small.txt",
-                body: { attachmentId: "att-ok", size: 5 },
+                body: { attachmentId: "att-ok", size: MAX_ATTACHMENT_BYTES },
               },
             ],
             headers: [
@@ -733,6 +737,69 @@ describe("GmailAdapter", () => {
 
       const result = await adapter.getAttachment("msg-ok", "att-ok");
       expect(result.data.toString("utf-8")).toBe("hello");
+    });
+
+    it("rejects a part ONE byte over MAX_ATTACHMENT_BYTES", async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          id: "msg-edge",
+          snippet: "x",
+          labelIds: [],
+          payload: {
+            mimeType: "multipart/mixed",
+            parts: [
+              {
+                mimeType: "text/plain",
+                filename: "edge.txt",
+                body: { attachmentId: "att-edge", size: MAX_ATTACHMENT_BYTES + 1 },
+              },
+            ],
+            headers: [
+              { name: "From", value: "a@b.com" },
+              { name: "To", value: "c@d.com" },
+              { name: "Subject", value: "x" },
+              { name: "Date", value: "Mon, 7 Apr 2026 10:00:00 +0000" },
+            ],
+          },
+        },
+      });
+
+      await expect(adapter.getAttachment("msg-edge", "att-edge")).rejects.toThrow(/too large/i);
+      expect(mockAttachmentsGet).not.toHaveBeenCalled();
+    });
+
+    it("downloads when the part declares no size at all — a missing signal must not block a legal attachment", async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          id: "msg-nosize",
+          snippet: "x",
+          labelIds: [],
+          payload: {
+            mimeType: "multipart/mixed",
+            parts: [
+              {
+                mimeType: "text/plain",
+                filename: "nosize.txt",
+                // No `size` — index.ts's post-download check is the fallback.
+                body: { attachmentId: "att-nosize" },
+              },
+            ],
+            headers: [
+              { name: "From", value: "a@b.com" },
+              { name: "To", value: "c@d.com" },
+              { name: "Subject", value: "x" },
+              { name: "Date", value: "Mon, 7 Apr 2026 10:00:00 +0000" },
+            ],
+          },
+        },
+      });
+      mockAttachmentsGet.mockResolvedValue({
+        data: { size: 5, data: Buffer.from("hello").toString("base64url") },
+      });
+
+      const result = await adapter.getAttachment("msg-nosize", "att-nosize");
+      expect(result.data.toString("utf-8")).toBe("hello");
+      expect(mockAttachmentsGet).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/gmail-adapter.test.ts
@@ -669,6 +669,71 @@ describe("GmailAdapter", () => {
       // Must not attempt the bytes fetch when the id can't be resolved.
       expect(mockAttachmentsGet).not.toHaveBeenCalled();
     });
+
+    it("rejects an oversized attachment by the part-listing `size` field WITHOUT ever calling attachments.get — the size is already known before download", async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          id: "msg-huge",
+          snippet: "x",
+          labelIds: [],
+          payload: {
+            mimeType: "multipart/mixed",
+            parts: [
+              {
+                mimeType: "application/zip",
+                filename: "huge.zip",
+                // 50 MB — over the 25 MB MAX_ATTACHMENT_BYTES cap.
+                body: { attachmentId: "att-huge", size: 50 * 1024 * 1024 },
+              },
+            ],
+            headers: [
+              { name: "From", value: "a@b.com" },
+              { name: "To", value: "c@d.com" },
+              { name: "Subject", value: "x" },
+              { name: "Date", value: "Mon, 7 Apr 2026 10:00:00 +0000" },
+            ],
+          },
+        },
+      });
+
+      await expect(adapter.getAttachment("msg-huge", "att-huge")).rejects.toThrow(
+        /too large.*50\.0 MB.*max allowed is 25 MB/is
+      );
+      // The whole point: never download bytes we already know are too big.
+      expect(mockAttachmentsGet).not.toHaveBeenCalled();
+    });
+
+    it("does not reject a size right at the threshold", async () => {
+      mockGet.mockResolvedValue({
+        data: {
+          id: "msg-ok",
+          snippet: "x",
+          labelIds: [],
+          payload: {
+            mimeType: "multipart/mixed",
+            parts: [
+              {
+                mimeType: "text/plain",
+                filename: "small.txt",
+                body: { attachmentId: "att-ok", size: 5 },
+              },
+            ],
+            headers: [
+              { name: "From", value: "a@b.com" },
+              { name: "To", value: "c@d.com" },
+              { name: "Subject", value: "x" },
+              { name: "Date", value: "Mon, 7 Apr 2026 10:00:00 +0000" },
+            ],
+          },
+        },
+      });
+      mockAttachmentsGet.mockResolvedValue({
+        data: { size: 5, data: Buffer.from("hello").toString("base64url") },
+      });
+
+      const result = await adapter.getAttachment("msg-ok", "att-ok");
+      expect(result.data.toString("utf-8")).toBe("hello");
+    });
   });
 
   describe("search", () => {

--- a/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
-import { GraphAdapter } from "../graph-adapter.js";
+import { GraphAdapter, MAX_ATTACHMENT_RESPONSE_BYTES } from "../graph-adapter.js";
 import { resetInsecureMockWarningsForTest } from "../email-adapter.js";
 
 describe("GraphAdapter.list", () => {
@@ -461,6 +461,25 @@ describe("GraphAdapter.getAttachment", () => {
   beforeEach(() => vi.stubGlobal("fetch", vi.fn()));
   afterEach(() => vi.unstubAllGlobals());
 
+  // A real `fetch` Response ALWAYS carries a Headers object — a response with
+  // no declared Content-Length answers `headers.get("content-length") === null`,
+  // it does not lack `headers`. Mocking the latter would let the adapter get
+  // away with `res.headers?.get(...)`, i.e. an optional chain that exists only
+  // because a test lied about the shape. Every mock in this block goes through
+  // this helper so the header lookup under test is the one production performs.
+  const attachmentResponse = (opts: {
+    contentLength?: string | null;
+    json: () => Promise<unknown>;
+    body?: { cancel: () => Promise<void> };
+  }) => ({
+    ok: true,
+    headers: {
+      get: (name: string) => (name === "content-length" ? (opts.contentLength ?? null) : null),
+    },
+    body: opts.body,
+    json: opts.json,
+  });
+
   it("downloads a fileAttachment and reconstructs its raw bytes", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
     // Include high-bit bytes that encode to '+' and '/' in standard base64
@@ -470,18 +489,20 @@ describe("GraphAdapter.getAttachment", () => {
     // alphabets interchangeably; the adapter's choice of "base64" is a
     // correctness-of-intent signal.)
     const bytes = Buffer.concat([Buffer.from("%PDF-1.7"), Buffer.from([0xfb, 0xff, 0xbf])]);
-    (fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        "@odata.type": "#microsoft.graph.fileAttachment",
-        id: "att-1",
-        name: "invoice.pdf",
-        contentType: "application/pdf",
-        size: bytes.length,
-        isInline: false,
-        contentBytes: bytes.toString("base64"),
-      }),
-    });
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: "512",
+        json: async () => ({
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          id: "att-1",
+          name: "invoice.pdf",
+          contentType: "application/pdf",
+          size: bytes.length,
+          isInline: false,
+          contentBytes: bytes.toString("base64"),
+        }),
+      })
+    );
 
     const result = await adapter.getAttachment("msg1", "att-1");
 
@@ -496,15 +517,17 @@ describe("GraphAdapter.getAttachment", () => {
 
   it("URL-encodes message and attachment ids in the path", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
-    (fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        "@odata.type": "#microsoft.graph.fileAttachment",
-        name: "f.bin",
-        contentType: "application/octet-stream",
-        contentBytes: Buffer.from("x").toString("base64"),
-      }),
-    });
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: "256",
+        json: async () => ({
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          name: "f.bin",
+          contentType: "application/octet-stream",
+          contentBytes: Buffer.from("x").toString("base64"),
+        }),
+      })
+    );
 
     await adapter.getAttachment("msg/a+b", "att/c+d");
 
@@ -515,18 +538,20 @@ describe("GraphAdapter.getAttachment", () => {
 
   it("throws for an itemAttachment that has no downloadable contentBytes", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
-    (fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        "@odata.type": "#microsoft.graph.itemAttachment",
-        id: "att-item",
-        name: "Forwarded message",
-        contentType: null,
-        size: 5000,
-        isInline: false,
-        // no contentBytes
-      }),
-    });
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: "5000",
+        json: async () => ({
+          "@odata.type": "#microsoft.graph.itemAttachment",
+          id: "att-item",
+          name: "Forwarded message",
+          contentType: null,
+          size: 5000,
+          isInline: false,
+          // no contentBytes
+        }),
+      })
+    );
 
     await expect(adapter.getAttachment("msg1", "att-item")).rejects.toThrow(/embedded item/i);
   });
@@ -547,56 +572,120 @@ describe("GraphAdapter.getAttachment", () => {
     const jsonSpy = vi.fn(async () => {
       throw new Error("res.json() must not be called for an oversized response");
     });
-    const cancelSpy = vi.fn();
-    (fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      headers: { get: (name: string) => (name === "content-length" ? "52428800" : null) }, // 50 MB
-      body: { cancel: cancelSpy },
-      json: jsonSpy,
-    });
+    const cancelSpy = vi.fn(async () => {});
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: String(50 * 1024 * 1024), // 50 MB
+        body: { cancel: cancelSpy },
+        json: jsonSpy,
+      })
+    );
 
     await expect(adapter.getAttachment("msg1", "att-huge")).rejects.toThrow(
-      /too large.*50\.0 MB.*max allowed is 40 MB/is
+      // The cap quoted back to the caller is the 25 MB ATTACHMENT limit they
+      // can act on, not the ~40 MB wire bound the check compares against.
+      /too large.*50\.0 MB.*max allowed is 25 MB/is
     );
     expect(jsonSpy).not.toHaveBeenCalled();
     expect(cancelSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("does not reject a response right at the Content-Length threshold", async () => {
+  // The pair below is the actual boundary. Asserting "1000 bytes is allowed"
+  // proves nothing about where the cut sits — a `>=` typo would pass it — so
+  // these pin the exact threshold from both sides.
+  it("allows a response whose Content-Length is EXACTLY the threshold", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
     const bytes = Buffer.from("ok");
-    (fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      headers: { get: (name: string) => (name === "content-length" ? "1000" : null) },
-      json: async () => ({
-        "@odata.type": "#microsoft.graph.fileAttachment",
-        id: "att-small",
-        name: "small.txt",
-        contentType: "text/plain",
-        contentBytes: bytes.toString("base64"),
-      }),
-    });
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: String(MAX_ATTACHMENT_RESPONSE_BYTES),
+        json: async () => ({
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          id: "att-small",
+          name: "small.txt",
+          contentType: "text/plain",
+          contentBytes: bytes.toString("base64"),
+        }),
+      })
+    );
 
     const result = await adapter.getAttachment("msg1", "att-small");
     expect(result.data.equals(bytes)).toBe(true);
   });
 
+  it("rejects a response ONE byte over the threshold", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    const jsonSpy = vi.fn(async () => ({}));
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: String(MAX_ATTACHMENT_RESPONSE_BYTES + 1),
+        body: { cancel: vi.fn(async () => {}) },
+        json: jsonSpy,
+      })
+    );
+
+    await expect(adapter.getAttachment("msg1", "att-edge")).rejects.toThrow(/too large/i);
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
+  it("still reports the size when draining the oversized body fails — a stream error must not replace the diagnosis", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: String(50 * 1024 * 1024),
+        body: {
+          cancel: vi.fn(async () => {
+            throw new Error("stream already errored");
+          }),
+        },
+        json: async () => ({}),
+      })
+    );
+
+    await expect(adapter.getAttachment("msg1", "att-huge")).rejects.toThrow(
+      /too large.*50\.0 MB/is
+    );
+  });
+
   it("proceeds to res.json() when Content-Length is absent — the post-download length check in index.ts is the fallback guard", async () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
     const bytes = Buffer.from("no content-length header here");
-    (fetch as Mock).mockResolvedValueOnce({
-      ok: true,
-      // No `headers` at all — mirrors a lenient mock/provider that omits it.
-      json: async () => ({
-        "@odata.type": "#microsoft.graph.fileAttachment",
-        id: "att-nolen",
-        name: "nolen.txt",
-        contentType: "text/plain",
-        contentBytes: bytes.toString("base64"),
-      }),
-    });
+    (fetch as Mock).mockResolvedValueOnce(
+      // A chunked-transfer response: `headers` is present, the lookup answers
+      // null. That is what "absent" looks like on the wire.
+      attachmentResponse({
+        contentLength: null,
+        json: async () => ({
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          id: "att-nolen",
+          name: "nolen.txt",
+          contentType: "text/plain",
+          contentBytes: bytes.toString("base64"),
+        }),
+      })
+    );
 
     const result = await adapter.getAttachment("msg1", "att-nolen");
+    expect(result.data.equals(bytes)).toBe(true);
+  });
+
+  it("proceeds to res.json() when Content-Length is present but unparseable — a broken proxy must not become a download failure", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    const bytes = Buffer.from("garbage header, real body");
+    (fetch as Mock).mockResolvedValueOnce(
+      attachmentResponse({
+        contentLength: "not-a-number",
+        json: async () => ({
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          id: "att-nan",
+          name: "nan.txt",
+          contentType: "text/plain",
+          contentBytes: bytes.toString("base64"),
+        }),
+      })
+    );
+
+    const result = await adapter.getAttachment("msg1", "att-nan");
     expect(result.data.equals(bytes)).toBe(true);
   });
 });
@@ -1070,6 +1159,9 @@ describe("GraphAdapter request bounds", () => {
     const adapter = new GraphAdapter({ accessToken: "tok" });
     (fetch as Mock).mockResolvedValueOnce({
       ok: true,
+      // getAttachment reads Content-Length before touching the body; a real
+      // Response always has a Headers object, so the mock must too.
+      headers: { get: () => "512" },
       json: async () => ({
         name: "invoice.pdf",
         contentType: "application/pdf",

--- a/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/graph-adapter.test.ts
@@ -541,6 +541,64 @@ describe("GraphAdapter.getAttachment", () => {
     });
     await expect(adapter.getAttachment("msg1", "gone")).rejects.toThrow(/Graph 404/);
   });
+
+  it("rejects an oversized attachment response by Content-Length WITHOUT ever calling res.json() — the whole point is to never buffer the body", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    const jsonSpy = vi.fn(async () => {
+      throw new Error("res.json() must not be called for an oversized response");
+    });
+    const cancelSpy = vi.fn();
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: (name: string) => (name === "content-length" ? "52428800" : null) }, // 50 MB
+      body: { cancel: cancelSpy },
+      json: jsonSpy,
+    });
+
+    await expect(adapter.getAttachment("msg1", "att-huge")).rejects.toThrow(
+      /too large.*50\.0 MB.*max allowed is 40 MB/is
+    );
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reject a response right at the Content-Length threshold", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    const bytes = Buffer.from("ok");
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      headers: { get: (name: string) => (name === "content-length" ? "1000" : null) },
+      json: async () => ({
+        "@odata.type": "#microsoft.graph.fileAttachment",
+        id: "att-small",
+        name: "small.txt",
+        contentType: "text/plain",
+        contentBytes: bytes.toString("base64"),
+      }),
+    });
+
+    const result = await adapter.getAttachment("msg1", "att-small");
+    expect(result.data.equals(bytes)).toBe(true);
+  });
+
+  it("proceeds to res.json() when Content-Length is absent — the post-download length check in index.ts is the fallback guard", async () => {
+    const adapter = new GraphAdapter({ accessToken: "tok" });
+    const bytes = Buffer.from("no content-length header here");
+    (fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      // No `headers` at all — mirrors a lenient mock/provider that omits it.
+      json: async () => ({
+        "@odata.type": "#microsoft.graph.fileAttachment",
+        id: "att-nolen",
+        name: "nolen.txt",
+        contentType: "text/plain",
+        contentBytes: bytes.toString("base64"),
+      }),
+    });
+
+    const result = await adapter.getAttachment("msg1", "att-nolen");
+    expect(result.data.equals(bytes)).toBe(true);
+  });
 });
 
 describe("GraphAdapter.search", () => {

--- a/packages/plugins/pinchy-email/gmail-adapter.ts
+++ b/packages/plugins/pinchy-email/gmail-adapter.ts
@@ -4,6 +4,7 @@ import {
   escapeDoubleQuoted,
   resolveInsecureMockBaseUrl,
   stripHtml,
+  MAX_ATTACHMENT_BYTES,
 } from "./email-adapter.js";
 import type {
   EmailAdapter,
@@ -155,6 +156,19 @@ export class GmailAdapter implements EmailAdapter {
         `attachment ${attachmentId} not found on message ${messageId}. ` +
           `Gmail attachment ids change between reads — re-read the message to get fresh attachment ids.`
       );
+    }
+
+    // Unlike Graph, Gmail's part-listing already carries the decoded byte
+    // size (part.body.size) BEFORE any download — so reject here rather
+    // than paying for attachments.get only to discard the result. This is
+    // best-effort (Gmail could in principle omit/misreport size), so
+    // index.ts's post-download length check on the real buffer stays the
+    // authoritative guard.
+    const declaredBytes = part.body?.size;
+    if (declaredBytes != null && declaredBytes > MAX_ATTACHMENT_BYTES) {
+      const declaredMb = (declaredBytes / 1024 / 1024).toFixed(1);
+      const maxMb = (MAX_ATTACHMENT_BYTES / 1024 / 1024).toFixed(0);
+      throw new Error(`Attachment too large: ${declaredMb} MB, max allowed is ${maxMb} MB.`);
     }
 
     const response = await this.gmail.users.messages.attachments.get(

--- a/packages/plugins/pinchy-email/graph-adapter.ts
+++ b/packages/plugins/pinchy-email/graph-adapter.ts
@@ -28,7 +28,18 @@ import type {
 // 4/3 ≈ 33.3 MB of base64 text inside the response; 40 MB leaves headroom for
 // the surrounding JSON envelope (id/name/contentType/... fields) on top of
 // that.
-const MAX_ATTACHMENT_RESPONSE_BYTES = Math.ceil((MAX_ATTACHMENT_BYTES * 4) / 3) + 7 * 1024 * 1024;
+//
+// Every source of error here points the same way — the wire size can only be
+// SMALLER than the payload this bound reasons about, never larger — so the
+// check fails open to index.ts's post-decode cap rather than rejecting a legal
+// attachment. Content-Length counts the COMPRESSED bytes when Graph answers
+// `content-encoding: gzip` (undici decompresses transparently, so `res.json()`
+// still sees the full text), and gzip on base64 recovers roughly the original
+// binary size — a 500 MB attachment still declares hundreds of MB and is still
+// caught. Exported so the tests can pin the exact boundary instead of asserting
+// a value far from it.
+export const MAX_ATTACHMENT_RESPONSE_BYTES =
+  Math.ceil((MAX_ATTACHMENT_BYTES * 4) / 3) + 7 * 1024 * 1024;
 
 const mapFolder = createFolderMapper({
   INBOX: "inbox",
@@ -281,21 +292,30 @@ export class GraphAdapter implements EmailAdapter {
 
     // Precheck against Content-Length BEFORE res.json() buffers the whole
     // body — see MAX_ATTACHMENT_RESPONSE_BYTES above. Best-effort only: a
-    // missing/absent header (chunked transfer, or a provider that omits it)
-    // falls straight through to res.json(), same as before this check
-    // existed — index.ts's post-decode length check is what protects the
-    // process in that case.
-    const declaredLength = res.headers?.get("content-length");
+    // missing header (chunked transfer, or a provider that omits it) or an
+    // unparseable one falls straight through to res.json(), same as before
+    // this check existed — index.ts's post-decode length check is what
+    // protects the process in that case.
+    const declaredLength = res.headers.get("content-length");
     if (declaredLength != null) {
       const declaredBytes = Number(declaredLength);
       if (Number.isFinite(declaredBytes) && declaredBytes > MAX_ATTACHMENT_RESPONSE_BYTES) {
         // Never read the body we just proved is too large — cancel/drain it
-        // instead of letting it sit un-consumed on the connection.
-        await res.body?.cancel?.();
+        // instead of letting it sit un-consumed on the connection. Swallow a
+        // cancel failure (an already-errored stream rejects): the caller needs
+        // the size diagnosis below, not a stream error that hides it.
+        await res.body?.cancel().catch(() => {});
+        // Report the cap the CALLER can act on (the 25 MB attachment limit),
+        // not the ~40 MB wire bound this check actually compares against —
+        // MAX_ATTACHMENT_RESPONSE_BYTES is a base64-inflated derivative of it,
+        // and an agent told "max allowed is 40 MB" would reasonably conclude a
+        // 30 MB attachment is fine when index.ts will reject it too.
         const declaredMb = (declaredBytes / 1024 / 1024).toFixed(1);
-        const maxMb = (MAX_ATTACHMENT_RESPONSE_BYTES / 1024 / 1024).toFixed(0);
+        const maxMb = (MAX_ATTACHMENT_BYTES / 1024 / 1024).toFixed(0);
         throw new Error(
-          `Attachment response too large: ${declaredMb} MB, max allowed is ${maxMb} MB.`
+          `Attachment too large: the provider's response declares ${declaredMb} MB on the wire ` +
+            `(base64-encoded), over the ceiling a ${maxMb} MB attachment can occupy. ` +
+            `Max allowed is ${maxMb} MB.`
         );
       }
     }

--- a/packages/plugins/pinchy-email/graph-adapter.ts
+++ b/packages/plugins/pinchy-email/graph-adapter.ts
@@ -3,6 +3,7 @@ import {
   escapeDoubleQuoted,
   resolveInsecureMockBaseUrl,
   stripHtml,
+  MAX_ATTACHMENT_BYTES,
 } from "./email-adapter.js";
 import type {
   EmailAdapter,
@@ -13,6 +14,21 @@ import type {
   EmailSummary,
   EmailFull,
 } from "./email-adapter.js";
+
+// Graph's attachment-get endpoint wraps the file's base64 payload inside a
+// JSON body — GET /me/messages/{id}/attachments/{id} — so a naive
+// `await res.json()` fully materializes that whole body in memory BEFORE
+// index.ts's post-decode length check on the returned buffer ever runs. A
+// 500 MB attachment (or a provider that misreports its own size) would OOM
+// the process before the 25 MB cap (MAX_ATTACHMENT_BYTES) ever gets a chance
+// to fire.
+//
+// Base64 inflates the decoded byte count by ~4/3 (with padding), so
+// MAX_ATTACHMENT_BYTES worth of file content becomes MAX_ATTACHMENT_BYTES *
+// 4/3 ≈ 33.3 MB of base64 text inside the response; 40 MB leaves headroom for
+// the surrounding JSON envelope (id/name/contentType/... fields) on top of
+// that.
+const MAX_ATTACHMENT_RESPONSE_BYTES = Math.ceil((MAX_ATTACHMENT_BYTES * 4) / 3) + 7 * 1024 * 1024;
 
 const mapFolder = createFolderMapper({
   INBOX: "inbox",
@@ -262,6 +278,28 @@ export class GraphAdapter implements EmailAdapter {
       `/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`,
       { timeoutMs: ATTACHMENT_TIMEOUT_MS }
     );
+
+    // Precheck against Content-Length BEFORE res.json() buffers the whole
+    // body — see MAX_ATTACHMENT_RESPONSE_BYTES above. Best-effort only: a
+    // missing/absent header (chunked transfer, or a provider that omits it)
+    // falls straight through to res.json(), same as before this check
+    // existed — index.ts's post-decode length check is what protects the
+    // process in that case.
+    const declaredLength = res.headers?.get("content-length");
+    if (declaredLength != null) {
+      const declaredBytes = Number(declaredLength);
+      if (Number.isFinite(declaredBytes) && declaredBytes > MAX_ATTACHMENT_RESPONSE_BYTES) {
+        // Never read the body we just proved is too large — cancel/drain it
+        // instead of letting it sit un-consumed on the connection.
+        await res.body?.cancel?.();
+        const declaredMb = (declaredBytes / 1024 / 1024).toFixed(1);
+        const maxMb = (MAX_ATTACHMENT_RESPONSE_BYTES / 1024 / 1024).toFixed(0);
+        throw new Error(
+          `Attachment response too large: ${declaredMb} MB, max allowed is ${maxMb} MB.`
+        );
+      }
+    }
+
     const a = (await res.json()) as GraphAttachment;
     if (a.contentBytes == null) {
       throw new Error(

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -1311,13 +1311,16 @@ const plugin = {
               const messageId = resolvedMessageId.realId;
               const attachmentId = resolvedAttachmentId.realId;
 
-              // No pre-download size precheck is possible here: the
-              // EmailAdapter#getAttachment contract returns { filename,
-              // mimeType, data } — the provider APIs don't expose a byte
-              // size before the body is fetched, unlike odoo_attach_file's
-              // local-file stat() precheck. We always postcheck data.length
-              // below, which is what actually protects the process (metadata
-              // can lie or be absent; the downloaded buffer cannot).
+              // Each adapter prechecks the size signal its provider offers,
+              // before the bytes are materialized: Graph reads Content-Length
+              // off the attachment response ahead of res.json(), Gmail the
+              // part-listing `size` ahead of attachments.get, IMAP the
+              // message-level RFC822.SIZE ahead of the full fetch
+              // (MAX_MESSAGE_BYTES, see imap-adapter.ts). All three are
+              // best-effort — a provider can omit or misreport its own size —
+              // so the postcheck below on the buffer that actually arrived
+              // stays the authoritative guard: metadata can lie, the
+              // downloaded buffer cannot.
               const attachment = await withAuthRetry(agentId, config, (adapter) =>
                 adapter.getAttachment(messageId, attachmentId)
               );


### PR DESCRIPTION
## Summary
- `email_get_attachment` only capped attachment size (25 MB, `MAX_ATTACHMENT_BYTES`) **after** the provider response was fully materialized in memory — Graph's attachment endpoint wraps the base64 payload in JSON, so `res.json()` buffered the entire body before the cap could fire; a 500 MB attachment (or a lying provider) could OOM the OpenClaw process before the check ever ran.
- Graph adapter now prechecks `Content-Length` on the raw `Response` **before** calling `res.json()`. Threshold is `MAX_ATTACHMENT_BYTES * 4/3` (base64 inflation) `+ 7 MB` headroom for the JSON envelope (~40 MB), derived and commented in `graph-adapter.ts`. Missing/absent `Content-Length` (chunked transfer, lenient mock) falls through unchanged — the existing post-decode check in `index.ts` is the fallback.
- Gmail adapter now prechecks the part-listing `size` field (already available from `collectAttachments`/`findAttachmentPart`, no extra round trip) **before** calling `attachments.get`, so an oversized attachment is never downloaded at all.
- `MAX_ATTACHMENT_BYTES` moved from `index.ts` to the shared `email-adapter.ts` so both adapters can precheck against the same cap without a circular import.
- `index.ts`'s comment above the post-decode check was stale ("no precheck is possible") and is updated to describe the new upstream prechecks while explaining why the post-decode check on the real buffer stays authoritative (a provider can still omit/misreport its declared size).

## IMAP: deliberately unchanged, tracked as #1093
IMAP's `getAttachment`/`read` share `fetchParsed()`, which always fetches the **entire RFC822 message** via `{ source: true }` and hands the whole buffer to `mailparser` — by the time `getAttachment` looks at one attachment's size, the full message (every attachment's bytes) is already in memory. `BODYSTRUCTURE` does carry per-part sizes before download, but matching a `BODYSTRUCTURE` node to the `contentId`/`cid`/index identity this plugin already hands callers (via `mailparser`'s own attachment enumeration) is real, error-prone work, and a precheck scoped to `getAttachment` alone wouldn't close the gap anyway — `read()` already fully materializes every attachment for any message with attachments. Filed #1093 with the fuller reasoning and a proposed shape (BODYSTRUCTURE + targeted `client.download(uid, part, ...)`) for a follow-up that also touches `read()`.

## Test plan
- [x] `graph-adapter.test.ts`: new tests — oversized `Content-Length` rejects **without** `res.json()` being called (spy asserts zero calls) and drains the body via `res.body.cancel()`; a response right at the threshold still downloads; a response with **no** `Content-Length` header still falls through to `res.json()` (existing behavior preserved).
- [x] `gmail-adapter.test.ts`: new tests — an oversized part-listing `size` rejects **without** `attachments.get` being called; a size right at the threshold still downloads.
- [x] `pnpm test:plugins` — 366/366 pinchy-email tests pass (all suites: 9/9 plugin packages green).
- [x] `pnpm typecheck:plugins` — all 9 plugin packages typecheck cleanly.
- [x] `pnpm test:related` on the 5 touched files — 332/332 web tests that import them pass.
- [x] `pnpm format:check` — clean.
- [x] `pnpm test` (full suite) — 10922 passed, 18 skipped.

Docs-not-needed: internal OOM guard, no reader-facing change