### PR TITLE
fix(db): wrap group/user-deactivation writes in transactions, batch N+1 queries

### DIFF
--- a/packages/web/src/__tests__/api/agents-audit.test.ts
+++ b/packages/web/src/__tests__/api/agents-audit.test.ts
@@ -46,8 +46,8 @@ vi.mock("@/lib/openclaw-config", () => ({
   regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/db", () => ({
-  db: {
+vi.mock("@/db", () => {
+  const db: Record<string, unknown> = {
     insert: vi.fn().mockReturnValue({
       values: vi.fn().mockReturnValue({
         returning: vi.fn().mockResolvedValue([
@@ -70,8 +70,13 @@ vi.mock("@/db", () => ({
         where: vi.fn().mockResolvedValue([]),
       }),
     })),
-  },
-}));
+  };
+  // Default: run the callback against the SAME db object, so tx.delete /
+  // tx.insert are the exact mocks above and existing per-test overrides via
+  // db.delete/db.insert.mockReturnValueOnce keep working unchanged.
+  db.transaction = vi.fn((cb: (tx: unknown) => unknown) => cb(db));
+  return { db };
+});
 
 vi.mock("@/db/schema", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/db/schema")>();
@@ -458,6 +463,107 @@ describe("PATCH /api/agents/[agentId] audit logging", () => {
         },
       },
     });
+  });
+
+  it("wraps the group delete+insert in a single transaction (atomic replace)", async () => {
+    // As two standalone statements, an insert failure between them would strip
+    // a restricted agent of every group with none re-added — silent access
+    // loss. Mirrors the same assertion for user-groups and group-members.
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "user-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    mockAgent({
+      id: "agent-1",
+      name: "Test Agent",
+      model: "anthropic/claude-sonnet-4-6",
+      isPersonal: false,
+      ownerId: null,
+    });
+
+    vi.mocked(getAgentGroupIds).mockResolvedValueOnce(["group-keep"]);
+    vi.mocked(db.delete).mockReturnValueOnce({
+      where: vi.fn().mockResolvedValue(undefined),
+    } as never);
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockResolvedValue(undefined),
+    } as never);
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "group-keep", name: "Keep" }]),
+      }),
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ groupIds: ["group-keep"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, {
+      params: Promise.resolve({ agentId: "agent-1" }),
+    });
+    expect(response.status).toBe(200);
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.delete).toHaveBeenCalled();
+    expect(db.insert).toHaveBeenCalled();
+  });
+
+  it("rolls back the group delete when the insert fails, leaving previous groups intact", async () => {
+    // Simulates a real transaction's rollback semantics with a stateful fake
+    // store: the delete only takes effect once the whole callback commits.
+    // Pre-fix, the route calls db.delete/db.insert directly (never touching
+    // db.transaction), so this test's fake store never rejects and the PATCH
+    // resolves 200 instead of rejecting — the red state this test starts from.
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "user-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    mockAgent({
+      id: "agent-1",
+      name: "Test Agent",
+      model: "anthropic/claude-sonnet-4-6",
+      isPersonal: false,
+      ownerId: null,
+    });
+
+    vi.mocked(getAgentGroupIds).mockResolvedValueOnce(["group-keep"]);
+
+    let committedGroupIds = ["group-keep"];
+    vi.mocked(db.transaction).mockImplementationOnce((async (cb: (tx: unknown) => unknown) => {
+      let pendingGroupIds = committedGroupIds;
+      const tx = {
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(async () => {
+            pendingGroupIds = [];
+          }),
+        }),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockImplementation(async () => {
+            throw new Error("insert failed");
+          }),
+        }),
+      };
+      await cb(tx);
+      // Only reached if cb() didn't throw — a real transaction rolls back on
+      // any error inside the callback, so a thrown error must skip this line.
+      committedGroupIds = pendingGroupIds;
+    }) as never);
+
+    const request = new NextRequest("http://localhost:7777/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ groupIds: ["group-keep", "group-new"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(
+      PATCH(request, { params: Promise.resolve({ agentId: "agent-1" }) })
+    ).rejects.toThrow("insert failed");
+
+    expect(committedGroupIds).toEqual(["group-keep"]);
   });
 
   it("PATCH with model-only change writes audit entry with before/after snapshot", async () => {

--- a/packages/web/src/__tests__/api/agents-visibility.test.ts
+++ b/packages/web/src/__tests__/api/agents-visibility.test.ts
@@ -60,13 +60,16 @@ vi.mock("@/db", () => {
     }),
   });
 
-  return {
-    db: {
-      insert: mockInsert,
-      select: vi.fn().mockImplementation(defaultSelect),
-      delete: mockDelete,
-    },
+  const db: Record<string, unknown> = {
+    insert: mockInsert,
+    select: vi.fn().mockImplementation(defaultSelect),
+    delete: mockDelete,
   };
+  // Runs the callback against the SAME db object, so tx.delete/tx.insert are
+  // the exact mocks above and per-test overrides keep working unchanged.
+  db.transaction = vi.fn((cb: (tx: unknown) => unknown) => cb(db));
+
+  return { db };
 });
 
 vi.mock("@/db/schema", async (importOriginal) => {

--- a/packages/web/src/__tests__/api/user-config-audit.test.ts
+++ b/packages/web/src/__tests__/api/user-config-audit.test.ts
@@ -99,8 +99,8 @@ vi.mock("@/lib/workspace", () => ({
   deleteWorkspace: vi.fn(),
 }));
 
-vi.mock("@/db", () => ({
-  db: {
+vi.mock("@/db", () => {
+  const db: Record<string, unknown> = {
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([]),
@@ -125,8 +125,13 @@ vi.mock("@/db", () => ({
         }),
       },
     },
-  },
-}));
+  };
+  // Default: run the callback against the SAME db object, so tx.update /
+  // tx.delete are the exact mocks above and existing per-test overrides via
+  // db.update/db.delete.mockReturnValueOnce keep working unchanged.
+  db.transaction = vi.fn((cb: (tx: unknown) => unknown) => cb(db));
+  return { db };
+});
 
 import { appendAuditLog } from "@/lib/audit";
 import { requireAdmin } from "@/lib/api-auth";

--- a/packages/web/src/__tests__/api/users.test.ts
+++ b/packages/web/src/__tests__/api/users.test.ts
@@ -47,8 +47,8 @@ vi.mock("@/lib/telegram-allow-store", () => ({
   recalculateTelegramAllowStores: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/db", () => ({
-  db: {
+vi.mock("@/db", () => {
+  const db: Record<string, unknown> = {
     query: {
       users: {
         findMany: vi.fn().mockResolvedValue([]),
@@ -71,15 +71,20 @@ vi.mock("@/db", () => ({
         returning: vi.fn().mockResolvedValue([]),
       }),
     }),
-  },
-}));
+  };
+  // Default: run the callback against the SAME db object, so tx.update /
+  // tx.delete are the exact mocks above and existing per-test overrides via
+  // db.update/db.delete.mockReturnValueOnce keep working unchanged.
+  db.transaction = vi.fn((cb: (tx: unknown) => unknown) => cb(db));
+  return { db };
+});
 
 import { auth } from "@/lib/auth";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { deleteWorkspace } from "@/lib/workspace";
 import { appendAuditLog } from "@/lib/audit";
 import { db } from "@/db";
-import { users, sessions } from "@/db/schema";
+import { users, sessions, agents } from "@/db/schema";
 
 // ── GET /api/users ───────────────────────────────────────────────────────
 
@@ -495,13 +500,7 @@ describe("DELETE /api/users/[userId]", () => {
       }),
     } as never);
 
-    // Mock: update for personal agent-1 soft-delete
-    vi.mocked(db.update).mockReturnValueOnce({
-      set: vi.fn().mockReturnThis(),
-      where: vi.fn().mockResolvedValue(undefined),
-    } as never);
-
-    // Mock: update for personal agent-2 soft-delete
+    // Mock: one batched update soft-deletes both personal agents (#…, N+1 fix)
     vi.mocked(db.update).mockReturnValueOnce({
       set: vi.fn().mockReturnThis(),
       where: vi.fn().mockResolvedValue(undefined),
@@ -518,6 +517,142 @@ describe("DELETE /api/users/[userId]", () => {
     expect(deleteWorkspace).toHaveBeenCalledWith("agent-1");
     expect(deleteWorkspace).toHaveBeenCalledWith("agent-2");
     expect(deleteWorkspace).toHaveBeenCalledTimes(2);
+  });
+
+  it("soft-deletes every personal agent in a single batched update, not one per agent", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "agent-1" }, { id: "agent-2" }]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "user-1" }]),
+      }),
+    } as never);
+
+    const agentUpdateSet = vi.fn().mockReturnThis();
+    const agentUpdateWhere = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: agentUpdateSet,
+      where: agentUpdateWhere,
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1", {
+      method: "DELETE",
+    });
+
+    await DELETE(request, {
+      params: Promise.resolve({ userId: "user-1" }),
+    });
+
+    // Ban + one batched agent update — never one db.update per agent.
+    expect(db.update).toHaveBeenCalledTimes(2);
+    expect(db.update).toHaveBeenNthCalledWith(2, agents);
+    expect(agentUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedAt: expect.any(Date) })
+    );
+  });
+
+  it("wraps ban + session revocation + agent soft-delete in a single transaction (atomic deactivation)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "agent-1" }]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "user-1", name: "Test User" }]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1", {
+      method: "DELETE",
+    });
+
+    const response = await DELETE(request, {
+      params: Promise.resolve({ userId: "user-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.update).toHaveBeenCalled();
+    expect(db.delete).toHaveBeenCalledWith(sessions);
+  });
+
+  it("does not ban the user when the session revocation fails inside the transaction (atomicity)", async () => {
+    // Simulates a real transaction's rollback semantics with a stateful fake
+    // store: the ban only takes effect once the whole callback commits.
+    // Pre-fix, the route calls db.update/db.delete directly (never touching
+    // db.transaction), so this test's fake store is never exercised and the
+    // DELETE resolves 200 instead of rejecting — the red state this test
+    // starts from.
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as never);
+
+    let bannedCommitted = false;
+    vi.mocked(db.transaction).mockImplementationOnce((async (cb: (tx: unknown) => unknown) => {
+      let pendingBanned = false;
+      const tx = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockImplementation(async () => {
+                pendingBanned = true;
+                return [{ id: "user-1", name: "Test User" }];
+              }),
+            }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(async () => {
+            throw new Error("session delete failed");
+          }),
+        }),
+      };
+      await cb(tx);
+      // Only reached if cb() didn't throw — a real transaction rolls back on
+      // any error inside the callback, so a thrown error must skip this line.
+      bannedCommitted = pendingBanned;
+    }) as never);
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1", {
+      method: "DELETE",
+    });
+
+    await expect(
+      DELETE(request, { params: Promise.resolve({ userId: "user-1" }) })
+    ).rejects.toThrow("session delete failed");
+
+    expect(bannedCommitted).toBe(false);
+    expect(appendAuditLog).not.toHaveBeenCalled();
   });
 
   it("calls regenerateOpenClawConfig after deletion", async () => {

--- a/packages/web/src/__tests__/lib/migrate-onboarding.test.ts
+++ b/packages/web/src/__tests__/lib/migrate-onboarding.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/db", () => ({
         findMany: vi.fn().mockResolvedValue([]),
       },
       users: {
-        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn().mockResolvedValue([]),
       },
     },
   },
@@ -38,11 +38,9 @@ describe("migrateExistingSmithers", () => {
     vi.mocked(db.query.agents.findMany).mockResolvedValue([
       { id: "smithers-1", ownerId: "user-1", isPersonal: true, allowedTools: [] },
     ] as any);
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: "user-1",
-      role: "member",
-      context: null,
-    } as any);
+    vi.mocked(db.query.users.findMany).mockResolvedValue([
+      { id: "user-1", role: "member", context: null },
+    ] as any);
 
     const { migrateExistingSmithers } = await import("@/lib/migrate-onboarding");
     await migrateExistingSmithers();
@@ -59,11 +57,9 @@ describe("migrateExistingSmithers", () => {
     vi.mocked(db.query.agents.findMany).mockResolvedValue([
       { id: "smithers-2", ownerId: "user-2", isPersonal: true, allowedTools: [] },
     ] as any);
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: "user-2",
-      role: "member",
-      context: "I am a developer",
-    } as any);
+    vi.mocked(db.query.users.findMany).mockResolvedValue([
+      { id: "user-2", role: "member", context: "I am a developer" },
+    ] as any);
 
     const { migrateExistingSmithers } = await import("@/lib/migrate-onboarding");
     await migrateExistingSmithers();
@@ -76,11 +72,9 @@ describe("migrateExistingSmithers", () => {
     vi.mocked(db.query.agents.findMany).mockResolvedValue([
       { id: "smithers-3", ownerId: "admin-1", isPersonal: true, allowedTools: [] },
     ] as any);
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: "admin-1",
-      role: "admin",
-      context: null,
-    } as any);
+    vi.mocked(db.query.users.findMany).mockResolvedValue([
+      { id: "admin-1", role: "admin", context: null },
+    ] as any);
 
     const { migrateExistingSmithers } = await import("@/lib/migrate-onboarding");
     await migrateExistingSmithers();
@@ -98,5 +92,41 @@ describe("migrateExistingSmithers", () => {
     await expect(migrateExistingSmithers()).resolves.not.toThrow();
 
     expect(writeWorkspaceFileInternal).not.toHaveBeenCalled();
+    // No owner ids to look up when there are no personal agents.
+    expect(db.query.users.findMany).not.toHaveBeenCalled();
+  });
+
+  it("resolves every Smithers owner in a single batched query, not one findFirst per agent", async () => {
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "smithers-1", ownerId: "user-1", isPersonal: true, allowedTools: [] },
+      { id: "smithers-2", ownerId: "user-2", isPersonal: true, allowedTools: [] },
+      { id: "smithers-3", ownerId: "user-1", isPersonal: true, allowedTools: [] }, // shared owner
+    ] as any);
+    vi.mocked(db.query.users.findMany).mockResolvedValue([
+      { id: "user-1", role: "member", context: null },
+      { id: "user-2", role: "member", context: "already onboarded" },
+    ] as any);
+
+    const { migrateExistingSmithers } = await import("@/lib/migrate-onboarding");
+    await migrateExistingSmithers();
+
+    // One batched lookup covering every owner, regardless of agent count.
+    expect(db.query.users.findMany).toHaveBeenCalledTimes(1);
+    // user-1 has null context (write); user-2 already has context (skip).
+    expect(writeWorkspaceFileInternal).toHaveBeenCalledWith(
+      "smithers-1",
+      "USER.md",
+      expect.any(String)
+    );
+    expect(writeWorkspaceFileInternal).toHaveBeenCalledWith(
+      "smithers-3",
+      "USER.md",
+      expect.any(String)
+    );
+    expect(writeWorkspaceFileInternal).not.toHaveBeenCalledWith(
+      "smithers-2",
+      "USER.md",
+      expect.any(String)
+    );
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -6325,6 +6325,53 @@ describe("restart-state integration", () => {
     });
   });
 
+  it("resolves telegram_conflict_disabled markers via a single batched prefix query, not one getSetting per liveAgent", async () => {
+    let callCount = 0;
+    mockedDb.select.mockReturnValue({
+      from: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Object.assign(
+            Promise.resolve([
+              { id: "agent-1", name: "Smithers", model: "m", allowedTools: [] },
+              { id: "agent-2", name: "Support", model: "m", allowedTools: [] },
+            ]),
+            { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
+          );
+        }
+        return Object.assign(Promise.resolve([]), {
+          innerJoin: mockInnerJoin([]),
+          where: vi.fn().mockResolvedValue([]),
+        });
+      }),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-1") return "token-1";
+      if (key === "telegram_bot_token:agent-2") return "token-2";
+      // agent-2 is auto-disabled; agent-1 is not.
+      if (key === "telegram_conflict_disabled:agent-2") return JSON.stringify({ reason: "x" });
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    // Batched: exactly one getSettingsByPrefix("telegram_conflict_disabled:")
+    // call resolves both liveAgents' markers, instead of production code
+    // calling getSetting once per agent.
+    const conflictDisabledPrefixCalls = mockGetSettingsByPrefix.mock.calls.filter(
+      ([prefix]) => prefix === "telegram_conflict_disabled:"
+    );
+    expect(conflictDisabledPrefixCalls).toHaveLength(1);
+
+    const written = writtenOpenClawConfig(mockedWriteFileSync);
+    const config = JSON.parse(written);
+    // agent-2 stays excluded (conflict-disabled); agent-1 is included.
+    expect(config.channels.telegram.accounts).toEqual({
+      "agent-1": { botToken: "token-1" },
+    });
+  });
+
   it("should generate per-user peer bindings for personal agents (Smithers)", async () => {
     // Personal agent (Smithers) with bot token: each linked user should get
     // a peer-specific binding routing to their OWN personal Smithers agent.

--- a/packages/web/src/__tests__/lib/provider-deletion.test.ts
+++ b/packages/web/src/__tests__/lib/provider-deletion.test.ts
@@ -196,13 +196,34 @@ describe("repointAgentsOffRemovedModels", () => {
       keptModelIds: ["acme-large", "acme-small"],
     });
 
-    // Only the two agents on removed models are repointed, onto acme/acme-large.
-    expect(db.update).toHaveBeenCalledTimes(2);
+    // Only the two agents on removed models are repointed, onto acme/acme-large,
+    // via a single batched UPDATE rather than one per agent.
+    expect(db.update).toHaveBeenCalledTimes(1);
     expect(setSpy).toHaveBeenCalledWith({ model: "acme/acme-large" });
     expect(migrated).toEqual([
       { id: "a1", name: "One", fromModel: "acme/dropped", toModel: "acme/acme-large" },
       { id: "a4", name: "Four", fromModel: "acme/also-dropped", toModel: "acme/acme-large" },
     ]);
+  });
+
+  it("repoints every affected agent in a single batched UPDATE, not one per agent", async () => {
+    vi.mocked(db.query.agents.findMany).mockResolvedValue([
+      { id: "a1", name: "One", model: "acme/dropped" },
+      { id: "a2", name: "Two", model: "acme/also-dropped" },
+      { id: "a3", name: "Three", model: "acme/still-dropped" },
+    ] as any);
+    const whereSpy = vi.fn().mockResolvedValue(undefined);
+    const setSpy = vi.fn().mockReturnValue({ where: whereSpy });
+    vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+    await repointAgentsOffRemovedModels({
+      slug: "acme",
+      keptModelIds: ["acme-large"],
+    });
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith({ model: "acme/acme-large" });
+    expect(whereSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not touch an agent whose pinned model is still present", async () => {

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -212,14 +212,21 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
       ? await getAgentGroupIds(agentId)
       : [];
 
-  // Update group assignments if provided (zod already validated string[])
+  // Update group assignments if provided (zod already validated string[]).
+  // Atomic replace: the wipe and the re-insert must commit or roll back
+  // together. As two standalone statements, an insert failure (I/O error, a
+  // group deleted in the validation→insert window) would leave a restricted
+  // agent stripped of every group with none re-added — silent access loss.
+  // Mirrors users/[userId]/groups and groups/[groupId]/members.
   if (body.groupIds !== undefined && session.user.role === "admin") {
-    await db.delete(agentGroups).where(eq(agentGroups.agentId, agentId));
-    if (body.groupIds.length > 0) {
-      await db
-        .insert(agentGroups)
-        .values(body.groupIds.map((groupId: string) => ({ agentId, groupId })));
-    }
+    await db.transaction(async (tx) => {
+      await tx.delete(agentGroups).where(eq(agentGroups.agentId, agentId));
+      if (body.groupIds!.length > 0) {
+        await tx
+          .insert(agentGroups)
+          .values(body.groupIds!.map((groupId: string) => ({ agentId, groupId })));
+      }
+    });
   }
 
   if (data.name !== undefined || data.tagline !== undefined) {

--- a/packages/web/src/app/api/users/[userId]/route.ts
+++ b/packages/web/src/app/api/users/[userId]/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users, agents, sessions } from "@/db/schema";
-import { eq, and, count } from "drizzle-orm";
+import { eq, and, count, inArray } from "drizzle-orm";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { deleteWorkspace } from "@/lib/workspace";
 import { appendAuditLog } from "@/lib/audit";
@@ -93,22 +93,50 @@ export async function DELETE(
     .from(agents)
     .where(and(eq(agents.ownerId, userId), eq(agents.isPersonal, true)));
 
-  const [deactivated] = await db
-    .update(users)
-    .set({ banned: true, banReason: "Deactivated by admin" })
-    .where(eq(users.id, userId))
-    .returning();
+  // Atomic deactivation: the ban, the session revocation, and the personal-
+  // agent soft-delete must commit or roll back together. As standalone
+  // statements, a failure partway through (e.g. the session delete) would
+  // leave the user already banned with sessions and agents untouched, or vice
+  // versa — an inconsistent, partially-deactivated account. The filesystem
+  // workspace cleanup below stays OUTSIDE the transaction on purpose: rmSync
+  // has no place in a DB rollback.
+  const deactivated = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(users)
+      .set({ banned: true, banReason: "Deactivated by admin" })
+      .where(eq(users.id, userId))
+      .returning();
+
+    if (!row) return undefined;
+
+    // Revoke the user's active sessions immediately. Better Auth only
+    // enforces the `banned` flag at session-creation time, not on session
+    // reads, so an already-issued cookie would otherwise keep full access
+    // (incl. admin) until natural expiry. This mirrors the official
+    // admin.banUser behavior and the invite/claim reset flow, which both
+    // delete sessions.
+    await tx.delete(sessions).where(eq(sessions.userId, userId));
+
+    // Soft-delete every personal agent in one batched update instead of one
+    // per agent.
+    if (personalAgents.length > 0) {
+      await tx
+        .update(agents)
+        .set({ deletedAt: new Date() })
+        .where(
+          inArray(
+            agents.id,
+            personalAgents.map((a) => a.id)
+          )
+        );
+    }
+
+    return row;
+  });
 
   if (!deactivated) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
-
-  // Revoke the user's active sessions immediately. Better Auth only enforces
-  // the `banned` flag at session-creation time, not on session reads, so an
-  // already-issued cookie would otherwise keep full access (incl. admin) until
-  // natural expiry. This mirrors the official admin.banUser behavior and the
-  // invite/claim reset flow, which both delete sessions.
-  await db.delete(sessions).where(eq(sessions.userId, userId));
 
   after(() =>
     appendAuditLog({
@@ -124,9 +152,9 @@ export async function DELETE(
     })
   );
 
-  // Soft-delete personal agents + cleanup workspaces
+  // Cleanup workspaces (filesystem, not DB — deliberately outside the
+  // transaction above).
   for (const agent of personalAgents) {
-    await db.update(agents).set({ deletedAt: new Date() }).where(eq(agents.id, agent.id));
     deleteWorkspace(agent.id); // synchronous (uses rmSync)
   }
 

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -32,7 +32,7 @@ import { createHash } from "node:crypto";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, join, sep } from "node:path";
 
-import { and, count, eq } from "drizzle-orm";
+import { and, count, eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
 import { kbChunks, kbDocuments } from "@/db/schema";
@@ -436,14 +436,18 @@ async function removeVanishedDocuments(
 ): Promise<number> {
   const existingForOrg = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, orgId));
 
-  let removed = 0;
+  const vanishedIds: string[] = [];
   for (const doc of existingForOrg) {
     if (!isUnderRoot(doc.sourcePath, rootDir)) continue;
     if (discovered.has(doc.sourcePath)) continue;
-    await db.delete(kbDocuments).where(eq(kbDocuments.id, doc.id));
-    removed++;
+    vanishedIds.push(doc.id);
   }
-  return removed;
+
+  // Single batched DELETE instead of one per vanished document.
+  if (vanishedIds.length > 0) {
+    await db.delete(kbDocuments).where(inArray(kbDocuments.id, vanishedIds));
+  }
+  return vanishedIds.length;
 }
 
 /**

--- a/packages/web/src/lib/migrate-onboarding.ts
+++ b/packages/web/src/lib/migrate-onboarding.ts
@@ -1,6 +1,6 @@
 import { db } from "@/db";
 import { agents, users } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { writeWorkspaceFileInternal } from "@/lib/workspace";
 import { getOnboardingPrompt } from "@/lib/onboarding-prompt";
 
@@ -9,12 +9,18 @@ export async function migrateExistingSmithers(): Promise<void> {
     where: eq(agents.isPersonal, true),
   });
 
+  // Single batched owner lookup instead of one findFirst per agent.
+  const ownerIds = [...new Set(personalAgents.map((a) => a.ownerId).filter((id) => id !== null))];
+  const owners =
+    ownerIds.length > 0
+      ? await db.query.users.findMany({ where: inArray(users.id, ownerIds) })
+      : [];
+  const ownerById = new Map(owners.map((u) => [u.id, u]));
+
   for (const agent of personalAgents) {
     if (!agent.ownerId) continue;
 
-    const user = await db.query.users.findFirst({
-      where: eq(users.id, agent.ownerId),
-    });
+    const user = ownerById.get(agent.ownerId);
 
     if (!user || user.context !== null) continue;
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1527,6 +1527,9 @@ export async function regenerateOpenClawConfig() {
 
   // Single batched query instead of one getSetting per liveAgent (#261).
   const botTokenByKey = await getSettingsByPrefix("telegram_bot_token:");
+  // Same batching for the conflict-disabled marker — one getSetting per
+  // liveAgent otherwise.
+  const conflictDisabledByKey = await getSettingsByPrefix("telegram_conflict_disabled:");
   for (const agent of liveAgents) {
     const botToken = botTokenByKey.get(`telegram_bot_token:${agent.id}`);
     // #477 layer 2: an account auto-disabled after a sustained getUpdates-409
@@ -1534,7 +1537,7 @@ export async function regenerateOpenClawConfig() {
     // create, etc.) — not just at the moment of the targeted disable write.
     // The bot token is deliberately left in settings (so [Reconnect] can
     // re-enable it later); this guard is what makes the disable durable.
-    const conflictDisabled = await getSetting(`telegram_conflict_disabled:${agent.id}`);
+    const conflictDisabled = conflictDisabledByKey.get(`telegram_conflict_disabled:${agent.id}`);
     if (botToken && !conflictDisabled) {
       accounts[agent.id] = { botToken };
       if (agent.isPersonal) {

--- a/packages/web/src/lib/provider-deletion.ts
+++ b/packages/web/src/lib/provider-deletion.ts
@@ -21,7 +21,7 @@ import { listConfiguredBuiltIns } from "@/lib/provider-count";
 import { listOpenAiCompatibleProviders } from "@/lib/openai-compatible-providers";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 /** A provider an orphaned agent can migrate onto. */
 export interface RemainingCandidate {
@@ -223,7 +223,6 @@ export async function repointAgentsOffRemovedModels(opts: {
   const allAgents = await db.query.agents.findMany();
   for (const agent of allAgents) {
     if (agent.model?.startsWith(prefix) && !kept.has(agent.model)) {
-      await db.update(agents).set({ model: fallback }).where(eq(agents.id, agent.id));
       migrated.push({
         id: agent.id,
         name: agent.name,
@@ -232,6 +231,20 @@ export async function repointAgentsOffRemovedModels(opts: {
       });
     }
   }
+
+  // Single batched UPDATE instead of one per affected agent.
+  if (migrated.length > 0) {
+    await db
+      .update(agents)
+      .set({ model: fallback })
+      .where(
+        inArray(
+          agents.id,
+          migrated.map((a) => a.id)
+        )
+      );
+  }
+
   return migrated;
 }
 


### PR DESCRIPTION
## Summary

P3 DB-access-pattern fixes, six findings in one focused PR:

**Missing transactions (atomicity)**
1. `packages/web/src/app/api/agents/[agentId]/route.ts` — group reassignment (`db.delete(agentGroups)` then `db.insert(agentGroups)`) now runs inside `db.transaction()`. Previously, an insert failure after the delete left a restricted agent stripped of every group with none re-added — silent access loss. Mirrors the existing pattern in `users/[userId]/groups/route.ts` and `groups/[groupId]/members/route.ts`.
2. `packages/web/src/app/api/users/[userId]/route.ts` — user deactivation (ban → session revocation → personal-agent soft-delete) now runs inside `db.transaction()`. The N per-agent soft-delete updates are also collapsed into one `update … where inArray(agents.id, ids)`. The `deleteWorkspace()` filesystem cleanup (`rmSync`) stays **outside** the transaction, as it's not DB state.

**N+1 batches**
3. `packages/web/src/lib/openclaw-config/build.ts` — `telegram_conflict_disabled:<agentId>` lookup now uses `getSettingsByPrefix`, exactly like the sibling bot-token lookup two lines above it.
4. `packages/web/src/lib/migrate-onboarding.ts` — per-agent owner `findFirst` replaced with one batched `findMany({ where: inArray(users.id, ownerIds) })`.
5. `packages/web/src/lib/knowledge/ingest.ts` (`removeVanishedDocuments`) — per-document `DELETE` replaced with one `delete … where inArray(kbDocuments.id, ids)` (cascades to chunks exactly as before).
6. `packages/web/src/lib/provider-deletion.ts` (`repointAgentsOffRemovedModels`) — per-agent `UPDATE` replaced with one `update … where inArray(agents.id, ids)`.

## Test plan

TDD for the two transaction fixes: each has a red→green pair —

- A test pinning `db.transaction` wraps the writes (asserts it's called once).
- A rollback test using a stateful fake `tx` that only "commits" if the callback doesn't throw, proving that a mid-transaction failure (insert failure / session-delete failure) leaves prior state untouched. These fail pre-fix (the route resolves 200 instead of rejecting, since it never touches `db.transaction`) and pass post-fix.

For the four N+1 batches: existing tests stay green, and each got a new test pinning the batched call count (one `getSettingsByPrefix`/`findMany`/`update` call instead of N), except `knowledge/ingest.ts`. `removeVanishedDocuments` is a private function reachable only through the full ingest pipeline (discovery → extract → chunk → embed → upsert), which is exercised exclusively by `ingest.integration.test.ts` (real Postgres, `pnpm test:db`). Mocking that whole pipeline for one unit assertion wasn't proportionate, so behavioral equivalence rests on the existing integration coverage (`removes the document and its chunks when the source file disappears from disk`, `removes a root's documents when the root is readable and its files are gone`, `does not touch documents indexed from a different root directory`) — same row-id set selected for deletion, same returned count, only the DELETE statement is now batched. `pnpm test:db` was not run in this sandbox (no dev-stack Postgres available here).

### Gates
- `pnpm test:related` — 55 files, 1021 passed
- `pnpm test` — 774 passed | 4 skipped (778 files), 10925 passed | 18 skipped (10943 tests)
- `pnpm test:scripts` — 894 passed, 0 failed
- `pnpm -C packages/web lint` — 0 errors (981 pre-existing warnings, unrelated to this diff)
- `pnpm -C packages/web typecheck` — clean
- `pnpm format:check` — clean

Docs-not-needed: internal query batching and transaction hardening, no behavior change