### PR TITLE
fix(diagnostics): give a member without log access a step they can take

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -243,7 +243,7 @@ Repeated wrong guesses at the current password are also throttled now — five a
 
 A bug report filed from inside Pinchy used to carry the server's recent log lines for anyone signed in. That buffer is process-global — it holds error output from everyone's sessions, not only the reporter's — so it now goes to admins alone, and email addresses and secret-shaped strings are stripped out of it on the way in.
 
-Nothing to configure. A member's bug report now says the logs were left out and asks them to forward it to you rather than to run anything on the host. When one reaches you, `docker compose logs pinchy --tail 200` gives you the same output, unredacted.
+Nothing to configure. A member's bug report now says the logs were left out and asks them to forward it to you rather than to run anything on the host. When one reaches you, `docker compose logs pinchy --tail 200` gives you the same lines — unredacted, so read them there before deciding what goes into a public issue.
 
 ### Database migrations
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -243,7 +243,7 @@ Repeated wrong guesses at the current password are also throttled now — five a
 
 A bug report filed from inside Pinchy used to carry the server's recent log lines for anyone signed in. That buffer is process-global — it holds error output from everyone's sessions, not only the reporter's — so it now goes to admins alone, and email addresses and secret-shaped strings are stripped out of it on the way in.
 
-Nothing to configure. A member's bug report simply asks them to paste the logs by hand instead; if one arrives without them, `docker compose logs pinchy --tail 200` on the host is the same output, unredacted.
+Nothing to configure. A member's bug report now says the logs were left out and asks them to forward it to you rather than to run anything on the host. When one reaches you, `docker compose logs pinchy --tail 200` gives you the same output, unredacted.
 
 ### Database migrations
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -56,7 +56,7 @@ This is the endpoint to check after an upgrade: it answers what the container ac
 
 Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated **admins** additionally get a `logs` field with recent server logs (redacted of email addresses and known secret patterns). Nobody else gets that field — the log buffer is process-global and can carry detail from other users' sessions.
 
-A signed-in non-admin also gets `"logsWithheld": "admin-only"`. It lets a client tell "your role may not read these" apart from "there are none": the in-app bug reporter uses it to ask the reporter to forward their report to an administrator, rather than pointing them at a host shell they have no account on. Anonymous callers never get the field — for them the missing `logs` really does mean "go and look", since whoever runs the setup wizard operates the host.
+A signed-in non-admin also gets `"logsWithheld": "admin-only"`. It lets a client tell "your role may not read these" apart from "there are none": the in-app bug reporter uses it to ask the reporter to forward their report to an administrator, rather than pointing them at a host shell they have no account on. Anonymous callers never get the field: with no session there is no role to withhold for, and that caller may be the setup wizard's pre-flight check — run by whoever is installing Pinchy, who does hold the host shell. Nothing in the request separates that person from a signed-out member, so the bug reporter's fallback names the host command and the administrator both.
 
 ### `GET /api/health/openclaw`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -54,7 +54,9 @@ This is the endpoint to check after an upgrade: it answers what the container ac
 
 ### `GET /api/diagnostics`
 
-Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated **admins** additionally get a `logs` field with recent server logs (redacted of email addresses and known secret patterns). Anonymous callers and non-admin members get the status only — the log buffer is process-global and can carry detail from other users' sessions.
+Database and OpenClaw reachability, plus the running version. **Public**, but the session is inspected: authenticated **admins** additionally get a `logs` field with recent server logs (redacted of email addresses and known secret patterns). Nobody else gets that field — the log buffer is process-global and can carry detail from other users' sessions.
+
+A signed-in non-admin also gets `"logsWithheld": "admin-only"`. It lets a client tell "your role may not read these" apart from "there are none": the in-app bug reporter uses it to ask the reporter to forward their report to an administrator, rather than pointing them at a host shell they have no account on. Anonymous callers never get the field — for them the missing `logs` really does mean "go and look", since whoever runs the setup wizard operates the host.
 
 ### `GET /api/health/openclaw`
 

--- a/packages/web/src/__tests__/api/diagnostics.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics.test.ts
@@ -170,9 +170,12 @@ describe("GET /api/diagnostics", () => {
     expect(data).not.toHaveProperty("logsWithheld");
   });
 
-  // The anonymous caller here is the setup wizard's pre-flight check, run by
-  // whoever is installing Pinchy — they hold the host shell. Telling them to
-  // ask an administrator would send them looking for themselves.
+  // No session means no role to withhold for, so there is nothing to mark.
+  // This is not an assertion that the caller operates the host: it may be the
+  // setup wizard's pre-flight check, or a signed-out member hitting the error
+  // boundary on `/login`. Nothing in the request separates them, which is why
+  // the client's fallback copy names both routes rather than this endpoint
+  // picking one for it.
   it("should not mark logs as withheld for an anonymous caller", async () => {
     mockGetSession.mockResolvedValueOnce(null);
     mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);

--- a/packages/web/src/__tests__/api/diagnostics.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics.test.ts
@@ -143,4 +143,44 @@ describe("GET /api/diagnostics", () => {
 
     expect(data).not.toHaveProperty("logs");
   });
+
+  // A missing `logs` field has two very different causes, and the bug
+  // reporter that consumes this endpoint has to tell them apart: "your role
+  // may not read these" needs different copy from "there are none". Only the
+  // signed-in non-admin gets the marker.
+  it("should mark logs as withheld for role when the user is a signed-in member", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "1", role: "member" } });
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.logsWithheld).toBe("admin-only");
+  });
+
+  it("should not mark logs as withheld when the user is an admin", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "1", role: "admin" } });
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).not.toHaveProperty("logsWithheld");
+  });
+
+  // The anonymous caller here is the setup wizard's pre-flight check, run by
+  // whoever is installing Pinchy — they hold the host shell. Telling them to
+  // ask an administrator would send them looking for themselves.
+  it("should not mark logs as withheld for an anonymous caller", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    mockDb.execute.mockResolvedValueOnce([{ "?column?": 1 }]);
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({ ok: true } as Response);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).not.toHaveProperty("logsWithheld");
+  });
 });

--- a/packages/web/src/__tests__/lib/github-issue.test.ts
+++ b/packages/web/src/__tests__/lib/github-issue.test.ts
@@ -199,6 +199,57 @@ describe("buildIssueBody", () => {
     expect(body).toContain("docker compose logs pinchy");
   });
 
+  // Since logs became admin-only, a member's report reaches this branch every
+  // time — so it may not send them to a host shell they have no account on.
+  // The reporter's one workable next step is their own administrator.
+  it("should ask the reporter to forward the report when logs were withheld for role", () => {
+    const body = buildIssueBody({
+      error: "Setup failed",
+      page: "/setup",
+      diagnostics: {
+        database: "connected",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+        logsWithheld: "admin-only",
+      },
+    });
+    expect(body).toMatch(/forward this report to your Pinchy administrator/i);
+  });
+
+  it("should not instruct a reporter without log access to run a host command", () => {
+    const body = buildIssueBody({
+      error: "Setup failed",
+      page: "/setup",
+      diagnostics: {
+        database: "connected",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+        logsWithheld: "admin-only",
+      },
+    });
+    expect(body).not.toContain("docker compose");
+  });
+
+  // The distinction the marker exists for: no marker means the logs are
+  // simply not there (anonymous setup-wizard caller, or diagnostics that
+  // never answered), and whoever sees that does hold the host shell.
+  it("should keep the host command when diagnostics carry no logs and no withheld marker", () => {
+    const body = buildIssueBody({
+      error: "Setup failed",
+      page: "/setup",
+      diagnostics: {
+        database: "unreachable",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+      },
+    });
+    expect(body).toContain("docker compose logs pinchy");
+    expect(body).not.toMatch(/administrator/i);
+  });
+
   it("should handle special characters in error messages", () => {
     const body = buildIssueBody({
       error: "Failed: key=abc&status=error#hash",

--- a/packages/web/src/__tests__/lib/github-issue.test.ts
+++ b/packages/web/src/__tests__/lib/github-issue.test.ts
@@ -233,8 +233,9 @@ describe("buildIssueBody", () => {
   });
 
   // The distinction the marker exists for: no marker means the logs are
-  // simply not there (anonymous setup-wizard caller, or diagnostics that
-  // never answered), and whoever sees that does hold the host shell.
+  // simply not there (an anonymous caller, or diagnostics that never
+  // answered), so the host command stays. It must NOT read as the withheld
+  // case, which drops that command entirely.
   it("should keep the host command when diagnostics carry no logs and no withheld marker", () => {
     const body = buildIssueBody({
       error: "Setup failed",
@@ -247,7 +248,26 @@ describe("buildIssueBody", () => {
       },
     });
     expect(body).toContain("docker compose logs pinchy");
-    expect(body).not.toMatch(/administrator/i);
+    expect(body).not.toMatch(/only admins can read server logs/i);
+  });
+
+  // An anonymous caller is not necessarily the installer: `app/error.tsx` is
+  // the app's only error boundary, so it renders the reporter on `/login` and
+  // `/invite/[token]` as well, where the caller is a member with no host
+  // account. The server cannot tell the two apart from a missing session, so
+  // the copy carries a second route for whoever has no shell.
+  it("should offer the administrator as a fallback when no marker says who the reporter is", () => {
+    const body = buildIssueBody({
+      error: "Invite could not be claimed",
+      page: "/invite/abc123",
+      diagnostics: {
+        database: "connected",
+        openclaw: "connected",
+        version: "0.1.0",
+        nodeEnv: "production",
+      },
+    });
+    expect(body).toMatch(/ask your Pinchy administrator/i);
   });
 
   it("should handle special characters in error messages", () => {

--- a/packages/web/src/app/api/diagnostics/route.ts
+++ b/packages/web/src/app/api/diagnostics/route.ts
@@ -29,6 +29,15 @@ export async function GET() {
   // member has no business reading another user's error traces.
   if (session?.user?.role === "admin") {
     response.logs = logCapture.formatAsText();
+  } else if (session?.user) {
+    // Signed in, but not an admin. An absent `logs` field on its own cannot
+    // say WHY it is absent, and the in-app bug reporter has to tell the two
+    // causes apart: it can send whoever is holding the host shell to
+    // `docker compose logs`, but a member has no account there and needs
+    // their administrator instead. The anonymous caller is the setup
+    // wizard's pre-flight check — that person IS the host operator, so no
+    // marker for them.
+    response.logsWithheld = "admin-only";
   }
 
   return NextResponse.json(response);

--- a/packages/web/src/app/api/diagnostics/route.ts
+++ b/packages/web/src/app/api/diagnostics/route.ts
@@ -32,11 +32,14 @@ export async function GET() {
   } else if (session?.user) {
     // Signed in, but not an admin. An absent `logs` field on its own cannot
     // say WHY it is absent, and the in-app bug reporter has to tell the two
-    // causes apart: it can send whoever is holding the host shell to
-    // `docker compose logs`, but a member has no account there and needs
-    // their administrator instead. The anonymous caller is the setup
-    // wizard's pre-flight check — that person IS the host operator, so no
-    // marker for them.
+    // causes apart: a member has no account on the host, so sending them to
+    // `docker compose logs` yields a report with no logs and an instruction
+    // they cannot follow — their administrator is the step they can take.
+    // An anonymous caller gets no marker, because with no session there is
+    // no role to withhold for. That is deliberately NOT a claim that the
+    // caller holds the host shell: nothing in the request separates whoever
+    // is running the setup wizard from a signed-out member, so the client's
+    // fallback copy names both routes instead.
     response.logsWithheld = "admin-only";
   }
 

--- a/packages/web/src/lib/github-issue.ts
+++ b/packages/web/src/lib/github-issue.ts
@@ -122,9 +122,16 @@ export function buildIssueBody(context: IssueContext): string {
       "```"
     );
   } else {
+    // No marker means the server did not say why the logs are missing —
+    // either there was no session to withhold for, or diagnostics never
+    // answered. That is not the same as "this reporter holds the host
+    // shell": `app/error.tsx` is the only error boundary in the app, so it
+    // renders this link on `/login` and `/invite/[token]` too, where the
+    // anonymous caller is a member and not the installer. The copy names
+    // both routes rather than guessing which one is reading it.
     sections.push(
       "",
-      "**Logs:** (run `docker compose logs pinchy --tail 200` and paste below)",
+      "**Logs:** (run `docker compose logs pinchy --tail 200` on the server and paste below — if you have no shell there, ask your Pinchy administrator)",
       "```",
       "",
       "```"

--- a/packages/web/src/lib/github-issue.ts
+++ b/packages/web/src/lib/github-issue.ts
@@ -125,10 +125,13 @@ export function buildIssueBody(context: IssueContext): string {
     // No marker means the server did not say why the logs are missing —
     // either there was no session to withhold for, or diagnostics never
     // answered. That is not the same as "this reporter holds the host
-    // shell": `app/error.tsx` is the only error boundary in the app, so it
-    // renders this link on `/login` and `/invite/[token]` too, where the
-    // anonymous caller is a member and not the installer. The copy names
-    // both routes rather than guessing which one is reading it.
+    // shell": `ReportIssueLink` renders from both root error boundaries
+    // (`app/error.tsx`, `app/global-error.tsx`), which cover `/login`,
+    // `/invite/[token]` and `/share-target`, and from four components
+    // besides. A signed-out reporter is as likely to be a member on one of
+    // those pages as the person running the setup wizard, and nothing here
+    // separates them — so the copy names both routes rather than guessing
+    // which one is reading it.
     sections.push(
       "",
       "**Logs:** (run `docker compose logs pinchy --tail 200` on the server and paste below — if you have no shell there, ask your Pinchy administrator)",

--- a/packages/web/src/lib/github-issue.ts
+++ b/packages/web/src/lib/github-issue.ts
@@ -4,6 +4,13 @@ export interface DiagnosticsResult {
   version: string;
   nodeEnv: string;
   logs?: string;
+  /**
+   * Set by `GET /api/diagnostics` when the caller is signed in and the server
+   * deliberately held the logs back for their role — never when the logs are
+   * merely missing. The two need different copy in the report body, and an
+   * absent `logs` field alone cannot tell them apart.
+   */
+  logsWithheld?: "admin-only";
 }
 
 export interface IssueContext {
@@ -102,6 +109,18 @@ export function buildIssueBody(context: IssueContext): string {
 
   if (diagnostics?.logs) {
     sections.push("", "**Logs:**", "```", diagnostics.logs, "```");
+  } else if (diagnostics?.logsWithheld === "admin-only") {
+    // Since logs became admin-only this is what every member sees, so it is
+    // no longer a rare fallback. Pointing them at a host shell they have no
+    // account on produces a report with no logs and an instruction the
+    // reporter cannot follow — their administrator is the workable step.
+    sections.push(
+      "",
+      "**Logs:** Not included — only admins can read server logs. Forward this report to your Pinchy administrator, who can paste them below.",
+      "```",
+      "",
+      "```"
+    );
   } else {
     sections.push(
       "",


### PR DESCRIPTION
> **Stacked on [#1045](https://github.com/heypinchy/pinchy/pull/1045)** (`fix/diagnostics-log-leak`). Base is that branch, not `main` — the premise here is admin-only logs, which #1045 introduces. Rebase onto `main` once it lands.

## The problem

`buildIssueBody()` in `packages/web/src/lib/github-issue.ts` fell back to this whenever the diagnostics response carried no `logs`:

```
**Logs:** (run `docker compose logs pinchy --tail 200` and paste below)
```

Since #1045 restricted the `logs` field to admins, that branch stopped being the rare case — it is what **every non-admin member** now sees when they file a bug report from inside Pinchy. And it points them at a host shell they typically have no account on. The result is a report with no logs and an instruction the reporter cannot follow.

## The fix

An absent `logs` field cannot say *why* it is absent, so `GET /api/diagnostics` now says it. A signed-in non-admin gets:

```json
{ "logsWithheld": "admin-only" }
```

and `buildIssueBody()` grows a third branch for it:

```
**Logs:** Not included — only admins can read server logs. Forward this report to your Pinchy administrator, who can paste them below.
```

**Anonymous callers get no marker** — with no session there is no role to withhold for. That is deliberately *not* a claim that the caller operates the host. `ReportIssueLink` renders from both root error boundaries (`app/error.tsx`, `app/global-error.tsx`), which cover `/login`, `/invite/[token]` and `/share-target`, and from four components besides, so a signed-out reporter is at least as likely to be a member as the person running the setup wizard. Nothing in the request separates them, so the fallback copy stops guessing and names both routes: the host command for whoever can run it, the administrator for whoever cannot.

Copy checked against `PERSONALITY.md`: honest about what's missing, no blame, one workable next step, and "your administrator" matches the wording already used in `login/page.tsx`, `insecure-banner.tsx` and `error-hints.ts`.

## Tests (TDD, red → green)

Watched each fail first, for the missing feature rather than a typo:

- `__tests__/api/diagnostics.test.ts` — member gets `logsWithheld: "admin-only"`; admin does **not**; anonymous does **not** (the last two passed already and pin behaviour that must not move).
- `__tests__/lib/github-issue.test.ts` — withheld ⟹ the forwarding copy; withheld ⟹ **no** `docker compose` anywhere in the body; diagnostics with neither `logs` nor the marker ⟹ the host command stays and does not read as the withheld case; and the same fallback seen by an `/invite/…` reporter offers the administrator too.

The existing "should show manual logs instruction when no logs available" test is untouched — it is the unavailable case.

## Docs

- `reference/api.mdx` — documents `logsWithheld` and why anonymous callers never get it. Also reworded the preceding sentence, which said non-admin members "get the status only" and contradicted the new paragraph.
- `guides/upgrading.mdx` — #1045's own note said a member's report "asks them to paste the logs by hand". That is the behaviour being fixed, so the note is corrected here. It is the open `%%PINCHY_VERSION%%` section, so no `Allow-upgrade-note-edit` trailer is needed. A second pass removed the claim that `docker compose logs` gives "the same output, unredacted" without saying that those lines are on their way into a *public* issue — which is what #1045's redaction exists to prevent.

## Review round

Rebased onto the rewritten base (it had been rebased onto `main`, which left this PR conflicting over a duplicate copy of the upgrade note). Then one review finding fixed in `9d83946e`: the commit that established "the anonymous reporter is not always the host operator" updated `github-issue.ts` and the docs but left `route.ts` and `diagnostics.test.ts` asserting the opposite in prose, and justified itself with "`app/error.tsx` is the only error boundary in the app" — it is not, `app/global-error.tsx` is a second one and renders the same link. Comments only; the conclusion was right, the premise was not.

## Gates

- `pnpm test` — **11101 passed**, 18 skipped (778 files passed, 4 skipped)
- `pnpm test:scripts` — 960 passed, 0 failed
- `pnpm -C packages/web typecheck` — clean
- `pnpm -C packages/web lint` — 0 errors (1005 pre-existing warnings, unchanged)
- `pnpm format:check` — clean
- `cd docs && pnpm build && pnpm check:anchors && pnpm check:rendered && pnpm test` — 70 pages, all clean

**CI does not run on this PR automatically**: `ci.yml` triggers on `pull_request: branches: [main, "release/**"]`, and this one targets `fix/diagnostics-log-leak`. The checks above are local; a `workflow_dispatch` run is dispatched against the branch, and the real gate is the retarget onto `main` after #1045 lands.

One environment note for anyone reproducing: `better-sqlite3` here was prebuilt for Node 24 and had to be recompiled against the repo's Node 22 pin, otherwise the `pinchy-files` PDF tests fail with a `NODE_MODULE_VERSION` error that reads like a product failure. No code involved.
