### PR TITLE
fix(plugins): clamp odoo_read/odoo_aggregate limit and scope country lookups

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -55,6 +55,8 @@ import plugin, {
   ODOO_READ_RESULT_BUDGET_CHARS,
   ODOO_READ_TRUNCATION_HINT,
   ODOO_AGGREGATE_TRUNCATION_HINT,
+  ODOO_READ_DEFAULT_LIMIT,
+  ODOO_READ_LIMIT_CAP,
 } from "../index";
 
 const MOVE_FIELDS: OdooField[] = [
@@ -1501,9 +1503,11 @@ describe("odoo_read", () => {
     );
   });
 
-  // Same defect, missing rather than oversized: an omitted `limit` reached
-  // Odoo as `undefined` (no bound at all) despite the tool description
-  // promising "default: 100".
+  // Same parameter, missing rather than oversized. `odoo-node`'s `searchRead`
+  // does already substitute its own `DEFAULT_LIMIT = 100` for an `undefined`
+  // limit, so this was never the unbounded case — but the tool description
+  // promises "default: 100" and that promise should be pinned here rather
+  // than depend on a library constant we don't own.
   it("defaults limit to 100 when omitted, instead of forwarding undefined", async () => {
     mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 100, offset: 0 });
 
@@ -1520,6 +1524,70 @@ describe("odoo_read", () => {
       [],
       expect.objectContaining({ limit: 100 })
     );
+  });
+
+  // `Math.min` alone is a ONE-SIDED clamp, and the open side is the one that
+  // matters: Odoo reads `limit=0` as *no limit*, and odoo-node forwards it
+  // verbatim (`options?.limit ?? DEFAULT_LIMIT` — `0 ?? 100` is `0`). So a
+  // model writing `limit: 0` got the entire table back through the very cap
+  // that exists to prevent that. Anything that is not a usable row count
+  // falls back to the documented default.
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("treats a %s limit as unspecified rather than forwarding it", async (_label, limit) => {
+    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 100, offset: 0 });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-unusable-limit", {
+      model: "sale.order",
+      limit,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      expect.objectContaining({ limit: ODOO_READ_DEFAULT_LIMIT })
+    );
+  });
+
+  // A fractional limit reaches Postgres as a fractional LIMIT. Floor it to a
+  // row count instead of letting the database decide what 10.7 rows means.
+  it("floors a fractional limit to a whole row count", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 10, offset: 0 });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-fractional-limit", {
+      model: "sale.order",
+      limit: 10.7,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      expect.objectContaining({ limit: 10 })
+    );
+  });
+
+  // The numbers in the tool description are what the model plans against, so
+  // a description that drifts from the enforced bound is worse than no
+  // description. Pin them to the same constants the clamp reads.
+  it("documents the default and cap the clamp actually enforces", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+    const limitDescription = (tool.parameters as { properties: { limit: { description: string } } })
+      .properties.limit.description;
+
+    expect(limitDescription).toContain(String(ODOO_READ_DEFAULT_LIMIT));
+    expect(limitDescription).toContain(String(ODOO_READ_LIMIT_CAP));
   });
 
   // Regression (pinchy production, 2026-07-22): a real crm.lead read produced a
@@ -2191,6 +2259,38 @@ describe("odoo_aggregate", () => {
     );
   });
 
+  // Same one-sided-clamp hole as odoo_read: `Math.min(0, 500)` is `0`, which
+  // odoo-node forwards and Odoo reads as *no limit*. `odoo_aggregate` has no
+  // documented default, so an unusable value collapses to `undefined` — the
+  // same state as omitting the parameter, never a forwarded `0`/`-1`/`NaN`.
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", Number.NaN],
+  ])("treats a %s limit as unspecified rather than forwarding it", async (_label, limit) => {
+    mockReadGroup.mockResolvedValue({ groups: [] });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+
+    const result = await tool.execute("call-unusable-limit", {
+      model: "sale.order",
+      filters: [],
+      fields: ["partner_id", "amount_total:sum"],
+      groupby: ["partner_id"],
+      limit,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockReadGroup).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      ["partner_id", "amount_total:sum"],
+      ["partner_id"],
+      expect.objectContaining({ limit: undefined })
+    );
+  });
+
   // Same trap, two more model-supplied lists — `groupby` additionally
   // accepts the `field:agg` suffix form, which must strip by base name.
   it("strips synthetic `_pinchy_ref` entries from both `fields` and `groupby` before forwarding to Odoo", async () => {
@@ -2714,7 +2814,10 @@ describe("odoo_create", () => {
 
   // Same defect, name-based path: a country resolved by display name must not
   // fetch the whole table either — it should send an ilike domain scoped to
-  // the requested name.
+  // the requested name. Asserted as the exact domain, not `arrayContaining`:
+  // a domain that merely *contains* the right leaves passes that matcher even
+  // when the `"|"` operator is missing, which is an implicit AND and a
+  // different query.
   it("scopes the country search read to an ilike domain instead of scanning the whole table when resolving by name", async () => {
     mockFields.mockResolvedValue([
       { name: "name", string: "Name", type: "char" },
@@ -2743,13 +2846,82 @@ describe("odoo_create", () => {
 
     expect(result.isError).toBeFalsy();
     const [, domain] = mockSearchRead.mock.calls.find(([model]) => model === "res.country")!;
-    expect(domain).not.toEqual([]);
-    expect(domain).toEqual(
-      expect.arrayContaining([
-        expect.arrayContaining(["name", "ilike", "Austria"]),
-        expect.arrayContaining(["display_name", "ilike", "Austria"]),
-      ])
-    );
+    expect(domain).toEqual([["name", "ilike", "Austria"]]);
+  });
+
+  // A lookup carrying BOTH a code and a name used to resolve by name when the
+  // code matched nothing, because the whole table was in hand and
+  // `resolveReferenceFromRecords` falls through from the code branch to the
+  // exact-name branch. A code-only domain silently removes that fallback: the
+  // records the name branch needs are never fetched. OR the two.
+  it("keeps the name fallback reachable when a lookup carries both a code and a name", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    // The code matches nothing; only the name does.
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 14, name: "Austria", code: "AT" }],
+      total: 1,
+      limit: 1000,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(48);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-code-and-name", {
+      model: "res.partner",
+      values: {
+        name: "Wien Partner",
+        country_id: { lookup: { code: "XX", name: "Austria" } },
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, domain] = mockSearchRead.mock.calls.find(([model]) => model === "res.country")!;
+    expect(domain).toEqual(["|", ["code", "=", "XX"], ["name", "ilike", "Austria"]]);
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "Wien Partner",
+      country_id: 14,
+    });
+  });
+
+  // The one input shape carrying NO scoping information at all was the one
+  // that kept the old behaviour: `{lookup: {}}` (or a non-string `name`, which
+  // `parseLookup` drops) produced `["|", ["name","ilike",""], …]`, and
+  // `ilike ""` is `LIKE '%%'` — every row, exactly the full-table scan this
+  // change exists to remove. There is nothing to search for, so don't search:
+  // fail with the same "provide an exact name or ref" error, unqueried.
+  it("does not query res.country at all when the lookup carries neither a code nor a name", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-empty-lookup", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: { lookup: {} } },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Could not resolve country_id");
+    expect(mockSearchRead.mock.calls.filter(([model]) => model === "res.country")).toHaveLength(0);
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it("denies create on model without create permission", async () => {

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1477,6 +1477,51 @@ describe("odoo_read", () => {
     });
   });
 
+  // P3: `params.limit` used to reach `client.searchRead` unclamped — a model
+  // requesting `limit: 999999` got exactly that against Odoo, defeating the
+  // whole point of pagination. The tool description already promises a
+  // "default: 100"; this pins an actual cap so a runaway request can't ask
+  // for the entire table in one call.
+  it("clamps an oversized limit to the cap instead of forwarding it verbatim", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 500, offset: 0 });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-huge-limit", {
+      model: "sale.order",
+      limit: 999999,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      expect.objectContaining({ limit: 500 })
+    );
+  });
+
+  // Same defect, missing rather than oversized: an omitted `limit` reached
+  // Odoo as `undefined` (no bound at all) despite the tool description
+  // promising "default: 100".
+  it("defaults limit to 100 when omitted, instead of forwarding undefined", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 100, offset: 0 });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-default-limit", {
+      model: "sale.order",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      expect.objectContaining({ limit: 100 })
+    );
+  });
+
   // Regression (pinchy production, 2026-07-22): a real crm.lead read produced a
   // ~509,000-char result that OpenClaw cut mid-JSON, so Piper looped on "the
   // results are truncated". odoo_read must bound its own output so the returned
@@ -2118,6 +2163,34 @@ describe("odoo_aggregate", () => {
     );
   });
 
+  // P3, same defect as odoo_read: `params.limit` reached `client.readGroup`
+  // unclamped. Unlike odoo_read the tool never promised a default, so an
+  // omitted limit must stay `undefined` (pinned above) — only an oversized
+  // one gets capped.
+  it("clamps an oversized limit to the cap instead of forwarding it verbatim", async () => {
+    mockReadGroup.mockResolvedValue({ groups: [] });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+
+    const result = await tool.execute("call-huge-limit", {
+      model: "sale.order",
+      filters: [],
+      fields: ["partner_id", "amount_total:sum"],
+      groupby: ["partner_id"],
+      limit: 999999,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockReadGroup).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      ["partner_id", "amount_total:sum"],
+      ["partner_id"],
+      expect.objectContaining({ limit: 500 })
+    );
+  });
+
   // Same trap, two more model-supplied lists — `groupby` additionally
   // accepts the `field:agg` suffix form, which must strip by base name.
   it("strips synthetic `_pinchy_ref` entries from both `fields` and `groupby` before forwarding to Odoo", async () => {
@@ -2595,6 +2668,88 @@ describe("odoo_create", () => {
     expect(result.content[0].text).toContain("Uganda");
     expect(result.content[0].text).toContain("Uzbekistan");
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // P3: an unresolved country value used to fetch the whole res.country
+  // table (empty domain, limit: 1000) on every call, bypassing
+  // searchRelationByName only because that helper's field list omits `code`.
+  // A code lookup should scope the search read to that one code instead.
+  it("scopes the country search read to the resolved code instead of scanning the whole table", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 14, name: "Austria", code: "AT" }],
+      total: 1,
+      limit: 1000,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(46);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-code-domain", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: { lookup: { code: "AT" } } },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "res.country",
+      [["code", "=", "AT"]],
+      expect.objectContaining({ fields: expect.arrayContaining(["code"]) })
+    );
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "Wien Partner",
+      country_id: 14,
+    });
+  });
+
+  // Same defect, name-based path: a country resolved by display name must not
+  // fetch the whole table either — it should send an ilike domain scoped to
+  // the requested name.
+  it("scopes the country search read to an ilike domain instead of scanning the whole table when resolving by name", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 14, name: "Austria", code: "AT" }],
+      total: 1,
+      limit: 1000,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(47);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-name-domain", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: "Austria" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, domain] = mockSearchRead.mock.calls.find(([model]) => model === "res.country")!;
+    expect(domain).not.toEqual([]);
+    expect(domain).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(["name", "ilike", "Austria"]),
+        expect.arrayContaining(["display_name", "ilike", "Austria"]),
+      ])
+    );
   });
 
   it("denies create on model without create permission", async () => {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1264,6 +1264,24 @@ async function searchRelationByName(
   });
 }
 
+/**
+ * Domain for the `res.country` lookup, scoped to the parsed
+ * {@link RelationLookup} instead of matching every row. `res.country` is
+ * excluded from {@link searchRelationByName} only because that helper's
+ * field list omits `code` (it always requests `["id", "name",
+ * "display_name"]`) — but that made every unresolved country value fetch the
+ * *entire* table (empty domain, `limit: 1000`) on every call. A `code` (from
+ * an explicit `{lookup:{code}}` or a recognized alias/ISO input, see
+ * `countryCodeForInput`) narrows to an exact `code` match; otherwise fall
+ * back to an `ilike` match on `name` OR `display_name`, mirroring
+ * `searchRelationByName`'s `name` domain.
+ */
+function countryLookupDomain(lookup: RelationLookup): OdooDomain {
+  if (lookup.code) return [["code", "=", lookup.code]];
+  const name = lookup.name ?? "";
+  return ["|", ["name", "ilike", name], ["display_name", "ilike", name]];
+}
+
 async function resolveRelationValue(
   client: OdooClient,
   connectionId: string,
@@ -1318,7 +1336,7 @@ async function resolveRelationValue(
 
   const result =
     field.relation === "res.country"
-      ? await client.searchRead(field.relation, [], {
+      ? await client.searchRead(field.relation, countryLookupDomain(lookup), {
           fields: ["id", "name", "display_name", "code"],
           limit: 1000,
         })
@@ -2059,6 +2077,31 @@ function wrapReadResult(
     };
   }
   return result;
+}
+
+/**
+ * Row-count bounds for `odoo_read`/`odoo_aggregate`'s `limit` parameter.
+ *
+ * `params.limit` used to reach `client.searchRead`/`client.readGroup`
+ * unclamped: an omitted limit forwarded `undefined` (no bound at all,
+ * despite the `odoo_read` tool description promising "default: 100"), and an
+ * oversized one forwarded verbatim, letting a single call request the whole
+ * table. {@link clampReadLimit} enforces the documented default and a hard
+ * cap; {@link clampOptionalLimit} enforces only the cap, for `odoo_aggregate`
+ * whose `limit` (max groups) has no documented default and must stay
+ * `undefined` when omitted.
+ */
+export const ODOO_READ_DEFAULT_LIMIT = 100;
+export const ODOO_READ_LIMIT_CAP = 500;
+
+function clampReadLimit(limit: unknown): number {
+  const requested = typeof limit === "number" ? limit : ODOO_READ_DEFAULT_LIMIT;
+  return Math.min(requested, ODOO_READ_LIMIT_CAP);
+}
+
+function clampOptionalLimit(limit: unknown): number | undefined {
+  if (typeof limit !== "number") return undefined;
+  return Math.min(limit, ODOO_READ_LIMIT_CAP);
 }
 
 /**
@@ -2883,7 +2926,7 @@ const plugin = {
               },
               limit: {
                 type: "number",
-                description: "Max records (default: 100)",
+                description: "Max records (default: 100, capped at 500)",
               },
               offset: {
                 type: "number",
@@ -2920,7 +2963,7 @@ const plugin = {
                 );
                 const records = await client.searchRead(model, asDomain(params.filters), {
                   fields: effectiveFields,
-                  limit: params.limit as number | undefined,
+                  limit: clampReadLimit(params.limit),
                   offset: params.offset as number | undefined,
                   order: params.order as string | undefined,
                 });
@@ -3037,7 +3080,7 @@ const plugin = {
                 items: { type: "string" },
                 description: "Fields to group by, e.g. ['partner_id'] or ['date_order:month']",
               },
-              limit: { type: "number", description: "Max groups to return" },
+              limit: { type: "number", description: "Max groups to return (capped at 500)" },
               offset: {
                 type: "number",
                 description: "Skip N groups for pagination",
@@ -3064,7 +3107,7 @@ const plugin = {
 
               const result = await withAuthRetry(agentId, config, (client) =>
                 client.readGroup(model, asDomain(params.filters), fields, groupby, {
-                  limit: params.limit as number | undefined,
+                  limit: clampOptionalLimit(params.limit),
                   offset: params.offset as number | undefined,
                   orderby: params.orderby as string | undefined,
                 })

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1266,20 +1266,60 @@ async function searchRelationByName(
 
 /**
  * Domain for the `res.country` lookup, scoped to the parsed
- * {@link RelationLookup} instead of matching every row. `res.country` is
- * excluded from {@link searchRelationByName} only because that helper's
- * field list omits `code` (it always requests `["id", "name",
+ * {@link RelationLookup} instead of matching every row — or `null` when the
+ * lookup carries nothing to scope on.
+ *
+ * `res.country` is excluded from {@link searchRelationByName} only because
+ * that helper's field list omits `code` (it always requests `["id", "name",
  * "display_name"]`) — but that made every unresolved country value fetch the
- * *entire* table (empty domain, `limit: 1000`) on every call. A `code` (from
- * an explicit `{lookup:{code}}` or a recognized alias/ISO input, see
- * `countryCodeForInput`) narrows to an exact `code` match; otherwise fall
- * back to an `ilike` match on `name` OR `display_name`, mirroring
- * `searchRelationByName`'s `name` domain.
+ * *entire* table (empty domain, `limit: 1000`) on every call.
+ *
+ * Three shapes, and each one exists because of how
+ * {@link resolveReferenceFromRecords} consumes the result:
+ *
+ * - A `code` (explicit `{lookup:{code}}`, or a recognized alias/ISO input via
+ *   `countryCodeForInput`) narrows to an exact `code` match.
+ * - A `name` narrows to an `ilike` match, mirroring `searchRelationByName`'s
+ *   domain. `name` only, deliberately: no other search domain in this plugin
+ *   touches `display_name`, which is a computed non-stored field whose
+ *   searchability depends on the Odoo version — and for `res.country`
+ *   (`_rec_name` is `name`) it would match nothing `name` doesn't. The
+ *   client-side matcher still compares both.
+ * - BOTH are OR-ed rather than letting `code` win, because
+ *   `resolveReferenceFromRecords` falls through from its code branch to its
+ *   exact-name branch. A code-only domain never fetches the records that
+ *   fallback needs, so a wrong code would make a correct name unresolvable.
+ *
+ * `null` is the neither case (`{lookup: {}}`, or a non-string `name` that
+ * `parseLookup` drops). An `ilike ""` there is `LIKE '%%'`, i.e. every row —
+ * the full-table scan this function exists to remove, reached through the one
+ * input that carries no information to scan for. The caller resolves against
+ * no records instead, which produces the identical error unqueried.
  */
-function countryLookupDomain(lookup: RelationLookup): OdooDomain {
-  if (lookup.code) return [["code", "=", lookup.code]];
-  const name = lookup.name ?? "";
-  return ["|", ["name", "ilike", name], ["display_name", "ilike", name]];
+function countryLookupDomain(lookup: RelationLookup): OdooDomain | null {
+  const byCode: OdooDomain | null = lookup.code ? [["code", "=", lookup.code]] : null;
+  const byName: OdooDomain | null = lookup.name ? [["name", "ilike", lookup.name]] : null;
+  if (byCode && byName) return ["|", ...byCode, ...byName];
+  return byCode ?? byName;
+}
+
+/**
+ * Candidate `res.country` rows for a lookup, or an empty result when
+ * {@link countryLookupDomain} has nothing to search for. The `limit` is a
+ * backstop rather than the bound that matters now that the domain is scoped —
+ * a one-letter `ilike` still matches a good share of the table.
+ */
+async function readCountryCandidates(
+  client: OdooClient,
+  relation: string,
+  lookup: RelationLookup
+): Promise<unknown> {
+  const domain = countryLookupDomain(lookup);
+  if (!domain) return { records: [] };
+  return client.searchRead(relation, domain, {
+    fields: ["id", "name", "display_name", "code"],
+    limit: 1000,
+  });
 }
 
 async function resolveRelationValue(
@@ -1336,10 +1376,7 @@ async function resolveRelationValue(
 
   const result =
     field.relation === "res.country"
-      ? await client.searchRead(field.relation, countryLookupDomain(lookup), {
-          fields: ["id", "name", "display_name", "code"],
-          limit: 1000,
-        })
+      ? await readCountryCandidates(client, field.relation, lookup)
       : await searchRelationByName(client, field, lookup, scopeCompanyId, fieldsCache);
 
   return resolveReferenceFromRecords(field, lookup, getSearchReadRecords(result));
@@ -2082,26 +2119,58 @@ function wrapReadResult(
 /**
  * Row-count bounds for `odoo_read`/`odoo_aggregate`'s `limit` parameter.
  *
- * `params.limit` used to reach `client.searchRead`/`client.readGroup`
- * unclamped: an omitted limit forwarded `undefined` (no bound at all,
- * despite the `odoo_read` tool description promising "default: 100"), and an
- * oversized one forwarded verbatim, letting a single call request the whole
- * table. {@link clampReadLimit} enforces the documented default and a hard
- * cap; {@link clampOptionalLimit} enforces only the cap, for `odoo_aggregate`
- * whose `limit` (max groups) has no documented default and must stay
- * `undefined` when omitted.
+ * `params.limit` reached `client.searchRead`/`client.readGroup` verbatim, so
+ * a model asking for `limit: 999999` got exactly that against Odoo and a
+ * single call could pull the whole table. These are the bounds the tool
+ * descriptions promise — interpolated into those descriptions rather than
+ * restated, so the number the model plans against and the number actually
+ * enforced cannot drift apart.
+ *
+ * `ODOO_READ_DEFAULT_LIMIT` also happens to match `odoo-node`'s own
+ * `DEFAULT_LIMIT`, which its `searchRead` substitutes for an `undefined`
+ * limit — so an omitted limit was never the unbounded case. Pinning it here
+ * makes the documented default ours instead of a library constant we don't
+ * own and would not notice changing.
  */
 export const ODOO_READ_DEFAULT_LIMIT = 100;
 export const ODOO_READ_LIMIT_CAP = 500;
 
-function clampReadLimit(limit: unknown): number {
-  const requested = typeof limit === "number" ? limit : ODOO_READ_DEFAULT_LIMIT;
-  return Math.min(requested, ODOO_READ_LIMIT_CAP);
+/**
+ * Reduce a model-supplied `limit` to a usable row count, or `null` when it
+ * carries no usable bound at all.
+ *
+ * A bare `Math.min` is a ONE-SIDED clamp, and the side it leaves open is the
+ * one that matters. Odoo reads `limit=0` as *no limit*, and `odoo-node`
+ * forwards it verbatim (`options?.limit ?? DEFAULT_LIMIT` — `0 ?? 100` is
+ * `0`), so `limit: 0` walked straight through the cap and returned the entire
+ * table: the exact outcome the cap exists to prevent, one plausible model
+ * output away. The other open cases end the same way or worse — a negative
+ * value reaches Postgres as a negative `LIMIT`, and `NaN`/`Infinity` are
+ * `typeof "number"` but serialize to JSON `null`, i.e. unbounded again.
+ *
+ * So the rule is positive rather than subtractive: a limit is honoured only
+ * if it is a finite row count of at least 1, floored to a whole row and
+ * capped. Anything else is "not specified" and left to the caller's default.
+ */
+function usableLimit(limit: unknown): number | null {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return null;
+  const rows = Math.floor(limit);
+  if (rows < 1) return null;
+  return Math.min(rows, ODOO_READ_LIMIT_CAP);
 }
 
+/** `odoo_read`: an unusable limit falls back to the documented default. */
+function clampReadLimit(limit: unknown): number {
+  return usableLimit(limit) ?? ODOO_READ_DEFAULT_LIMIT;
+}
+
+/**
+ * `odoo_aggregate`: its `limit` (max groups) has no documented default, so an
+ * unusable value collapses to `undefined` — the same state as omitting the
+ * parameter, never a forwarded `0` that Odoo would read as "all groups".
+ */
 function clampOptionalLimit(limit: unknown): number | undefined {
-  if (typeof limit !== "number") return undefined;
-  return Math.min(limit, ODOO_READ_LIMIT_CAP);
+  return usableLimit(limit) ?? undefined;
 }
 
 /**
@@ -2926,7 +2995,7 @@ const plugin = {
               },
               limit: {
                 type: "number",
-                description: "Max records (default: 100, capped at 500)",
+                description: `Max records (default: ${ODOO_READ_DEFAULT_LIMIT}, capped at ${ODOO_READ_LIMIT_CAP})`,
               },
               offset: {
                 type: "number",
@@ -3080,7 +3149,10 @@ const plugin = {
                 items: { type: "string" },
                 description: "Fields to group by, e.g. ['partner_id'] or ['date_order:month']",
               },
-              limit: { type: "number", description: "Max groups to return (capped at 500)" },
+              limit: {
+                type: "number",
+                description: `Max groups to return (capped at ${ODOO_READ_LIMIT_CAP})`,
+              },
               offset: {
                 type: "number",
                 description: "Skip N groups for pagination",


### PR DESCRIPTION
## Finding (2026-08-04 repo review, plugin pass)

- `odoo_read`'s `params.limit` reached `client.searchRead` unclamped: omitted forwarded `undefined` despite the tool description promising "default: 100", and an oversized value forwarded verbatim — a single call could request the entire table. `odoo_aggregate` had the same defect on `client.readGroup`.
- `resolveRelationValue`'s `res.country` path unconditionally fetched up to 1000 rows with an empty domain on every unresolved country value. It now builds a targeted domain: exact `code` match when the input resolved to a country code, otherwise ilike on name/display_name (the `code` field stays in the read).

## Tests
TDD red→green: clamp asserted via RPC mock (effective limit), default applied when omitted, aggregate clamp, code-domain and ilike-domain for country lookups. No tests deleted.

## Gates (run by the implementing agent before its session ended)
pnpm test:plugins (pinchy-odoo green), pnpm typecheck:plugins, pnpm format:check — all green; commit passed the pre-commit hooks.

Part of the 2026-08-04 repo-review fix series.