### PR TITLE
fix: cap title cache growth, bound chat RPC fan-out, deasync workspace delete

### DIFF
--- a/packages/web/src/__tests__/api/agent-chats-list.test.ts
+++ b/packages/web/src/__tests__/api/agent-chats-list.test.ts
@@ -118,9 +118,11 @@ describe("GET /api/agents/[agentId]/chats", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Fresh module per test so the route's process-local title cache (keyed by
-    // sessionId, 60s TTL) doesn't leak a derived title from one test into the
-    // next (several tests reuse the s-web-legacy sessionId).
+    // Fresh module graph per test so the process-local title cache (keyed by
+    // sessionId, 60s TTL — it lives in @/lib/chats/title-cache, which the
+    // dynamic import below re-evaluates along with the route) doesn't leak a
+    // derived title from one test into the next (several tests reuse the
+    // s-web-legacy sessionId).
     vi.resetModules();
     mockGetSession.mockResolvedValue({
       user: { id: "user-1", email: "user@test.com", role: "member" },

--- a/packages/web/src/__tests__/api/agent-chats-list.test.ts
+++ b/packages/web/src/__tests__/api/agent-chats-list.test.ts
@@ -301,4 +301,44 @@ describe("GET /api/agents/[agentId]/chats", () => {
       expect(legacy.title).toBeNull();
     });
   });
+
+  // ── Fix: bound the title-derivation RPC fan-out ───────────────────────────
+  //
+  // Every unlabeled web chat triggers a `sessions.history` RPC against
+  // OpenClaw. Before this fix, `Promise.all` fired all of them at once — 100
+  // unlabeled chats meant 100 simultaneous RPCs on a single dropdown open.
+  describe("bounded concurrency for the title-derivation history fan-out", () => {
+    it("never has more than 5 sessions.history calls in flight at once", async () => {
+      const N = 20;
+      mockList.mockResolvedValue({
+        sessions: Array.from({ length: N }, (_, i) => ({
+          key: `agent:agent-1:direct:user-1:chat-${i}`,
+          sessionId: `s-${i}`,
+          // no label → every one of these triggers deriveWebChatTitle
+          lastInteractionAt: i,
+        })),
+      });
+
+      let active = 0;
+      let maxActive = 0;
+      mockHistory.mockImplementation(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active--;
+        return { messages: [] };
+      });
+
+      const res = await GET(makeRequest(), ctx as never);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.chats).toHaveLength(N);
+
+      expect(mockHistory).toHaveBeenCalledTimes(N);
+      // Proves the fan-out is actually bounded...
+      expect(maxActive).toBeLessThanOrEqual(5);
+      // ...and not accidentally serialized down to one-at-a-time.
+      expect(maxActive).toBeGreaterThan(1);
+    });
+  });
 });

--- a/packages/web/src/__tests__/api/users.test.ts
+++ b/packages/web/src/__tests__/api/users.test.ts
@@ -655,6 +655,76 @@ describe("DELETE /api/users/[userId]", () => {
     expect(appendAuditLog).not.toHaveBeenCalled();
   });
 
+  // Regression for the event-loop-blocking finding: deleteWorkspace used to be
+  // a synchronous rmSync call made directly in the request handler, so a large
+  // (GB-sized knowledge-base) workspace froze the whole process — every other
+  // chat and WS heartbeat — until it finished. It must now be scheduled via
+  // after() (already used elsewhere in this file for the audit write) so it
+  // runs once the response is on its way, not inline in the request path.
+  it("schedules workspace deletion via after() rather than calling it synchronously in the request path", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "agent-1" }]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "user-1" }]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    // test-setup.ts mocks next/server's after() to run its callback
+    // immediately, so existing tests can assert deferred side effects without
+    // a real request lifecycle. That default would make this test unable to
+    // tell "called via after()" apart from "called synchronously in the
+    // handler body" — so for THIS test only, capture the callbacks instead of
+    // auto-running them, and restore the shared default afterwards.
+    const { after } = await import("next/server");
+    const runImmediately = vi.mocked(after).getMockImplementation();
+    const capturedCallbacks: Array<() => void | Promise<void>> = [];
+    vi.mocked(after).mockImplementation((task: Parameters<typeof after>[0]) => {
+      capturedCallbacks.push(task as () => void | Promise<void>);
+    });
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1", {
+      method: "DELETE",
+    });
+
+    let response: Awaited<ReturnType<typeof DELETE>>;
+    try {
+      response = await DELETE(request, {
+        params: Promise.resolve({ userId: "user-1" }),
+      });
+
+      // The response resolved without deleteWorkspace having run at all — it
+      // only exists inside a captured (not-yet-run) after() callback.
+      expect(deleteWorkspace).not.toHaveBeenCalled();
+
+      // Running the captured callbacks is what next/server does once the
+      // response has actually been sent — this is what triggers cleanup.
+      for (const cb of capturedCallbacks) {
+        await cb();
+      }
+    } finally {
+      if (runImmediately) vi.mocked(after).mockImplementation(runImmediately);
+    }
+
+    expect(response.status).toBe(200);
+    expect(deleteWorkspace).toHaveBeenCalledWith("agent-1");
+  });
+
   it("calls regenerateOpenClawConfig after deletion", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "admin-1", role: "admin" },

--- a/packages/web/src/__tests__/api/users.test.ts
+++ b/packages/web/src/__tests__/api/users.test.ts
@@ -725,6 +725,80 @@ describe("DELETE /api/users/[userId]", () => {
     expect(deleteWorkspace).toHaveBeenCalledWith("agent-1");
   });
 
+  // The after() callback must RETURN the deletion promise, not fire-and-forget
+  // it. after() awaits what its callback returns — that costs nothing (the
+  // response is already on its way) and buys two things a discarded promise
+  // loses: Next keeps the request lifecycle open until cleanup finishes, so a
+  // graceful shutdown mid-request doesn't silently orphan a GB-sized
+  // workspace directory (nothing in the repo sweeps for orphans); and a
+  // rejection reaches Next's error handler instead of surfacing as an
+  // unhandled rejection, which Node 22 answers by killing the process.
+  it("returns the deletion promise from the after() callback instead of discarding it", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "agent-1" }]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "user-1" }]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    // A deletion that is still in flight — the whole question is whether the
+    // callback's own promise stays pending alongside it.
+    let finishDeletion!: () => void;
+    vi.mocked(deleteWorkspace).mockImplementationOnce(
+      () => new Promise<void>((resolve) => (finishDeletion = resolve))
+    );
+
+    const { after } = await import("next/server");
+    const runImmediately = vi.mocked(after).getMockImplementation();
+    const capturedCallbacks: Array<() => void | Promise<void>> = [];
+    vi.mocked(after).mockImplementation((task: Parameters<typeof after>[0]) => {
+      capturedCallbacks.push(task as () => void | Promise<void>);
+    });
+
+    try {
+      const response = await DELETE(
+        new NextRequest("http://localhost:7777/api/users/user-1", { method: "DELETE" }),
+        { params: Promise.resolve({ userId: "user-1" }) }
+      );
+      expect(response.status).toBe(200);
+
+      // The audit callback is scheduled first; the workspace one is last.
+      const workspaceCallback = capturedCallbacks[capturedCallbacks.length - 1];
+      let settled = false;
+      const pending = Promise.resolve(workspaceCallback()).then(() => {
+        settled = true;
+      });
+
+      // Drain the microtask queue. A callback that discarded the promise has
+      // already resolved to undefined by now, even though the rm() behind it
+      // has not finished.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      expect(settled).toBe(false);
+
+      finishDeletion();
+      await pending;
+      expect(settled).toBe(true);
+    } finally {
+      if (runImmediately) vi.mocked(after).mockImplementation(runImmediately);
+    }
+  });
+
   it("calls regenerateOpenClawConfig after deletion", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "admin-1", role: "admin" },

--- a/packages/web/src/__tests__/lib/concurrency.test.ts
+++ b/packages/web/src/__tests__/lib/concurrency.test.ts
@@ -49,4 +49,21 @@ describe("runWithConcurrency", () => {
     const results = await runWithConcurrency([], 5);
     expect(results).toEqual([]);
   });
+
+  // A worker pool sized `Math.min(concurrency, tasks.length)` spawns zero
+  // workers for a non-positive limit, so every task is skipped and the caller
+  // gets back a sparse array of undefined — silent data loss rather than an
+  // error. Today's call sites pass constants, but this is a shared helper now.
+  it.each([0, -1])("still runs every task when the limit is %i", async (limit) => {
+    const calls: number[] = [];
+    const tasks = [0, 1, 2].map((i) => async () => {
+      calls.push(i);
+      return i;
+    });
+
+    const results = await runWithConcurrency(tasks, limit);
+
+    expect(calls).toHaveLength(3);
+    expect(results).toEqual([0, 1, 2]);
+  });
 });

--- a/packages/web/src/__tests__/lib/concurrency.test.ts
+++ b/packages/web/src/__tests__/lib/concurrency.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { runWithConcurrency } from "@/lib/concurrency";
+
+describe("runWithConcurrency", () => {
+  it("never runs more than the given concurrency limit at once", async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    const tasks = Array.from({ length: 20 }, (_, i) => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      // Yield without a real timer so every task gets a chance to overlap if
+      // the limiter isn't actually bounding concurrency.
+      await Promise.resolve();
+      await Promise.resolve();
+      active--;
+      return i;
+    });
+
+    await runWithConcurrency(tasks, 5);
+
+    expect(maxActive).toBeLessThanOrEqual(5);
+  });
+
+  it("preserves result order regardless of completion order", async () => {
+    const tasks = [3, 1, 2].map(
+      (delay, i) => () => new Promise<number>((resolve) => setTimeout(() => resolve(i), delay))
+    );
+
+    const results = await runWithConcurrency(tasks, 3);
+
+    expect(results).toEqual([0, 1, 2]);
+  });
+
+  it("runs every task even when concurrency exceeds the task count", async () => {
+    const calls: number[] = [];
+    const tasks = [0, 1, 2].map((i) => async () => {
+      calls.push(i);
+      return i;
+    });
+
+    const results = await runWithConcurrency(tasks, 10);
+
+    expect(calls.sort()).toEqual([0, 1, 2]);
+    expect(results).toEqual([0, 1, 2]);
+  });
+
+  it("resolves to an empty array for an empty task list", async () => {
+    const results = await runWithConcurrency([], 5);
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/web/src/app/api/agents/[agentId]/chats/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/chats/route.ts
@@ -4,6 +4,8 @@ import { getAgentWithAccess } from "@/lib/agent-access";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { listUserAgentChats } from "@/lib/chats/list-user-agent-chats";
 import { firstUserMessageTitle } from "@/lib/chats/first-user-message-title";
+import { getCachedChatTitle, setCachedChatTitle } from "@/lib/chats/title-cache";
+import { runWithConcurrency } from "@/lib/concurrency";
 import type { RawHistoryMessage } from "@/lib/chats/telegram-transcript";
 import type { ChatListItem } from "@/lib/schemas/sessions";
 
@@ -14,25 +16,20 @@ type RouteContext = { params: Promise<{ agentId: string }> };
 // pull a small window that reliably contains the opening turn of short chats.
 const TITLE_HISTORY_LIMIT = 30;
 
-/**
- * Short-lived, process-local cache of derived titles, keyed by sessionId. The
- * dropdown re-fetches on every open, and a chat's first user message never
- * changes, so a brief TTL spares us re-reading the same transcripts on rapid
- * re-opens. Best-effort: it's fine for entries to be evicted or for the process
- * to restart cold.
- */
-const TITLE_CACHE_TTL_MS = 60_000;
-const titleCache = new Map<string, { title: string | null; at: number }>();
+// Every unlabeled web chat needs one `sessions.history` RPC against OpenClaw
+// to derive its title. Bounding how many run at once keeps a dropdown open
+// on an agent with 100+ unlabeled chats from firing 100+ simultaneous RPCs.
+const TITLE_FETCH_CONCURRENCY = 5;
 
 /**
  * Derive a labelless web chat's title from its first user message, with a brief
- * cache. Returns `null` (the date-fallback signal) when the chat has no usable
- * user message or its history can't be read — a title is a convenience, never a
- * reason to fail the whole list.
+ * cache (see `@/lib/chats/title-cache`). Returns `null` (the date-fallback
+ * signal) when the chat has no usable user message or its history can't be
+ * read — a title is a convenience, never a reason to fail the whole list.
  */
 async function deriveWebChatTitle(sessionKey: string, sessionId: string): Promise<string | null> {
-  const cached = titleCache.get(sessionId);
-  if (cached && Date.now() - cached.at < TITLE_CACHE_TTL_MS) return cached.title;
+  const cached = getCachedChatTitle(sessionId);
+  if (cached !== undefined) return cached;
 
   let title: string | null = null;
   try {
@@ -45,7 +42,7 @@ async function deriveWebChatTitle(sessionKey: string, sessionId: string): Promis
     title = null;
   }
 
-  titleCache.set(sessionId, { title, at: Date.now() });
+  setCachedChatTitle(sessionId, title);
   return title;
 }
 
@@ -81,10 +78,12 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
   // Title precedence: the saved session label wins; otherwise, for the user's
   // OWN web chats, derive it from the first user message. Telegram chats keep
   // their label/null (their transcript has a dedicated endpoint), and labelled
-  // chats never trigger a history read.
+  // chats never trigger a history read. Bounded fan-out (see
+  // TITLE_FETCH_CONCURRENCY above) — a plain Promise.all would fire one RPC
+  // per unlabeled chat all at once.
   const chats: ChatListItem[] = (
-    await Promise.all(
-      classified.map(async (c) => {
+    await runWithConcurrency(
+      classified.map((c) => async () => {
         const label = labelByKey.get(c.key) ?? null;
         let title = label;
         if (!title && c.origin === "web") {
@@ -98,7 +97,8 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
           title,
           lastInteractionAt: c.lastInteractionAt,
         };
-      })
+      }),
+      TITLE_FETCH_CONCURRENCY
     )
   ).sort((a, b) => b.lastInteractionAt - a.lastInteractionAt);
 

--- a/packages/web/src/app/api/users/[userId]/route.ts
+++ b/packages/web/src/app/api/users/[userId]/route.ts
@@ -98,7 +98,7 @@ export async function DELETE(
   // statements, a failure partway through (e.g. the session delete) would
   // leave the user already banned with sessions and agents untouched, or vice
   // versa — an inconsistent, partially-deactivated account. The filesystem
-  // workspace cleanup below stays OUTSIDE the transaction on purpose: rmSync
+  // workspace cleanup below stays OUTSIDE the transaction on purpose: an rm()
   // has no place in a DB rollback.
   const deactivated = await db.transaction(async (tx) => {
     const [row] = await tx
@@ -154,9 +154,19 @@ export async function DELETE(
 
   // Cleanup workspaces (filesystem, not DB — deliberately outside the
   // transaction above).
-  for (const agent of personalAgents) {
-    deleteWorkspace(agent.id); // synchronous (uses rmSync)
-  }
+  //
+  // A personal agent's workspace (KB corpora especially) can be GB-sized.
+  // deleteWorkspace() itself now uses fs.promises.rm rather than rmSync, so it
+  // no longer blocks the Node event loop while it walks the directory — but
+  // awaiting it here would still hold this response open for however long
+  // that takes. The ban and soft-delete above already committed, so the
+  // user's deactivation is complete and auditable regardless of how long
+  // cleanup takes. deleteWorkspace() is idempotent (rm with force: true) and
+  // logs its own failures rather than throwing, so scheduling it via after()
+  // and not waiting on the result is safe.
+  after(() => {
+    void Promise.all(personalAgents.map((agent) => deleteWorkspace(agent.id)));
+  });
 
   await regenerateOpenClawConfig();
   await recalculateTelegramAllowStores();

--- a/packages/web/src/app/api/users/[userId]/route.ts
+++ b/packages/web/src/app/api/users/[userId]/route.ts
@@ -161,12 +161,22 @@ export async function DELETE(
   // awaiting it here would still hold this response open for however long
   // that takes. The ban and soft-delete above already committed, so the
   // user's deactivation is complete and auditable regardless of how long
-  // cleanup takes. deleteWorkspace() is idempotent (rm with force: true) and
-  // logs its own failures rather than throwing, so scheduling it via after()
-  // and not waiting on the result is safe.
-  after(() => {
-    void Promise.all(personalAgents.map((agent) => deleteWorkspace(agent.id)));
-  });
+  // cleanup takes.
+  //
+  // RETURN the promise rather than discarding it: after() awaits what its
+  // callback returns, which costs nothing here (the response is already on
+  // its way) and is what keeps the request lifecycle open until cleanup
+  // finishes. A discarded promise also puts any rejection outside anyone's
+  // reach — deleteWorkspace() swallows rm() failures, but its agent-id
+  // validation throws before that catch, and Node answers an unhandled
+  // rejection by killing the process.
+  //
+  // Residual risk, stated rather than papered over: this is best-effort. A
+  // hard crash between the response and the rm() completing leaves the
+  // directory on disk, and nothing sweeps for orphaned workspaces. That costs
+  // disk, never correctness — deleteWorkspace() is idempotent (force: true)
+  // and logs its own failures.
+  after(() => Promise.all(personalAgents.map((agent) => deleteWorkspace(agent.id))));
 
   await regenerateOpenClawConfig();
   await recalculateTelegramAllowStores();

--- a/packages/web/src/lib/agents.ts
+++ b/packages/web/src/lib/agents.ts
@@ -136,7 +136,10 @@ export async function deleteAgent(id: string, onDeleted?: OnAgentDeleted) {
   if (updated) {
     // Committed, and everything below can throw. Record it now.
     onDeleted?.(updated);
-    deleteWorkspace(id);
+    // deleteWorkspace() is async (fs.promises.rm, not rmSync) so this await
+    // yields to the event loop rather than blocking it, but the ordering
+    // relative to the rest of this cleanup tail is unchanged.
+    await deleteWorkspace(id);
     // Remove the agent's integration grants at the DB level so they can't be
     // re-emitted into the runtime config (the Odoo/email permission loops key
     // off agentConnectionPermissions, not agents.deletedAt).

--- a/packages/web/src/lib/chats/__tests__/title-cache.test.ts
+++ b/packages/web/src/lib/chats/__tests__/title-cache.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  getCachedChatTitle,
+  setCachedChatTitle,
+  getTitleCacheSizeForTest,
+  resetTitleCacheForTest,
+} from "@/lib/chats/title-cache";
+
+describe("title cache", () => {
+  beforeEach(() => {
+    resetTitleCacheForTest();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns undefined for a session that was never cached", () => {
+    expect(getCachedChatTitle("never-seen")).toBeUndefined();
+  });
+
+  it("returns the cached title (including a cached null) on a fresh entry", () => {
+    setCachedChatTitle("session-1", "Hello there");
+    expect(getCachedChatTitle("session-1")).toBe("Hello there");
+
+    setCachedChatTitle("session-2", null);
+    expect(getCachedChatTitle("session-2")).toBeNull();
+  });
+
+  it("expires an entry past the TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    setCachedChatTitle("session-1", "Hello there");
+    expect(getCachedChatTitle("session-1")).toBe("Hello there");
+
+    vi.setSystemTime(60_001);
+    expect(getCachedChatTitle("session-1")).toBeUndefined();
+  });
+
+  // Regression for the unbounded-growth finding: the TTL above was only ever
+  // checked on read, never evicted on its own, so a long-lived process reading
+  // an ever-growing set of distinct sessionIds accumulated an entry per
+  // sessionId forever, expired or not.
+  it("evicts the oldest entry once the cache exceeds its size cap", () => {
+    const CAP = 500;
+
+    for (let i = 0; i < CAP; i++) {
+      setCachedChatTitle(`session-${i}`, `title-${i}`);
+    }
+    expect(getTitleCacheSizeForTest()).toBe(CAP);
+
+    // One more insert must evict, not grow past the cap.
+    setCachedChatTitle("session-overflow", "title-overflow");
+    expect(getTitleCacheSizeForTest()).toBe(CAP);
+
+    // The oldest entry (session-0) is the one that got evicted.
+    expect(getCachedChatTitle("session-0")).toBeUndefined();
+    // The newest entries, including the one that triggered eviction, survive.
+    expect(getCachedChatTitle("session-overflow")).toBe("title-overflow");
+    expect(getCachedChatTitle(`session-${CAP - 1}`)).toBe(`title-${CAP - 1}`);
+  });
+
+  it("never grows past the cap across many more inserts than the cap", () => {
+    for (let i = 0; i < 2000; i++) {
+      setCachedChatTitle(`session-${i}`, `title-${i}`);
+    }
+    expect(getTitleCacheSizeForTest()).toBeLessThanOrEqual(500);
+  });
+});

--- a/packages/web/src/lib/chats/title-cache.ts
+++ b/packages/web/src/lib/chats/title-cache.ts
@@ -1,0 +1,64 @@
+/**
+ * Module-private, process-local cache of derived chat titles, keyed by
+ * sessionId, used by GET /api/agents/[agentId]/chats.
+ *
+ * Lives outside the route file on purpose: Next.js App Router route modules
+ * may only export HTTP method handlers and well-known config symbols (same
+ * reason `usage-record-rate-limiter.ts` keeps its limiter out of its route
+ * file). Keeping the cache here also lets tests drive eviction
+ * deterministically instead of poking at a module-private Map through the
+ * route's exported GET handler alone.
+ *
+ * Bounded two ways:
+ *  - TTL: a chat's first user message never changes, so a short TTL just
+ *    spares re-reading the same transcript on rapid re-opens (dropdown
+ *    re-fetches on every open).
+ *  - Max entry count: the TTL above is only checked on READ, never evicted
+ *    on its own, so without a cap this Map grew by one entry per distinct
+ *    sessionId ever looked up, for the lifetime of the process — a slow,
+ *    unbounded memory leak. Eviction is FIFO by insertion order: `Map`
+ *    preserves insertion order, and re-`set`-ting an EXISTING key does not
+ *    move it, so the oldest entry is always `titleCache.keys().next().value`.
+ *    That is good enough here — this is a size safety valve, not an LRU cache
+ *    tuned for hit rate, so a real LRU library would solve a problem this
+ *    cache doesn't have.
+ */
+
+const TITLE_CACHE_TTL_MS = 60_000;
+const TITLE_CACHE_MAX_ENTRIES = 500;
+
+interface TitleCacheEntry {
+  title: string | null;
+  at: number;
+}
+
+const titleCache = new Map<string, TitleCacheEntry>();
+
+/**
+ * Returns the cached title, or `undefined` if there is no entry or it's past
+ * its TTL (the caller re-derives the title in that case).
+ */
+export function getCachedChatTitle(sessionId: string): string | null | undefined {
+  const cached = titleCache.get(sessionId);
+  if (!cached || Date.now() - cached.at >= TITLE_CACHE_TTL_MS) return undefined;
+  return cached.title;
+}
+
+/** Caches a derived title, evicting the oldest entry once over the cap. */
+export function setCachedChatTitle(sessionId: string, title: string | null): void {
+  titleCache.set(sessionId, { title, at: Date.now() });
+  if (titleCache.size > TITLE_CACHE_MAX_ENTRIES) {
+    const oldestKey = titleCache.keys().next().value;
+    if (oldestKey !== undefined) titleCache.delete(oldestKey);
+  }
+}
+
+/** Test-only: current entry count, to assert the eviction cap holds. */
+export function getTitleCacheSizeForTest(): number {
+  return titleCache.size;
+}
+
+/** Test-only: clears the cache so tests don't leak state into each other. */
+export function resetTitleCacheForTest(): void {
+  titleCache.clear();
+}

--- a/packages/web/src/lib/concurrency.ts
+++ b/packages/web/src/lib/concurrency.ts
@@ -11,6 +11,11 @@
  * same "bounded concurrent fan-out" shape, and letting the OpenClaw or Odoo
  * side of either one hang no longer costs the request 100+ simultaneous
  * in-flight RPCs.
+ *
+ * A non-positive `concurrency` is clamped to 1 rather than honoured: the pool
+ * size is `min(concurrency, tasks.length)`, so a 0 would spawn no workers at
+ * all and return a sparse array of `undefined` with nothing having run —
+ * silent data loss where the caller asked for slow.
  */
 export async function runWithConcurrency<T>(
   tasks: (() => Promise<T>)[],
@@ -26,6 +31,7 @@ export async function runWithConcurrency<T>(
     }
   }
 
-  await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, () => worker()));
+  const workerCount = Math.min(Math.max(1, concurrency), tasks.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
   return results;
 }

--- a/packages/web/src/lib/concurrency.ts
+++ b/packages/web/src/lib/concurrency.ts
@@ -1,0 +1,31 @@
+/**
+ * Runs `tasks` with at most `concurrency` in flight at a time, preserving
+ * result order. A worker pool of `min(concurrency, tasks.length)` workers
+ * each pull the next unclaimed index and await it before pulling another, so
+ * task N+1 never starts before some earlier task has finished (unlike a bare
+ * `Promise.all`, which starts everything at once).
+ *
+ * Shared rather than duplicated per call site: the fan-out over N chats in
+ * GET /api/agents/[agentId]/chats (one `sessions.history` RPC per unlabeled
+ * chat) and the fan-out over Odoo model probes in `fetchOdooSchema` are the
+ * same "bounded concurrent fan-out" shape, and letting the OpenClaw or Odoo
+ * side of either one hang no longer costs the request 100+ simultaneous
+ * in-flight RPCs.
+ */
+export async function runWithConcurrency<T>(
+  tasks: (() => Promise<T>)[],
+  concurrency: number
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex++;
+      results[index] = await tasks[index]();
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, () => worker()));
+  return results;
+}

--- a/packages/web/src/lib/integrations/odoo-sync.ts
+++ b/packages/web/src/lib/integrations/odoo-sync.ts
@@ -1,4 +1,5 @@
 import { OdooClient } from "odoo-node";
+import { runWithConcurrency } from "@/lib/concurrency";
 
 /**
  * Curated list of common Odoo models organized by category.
@@ -301,25 +302,6 @@ function isTransientOdooProbeError(error: unknown): boolean {
     msg.includes("gateway timeout") ||
     msg.includes("temporarily unavailable")
   );
-}
-
-/** Run async tasks with limited concurrency. */
-async function runWithConcurrency<T>(
-  tasks: (() => Promise<T>)[],
-  concurrency: number
-): Promise<T[]> {
-  const results: T[] = new Array(tasks.length);
-  let nextIndex = 0;
-
-  async function worker() {
-    while (nextIndex < tasks.length) {
-      const index = nextIndex++;
-      results[index] = await tasks[index]();
-    }
-  }
-
-  await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, () => worker()));
-  return results;
 }
 
 /**

--- a/packages/web/src/lib/workspace.ts
+++ b/packages/web/src/lib/workspace.ts
@@ -1,4 +1,5 @@
 import { writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, renameSync } from "fs";
+import { rm } from "fs/promises";
 import { join, dirname, basename } from "path";
 
 // =============================================================================
@@ -203,13 +204,33 @@ export function ensureWorkspace(agentId: string): void {
   }
 }
 
-export function deleteWorkspace(agentId: string): void {
+/**
+ * Recursively removes an agent's workspace. Uses `fs.promises.rm` rather than
+ * `rmSync` — a knowledge-base agent's workspace can be GB-sized, and the sync
+ * form blocks the whole Node event loop (every other request, every WS
+ * heartbeat) for as long as the recursive delete takes. The promise form
+ * still runs the actual directory walk off the JS thread via libuv's thread
+ * pool, but callers that need the response to go out before cleanup finishes
+ * should schedule this rather than await it (see the `after()` use in
+ * DELETE /api/users/[userId]).
+ */
+export async function deleteWorkspace(agentId: string): Promise<void> {
   assertValidAgentId(agentId);
   const workspacePath = getWorkspacePath(agentId);
   try {
-    rmSync(workspacePath, { recursive: true, force: true });
-  } catch {
-    // Workspace may not exist, that's fine
+    await rm(workspacePath, { recursive: true, force: true });
+  } catch (err) {
+    // `force: true` already no-ops a missing workspace, so reaching this
+    // catch means something else went wrong (permissions, disk error) —
+    // worth a structured log rather than a silent swallow.
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "workspace_delete_failed",
+        agentId,
+        error: { message: err instanceof Error ? err.message : String(err) },
+      })
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Three P3 event-loop/memory hardening fixes, no user-visible behavior change:

- **Unbounded title cache** (`GET /api/agents/[agentId]/chats`): the process-local `titleCache` only checked its TTL on read and was never evicted, so it grew by one entry per distinct `sessionId` ever looked up for the life of the process — a slow, unbounded memory leak. Extracted into `packages/web/src/lib/chats/title-cache.ts` (Next.js App Router route modules may only export HTTP handlers, matching the existing `usage-record-rate-limiter.ts` pattern) with a 500-entry FIFO cap, evicted on write.
- **Unbounded RPC fan-out** (same route): the `Promise.all` over unlabeled chats fired one `sessions.history` RPC per chat with no limit — 100 unlabeled chats meant 100 simultaneous RPCs against OpenClaw on a single dropdown open. Bounded to 5 concurrent via a new shared `runWithConcurrency()` helper (`packages/web/src/lib/concurrency.ts`).
- **Synchronous `rmSync` in the request path** (`DELETE /api/users/[userId]`): `deleteWorkspace()` called `rmSync` directly in the request handler. A GB-sized knowledge-base workspace blocked the entire Node event loop — every other chat, every WS heartbeat — until the recursive delete finished. `deleteWorkspace()` (`packages/web/src/lib/workspace.ts`) now uses `fs.promises.rm`, and the route schedules it via `after()` (already used in this file for the audit write) instead of awaiting it inline. `deleteAgent()` in `lib/agents.ts` — the only other caller — keeps awaiting it in place; its ordering contract is unaffected, it just no longer blocks the event loop while doing so.

## Test plan

- [x] `pnpm test:related` — 155 files, 2274 passed, 1 skipped (pre-existing)
- [x] `pnpm test` (full suite) — 776 files passed / 4 skipped, 10928 tests passed / 18 skipped (pre-existing)
- [x] `pnpm -C packages/web lint` — 0 errors (983 pre-existing warnings, unrelated files)
- [x] `pnpm -C packages/web typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm build` (via pre-push hook) — succeeded

New/changed tests (red→green, see report):
- `packages/web/src/lib/chats/__tests__/title-cache.test.ts` — TTL + FIFO eviction cap
- `packages/web/src/__tests__/lib/concurrency.test.ts` — `runWithConcurrency` bounding, ordering, empty-list
- `packages/web/src/__tests__/api/agent-chats-list.test.ts` — new: "never has more than 5 sessions.history calls in flight at once"
- `packages/web/src/__tests__/api/users.test.ts` — new: "schedules workspace deletion via after() rather than calling it synchronously in the request path"

Docs-not-needed: internal memory/event-loop hardening, no reader-facing change