### PR TITLE
refactor(web): route every mutating client fetch through the typed api-client (#1075)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -566,9 +566,32 @@ Checklist for state-changing routes:
 
 For state-changing API routes, define request schemas in `packages/web/src/lib/schemas/<feature>.ts` and import them from BOTH the route handler (for `parseRequestBody`) and the client component (for typed request bodies via `z.infer`).
 
-Use the typed helpers in `packages/web/src/lib/api-client.ts` (`apiPost`, `apiPatch`, `apiPut`, `apiDelete`, `apiGet`) instead of raw `fetch` in client components. They throw `ApiError` on non-2xx responses, which components catch and surface via `toast.error(e.message)`.
+Use the typed helpers in `packages/web/src/lib/api-client.ts` (`apiPost`, `apiPatch`, `apiPut`, `apiDelete`, `apiGet`) instead of raw `fetch` in client components. They throw `ApiError` on non-2xx responses, which components catch and surface via `toast.error(errorMessage(e, "<fallback>"))`.
 
 This makes contract drift between client payload and server schema a compile-time error rather than a runtime 400.
+
+### The promise had no guard, so it was half-kept
+
+That paragraph sat here while the tree drifted the other way: the 2026-08-04 review (#1075) counted **43 mutating raw fetches across 19 files** against 23 files that had adopted the helper — three of them using both side by side. `JSON.stringify(anything)` type-checks, so nothing was ever red.
+
+What it cost is not only the missing type. `send()` reads the route's error contract and raises an `ApiError` carrying the server's own wording; a hand-rolled `if (!res.ok)` almost always threw that away. `settings-users.tsx` showed "Failed to revoke invite. Please try again." while the route was answering "Invite not found" — the admin could not tell a stale list from an outage. And the contract itself was read wrong: several routes answer `{ error: "<headline>", message: "<what to do about it>" }` (users/invite's seat cap, groups membership's licence gate), and `api-client` read only `error`, dropping the actionable half. It now joins the two.
+
+`pinchy/no-raw-fetch-mutation` (`packages/web/eslint-rules/`, unit tests in `src/__tests__/eslint/`) is the guard. It reports `fetch(url, { method: "POST" | "PUT" | "PATCH" | "DELETE" })` under `src/components/**`, `src/hooks/**` and `src/app/**/*.tsx`.
+
+- **The exemption is per statement, not per file**: `// raw-fetch-exempt: <reason>` in the comment block directly above the call, with no code in between. A file-wide marker is exactly the blind spot #1060 closed in `require-audit-log` — one legitimate raw fetch would clear every other one in the same file.
+- **It takes a written reason, not an issue number.** A skip _defers_ work and needs somewhere for the work to live; "this call cannot use the helper" _asserts a fact_ (a multipart upload, a streamed response, a raw `Response` you need). The assertion is the artefact. Same reasoning as the `Docs-not-needed:` trailer.
+- **Two limits, so nobody reads the green check as more than it is.** The rule matches a **string-literal** method — `fetch(url, { method: verb })` is not reported, because reporting it would mean guessing whether `verb` is `"GET"`. And it says nothing about GET, where a streamed or aborted read is legitimate. Writing the indirection to dodge the rule is a deliberate act, and review owns that case.
+- **`ApiError.body` carries the whole parsed error payload**, for the routes that answer a field beyond `{ error, message, details }` (`/api/setup/provider` returns a `docs` link with its 400). Without it, such a caller would drop back to a raw `fetch` and hand-roll the contract again — which is the drift this module exists to stop.
+- **Prefer `errorMessage(e, "<fallback>")` over a bare `e.message` in a catch.** `ApiError.message` falls back to a deliberately generic sentence when the route sent no wording at all, and a component almost always knows something more useful. Two files had already grown a private copy of this helper before it was extracted.
+
+One consequence worth knowing before the next migration: typing a payload against the route's schema surfaces drift that was previously invisible. This one turned up four cases — `visibility` and `role` typed as bare `string` on their way into an enum column, an untyped `Record<string, unknown>` patch body, and a `templateId` that could be `null` at the call site. Narrow the source (the DB `CHECK` constraints in `db/enums.ts` are the evidence) rather than casting at the boundary.
+
+Test fetch mocks go through `jsonResponse(body, { status })` in `packages/web/src/test-helpers/fetch.ts`. `send()` reads the body with `res.text()`, which a hand-rolled `{ ok: true, json: async () => x } as Response` does not have — and the failure is a rejected promise deep inside the helper rather than an assertion naming the missing method.
+
+Two smaller rules the first review of this change turned up, both of which every gate was green on:
+
+- **A catch that surfaces text to the user takes `errorMessage(e, "<fallback>")`, never `e.message`.** Migrating a call site changes what its catch can _see_: before, the handler threw its own `new Error(<curated copy>)`, so `e.message` was always copy; afterwards the same catch also receives a network `TypeError`, whose message is `"Failed to fetch"`. `setup-form.tsx` shipped that string onto the first screen a new install shows. `errorMessage` is unit-tested directly (`__tests__/lib/api-client.test.ts`) rather than only through its callers.
+- **Typing a payload is not licence to invent a value for it.** `uid: connectionResult?.uid ?? 0` type-checks and can only ever produce a 400, because the route requires `.positive()` — a 400 that reads as a credential problem. Guard, or narrow the source; `??` at the call site is the boundary cast this section exists to remove.
 
 ## Error And Notification UI
 

--- a/packages/web/eslint-rules/no-raw-fetch-mutation.js
+++ b/packages/web/eslint-rules/no-raw-fetch-mutation.js
@@ -1,0 +1,189 @@
+// ESLint rule: forbid raw `fetch(url, { method: "POST" | "PUT" | "PATCH" |
+// "DELETE" })` in client components, hooks and client pages. Mutating calls go
+// through the typed helpers in `@/lib/api-client` (`apiPost`, `apiPut`,
+// `apiPatch`, `apiDelete`).
+//
+// Why: AGENTS.md § "Shared Schemas And Typed Client" promises that a drift
+// between the client's payload and the route's Zod schema is a compile-time
+// error rather than a runtime 400 — a promise a raw `fetch` cannot keep,
+// because `JSON.stringify(anything)` type-checks. The 2026-08-04 repo review
+// (#1075) counted 43 mutating raw fetches across 19 files against 23 files
+// that had adopted the helper, three of which used both side by side. (The
+// issue's own estimate was 37; the count above is the verified one.)
+//
+// The cost is not only the missing type. `send()` in api-client.ts reads the
+// route's error contract (`{ error, message, details }`) and raises an
+// `ApiError` carrying the server's own wording; a hand-rolled `if (!res.ok)`
+// almost always throws that wording away. `settings-users.tsx` showed a
+// generic "Something went wrong" toast while the route was answering
+// "Invite not found" — the user could not tell a stale list from an outage.
+//
+// Scope: `src/components/**`, `src/hooks/**` and `src/app/**/*.tsx`. Server
+// code is deliberately out — `src/lib/**`, `src/server/**` and the route
+// handlers under `src/app/api/**/route.ts` reach real third-party endpoints
+// where there is no api-client to reach for. Note that this is a path scope,
+// not a "runs in the browser" scope: a Server Component under src/app that
+// calls a third-party API needs the exemption comment, and its reason is a
+// true statement rather than a dodge.
+//
+// Two limits, stated plainly rather than papered over:
+//
+//   - The rule reads a STRING LITERAL method. `fetch(url, { method: verb })`
+//     is not reported, because reporting it would mean guessing: the rule
+//     cannot see whether `verb` is "GET". No call site in the tree does this
+//     today. Writing the indirection to dodge the rule is a deliberate act,
+//     and review owns that case — the same limit no-untracked-sleeps states
+//     about the `setTimeout` spelling of a sleep.
+//   - It says nothing about GET. `apiGet` exists and is preferable, but a GET
+//     that streams, reads headers, or is aborted via a signal is legitimate,
+//     and this rule is about the error-contract drift that only mutations
+//     produce.
+//
+// The exemption is `// raw-fetch-exempt: <reason>` in the comment block
+// directly above the call's own statement, with no code in between — narrow
+// like no-untracked-sleeps rather than file-wide like `// audit-exempt:`,
+// because a file-wide marker is exactly the blind spot #1060 closed in
+// require-audit-log: one legitimate raw fetch would silently clear every other
+// one in the same file.
+//
+// It takes a written REASON, not an issue number, and that difference from the
+// skip policy is deliberate: a skip DEFERS work and so needs somewhere for the
+// work to live, while "this call cannot use the helper" ASSERTS a fact —
+// a multipart upload, a streamed response, a call that needs the raw
+// `Response`. The useful artefact is the assertion itself, sitting next to the
+// call it describes. Same reasoning as the `Docs-not-needed:` trailer.
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+const HELPER_FOR_METHOD = {
+  POST: "apiPost",
+  PUT: "apiPut",
+  PATCH: "apiPatch",
+  DELETE: "apiDelete",
+};
+
+// `// raw-fetch-exempt:` followed by at least one word character — a bare
+// marker asserts nothing and is not an exemption.
+const EXEMPTION_RE = /raw-fetch-exempt:\s*\S/;
+
+/**
+ * Client-side surfaces only. Route handlers live under src/app too but are
+ * server code, so `.tsx` is what separates a page from a handler there.
+ */
+function isInScope(filename) {
+  const path = filename.replace(/\\/g, "/");
+  if (path.includes("/src/__tests__/")) return false;
+  if (path.includes("/src/components/") || path.includes("/src/hooks/")) {
+    return /\.(ts|tsx)$/.test(path);
+  }
+  if (path.includes("/src/app/")) return path.endsWith(".tsx");
+  return false;
+}
+
+/** Unwrap `"POST" as const` / `"POST" satisfies string` down to the literal. */
+function unwrapTypeAssertions(node) {
+  let current = node;
+  while (
+    current &&
+    (current.type === "TSAsExpression" ||
+      current.type === "TSSatisfiesExpression" ||
+      current.type === "TSNonNullExpression" ||
+      current.type === "TSTypeAssertion")
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** The method as written, or null when it is not a plain string. */
+function staticMethodValue(node) {
+  const value = unwrapTypeAssertions(node);
+  if (!value) return null;
+  if (value.type === "Literal" && typeof value.value === "string") return value.value;
+  if (value.type === "TemplateLiteral" && value.expressions.length === 0) {
+    return value.quasis.map((q) => q.value.cooked ?? "").join("");
+  }
+  return null;
+}
+
+function isFetchCallee(callee) {
+  if (callee.type === "Identifier") return callee.name === "fetch";
+  return (
+    callee.type === "MemberExpression" &&
+    !callee.computed &&
+    callee.property.type === "Identifier" &&
+    callee.property.name === "fetch" &&
+    callee.object.type === "Identifier" &&
+    (callee.object.name === "window" || callee.object.name === "globalThis")
+  );
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid raw mutating fetch() in client components, hooks and pages — use the typed helpers in @/lib/api-client",
+    },
+    messages: {
+      rawFetchMutation:
+        'Do not call `fetch(url, { method: "{{method}}" })` here. Use `{{helper}}` from `@/lib/api-client`: it types the request body against the route\'s shared schema (so payload drift is a compile error, not a runtime 400) and raises an `ApiError` carrying the server\'s own message instead of a generic toast. If this call genuinely cannot use the helper — a multipart upload, a streamed response, a raw `Response` you need — put `// raw-fetch-exempt: <reason>` directly above the statement. See AGENTS.md § "Shared Schemas And Typed Client".',
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    if (!isInScope(filename)) return {};
+
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    /**
+     * The comments attached directly above the call's own statement — i.e.
+     * everything between the previous token and this one. Any code in between
+     * ends the block, which is what keeps one legitimate raw fetch from
+     * clearing every other one in the file.
+     */
+    function hasExemption(node) {
+      let statement = node;
+      while (statement.parent && !/Statement|Declaration/.test(statement.type)) {
+        statement = statement.parent;
+      }
+      return sourceCode
+        .getCommentsBefore(statement)
+        .some((comment) => EXEMPTION_RE.test(comment.value));
+    }
+
+    return {
+      CallExpression(node) {
+        if (!isFetchCallee(node.callee)) return;
+
+        const init = node.arguments[1];
+        if (!init || init.type !== "ObjectExpression") return;
+
+        for (const property of init.properties) {
+          if (property.type !== "Property" || property.computed) continue;
+          const key =
+            property.key.type === "Identifier"
+              ? property.key.name
+              : property.key.type === "Literal"
+                ? property.key.value
+                : null;
+          if (key !== "method") continue;
+
+          const method = staticMethodValue(property.value);
+          if (method === null) return;
+          if (!MUTATING_METHODS.has(method.toUpperCase())) return;
+          if (hasExemption(node)) return;
+
+          context.report({
+            node,
+            messageId: "rawFetchMutation",
+            data: { method, helper: HELPER_FOR_METHOD[method.toUpperCase()] },
+          });
+          return;
+        }
+      },
+    };
+  },
+};

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -8,6 +8,7 @@ import noDirectSession from "./eslint-rules/no-direct-session.js";
 import noPiiInAuditDetail from "./eslint-rules/no-pii-in-audit-detail.js";
 import noUntrackedSkips from "./eslint-rules/no-untracked-skips.js";
 import noUntrackedSleeps from "./eslint-rules/no-untracked-sleeps.js";
+import noRawFetchMutation from "./eslint-rules/no-raw-fetch-mutation.js";
 
 const pinchyPlugin = {
   rules: {
@@ -17,6 +18,7 @@ const pinchyPlugin = {
     "require-parse-request-body": requireParseRequestBody,
     "no-untracked-skips": noUntrackedSkips,
     "no-untracked-sleeps": noUntrackedSleeps,
+    "no-raw-fetch-mutation": noRawFetchMutation,
   },
 };
 
@@ -124,6 +126,23 @@ const eslintConfig = defineConfig([
     rules: {
       "pinchy/no-direct-session": "error",
       "pinchy/require-parse-request-body": "error",
+    },
+  },
+  // Pinchy custom rules — client components, hooks and client pages:
+  // - no-raw-fetch-mutation: a state-changing call goes through the typed
+  //   helpers in @/lib/api-client (apiPost/apiPut/apiPatch/apiDelete), never
+  //   raw `fetch(url, { method: "POST" })`. AGENTS.md § "Shared Schemas And
+  //   Typed Client" promises that payload drift is a compile-time error rather
+  //   than a runtime 400 — a promise `JSON.stringify(anything)` cannot keep —
+  //   and the helper is also what surfaces the route's own error wording
+  //   instead of a generic toast (#1075). The rule's own scope check lives
+  //   inside the rule so it stays honest under RuleTester; this glob is the
+  //   outer bound. Opt out per statement with `// raw-fetch-exempt: <reason>`.
+  {
+    files: ["src/components/**/*.{ts,tsx}", "src/hooks/**/*.{ts,tsx}", "src/app/**/*.tsx"],
+    plugins: { pinchy: pinchyPlugin },
+    rules: {
+      "pinchy/no-raw-fetch-mutation": "error",
     },
   },
   // Override default ignores of eslint-config-next.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -102,6 +102,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/turndown": "^5.0.5",
     "@types/ws": "^8.18.1",
+    "@typescript-eslint/parser": "^8.62.1",
     "@vitejs/plugin-react": "^6.0.5",
     "eslint": "^9.39.4",
     "eslint-config-next": "16.2.12",

--- a/packages/web/src/__tests__/app/agent-settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/agent-settings-page.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { AgentSettingsPageContent as AgentSettingsPage } from "@/components/agent-settings-page-content";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 // Capture onChange callbacks from tab components
 let capturedOnChangeGeneral: ((v: unknown, isDirty: boolean) => void) | undefined;
@@ -80,21 +81,21 @@ function mockFetchResponses() {
   return vi.spyOn(global, "fetch").mockImplementation(async (url) => {
     const urlStr = typeof url === "string" ? url : url.toString();
     if (urlStr.includes("/api/agents/agent-1/files/SOUL.md")) {
-      return { ok: true, json: async () => ({ content: "# Soul" }) } as Response;
+      return jsonResponse({ content: "# Soul" });
     }
     if (urlStr.includes("/api/agents/agent-1/files/AGENTS.md")) {
-      return { ok: true, json: async () => ({ content: "# Agents" }) } as Response;
+      return jsonResponse({ content: "# Agents" });
     }
     if (urlStr.includes("/api/agents/agent-1") && !urlStr.includes("/files/")) {
-      return { ok: true, json: async () => agentData } as Response;
+      return jsonResponse(agentData);
     }
     if (urlStr.includes("/api/providers/models")) {
-      return { ok: true, json: async () => ({ providers: [] }) } as Response;
+      return jsonResponse({ providers: [] });
     }
     if (urlStr.includes("/api/data-directories")) {
-      return { ok: true, json: async () => ({ directories: [] }) } as Response;
+      return jsonResponse({ directories: [] });
     }
-    return { ok: true, json: async () => ({}) } as Response;
+    return jsonResponse({});
   });
 }
 
@@ -448,7 +449,7 @@ describe("AgentSettingsPage", () => {
           patchStartedBeforePutResolved = true;
         }
       }
-      return { ok: true, json: async () => ({}) } as Response;
+      return jsonResponse({});
     });
 
     await userEvent.click(screen.getByRole("button", { name: /save & restart/i }));

--- a/packages/web/src/__tests__/app/agents-new-page.test.tsx
+++ b/packages/web/src/__tests__/app/agents-new-page.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/components/template-selector", () => ({
 
 import { NewAgentForm } from "@/components/new-agent-form";
 import { useRouter } from "next/navigation";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const TEMPLATES_WITH_DIRS = [
   {
@@ -57,18 +58,12 @@ const DIRECTORIES = [
 function mockFetch(dirs: typeof DIRECTORIES = DIRECTORIES) {
   vi.mocked(global.fetch).mockImplementation(async (url) => {
     if (String(url).includes("/api/templates")) {
-      return {
-        ok: true,
-        json: async () => ({ templates: TEMPLATES_WITH_DIRS }),
-      } as Response;
+      return jsonResponse({ templates: TEMPLATES_WITH_DIRS });
     }
     if (String(url).includes("/api/data-directories")) {
-      return {
-        ok: true,
-        json: async () => ({ directories: dirs }),
-      } as Response;
+      return jsonResponse({ directories: dirs });
     }
-    return { ok: true, json: async () => ({}) } as Response;
+    return jsonResponse({});
   });
 }
 
@@ -196,25 +191,15 @@ describe("NewAgentForm", () => {
 
     vi.mocked(global.fetch).mockImplementation(async (url, opts) => {
       if (String(url).includes("/api/agents") && opts?.method === "POST") {
-        return {
-          ok: true,
-          status: 201,
-          json: async () => ({ id: "new-id", name: "Test KB" }),
-        } as Response;
+        return jsonResponse({ id: "new-id", name: "Test KB" }, { status: 201 });
       }
       if (String(url).includes("/api/templates")) {
-        return {
-          ok: true,
-          json: async () => ({ templates: TEMPLATES_WITH_DIRS }),
-        } as Response;
+        return jsonResponse({ templates: TEMPLATES_WITH_DIRS });
       }
       if (String(url).includes("/api/data-directories")) {
-        return {
-          ok: true,
-          json: async () => ({ directories: DIRECTORIES }),
-        } as Response;
+        return jsonResponse({ directories: DIRECTORIES });
       }
-      return { ok: true, json: async () => ({}) } as Response;
+      return jsonResponse({});
     });
 
     render(<NewAgentForm />);
@@ -282,19 +267,12 @@ describe("NewAgentForm", () => {
 
     vi.mocked(global.fetch).mockImplementation(async (url, opts) => {
       if (String(url).includes("/api/agents") && opts?.method === "POST") {
-        return {
-          ok: true,
-          status: 201,
-          json: async () => ({ id: "new-id", name: "Dev Bot" }),
-        } as Response;
+        return jsonResponse({ id: "new-id", name: "Dev Bot" }, { status: 201 });
       }
       if (String(url).includes("/api/templates")) {
-        return {
-          ok: true,
-          json: async () => ({ templates: TEMPLATES_WITH_DIRS }),
-        } as Response;
+        return jsonResponse({ templates: TEMPLATES_WITH_DIRS });
       }
-      return { ok: true, json: async () => ({}) } as Response;
+      return jsonResponse({});
     });
 
     render(<NewAgentForm />);

--- a/packages/web/src/__tests__/app/invite-claim-page.test.tsx
+++ b/packages/web/src/__tests__/app/invite-claim-page.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { toast } from "sonner";
 import InviteClaimPage from "@/app/invite/[token]/page";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const pushMock = vi.fn();
 
@@ -66,10 +67,12 @@ describe("Invite Claim Page", () => {
           // widens `getResponse` back to `MockResponse | "pending"` inside
           // the `json` closure below since it's a reassignable outer `let`.
           const response = getResponse;
-          return Promise.resolve({ ok: response.ok, json: async () => response.body });
+          return Promise.resolve(jsonResponse(response.body, { status: response.ok ? 200 : 400 }));
         }
         if (method === "POST" && url === "/api/invite/claim") {
-          return Promise.resolve({ ok: postResponse.ok, json: async () => postResponse.body });
+          return Promise.resolve(
+            jsonResponse(postResponse.body, { status: postResponse.ok ? 200 : 400 })
+          );
         }
         throw new Error(`Unexpected fetch: ${method} ${url}`);
       }

--- a/packages/web/src/__tests__/app/setup-page.test.tsx
+++ b/packages/web/src/__tests__/app/setup-page.test.tsx
@@ -35,21 +35,21 @@ vi.mock("@/lib/github-issue", () => ({
 
 import { SetupForm, PREFLIGHT_CONFIG } from "@/components/setup-form";
 import SetupPage, * as SetupPageModule from "@/app/setup/page";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 global.fetch = vi.fn();
 
 function mockFetchSetupStatus(infrastructure?: { database: string; openclaw: string }) {
   (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
     if (url === "/api/setup/status") {
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
+      return Promise.resolve(
+        jsonResponse({
           setupComplete: false,
           infrastructure: infrastructure ?? { database: "connected", openclaw: "connected" },
-        }),
-      });
+        })
+      );
     }
-    return Promise.resolve({ ok: true, json: async () => ({}) });
+    return Promise.resolve(jsonResponse({}));
   });
 }
 
@@ -301,18 +301,14 @@ describe("Setup Form", () => {
     const user = userEvent.setup();
     (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
       if (url === "/api/setup/status") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
+        return Promise.resolve(
+          jsonResponse({
             setupComplete: false,
             infrastructure: { database: "connected", openclaw: "connected" },
-          }),
-        });
+          })
+        );
       }
-      return Promise.resolve({
-        ok: false,
-        json: async () => ({ error: "Setup already completed" }),
-      });
+      return Promise.resolve(jsonResponse({ error: "Setup already completed" }, { status: 400 }));
     });
 
     render(<SetupForm />);
@@ -335,18 +331,14 @@ describe("Setup Form", () => {
     const user = userEvent.setup();
     (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
       if (url === "/api/setup/status") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
+        return Promise.resolve(
+          jsonResponse({
             setupComplete: false,
             infrastructure: { database: "connected", openclaw: "connected" },
-          }),
-        });
+          })
+        );
       }
-      return Promise.resolve({
-        ok: false,
-        json: async () => ({ error: "Setup already completed" }),
-      });
+      return Promise.resolve(jsonResponse({ error: "Setup already completed" }, { status: 400 }));
     });
 
     render(<SetupForm />);
@@ -402,15 +394,14 @@ describe("Setup Form pre-flight checks", () => {
       if (url === "/api/setup/status") {
         callCount++;
         const openclaw = callCount <= 2 ? "unreachable" : "connected";
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
+        return Promise.resolve(
+          jsonResponse({
             setupComplete: false,
             infrastructure: { database: "connected", openclaw },
-          }),
-        });
+          })
+        );
       }
-      return Promise.resolve({ ok: true, json: async () => ({}) });
+      return Promise.resolve(jsonResponse({}));
     });
 
     render(<SetupForm />);

--- a/packages/web/src/__tests__/components/add-integration-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/add-integration-dialog.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/lib/api-client", async (importOriginal) => {
 });
 
 import { apiGet } from "@/lib/api-client";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 function resolveUrl(url: string | URL | Request): string {
   return typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
@@ -30,12 +31,11 @@ function mockListDatabases(databases: string[], success = true) {
   return vi.spyOn(global, "fetch").mockImplementation((url) => {
     const urlStr = resolveUrl(url);
     if (urlStr.includes("/api/integrations/list-databases")) {
-      return Promise.resolve({
-        ok: true,
-        json: async () => (success ? { success: true, databases } : { success: false }),
-      } as Response);
+      return Promise.resolve(
+        jsonResponse(success ? { success: true, databases } : { success: false })
+      );
     }
-    return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    return Promise.resolve(jsonResponse({}));
   });
 }
 
@@ -139,7 +139,7 @@ describe("AddIntegrationDialog", () => {
     it("should not show database field when URL is invalid", async () => {
       const user = userEvent.setup();
       const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(() => {
-        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+        return Promise.resolve(jsonResponse({}));
       });
 
       render(<AddIntegrationDialog {...defaultProps} />);
@@ -490,25 +490,13 @@ describe("AddIntegrationDialog", () => {
       const fetchSpy = vi.spyOn(global, "fetch").mockImplementation((input) => {
         const urlStr = resolveUrl(input as string | URL | Request);
         if (urlStr.includes("/api/integrations/imap/test")) {
-          return Promise.resolve({
-            ok: true,
-            text: async () => JSON.stringify({ ok: true }),
-            json: async () => ({ ok: true }),
-          } as Response);
+          return Promise.resolve(jsonResponse({ ok: true }));
         }
         if (urlStr.includes("/api/integrations/imap")) {
           const body = { id: "conn-imap-1", name: "me@example.com" };
-          return Promise.resolve({
-            ok: true,
-            text: async () => JSON.stringify(body),
-            json: async () => body,
-          } as Response);
+          return Promise.resolve(jsonResponse(body));
         }
-        return Promise.resolve({
-          ok: true,
-          text: async () => "{}",
-          json: async () => ({}),
-        } as Response);
+        return Promise.resolve(jsonResponse({}));
       });
 
       await user.click(screen.getByRole("button", { name: /test & save/i }));
@@ -541,26 +529,14 @@ describe("AddIntegrationDialog", () => {
       const fetchSpy = vi.spyOn(global, "fetch").mockImplementation((input, init) => {
         const urlStr = resolveUrl(input as string | URL | Request);
         if (urlStr.includes("/api/integrations/imap/test")) {
-          return Promise.resolve({
-            ok: true,
-            text: async () => JSON.stringify({ ok: true }),
-            json: async () => ({ ok: true }),
-          } as Response);
+          return Promise.resolve(jsonResponse({ ok: true }));
         }
         if (urlStr.includes("/api/integrations/imap")) {
           createBody = JSON.parse((init?.body as string) ?? "{}");
           const body = { id: "conn-imap-1", name: "me@example.com" };
-          return Promise.resolve({
-            ok: true,
-            text: async () => JSON.stringify(body),
-            json: async () => body,
-          } as Response);
+          return Promise.resolve(jsonResponse(body));
         }
-        return Promise.resolve({
-          ok: true,
-          text: async () => "{}",
-          json: async () => ({}),
-        } as Response);
+        return Promise.resolve(jsonResponse({}));
       });
 
       await user.click(screen.getByRole("button", { name: /test & save/i }));

--- a/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
+++ b/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
@@ -4,6 +4,7 @@ import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AgentTelegramSettings } from "@/components/agent-telegram-settings";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/components/restart-provider", () => ({
@@ -13,9 +14,9 @@ vi.mock("@/components/restart-provider", () => ({
 function mockFetch(response: object) {
   return vi.fn().mockImplementation((url: string) => {
     if (typeof url === "string" && url.includes("/channels/telegram")) {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(response) });
+      return Promise.resolve(jsonResponse(response));
     }
-    return Promise.resolve({ ok: false });
+    return Promise.resolve(jsonResponse(undefined, { status: 400 }));
   });
 }
 
@@ -201,28 +202,23 @@ describe("AgentTelegramSettings", () => {
       global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
         if (typeof url === "string" && url.includes("/channels/telegram")) {
           if (init?.method === "POST") {
-            return Promise.resolve({
-              ok: true,
-              json: () => Promise.resolve({ botUsername: "acme_bot", botId: "123" }),
-            });
+            return Promise.resolve(jsonResponse({ botUsername: "acme_bot", botId: "123" }));
           }
           telegramGetCount++;
           const disabled = telegramGetCount === 1;
-          return Promise.resolve({
-            ok: true,
-            json: () =>
-              Promise.resolve({
-                configured: true,
-                hint: "xY9z",
-                mainBotConfigured: true,
-                conflictDisabled: disabled,
-                ...(disabled
-                  ? { lastError: "Conflict: terminated by other getUpdates request" }
-                  : {}),
-              }),
-          });
+          return Promise.resolve(
+            jsonResponse({
+              configured: true,
+              hint: "xY9z",
+              mainBotConfigured: true,
+              conflictDisabled: disabled,
+              ...(disabled
+                ? { lastError: "Conflict: terminated by other getUpdates request" }
+                : {}),
+            })
+          );
         }
-        return Promise.resolve({ ok: false });
+        return Promise.resolve(jsonResponse(undefined, { status: 400 }));
       });
 
       render(<AgentTelegramSettings agentId="agent-1" />);

--- a/packages/web/src/__tests__/components/delete-agent-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/delete-agent-dialog.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { DeleteAgentDialog } from "@/components/delete-agent-dialog";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const pushMock = vi.fn();
 const refreshMock = vi.fn();
@@ -45,10 +46,7 @@ describe("DeleteAgentDialog", () => {
   });
 
   it("should call DELETE /api/agents/:id when confirmed", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<DeleteAgentDialog agentId="agent-1" agentName="Smithers" />);
 
@@ -63,10 +61,7 @@ describe("DeleteAgentDialog", () => {
   });
 
   it("should redirect to / on successful delete", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<DeleteAgentDialog agentId="agent-1" agentName="Smithers" />);
 
@@ -79,10 +74,9 @@ describe("DeleteAgentDialog", () => {
   });
 
   it("should show error message on failure", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Personal agents cannot be deleted" }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Personal agents cannot be deleted" }, { status: 400 })
+    );
 
     render(<DeleteAgentDialog agentId="agent-1" agentName="Smithers" />);
 
@@ -95,10 +89,9 @@ describe("DeleteAgentDialog", () => {
   });
 
   it("should not redirect on failure", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Failed to delete agent" }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Failed to delete agent" }, { status: 400 })
+    );
 
     render(<DeleteAgentDialog agentId="agent-1" agentName="Smithers" />);
 

--- a/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
@@ -4,22 +4,20 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog";
 
-vi.mock("@/lib/api-client", () => ({
-  apiPost: vi.fn(async () => ({ schemaVersion: "pinchy.bugreport.v1" })),
-  // The chat picker (#639) fetches the user's chats on open. Default to an
-  // empty list so the legacy tests below export the default chat (no sessionId).
-  apiGet: vi.fn(async () => ({ chats: [] })),
-  ApiError: class ApiError extends Error {
-    constructor(
-      public readonly status: number,
-      message: string,
-      public readonly details?: unknown
-    ) {
-      super(message);
-      this.name = "ApiError";
-    }
-  },
-}));
+// Spread the real module rather than re-declaring its exports: a hand-rolled
+// factory silently drops anything it forgets (a re-declared `ApiError` also
+// breaks `instanceof` against the real one), and the component reads
+// `errorMessage` from here too.
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return {
+    ...actual,
+    apiPost: vi.fn(async () => ({ schemaVersion: "pinchy.bugreport.v1" })),
+    // The chat picker (#639) fetches the user's chats on open. Default to an
+    // empty list so the legacy tests below export the default chat (no sessionId).
+    apiGet: vi.fn(async () => ({ chats: [] })),
+  };
+});
 
 vi.mock("@/lib/diagnostics/download", () => ({
   downloadBundle: vi.fn(),

--- a/packages/web/src/__tests__/components/invite-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/invite-dialog.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { InviteDialog } from "@/components/invite-dialog";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 // Mock window.location.origin for invite link generation
 Object.defineProperty(window, "location", {
@@ -16,7 +17,7 @@ function resolveUrl(url: string | URL | Request): string {
 }
 
 function mockFetchForInvite(
-  inviteResponse: { ok: boolean; json: () => Promise<unknown> },
+  inviteResponse: Response,
   options?: {
     enterprise?: boolean;
     groups?: { id: string; name: string }[];
@@ -31,18 +32,12 @@ function mockFetchForInvite(
   return (url: string | URL | Request) => {
     const urlStr = resolveUrl(url);
     if (urlStr.includes("/api/enterprise/status")) {
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ enterprise, maxUsers, seatsUsed }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ enterprise, maxUsers, seatsUsed }));
     }
     if (urlStr.includes("/api/groups")) {
-      return Promise.resolve({
-        ok: true,
-        json: async () => groups,
-      } as Response);
+      return Promise.resolve(jsonResponse(groups));
     }
-    return Promise.resolve(inviteResponse as Response);
+    return Promise.resolve(inviteResponse);
   };
 }
 
@@ -51,9 +46,7 @@ describe("InviteDialog", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    fetchSpy = vi
-      .spyOn(global, "fetch")
-      .mockImplementation(mockFetchForInvite({ ok: true, json: async () => ({}) }));
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(mockFetchForInvite(jsonResponse({})));
   });
 
   afterEach(() => {
@@ -81,9 +74,7 @@ describe("InviteDialog", () => {
   it("should submit form with default values when Create Invite is clicked", async () => {
     const user = userEvent.setup();
 
-    fetchSpy.mockImplementation(
-      mockFetchForInvite({ ok: true, json: async () => ({ token: "test-token" }) })
-    );
+    fetchSpy.mockImplementation(mockFetchForInvite(jsonResponse({ token: "test-token" })));
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
 
@@ -101,9 +92,7 @@ describe("InviteDialog", () => {
   it("should submit form with entered email", async () => {
     const user = userEvent.setup();
 
-    fetchSpy.mockImplementation(
-      mockFetchForInvite({ ok: true, json: async () => ({ token: "test-token" }) })
-    );
+    fetchSpy.mockImplementation(mockFetchForInvite(jsonResponse({ token: "test-token" })));
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
 
@@ -122,9 +111,7 @@ describe("InviteDialog", () => {
   it("should show invite link after successful creation", async () => {
     const user = userEvent.setup();
 
-    fetchSpy.mockImplementation(
-      mockFetchForInvite({ ok: true, json: async () => ({ token: "invite-token-abc" }) })
-    );
+    fetchSpy.mockImplementation(mockFetchForInvite(jsonResponse({ token: "invite-token-abc" })));
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
 
@@ -141,7 +128,7 @@ describe("InviteDialog", () => {
     const user = userEvent.setup();
 
     fetchSpy.mockImplementation(
-      mockFetchForInvite({ ok: false, json: async () => ({ error: "Invite limit reached" }) })
+      mockFetchForInvite(jsonResponse({ error: "Invite limit reached" }, { status: 403 }))
     );
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
@@ -155,10 +142,7 @@ describe("InviteDialog", () => {
 
   it("shows a factual notice inside the grace window (§ 5)", async () => {
     fetchSpy.mockImplementation(
-      mockFetchForInvite(
-        { ok: true, json: async () => ({}) },
-        { enterprise: true, maxUsers: 10, seatsUsed: 11 }
-      )
+      mockFetchForInvite(jsonResponse({}), { enterprise: true, maxUsers: 10, seatsUsed: 11 })
     );
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
     await waitFor(() => {
@@ -173,10 +157,7 @@ describe("InviteDialog", () => {
 
   it("shows no seat notice at or below 100%", async () => {
     fetchSpy.mockImplementation(
-      mockFetchForInvite(
-        { ok: true, json: async () => ({}) },
-        { enterprise: true, maxUsers: 10, seatsUsed: 10 }
-      )
+      mockFetchForInvite(jsonResponse({}), { enterprise: true, maxUsers: 10, seatsUsed: 10 })
     );
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
     await waitFor(() => {
@@ -188,17 +169,19 @@ describe("InviteDialog", () => {
   it("prefers the structured message of a seat-cap 403", async () => {
     const user = userEvent.setup();
     fetchSpy.mockImplementation(
-      mockFetchForInvite({
-        ok: false,
-        json: async () => ({
-          error: "Seat limit reached",
-          message:
-            "Your license includes 10 seats with grace up to 12. Remove an existing user or pending invitation, or email sales@heypinchy.com for a quote you can accept online.",
-          seatsUsed: 12,
-          maxUsers: 10,
-          graceCap: 12,
-        }),
-      })
+      mockFetchForInvite(
+        jsonResponse(
+          {
+            error: "Seat limit reached",
+            message:
+              "Your license includes 10 seats with grace up to 12. Remove an existing user or pending invitation, or email sales@heypinchy.com for a quote you can accept online.",
+            seatsUsed: 12,
+            maxUsers: 10,
+            graceCap: 12,
+          },
+          { status: 403 }
+        )
+      )
     );
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
     await user.click(screen.getByRole("button", { name: "Create Invite" }));
@@ -213,10 +196,7 @@ describe("InviteDialog", () => {
     fetchSpy.mockImplementation((url: string | URL | Request) => {
       const urlStr = resolveUrl(url);
       if (urlStr.includes("/api/enterprise/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ enterprise: false }),
-        } as Response);
+        return Promise.resolve(jsonResponse({ enterprise: false }));
       }
       return Promise.reject(new Error("Network error"));
     });
@@ -261,9 +241,7 @@ describe("InviteDialog", () => {
       configurable: true,
     });
 
-    fetchSpy.mockImplementation(
-      mockFetchForInvite({ ok: true, json: async () => ({ token: "share-token" }) })
-    );
+    fetchSpy.mockImplementation(mockFetchForInvite(jsonResponse({ token: "share-token" })));
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
 
@@ -297,9 +275,7 @@ describe("InviteDialog", () => {
     // @ts-expect-error removing for test
     delete navigator.share;
 
-    fetchSpy.mockImplementation(
-      mockFetchForInvite({ ok: true, json: async () => ({ token: "copy-token" }) })
-    );
+    fetchSpy.mockImplementation(mockFetchForInvite(jsonResponse({ token: "copy-token" })));
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
 
@@ -320,24 +296,17 @@ describe("InviteDialog", () => {
     fetchSpy.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       if (urlStr.includes("/api/enterprise/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ enterprise: true }),
-        } as Response);
+        return Promise.resolve(jsonResponse({ enterprise: true }));
       }
       if (urlStr.includes("/api/groups")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => [
+        return Promise.resolve(
+          jsonResponse([
             { id: "g1", name: "HR" },
             { id: "g2", name: "Engineering" },
-          ],
-        } as Response);
+          ])
+        );
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ token: "test" }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ token: "test" }));
     });
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
@@ -353,18 +322,12 @@ describe("InviteDialog", () => {
     fetchSpy.mockImplementation((url: string | URL | Request) => {
       const urlStr = resolveUrl(url);
       if (urlStr.includes("/api/enterprise/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ enterprise: true }),
-        } as Response);
+        return Promise.resolve(jsonResponse({ enterprise: true }));
       }
       if (urlStr.includes("/api/groups")) {
         return Promise.reject(new Error("Network error"));
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ token: "test" }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ token: "test" }));
     });
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
@@ -381,15 +344,9 @@ describe("InviteDialog", () => {
     fetchSpy.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       if (urlStr.includes("/api/enterprise/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ enterprise: false }),
-        } as Response);
+        return Promise.resolve(jsonResponse({ enterprise: false }));
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ token: "test" }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ token: "test" }));
     });
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
@@ -408,24 +365,17 @@ describe("InviteDialog", () => {
     fetchSpy.mockImplementation((url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
       if (urlStr.includes("/api/enterprise/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ enterprise: true }),
-        } as Response);
+        return Promise.resolve(jsonResponse({ enterprise: true }));
       }
       if (urlStr.includes("/api/groups")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => [
+        return Promise.resolve(
+          jsonResponse([
             { id: "g1", name: "HR" },
             { id: "g2", name: "Engineering" },
-          ],
-        } as Response);
+          ])
+        );
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ token: "test-token" }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ token: "test-token" }));
     });
 
     render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
@@ -459,21 +409,12 @@ describe("InviteDialog", () => {
     fetchSpy.mockImplementation((url: string | URL | Request) => {
       const urlStr = resolveUrl(url);
       if (urlStr.includes("/api/enterprise/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ enterprise: true }),
-        } as Response);
+        return Promise.resolve(jsonResponse({ enterprise: true }));
       }
       if (urlStr.includes("/api/groups")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => [],
-        } as Response);
+        return Promise.resolve(jsonResponse([]));
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ token: "test" }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ token: "test" }));
     });
 
     const { rerender } = render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
@@ -491,21 +432,12 @@ describe("InviteDialog", () => {
     fetchSpy.mockImplementation((url: string | URL | Request) => {
       const urlStr = resolveUrl(url);
       if (urlStr.includes("/api/enterprise/status")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ enterprise: true }),
-        } as Response);
+        return Promise.resolve(jsonResponse({ enterprise: true }));
       }
       if (urlStr.includes("/api/groups")) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => [{ id: "g1", name: "Engineering" }],
-        } as Response);
+        return Promise.resolve(jsonResponse([{ id: "g1", name: "Engineering" }]));
       }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ token: "test" }),
-      } as Response);
+      return Promise.resolve(jsonResponse({ token: "test" }));
     });
 
     // Reopen dialog
@@ -522,9 +454,7 @@ describe("InviteDialog", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    fetchSpy.mockImplementation(
-      mockFetchForInvite({ ok: true, json: async () => ({ token: "test-token" }) })
-    );
+    fetchSpy.mockImplementation(mockFetchForInvite(jsonResponse({ token: "test-token" })));
 
     const { rerender } = render(<InviteDialog open={true} onOpenChange={onOpenChange} />);
 

--- a/packages/web/src/__tests__/components/new-agent-form.test.tsx
+++ b/packages/web/src/__tests__/components/new-agent-form.test.tsx
@@ -7,6 +7,7 @@ import "@testing-library/jest-dom";
 import { flushPendingRenders } from "@/test-helpers/react";
 import { NewAgentForm } from "@/components/new-agent-form";
 import { toast } from "sonner";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const { mockPush, mockReplace, mockSearchParams } = vi.hoisted(() => {
   const searchParamsRef = { current: new URLSearchParams() };
@@ -65,12 +66,9 @@ describe("NewAgentForm — name max length", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -103,12 +101,9 @@ describe("NewAgentForm — cancel button", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -157,12 +152,9 @@ describe("NewAgentForm — URL history", () => {
 
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -221,18 +213,12 @@ describe("NewAgentForm — tagline field", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
       if (String(url) === "/api/data-directories") {
-        return {
-          ok: true,
-          json: async () => ({ directories: [] }),
-        } as Response;
+        return jsonResponse({ directories: [] });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -303,24 +289,15 @@ describe("NewAgentForm — tagline field", () => {
 
     fetchSpy.mockImplementation(async (url, init) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: emailTemplates }),
-        } as Response;
+        return jsonResponse({ templates: emailTemplates });
       }
       if (String(url) === "/api/integrations") {
-        return {
-          ok: true,
-          json: async () => [{ id: "email-conn-1", name: "Gmail Work", type: "google" }],
-        } as Response;
+        return jsonResponse([{ id: "email-conn-1", name: "Gmail Work", type: "google" }]);
       }
       if (String(url) === "/api/agents" && init?.method === "POST") {
-        return {
-          ok: true,
-          json: async () => ({ id: "new-agent-id" }),
-        } as Response;
+        return jsonResponse({ id: "new-agent-id" });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
 
     render(<NewAgentForm />);
@@ -355,18 +332,12 @@ describe("NewAgentForm — tagline field", () => {
   it("includes tagline in POST body on submit", async () => {
     fetchSpy.mockImplementation(async (url, init) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
       if (String(url) === "/api/agents" && init?.method === "POST") {
-        return {
-          ok: true,
-          json: async () => ({ id: "new-agent-id" }),
-        } as Response;
+        return jsonResponse({ id: "new-agent-id" });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
 
     render(<NewAgentForm />);
@@ -403,21 +374,15 @@ describe("NewAgentForm — tagline field", () => {
   it("navigates and shows a warning toast when creation reports a runtime warning (#880)", async () => {
     fetchSpy.mockImplementation(async (url, init) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
       if (String(url) === "/api/agents" && init?.method === "POST") {
-        return {
-          ok: true,
-          json: async () => ({
-            id: "new-agent-id",
-            warning: "Agent created. Applying it to the runtime failed.",
-          }),
-        } as Response;
+        return jsonResponse({
+          id: "new-agent-id",
+          warning: "Agent created. Applying it to the runtime failed.",
+        });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
 
     render(<NewAgentForm />);
@@ -466,24 +431,15 @@ describe("NewAgentForm — email mailbox picker", () => {
   function mockApis(connections: Array<{ id: string; name: string; type: string }>) {
     fetchSpy.mockImplementation(async (url, init) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: emailTemplates }),
-        } as Response;
+        return jsonResponse({ templates: emailTemplates });
       }
       if (String(url) === "/api/integrations") {
-        return {
-          ok: true,
-          json: async () => connections,
-        } as Response;
+        return jsonResponse(connections);
       }
       if (String(url) === "/api/agents" && init?.method === "POST") {
-        return {
-          ok: true,
-          json: async () => ({ id: "new-agent-id" }),
-        } as Response;
+        return jsonResponse({ id: "new-agent-id" });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   }
 
@@ -595,12 +551,9 @@ describe("NewAgentForm — intro text", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -627,12 +580,9 @@ describe("NewAgentForm — tagline helper", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -678,30 +628,18 @@ describe("NewAgentForm — permission preview", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: odooTemplates }),
-        } as Response;
+        return jsonResponse({ templates: odooTemplates });
       }
       if (String(url) === "/api/data-directories") {
-        return {
-          ok: true,
-          json: async () => ({ directories: [] }),
-        } as Response;
+        return jsonResponse({ directories: [] });
       }
       if (String(url) === "/api/integrations") {
-        return {
-          ok: true,
-          json: async () => [{ id: "conn-1", name: "My Odoo", type: "odoo", data: {} }],
-        } as Response;
+        return jsonResponse([{ id: "conn-1", name: "My Odoo", type: "odoo", data: {} }]);
       }
       if (String(url) === "/api/agents") {
-        return {
-          ok: true,
-          json: async () => [],
-        } as Response;
+        return jsonResponse([]);
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -795,24 +733,15 @@ describe("NewAgentForm — no connections link", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: odooTemplates }),
-        } as Response;
+        return jsonResponse({ templates: odooTemplates });
       }
       if (String(url) === "/api/integrations") {
-        return {
-          ok: true,
-          json: async () => [],
-        } as Response;
+        return jsonResponse([]);
       }
       if (String(url) === "/api/agents") {
-        return {
-          ok: true,
-          json: async () => [],
-        } as Response;
+        return jsonResponse([]);
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -849,24 +778,15 @@ describe("NewAgentForm — suggested name", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: mockTemplates }),
-        } as Response;
+        return jsonResponse({ templates: mockTemplates });
       }
       if (String(url) === "/api/agents") {
-        return {
-          ok: true,
-          json: async () => [{ name: "Ada" }],
-        } as Response;
+        return jsonResponse([{ name: "Ada" }]);
       }
       if (String(url) === "/api/data-directories") {
-        return {
-          ok: true,
-          json: async () => ({ directories: [] }),
-        } as Response;
+        return jsonResponse({ directories: [] });
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 
@@ -1010,31 +930,25 @@ describe("NewAgentForm — optional Odoo models do not block creation", () => {
     mockSearchParams.current = new URLSearchParams();
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
       if (String(url) === "/api/templates") {
-        return {
-          ok: true,
-          json: async () => ({ templates: approvalManagerInList }),
-        } as Response;
+        return jsonResponse({ templates: approvalManagerInList });
       }
       if (String(url) === "/api/data-directories") {
-        return { ok: true, json: async () => ({ directories: [] }) } as Response;
+        return jsonResponse({ directories: [] });
       }
       if (String(url) === "/api/integrations") {
-        return {
-          ok: true,
-          json: async () => [
-            {
-              id: "conn-community",
-              name: "Odoo Community",
-              type: "odoo",
-              data: { models: communityConnectionModels },
-            },
-          ],
-        } as Response;
+        return jsonResponse([
+          {
+            id: "conn-community",
+            name: "Odoo Community",
+            type: "odoo",
+            data: { models: communityConnectionModels },
+          },
+        ]);
       }
       if (String(url) === "/api/agents") {
-        return { ok: true, json: async () => [] } as Response;
+        return jsonResponse([]);
       }
-      return { ok: false, json: async () => ({}) } as Response;
+      return jsonResponse({}, { status: 400 });
     });
   });
 

--- a/packages/web/src/__tests__/components/provider-key-form.test.tsx
+++ b/packages/web/src/__tests__/components/provider-key-form.test.tsx
@@ -6,6 +6,7 @@ import "@testing-library/jest-dom";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { toast } from "sonner";
 import type { DeletionPreviewResponse } from "@/lib/schemas/provider-deletion";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
@@ -33,12 +34,7 @@ function previewResponse(overrides: Partial<DeletionPreviewResponse> = {}): Resp
     ],
     ...overrides,
   };
-  return {
-    ok: true,
-    status: 200,
-    json: async () => body,
-    text: async () => JSON.stringify(body),
-  } as Response;
+  return jsonResponse(body);
 }
 
 /**
@@ -51,12 +47,7 @@ function deleteFlowResponse(
   previewOverrides: Partial<DeletionPreviewResponse> = {}
 ): Response {
   if (url.includes("deletion-preview")) return previewResponse(previewOverrides);
-  return {
-    ok: true,
-    status: 200,
-    json: async () => deleteBody,
-    text: async () => JSON.stringify(deleteBody),
-  } as Response;
+  return jsonResponse(deleteBody);
 }
 
 describe("ProviderKeyForm", () => {
@@ -115,10 +106,7 @@ describe("ProviderKeyForm", () => {
   });
 
   it("should call onSuccess and show success toast after successful submission", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<ProviderKeyForm onSuccess={onSuccess} />);
 
@@ -135,13 +123,12 @@ describe("ProviderKeyForm", () => {
   });
 
   it("shows a warning toast (not success) when the save reports a runtime warning (#880)", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({
         success: true,
         warning: "Saved. Applying it to the agent runtime failed.",
-      }),
-    } as Response);
+      })
+    );
 
     render(<ProviderKeyForm onSuccess={onSuccess} />);
 
@@ -161,10 +148,9 @@ describe("ProviderKeyForm", () => {
   });
 
   it("should show inline error message on failed validation", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Invalid API key. Please check and try again." }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Invalid API key. Please check and try again." }, { status: 400 })
+    );
 
     render(<ProviderKeyForm onSuccess={onSuccess} />);
 
@@ -180,10 +166,9 @@ describe("ProviderKeyForm", () => {
   });
 
   it("should show report issue link on failed validation", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Invalid API key." }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Invalid API key." }, { status: 400 })
+    );
 
     render(<ProviderKeyForm onSuccess={onSuccess} />);
 
@@ -199,10 +184,9 @@ describe("ProviderKeyForm", () => {
   });
 
   it("should show error indicator next to input on failed validation", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Invalid API key." }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Invalid API key." }, { status: 400 })
+    );
 
     render(<ProviderKeyForm onSuccess={onSuccess} />);
 
@@ -220,16 +204,7 @@ describe("ProviderKeyForm", () => {
   it("should show loading state during submission", async () => {
     vi.mocked(global.fetch).mockImplementation(
       () =>
-        new Promise((resolve) =>
-          setTimeout(
-            () =>
-              resolve({
-                ok: true,
-                json: async () => ({ success: true }),
-              } as Response),
-            100
-          )
-        )
+        new Promise((resolve) => setTimeout(() => resolve(jsonResponse({ success: true })), 100))
     );
 
     render(<ProviderKeyForm onSuccess={onSuccess} />);
@@ -270,10 +245,7 @@ describe("ProviderKeyForm", () => {
     });
 
     it("should call onDirtyChange(false) after successful save", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
       const onDirtyChange = vi.fn();
       render(<ProviderKeyForm onSuccess={onSuccess} onDirtyChange={onDirtyChange} />);
@@ -436,10 +408,9 @@ describe("ProviderKeyForm", () => {
     });
 
     it("should show error indicator instead of configured indicator on failed save", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({ error: "Invalid API key." }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        jsonResponse({ error: "Invalid API key." }, { status: 400 })
+      );
 
       render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
 
@@ -457,10 +428,7 @@ describe("ProviderKeyForm", () => {
     });
 
     it("should show configured indicator and success toast after successful save", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
       render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
 
@@ -552,12 +520,12 @@ describe("ProviderKeyForm", () => {
           return previewResponse();
         }
         void init;
-        return {
-          ok: false,
-          json: async () => ({
+        return jsonResponse(
+          {
             error: "Cannot remove the last configured provider. Add another provider first.",
-          }),
-        } as Response;
+          },
+          { status: 400 }
+        );
       });
 
       render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
@@ -588,7 +556,7 @@ describe("ProviderKeyForm", () => {
                   { id: "a3", name: "Reader" },
                 ],
               })
-            : ({ ok: true, json: async () => ({}) } as Response)
+            : jsonResponse({})
         );
 
         render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
@@ -613,7 +581,7 @@ describe("ProviderKeyForm", () => {
         vi.mocked(global.fetch).mockImplementation(async (input) =>
           String(input).includes("deletion-preview")
             ? previewResponse({ affectedAgents: [{ id: "a1", name: "Hermes" }] })
-            : ({ ok: true, json: async () => ({}) } as Response)
+            : jsonResponse({})
         );
 
         render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
@@ -631,7 +599,7 @@ describe("ProviderKeyForm", () => {
         vi.mocked(global.fetch).mockImplementation(async (input) =>
           String(input).includes("deletion-preview")
             ? previewResponse({ affectedAgents: [] })
-            : ({ ok: true, json: async () => ({}) } as Response)
+            : jsonResponse({})
         );
 
         render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
@@ -653,13 +621,8 @@ describe("ProviderKeyForm", () => {
       it("falls back to the generic sentence when the preview fails", async () => {
         vi.mocked(global.fetch).mockImplementation(async (input) =>
           String(input).includes("deletion-preview")
-            ? ({
-                ok: false,
-                status: 500,
-                json: async () => ({ error: "boom" }),
-                text: async () => '{"error":"boom"}',
-              } as Response)
-            : ({ ok: true, json: async () => ({}) } as Response)
+            ? jsonResponse({ error: "boom" }, { status: 500 })
+            : jsonResponse({})
         );
 
         render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={configuredProviders} />);
@@ -699,7 +662,7 @@ describe("ProviderKeyForm", () => {
               affectedAgents: [{ id: "a1", name: "Hermes" }],
             });
           }
-          return { ok: true, json: async () => ({}) } as Response;
+          return jsonResponse({});
         });
 
         render(<ProviderKeyForm onSuccess={onSuccess} configuredProviders={twoConfigured} />);
@@ -800,16 +763,16 @@ describe("ProviderKeyForm", () => {
   // user to copy a URL from prose text. The prose itself stays plain (no
   // long URL squashed in), and the link opens in a new tab.
   describe("structured docs hint on error (#296)", () => {
-    const unsupportedHostResponse = {
-      ok: false,
-      json: async () => ({
+    const unsupportedHostResponse = jsonResponse(
+      {
         error: 'Host "ollama" is not an allowed local Ollama host. Use localhost, ...',
         docs: {
           href: "https://docs.heypinchy.com/guides/ollama-setup/#b-ollama-as-a-docker-service",
           label: "See the recommended Docker setup",
         },
-      }),
-    } as Response;
+      },
+      { status: 400 }
+    );
 
     async function submitOllamaLocal() {
       fireEvent.click(screen.getByRole("button", { name: /ollama \(local\)/i }));
@@ -847,10 +810,9 @@ describe("ProviderKeyForm", () => {
     });
 
     it("does not render a docs link inside the error region when the response has no docs field", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({ error: "Could not connect to Ollama at this URL." }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        jsonResponse({ error: "Could not connect to Ollama at this URL." }, { status: 400 })
+      );
 
       render(<ProviderKeyForm onSuccess={onSuccess} />);
       await submitOllamaLocal();
@@ -892,10 +854,9 @@ describe("ProviderKeyForm", () => {
     it("clears a previously-shown docs link when the next error response has no docs", async () => {
       vi.mocked(global.fetch)
         .mockResolvedValueOnce(unsupportedHostResponse)
-        .mockResolvedValueOnce({
-          ok: false,
-          json: async () => ({ error: "Could not connect to Ollama at this URL." }),
-        } as Response);
+        .mockResolvedValueOnce(
+          jsonResponse({ error: "Could not connect to Ollama at this URL." }, { status: 400 })
+        );
 
       render(<ProviderKeyForm onSuccess={onSuccess} />);
       await submitOllamaLocal();
@@ -916,16 +877,18 @@ describe("ProviderKeyForm", () => {
     // requires the href to start with http(s):// — anything else falls back
     // to the plain error prose with no link.
     it("rejects a docs.href that is not a http(s) URL (e.g. javascript: scheme)", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({
-          error: 'Host "ollama" is not an allowed local Ollama host.',
-          docs: {
-            href: "javascript:alert(1)",
-            label: "See the recommended Docker setup",
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: 'Host "ollama" is not an allowed local Ollama host.',
+            docs: {
+              href: "javascript:alert(1)",
+              label: "See the recommended Docker setup",
+            },
           },
-        }),
-      } as Response);
+          { status: 400 }
+        )
+      );
 
       render(<ProviderKeyForm onSuccess={onSuccess} />);
       await submitOllamaLocal();
@@ -941,16 +904,18 @@ describe("ProviderKeyForm", () => {
     // ExternalLink icon — a click target with no visible text. Treat it the
     // same as a missing docs field.
     it("rejects a docs.label that is an empty string", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({
-          error: 'Host "ollama" is not an allowed local Ollama host.',
-          docs: {
-            href: "https://docs.heypinchy.com/guides/ollama-setup/",
-            label: "",
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        jsonResponse(
+          {
+            error: 'Host "ollama" is not an allowed local Ollama host.',
+            docs: {
+              href: "https://docs.heypinchy.com/guides/ollama-setup/",
+              label: "",
+            },
           },
-        }),
-      } as Response);
+          { status: 400 }
+        )
+      );
 
       render(<ProviderKeyForm onSuccess={onSuccess} />);
       await submitOllamaLocal();
@@ -991,10 +956,7 @@ describe("ProviderKeyForm", () => {
     });
 
     it("should send url field instead of apiKey for URL providers", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
       render(<ProviderKeyForm onSuccess={onSuccess} />);
 
@@ -1017,10 +979,7 @@ describe("ProviderKeyForm", () => {
     });
 
     it("should show success toast with 'URL saved' for URL providers", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
       render(<ProviderKeyForm onSuccess={onSuccess} />);
 

--- a/packages/web/src/__tests__/components/settings-context.test.tsx
+++ b/packages/web/src/__tests__/components/settings-context.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { SettingsContext } from "@/components/settings-context";
 import { CONTEXT_CONTENT_MAX_LENGTH, CONTEXT_TOO_LONG_MESSAGE } from "@/lib/schemas/context";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 vi.mock("@/components/markdown-editor", () => ({
   MarkdownEditor: ({
@@ -56,10 +57,7 @@ describe("SettingsContext", () => {
   });
 
   it("calls PUT /api/users/me/context when personal context is saved", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsContext userContext="My personal context" orgContext="" isAdmin={false} />);
 
@@ -76,10 +74,7 @@ describe("SettingsContext", () => {
   });
 
   it("calls PUT /api/settings/context when org context is saved", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsContext userContext="" orgContext="Org info" isAdmin={true} />);
 
@@ -97,10 +92,7 @@ describe("SettingsContext", () => {
   });
 
   it("shows success feedback after save", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsContext userContext="" orgContext="" isAdmin={false} />);
 
@@ -146,10 +138,7 @@ describe("SettingsContext", () => {
     });
 
     it("should call onDirtyChange(false) after content is successfully saved", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
       const onDirtyChange = vi.fn();
       render(
@@ -188,10 +177,9 @@ describe("SettingsContext", () => {
   });
 
   it("shows error feedback on failure", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Something went wrong" }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Something went wrong" }, { status: 400 })
+    );
 
     render(<SettingsContext userContext="" orgContext="" isAdmin={false} />);
 
@@ -206,16 +194,18 @@ describe("SettingsContext", () => {
     // parseRequestBody's 400 puts the actionable text in details.fieldErrors —
     // `error` alone is the generic "Validation failed", which tells the user
     // nothing they can act on.
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({
-        error: "Validation failed",
-        details: {
-          formErrors: [],
-          fieldErrors: { content: [CONTEXT_TOO_LONG_MESSAGE] },
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: "Validation failed",
+          details: {
+            formErrors: [],
+            fieldErrors: { content: [CONTEXT_TOO_LONG_MESSAGE] },
+          },
         },
-      }),
-    } as Response);
+        { status: 400 }
+      )
+    );
 
     render(<SettingsContext userContext="Some context" orgContext="" isAdmin={false} />);
 

--- a/packages/web/src/__tests__/components/settings-license.test.tsx
+++ b/packages/web/src/__tests__/components/settings-license.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { SettingsLicense } from "@/components/settings-license";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const noLicenseStatus = {
   enterprise: false,
@@ -19,11 +20,7 @@ const noLicenseStatus = {
   hasGatedConfig: false,
 };
 
-const statusOkResponse = (data: object) =>
-  ({
-    ok: true,
-    json: async () => data,
-  }) as Response;
+const statusOkResponse = (data: object) => jsonResponse(data);
 
 describe("SettingsLicense", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
@@ -39,9 +36,8 @@ describe("SettingsLicense", () => {
   });
 
   it("shows loading state initially when no initialLicense provided", () => {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
         enterprise: false,
         type: null,
         org: null,
@@ -50,8 +46,8 @@ describe("SettingsLicense", () => {
         managedByEnv: false,
         maxUsers: 0,
         seatsUsed: 0,
-      }),
-    } as Response);
+      })
+    );
     render(<SettingsLicense />);
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
@@ -207,10 +203,7 @@ describe("SettingsLicense", () => {
     expect(screen.getByText(/deletes all groups/i)).toBeInTheDocument();
     expect(screen.getByText(/recorded in the audit log/i)).toBeInTheDocument();
 
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ groupsRemoved: 2, agentsReset: 1 }),
-    } as Response);
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ groupsRemoved: 2, agentsReset: 1 }));
 
     await user.click(screen.getByRole("button", { name: /remove configuration/i }));
     await waitFor(() => {
@@ -409,10 +402,7 @@ describe("SettingsLicense", () => {
   });
 
   it("shows error message when save fails", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Invalid license key" }),
-    } as Response);
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "Invalid license key" }, { status: 400 }));
 
     render(<SettingsLicense initialLicense={noLicenseStatus} />);
 
@@ -526,10 +516,7 @@ describe("SettingsLicense", () => {
   });
 
   it("does not dispatch 'license-updated' when save fails", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Invalid license key" }),
-    } as Response);
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "Invalid license key" }, { status: 400 }));
     const onLicenseUpdated = vi.fn();
     window.addEventListener("license-updated", onLicenseUpdated);
 

--- a/packages/web/src/__tests__/components/settings-profile.test.tsx
+++ b/packages/web/src/__tests__/components/settings-profile.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { SettingsProfile } from "@/components/settings-profile";
 import { toast } from "sonner";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const { mockRouterPush } = vi.hoisted(() => ({
   mockRouterPush: vi.fn(),
@@ -51,10 +52,7 @@ describe("SettingsProfile", () => {
 
   it("should call PATCH /api/users/me when Save is clicked", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -74,10 +72,7 @@ describe("SettingsProfile", () => {
 
   it("should show success toast after saving name", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -109,10 +104,7 @@ describe("SettingsProfile", () => {
 
   it("should call POST /api/users/me/password when Change Password is clicked", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -132,10 +124,7 @@ describe("SettingsProfile", () => {
 
   it("should show success toast after changing password", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -156,10 +145,7 @@ describe("SettingsProfile", () => {
 
   it("should clear password fields after successful password change", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -229,10 +215,9 @@ describe("SettingsProfile", () => {
 
   it("should show inline error from API when saving name fails", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Name already taken" }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Name already taken" }, { status: 400 })
+    );
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -245,10 +230,7 @@ describe("SettingsProfile", () => {
 
   it("should show fallback inline error when saving name fails without message", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({}),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({}, { status: 400 }));
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -261,10 +243,9 @@ describe("SettingsProfile", () => {
 
   it("should show inline error from API when changing password fails", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Current password is incorrect" }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Current password is incorrect" }, { status: 400 })
+    );
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -280,10 +261,7 @@ describe("SettingsProfile", () => {
 
   it("should show fallback inline error when changing password fails without message", async () => {
     const user = userEvent.setup();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({}),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({}, { status: 400 }));
 
     render(<SettingsProfile userName="Alice" />);
 
@@ -322,10 +300,7 @@ describe("SettingsProfile", () => {
 
     it("should call onDirtyChange(false) after successful password change", async () => {
       const user = userEvent.setup();
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ success: true }));
 
       const onDirtyChange = vi.fn();
       render(<SettingsProfile userName="Alice" onDirtyChange={onDirtyChange} />);

--- a/packages/web/src/__tests__/components/settings-users.test.tsx
+++ b/packages/web/src/__tests__/components/settings-users.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { SettingsUsers } from "@/components/settings-users";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const mockToast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
 vi.mock("sonner", () => ({ toast: mockToast }));
@@ -83,18 +84,18 @@ describe("SettingsUsers", () => {
   ) {
     vi.mocked(global.fetch).mockImplementation(async (url) => {
       if (String(url) === "/api/users") {
-        return { ok: true, json: async () => ({ users }) } as Response;
+        return jsonResponse({ users });
       }
       if (String(url) === "/api/users/invites") {
-        return { ok: true, json: async () => ({ invites }) } as Response;
+        return jsonResponse({ invites });
       }
       if (String(url) === "/api/groups") {
-        return { ok: true, json: async () => [] } as Response;
+        return jsonResponse([]);
       }
       if (String(url) === "/api/enterprise/status") {
-        return { ok: true, json: async () => ({ enterprise, maxUsers, seatsUsed }) } as Response;
+        return jsonResponse({ enterprise, maxUsers, seatsUsed });
       }
-      return { ok: false } as Response;
+      return jsonResponse(undefined, { status: 400 });
     });
   }
 
@@ -270,10 +271,7 @@ describe("SettingsUsers", () => {
       expect(screen.getByLabelText("Role")).toBeInTheDocument();
     });
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ token: "invite-token-abc" }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ token: "invite-token-abc" }));
 
     await user.click(screen.getByRole("button", { name: "Create Invite" }));
 
@@ -316,10 +314,7 @@ describe("SettingsUsers", () => {
       await user.click(screen.getByRole("button", { name: "Invite User" }));
       await waitFor(() => expect(screen.getByLabelText("Role")).toBeInTheDocument());
 
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: "invite-token-abc" }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ token: "invite-token-abc" }));
       await user.click(screen.getByRole("button", { name: "Create Invite" }));
 
       await waitFor(() =>
@@ -449,18 +444,18 @@ describe("SettingsUsers", () => {
     // Initial load: enterprise enabled but no groups yet
     vi.mocked(global.fetch).mockImplementation(async (url) => {
       if (String(url) === "/api/users") {
-        return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+        return jsonResponse({ users: mockUsers });
       }
       if (String(url) === "/api/users/invites") {
-        return { ok: true, json: async () => ({ invites: [] }) } as Response;
+        return jsonResponse({ invites: [] });
       }
       if (String(url) === "/api/groups") {
-        return { ok: true, json: async () => [] } as Response;
+        return jsonResponse([]);
       }
       if (String(url) === "/api/enterprise/status") {
-        return { ok: true, json: async () => ({ enterprise: true }) } as Response;
+        return jsonResponse({ enterprise: true });
       }
-      return { ok: false } as Response;
+      return jsonResponse(undefined, { status: 400 });
     });
 
     render(<SettingsUsers currentUserId="user-1" />);
@@ -472,21 +467,18 @@ describe("SettingsUsers", () => {
     // Now a group was created (e.g. in Groups tab) — update mock to return it
     vi.mocked(global.fetch).mockImplementation(async (url) => {
       if (String(url) === "/api/users") {
-        return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+        return jsonResponse({ users: mockUsers });
       }
       if (String(url) === "/api/users/invites") {
-        return { ok: true, json: async () => ({ invites: [] }) } as Response;
+        return jsonResponse({ invites: [] });
       }
       if (String(url) === "/api/groups") {
-        return {
-          ok: true,
-          json: async () => [{ id: "g-new", name: "Support" }],
-        } as Response;
+        return jsonResponse([{ id: "g-new", name: "Support" }]);
       }
       if (String(url) === "/api/enterprise/status") {
-        return { ok: true, json: async () => ({ enterprise: true }) } as Response;
+        return jsonResponse({ enterprise: true });
       }
-      return { ok: false } as Response;
+      return jsonResponse(undefined, { status: 400 });
     });
 
     // Click on Bob to open the detail sheet
@@ -605,18 +597,18 @@ describe("SettingsUsers", () => {
           return deletePromise;
         }
         if (String(url) === "/api/users") {
-          return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+          return jsonResponse({ users: mockUsers });
         }
         if (String(url) === "/api/users/invites") {
-          return { ok: true, json: async () => ({ invites: [] }) } as Response;
+          return jsonResponse({ invites: [] });
         }
         if (String(url) === "/api/groups") {
-          return { ok: true, json: async () => [] } as Response;
+          return jsonResponse([]);
         }
         if (String(url) === "/api/enterprise/status") {
-          return { ok: true, json: async () => ({ enterprise: false }) } as Response;
+          return jsonResponse({ enterprise: false });
         }
-        return { ok: false } as Response;
+        return jsonResponse(undefined, { status: 400 });
       });
 
       const table = screen.getByRole("table");
@@ -630,7 +622,7 @@ describe("SettingsUsers", () => {
       });
 
       // Now let the DELETE resolve so React Testing Library can clean up.
-      releaseDelete({ ok: true, json: async () => ({ success: true }) } as Response);
+      releaseDelete(jsonResponse({ success: true }));
     });
 
     it("should call DELETE /api/users/invites/:id when Revoke is clicked", async () => {
@@ -644,21 +636,21 @@ describe("SettingsUsers", () => {
 
       vi.mocked(global.fetch).mockImplementation(async (url, init) => {
         if (String(url) === "/api/users/invites/inv-1" && init?.method === "DELETE") {
-          return { ok: true, json: async () => ({ success: true }) } as Response;
+          return jsonResponse({ success: true });
         }
         if (String(url) === "/api/users") {
-          return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+          return jsonResponse({ users: mockUsers });
         }
         if (String(url) === "/api/users/invites") {
-          return { ok: true, json: async () => ({ invites: [] }) } as Response;
+          return jsonResponse({ invites: [] });
         }
         if (String(url) === "/api/groups") {
-          return { ok: true, json: async () => [] } as Response;
+          return jsonResponse([]);
         }
         if (String(url) === "/api/enterprise/status") {
-          return { ok: true, json: async () => ({ enterprise: false }) } as Response;
+          return jsonResponse({ enterprise: false });
         }
-        return { ok: false } as Response;
+        return jsonResponse(undefined, { status: 400 });
       });
 
       const table = screen.getByRole("table");
@@ -683,21 +675,21 @@ describe("SettingsUsers", () => {
 
       vi.mocked(global.fetch).mockImplementation(async (url, init) => {
         if (String(url) === "/api/users/invites/inv-1" && init?.method === "DELETE") {
-          return { ok: false, status: 500 } as Response; // DELETE fails server-side
+          return jsonResponse(undefined, { status: 500 }); // DELETE fails server-side
         }
         if (String(url) === "/api/users") {
-          return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+          return jsonResponse({ users: mockUsers });
         }
         if (String(url) === "/api/users/invites") {
-          return { ok: true, json: async () => ({ invites: [pendingInvite] }) } as Response;
+          return jsonResponse({ invites: [pendingInvite] });
         }
         if (String(url) === "/api/groups") {
-          return { ok: true, json: async () => [] } as Response;
+          return jsonResponse([]);
         }
         if (String(url) === "/api/enterprise/status") {
-          return { ok: true, json: async () => ({ enterprise: false }) } as Response;
+          return jsonResponse({ enterprise: false });
         }
-        return { ok: false } as Response;
+        return jsonResponse(undefined, { status: 400 });
       });
 
       const table = screen.getByRole("table");
@@ -723,24 +715,24 @@ describe("SettingsUsers", () => {
         const key = `${init?.method || "GET"} ${String(url)}`;
         fetchCalls.push(key);
         if (String(url) === "/api/users/invites/inv-2" && init?.method === "DELETE") {
-          return { ok: true, json: async () => ({ success: true }) } as Response;
+          return jsonResponse({ success: true });
         }
         if (String(url) === "/api/users/invite" && init?.method === "POST") {
-          return { ok: true, json: async () => ({ token: "resend-token-xyz" }) } as Response;
+          return jsonResponse({ token: "resend-token-xyz" });
         }
         if (String(url) === "/api/users") {
-          return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+          return jsonResponse({ users: mockUsers });
         }
         if (String(url) === "/api/users/invites") {
-          return { ok: true, json: async () => ({ invites: [] }) } as Response;
+          return jsonResponse({ invites: [] });
         }
         if (String(url) === "/api/groups") {
-          return { ok: true, json: async () => [] } as Response;
+          return jsonResponse([]);
         }
         if (String(url) === "/api/enterprise/status") {
-          return { ok: true, json: async () => ({ enterprise: false }) } as Response;
+          return jsonResponse({ enterprise: false });
         }
-        return { ok: false } as Response;
+        return jsonResponse(undefined, { status: 400 });
       });
 
       const table = screen.getByRole("table");
@@ -793,24 +785,24 @@ describe("SettingsUsers", () => {
 
         vi.mocked(global.fetch).mockImplementation(async (url, init) => {
           if (String(url) === "/api/users/invites/inv-2" && init?.method === "DELETE") {
-            return { ok: true, json: async () => ({ success: true }) } as Response;
+            return jsonResponse({ success: true });
           }
           if (String(url) === "/api/users/invite" && init?.method === "POST") {
-            return { ok: true, json: async () => ({ token: "resend-token-xyz" }) } as Response;
+            return jsonResponse({ token: "resend-token-xyz" });
           }
           if (String(url) === "/api/users") {
-            return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+            return jsonResponse({ users: mockUsers });
           }
           if (String(url) === "/api/users/invites") {
-            return { ok: true, json: async () => ({ invites: [] }) } as Response;
+            return jsonResponse({ invites: [] });
           }
           if (String(url) === "/api/groups") {
-            return { ok: true, json: async () => [] } as Response;
+            return jsonResponse([]);
           }
           if (String(url) === "/api/enterprise/status") {
-            return { ok: true, json: async () => ({ enterprise: false }) } as Response;
+            return jsonResponse({ enterprise: false });
           }
-          return { ok: false } as Response;
+          return jsonResponse(undefined, { status: 400 });
         });
 
         const table = screen.getByRole("table");
@@ -845,19 +837,19 @@ describe("SettingsUsers", () => {
       let postCalled = false;
       vi.mocked(global.fetch).mockImplementation(async (url, init) => {
         if (String(url) === "/api/users/invites/inv-2" && init?.method === "DELETE") {
-          return { ok: false, status: 500 } as Response;
+          return jsonResponse(undefined, { status: 500 });
         }
         if (String(url) === "/api/users/invite" && init?.method === "POST") {
           postCalled = true;
-          return { ok: true, json: async () => ({ token: "x" }) } as Response;
+          return jsonResponse({ token: "x" });
         }
         if (String(url) === "/api/users") {
-          return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+          return jsonResponse({ users: mockUsers });
         }
         if (String(url) === "/api/users/invites") {
-          return { ok: true, json: async () => ({ invites: [] }) } as Response;
+          return jsonResponse({ invites: [] });
         }
-        return { ok: true, json: async () => [] } as Response;
+        return jsonResponse([]);
       });
 
       const table = screen.getByRole("table");
@@ -881,18 +873,18 @@ describe("SettingsUsers", () => {
 
       vi.mocked(global.fetch).mockImplementation(async (url, init) => {
         if (String(url) === "/api/users/invites/inv-2" && init?.method === "DELETE") {
-          return { ok: true, json: async () => ({ success: true }) } as Response;
+          return jsonResponse({ success: true });
         }
         if (String(url) === "/api/users/invite" && init?.method === "POST") {
-          return { ok: false, status: 500 } as Response;
+          return jsonResponse(undefined, { status: 500 });
         }
         if (String(url) === "/api/users") {
-          return { ok: true, json: async () => ({ users: mockUsers }) } as Response;
+          return jsonResponse({ users: mockUsers });
         }
         if (String(url) === "/api/users/invites") {
-          return { ok: true, json: async () => ({ invites: [] }) } as Response;
+          return jsonResponse({ invites: [] });
         }
-        return { ok: true, json: async () => [] } as Response;
+        return jsonResponse([]);
       });
 
       const table = screen.getByRole("table");

--- a/packages/web/src/__tests__/components/setup-form.test.tsx
+++ b/packages/web/src/__tests__/components/setup-form.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { SetupForm, PREFLIGHT_CONFIG } from "@/components/setup-form";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 const { mockRouterPush } = vi.hoisted(() => ({ mockRouterPush: vi.fn() }));
 vi.mock("next/navigation", () => ({
@@ -27,10 +28,9 @@ describe("SetupForm", () => {
   });
 
   function mockPreflightReady() {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      json: async () => ({ infrastructure: { database: "connected", openclaw: "connected" } }),
-    } as Response);
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ infrastructure: { database: "connected", openclaw: "connected" } })
+    );
   }
 
   it("shows checking state initially", () => {
@@ -59,12 +59,11 @@ describe("SetupForm", () => {
   });
 
   it("shows infrastructure error when services are unreachable", async () => {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
         infrastructure: { database: "unreachable", openclaw: "unreachable" },
-      }),
-    } as Response);
+      })
+    );
     render(<SetupForm />);
     await waitFor(() => expect(screen.getByText(/waiting for services/i)).toBeInTheDocument());
     expect(screen.getByText(/database/i)).toBeInTheDocument();
@@ -109,14 +108,10 @@ describe("SetupForm", () => {
   it("shows success state after successful submit", async () => {
     mockPreflightReady();
     fetchSpy
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ infrastructure: { database: "connected", openclaw: "connected" } }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      .mockResolvedValueOnce(
+        jsonResponse({ infrastructure: { database: "connected", openclaw: "connected" } })
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SetupForm />);
     await waitFor(() => screen.getByRole("button", { name: /create account/i }));
@@ -135,14 +130,10 @@ describe("SetupForm", () => {
   it("navigates to /login when Continue is clicked after success", async () => {
     mockPreflightReady();
     fetchSpy
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ infrastructure: { database: "connected", openclaw: "connected" } }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ success: true }),
-      } as Response);
+      .mockResolvedValueOnce(
+        jsonResponse({ infrastructure: { database: "connected", openclaw: "connected" } })
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
 
     render(<SetupForm />);
     await waitFor(() => screen.getByRole("button", { name: /create account/i }));
@@ -162,14 +153,10 @@ describe("SetupForm", () => {
   it("shows API error message on failed submit", async () => {
     mockPreflightReady();
     fetchSpy
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ infrastructure: { database: "connected", openclaw: "connected" } }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({ error: "Setup already complete" }),
-      } as Response);
+      .mockResolvedValueOnce(
+        jsonResponse({ infrastructure: { database: "connected", openclaw: "connected" } })
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: "Setup already complete" }, { status: 400 }));
 
     render(<SetupForm />);
     await waitFor(() => screen.getByRole("button", { name: /create account/i }));

--- a/packages/web/src/__tests__/components/timezone-settings.test.tsx
+++ b/packages/web/src/__tests__/components/timezone-settings.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { TimezoneSettings, getSupportedTimezones } from "@/components/timezone-settings";
 import { toast } from "sonner";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -26,10 +27,9 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("renders after fetching settings from /api/settings", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [{ key: "org.timezone", value: "UTC" }],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse([{ key: "org.timezone", value: "UTC" }])
+    );
 
     render(<TimezoneSettings />);
 
@@ -41,10 +41,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("renders a Save button", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse([]));
 
     render(<TimezoneSettings />);
 
@@ -54,10 +51,9 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("shows Europe/Vienna timezone option in the dropdown", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [{ key: "org.timezone", value: "UTC" }],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse([{ key: "org.timezone", value: "UTC" }])
+    );
 
     render(<TimezoneSettings />);
 
@@ -74,10 +70,9 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("POSTs the saved timezone to /api/settings when Save is clicked", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [{ key: "org.timezone", value: "UTC" }],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse([{ key: "org.timezone", value: "UTC" }])
+    );
 
     render(<TimezoneSettings />);
 
@@ -90,10 +85,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
     const option = await screen.findByRole("option", { name: "Europe/Vienna" });
     await userEvent.click(option);
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ ok: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -109,10 +101,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("POSTs the current timezone (UTC default) to /api/settings when no org.timezone setting exists", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse([]));
 
     render(<TimezoneSettings />);
 
@@ -120,10 +109,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     });
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ ok: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -139,10 +125,9 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("shows success toast after saving", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [{ key: "org.timezone", value: "UTC" }],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse([{ key: "org.timezone", value: "UTC" }])
+    );
 
     render(<TimezoneSettings />);
 
@@ -150,10 +135,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     });
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ ok: true }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -163,10 +145,9 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("shows inline error when save fails", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [{ key: "org.timezone", value: "UTC" }],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse([{ key: "org.timezone", value: "UTC" }])
+    );
 
     render(<TimezoneSettings />);
 
@@ -174,10 +155,9 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     });
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Invalid timezone" }),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "Invalid timezone" }, { status: 400 })
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -206,10 +186,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
 
       // The failed preload must leave the component on the sane UTC default,
       // provable through the payload it POSTs on Save.
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ ok: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
 
       await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -234,10 +211,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
     const onRejection = (reason: unknown) => rejections.push(reason);
     process.on("unhandledRejection", onRejection);
     try {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({}),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({}));
 
       render(<TimezoneSettings />);
 
@@ -247,10 +221,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ ok: true }),
-      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
 
       await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -283,10 +254,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
   });
 
   it("shows fallback inline error when save fails without message", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => [],
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse([]));
 
     render(<TimezoneSettings />);
 
@@ -294,10 +262,7 @@ describe("TimezoneSettings", { timeout: 30_000 }, () => {
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     });
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({}),
-    } as Response);
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({}, { status: 400 }));
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 

--- a/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
+++ b/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { UserDetailSheet } from "@/components/user-detail-sheet";
 import type { UserListItem } from "@/lib/user-list";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 vi.mock("@/lib/enterprise", () => ({
   // Client component — mock at fetch level instead
@@ -352,12 +353,12 @@ describe("UserDetailSheet", () => {
     // role PATCH lands, groups PUT fails — the classic partial-success case.
     vi.spyOn(global, "fetch").mockImplementation(async (url, init) => {
       if (String(url) === "/api/users/u1" && init?.method === "PATCH") {
-        return { ok: true, json: async () => ({}) } as Response;
+        return jsonResponse({});
       }
       if (String(url) === "/api/users/u1/groups" && init?.method === "PUT") {
-        return { ok: false, status: 500 } as Response;
+        return jsonResponse(undefined, { status: 500 });
       }
-      return { ok: true, json: async () => ({}) } as Response;
+      return jsonResponse({});
     });
 
     render(
@@ -416,10 +417,7 @@ describe("UserDetailSheet", () => {
     const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
 
     try {
-      vi.spyOn(global, "fetch").mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ token: "reset-token-xyz" }),
-      } as Response);
+      vi.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({ token: "reset-token-xyz" }));
 
       render(
         <UserDetailSheet

--- a/packages/web/src/__tests__/eslint/no-raw-fetch-mutation.test.ts
+++ b/packages/web/src/__tests__/eslint/no-raw-fetch-mutation.test.ts
@@ -1,0 +1,174 @@
+import { RuleTester } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const rule = require("../../../eslint-rules/no-raw-fetch-mutation.js");
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+const CLIENT = "/repo/packages/web/src/components/settings-users.tsx";
+
+tester.run("no-raw-fetch-mutation", rule, {
+  valid: [
+    // The typed client is the point of the rule — never reported.
+    {
+      code: `await apiPost("/api/users/invite", { email });`,
+      filename: CLIENT,
+    },
+    // A read is not a mutation. GET/HEAD stay on raw fetch (apiGet exists, but
+    // a GET that reads headers or streams is legitimate and this rule is about
+    // the error-contract drift that only mutations produce).
+    {
+      code: `await fetch("/api/agents");`,
+      filename: CLIENT,
+    },
+    {
+      code: `await fetch(url, { method: "GET" });`,
+      filename: CLIENT,
+    },
+    {
+      code: `await fetch(url, { method: "HEAD", signal: ctrl.signal });`,
+      filename: CLIENT,
+    },
+    // Outside the configured scope the rule does nothing — server code, tests
+    // and plugins reach real third-party endpoints where there is no api-client.
+    {
+      code: `await fetch("https://api.example.com", { method: "POST" });`,
+      filename: "/repo/packages/web/src/lib/some-server-lib.ts",
+    },
+    {
+      code: `await fetch("/api/x", { method: "POST" });`,
+      filename: "/repo/packages/web/src/__tests__/api/x.test.ts",
+    },
+    // An exemption with a written reason on the statement directly above.
+    {
+      code: `// raw-fetch-exempt: multipart upload — apiPost JSON-stringifies the body\nawait fetch("/api/upload", { method: "POST", body: form });`,
+      filename: CLIENT,
+    },
+    // Block comments carry the exemption too.
+    {
+      code: `/* raw-fetch-exempt: needs the raw Response to stream the download */\nconst res = await fetch("/api/export", { method: "POST" });`,
+      filename: CLIENT,
+    },
+    // The exemption clears only the statement it sits on, but it does clear a
+    // multi-line call.
+    {
+      code: `// raw-fetch-exempt: reads Content-Disposition off the response\nconst res = await fetch("/api/export", {\n  method: "POST",\n  body: JSON.stringify(x),\n});`,
+      filename: CLIENT,
+    },
+    // A non-literal method is out of the rule's reach by design (see the header
+    // comment) — it must not be reported, or the rule guesses.
+    {
+      code: `await fetch(url, { method: verb });`,
+      filename: CLIENT,
+    },
+    // `fetch` as a value, not a call.
+    {
+      code: `const f = fetch;`,
+      filename: CLIENT,
+    },
+    // A same-named method on something that is not fetch.
+    {
+      code: `await client.request(url, { method: "POST" });`,
+      filename: CLIENT,
+    },
+    // No init object at all.
+    {
+      code: `await fetch(url);`,
+      filename: CLIENT,
+    },
+    // API route handlers live under src/app too, and are server code — the
+    // rule must not reach them (`.ts`, not `.tsx`).
+    {
+      code: `await fetch("https://third-party.example", { method: "POST" });`,
+      filename: "/repo/packages/web/src/app/api/x/route.ts",
+    },
+  ],
+  invalid: [
+    {
+      code: `await fetch("/api/users/invite", { method: "POST", body: JSON.stringify(b) });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation", data: { method: "POST", helper: "apiPost" } }],
+    },
+    {
+      code: `await fetch(\`/api/users/\${id}\`, { method: "DELETE" });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation", data: { method: "DELETE", helper: "apiDelete" } }],
+    },
+    {
+      code: `await fetch(url, { method: "PATCH", body: b });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation", data: { method: "PATCH", helper: "apiPatch" } }],
+    },
+    {
+      code: `await fetch(url, { method: "PUT", body: b });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation", data: { method: "PUT", helper: "apiPut" } }],
+    },
+    // Lowercase and mixed case are the same request.
+    {
+      code: `await fetch(url, { method: "post" });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation", data: { method: "post", helper: "apiPost" } }],
+    },
+    // A template literal with no expressions is a string literal.
+    {
+      code: "await fetch(url, { method: `POST` });",
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+    // TypeScript wrappers must not hide the method.
+    {
+      code: `await fetch(url, { method: "POST" as const });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation" }],
+      languageOptions: { parser: tsParser },
+    },
+    // window.fetch / globalThis.fetch are the same call.
+    {
+      code: `await window.fetch(url, { method: "POST" });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+    {
+      code: `await globalThis.fetch(url, { method: "DELETE" });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+    // Hooks are in scope.
+    {
+      code: `await fetch("/api/integrations/x", { method: "POST" });`,
+      filename: "/repo/packages/web/src/hooks/use-integration-actions.ts",
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+    // Client pages under app/ are in scope; API route handlers (.ts) are not.
+    {
+      code: `await fetch("/api/invite/claim", { method: "POST" });`,
+      filename: "/repo/packages/web/src/app/invite/[token]/page.tsx",
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+    // A bare marker with no reason is not an exemption — same contract as the
+    // Docs-not-needed trailer: the assertion IS the artefact.
+    {
+      code: `// raw-fetch-exempt:\nawait fetch(url, { method: "POST" });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+    // A comment that does not carry the marker is not an exemption.
+    {
+      code: `// this one is fine, promise\nawait fetch(url, { method: "POST" });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+    // An exemption further up, with code in between, does not reach down.
+    {
+      code: `// raw-fetch-exempt: applies to the call above only\nawait fetch(a, { method: "POST" });\nawait fetch(b, { method: "POST" });`,
+      filename: CLIENT,
+      errors: [{ messageId: "rawFetchMutation" }],
+    },
+  ],
+});

--- a/packages/web/src/__tests__/lib/api-client.test.ts
+++ b/packages/web/src/__tests__/lib/api-client.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { apiPost, apiDelete, apiGet, ApiError, extractFieldErrors } from "@/lib/api-client";
+import {
+  apiPost,
+  apiDelete,
+  apiGet,
+  ApiError,
+  errorMessage,
+  extractFieldErrors,
+} from "@/lib/api-client";
 
 /**
  * Helper to build a Response-shaped mock that matches what `send()` reads.
@@ -99,6 +106,86 @@ describe("apiPost", () => {
     );
   });
 
+  // Several routes answer with BOTH a headline and the actionable sentence:
+  // `{ error: "Seat limit reached", message: "Your license includes 5 seats…" }`
+  // (users/invite, groups/[groupId]/members, users/[userId]/groups). Reading
+  // only `error` threw away the half that tells the user what to do about it.
+  it("joins the server's error headline and its actionable message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: false,
+          status: 403,
+          body: {
+            error: "Seat limit reached",
+            message: "Remove an existing user or email sales@heypinchy.com.",
+          },
+        })
+      )
+    );
+    await expect(apiPost("/api/users/invite", {})).rejects.toMatchObject({
+      status: 403,
+      message: "Seat limit reached — Remove an existing user or email sales@heypinchy.com.",
+    });
+  });
+
+  it("uses `message` alone when the body carries no `error` headline", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          mockResponse({ ok: false, status: 400, body: { message: "Mailbox is unreachable" } })
+        )
+    );
+    await expect(apiPost("/api/x", {})).rejects.toThrow("Mailbox is unreachable");
+  });
+
+  it("does not repeat itself when `error` and `message` say the same thing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: false,
+          status: 400,
+          body: { error: "Invite not found", message: "Invite not found" },
+        })
+      )
+    );
+    await expect(apiPost("/api/x", {})).rejects.toThrow(/^Invite not found$/);
+  });
+
+  // A non-string `error` must never reach `new Error(...)`, or the user is
+  // shown "[object Object]".
+  it("falls back rather than stringifying a non-string error field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: false,
+          status: 500,
+          body: { error: { message: "nested" } },
+        })
+      )
+    );
+    await expect(apiPost("/api/x", {})).rejects.toThrow("Something went wrong. Please try again.");
+  });
+
+  it("ignores a non-string message field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: false,
+          status: 400,
+          body: { error: "Validation failed", message: { nested: true } },
+        })
+      )
+    );
+    await expect(apiPost("/api/x", {})).rejects.toThrow(/^Validation failed$/);
+  });
+
   it("throws an ApiError instance on non-2xx (instanceof check)", async () => {
     vi.stubGlobal(
       "fetch",
@@ -114,6 +201,60 @@ describe("apiPost", () => {
       expect((e as ApiError).status).toBe(403);
       expect((e as ApiError).message).toBe("Forbidden");
     }
+  });
+
+  it("exposes the whole parsed error payload on ApiError.body", async () => {
+    // The escape hatch for routes that answer a field beyond
+    // `{ error, message, details }` — /api/setup/provider sends a `docs` link
+    // with its 400, and provider-key-form reads it back off `body`.
+    const payload = {
+      error: "Invalid API key",
+      docs: { href: "https://docs.heypinchy.com/x", label: "Read the guide" },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockResponse({ ok: false, status: 400, body: payload }))
+    );
+    try {
+      await apiPost("/api/setup/provider", {});
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as ApiError).body).toEqual(payload);
+    }
+  });
+});
+
+/**
+ * `errorMessage` is what every catch block in the app calls, so its contract is
+ * worth pinning directly rather than only through the components that use it.
+ *
+ * The rule it encodes: show the SERVER's wording when there was one, and the
+ * caller's context-specific fallback otherwise. The interesting case is the
+ * third one — an ApiError whose message is api-client's own generic sentence
+ * carries no server wording at all, so the fallback ("Failed to save timezone")
+ * is strictly more useful than passing the generic through.
+ */
+describe("errorMessage", () => {
+  it("prefers the server's own wording over the caller's fallback", () => {
+    const e = new ApiError(404, "Invite not found");
+    expect(errorMessage(e, "Failed to revoke invite. Please try again.")).toBe("Invite not found");
+  });
+
+  it("falls back when the route sent no wording at all", () => {
+    // What `send()` builds for a bare 500 or a proxy's HTML error page.
+    const e = new ApiError(500, "Something went wrong. Please try again.");
+    expect(errorMessage(e, "Failed to save timezone")).toBe("Failed to save timezone");
+  });
+
+  it("falls back for a network failure rather than leaking its internal text", () => {
+    // A fetch rejection is a TypeError whose message is "Failed to fetch" —
+    // never user-facing copy. Showing it on the setup screen is the regression
+    // this helper exists to prevent.
+    expect(errorMessage(new TypeError("Failed to fetch"), "Setup failed")).toBe("Setup failed");
+  });
+
+  it("falls back for a non-Error value", () => {
+    expect(errorMessage("boom", "Failed to create agent")).toBe("Failed to create agent");
   });
 });
 

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { requireAdmin, withAuth } from "@/lib/api-auth";
 import {
   validateTelegramBotToken,
@@ -17,10 +16,7 @@ import { db } from "@/db";
 import { agents, channelLinks, settings } from "@/db/schema";
 import { eq, like } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const setBotTokenSchema = z.object({
-  botToken: z.string().min(1),
-});
+import { setBotTokenSchema } from "@/lib/schemas/telegram";
 
 export async function GET(req: Request, { params }: { params: Promise<{ agentId: string }> }) {
   const admin = await requireAdmin();

--- a/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
@@ -1,12 +1,11 @@
 // audit-exempt: knowledge base file edits are per-agent content changes, not admin actions
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
 import { parseRequestBody } from "@/lib/api-validation";
 
-const writeFileSchema = z.object({ content: z.string() });
+import { writeAgentFileSchema } from "@/lib/schemas/agents";
 
 type Params = { params: Promise<{ agentId: string; filename: string }> };
 
@@ -35,7 +34,7 @@ export const PUT = withAuth<Params>(async (request, { params }, session) => {
   const denied = requireAgentWriteAccess(agentOrError, session.user.id!, session.user.role);
   if (denied) return denied;
 
-  const parsed = await parseRequestBody(writeFileSchema, request);
+  const parsed = await parseRequestBody(writeAgentFileSchema, request);
   if ("error" in parsed) return parsed.error;
   const { content } = parsed.data;
 

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -1,13 +1,7 @@
 import { NextResponse, after } from "next/server";
 import { revalidatePath } from "next/cache";
 import { eq, inArray } from "drizzle-orm";
-import { z } from "zod";
-import {
-  updateAgent,
-  deleteAgent,
-  AGENT_NAME_MAX_LENGTH,
-  AgentRuntimeUpdateError,
-} from "@/lib/agents";
+import { updateAgent, deleteAgent, AgentRuntimeUpdateError } from "@/lib/agents";
 import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
 import { appendAuditLog, safeProviderError } from "@/lib/audit";
@@ -16,33 +10,14 @@ import { isEnterprise } from "@/lib/enterprise";
 import { writeIdentityFile } from "@/lib/workspace";
 import { db } from "@/db";
 import { agentGroups, groups, type AgentPluginConfig } from "@/db/schema";
-import { AGENT_VISIBILITIES, type AgentVisibility } from "@/db/enums";
+import type { AgentVisibility } from "@/db/enums";
 import { getAgentGroupIds } from "@/lib/groups";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
-import { validatePinchyWebConfig, pluginConfigSchema } from "@/lib/domain-validation";
+import { validatePinchyWebConfig } from "@/lib/domain-validation";
 import { parseRequestBody } from "@/lib/api-validation";
 import { validateAgentModel } from "@/lib/agent-model-validation";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
-import { starterPromptsSchema } from "@/lib/schemas/starter-prompts";
-
-const updateAgentSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .max(AGENT_NAME_MAX_LENGTH)
-    .refine((v) => v.trim().length > 0, "Name is required")
-    .optional(),
-  model: z.string().optional(),
-  allowedTools: z.array(z.string()).optional(),
-  pluginConfig: pluginConfigSchema.nullable().optional(),
-  greetingMessage: z.string().min(1, "Greeting message cannot be empty").optional(),
-  tagline: z.string().nullable().optional(),
-  starterPrompts: starterPromptsSchema.optional(),
-  avatarSeed: z.string().nullable().optional(),
-  personalityPresetId: z.string().nullable().optional(),
-  visibility: z.enum(AGENT_VISIBILITIES).optional(),
-  groupIds: z.array(z.string()).optional(),
-});
+import { updateAgentSchema } from "@/lib/schemas/agents";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 

--- a/packages/web/src/app/api/enterprise/key/route.ts
+++ b/packages/web/src/app/api/enterprise/key/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { setSetting } from "@/lib/settings";
 import { clearLicenseCache, validateLicenseToken, isKeyFromEnv } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const setLicenseKeySchema = z.object({ key: z.string().min(1) });
+import { setLicenseKeySchema } from "@/lib/schemas/enterprise";
 
 export async function PUT(req: NextRequest) {
   const sessionOrError = await requireAdmin();

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -6,7 +6,7 @@ import { integrationConnections } from "@/db/schema";
 import { encrypt, decrypt } from "@/lib/encryption";
 import { appendAuditLog, scrubEmails } from "@/lib/audit";
 import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
-import { imapEditSchema } from "@/lib/schemas/integration-edit";
+import { imapEditSchema, updateConnectionSchema } from "@/lib/schemas/integration-edit";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { maskConnectionCredentials } from "@/lib/integrations/mask-credentials";
 import { probeIntegrationCredentials } from "@/lib/integrations/probe";
@@ -14,14 +14,6 @@ import { getOAuthProvider } from "@/lib/integrations/oauth-providers";
 import { clearIntegrationAuthError } from "@/lib/integrations/auth-state";
 import { z } from "zod";
 import { parseRequestBody, formatValidationError } from "@/lib/api-validation";
-
-const updateConnectionSchema = z
-  .object({
-    name: z.string().min(1).max(100).optional(),
-    description: z.string().max(500).optional(),
-    credentials: z.record(z.string(), z.unknown()).optional(),
-  })
-  .passthrough();
 
 const credentialSchemas: Record<string, z.ZodType> = {
   odoo: odooCredentialsSchema.partial(),

--- a/packages/web/src/app/api/integrations/list-databases/route.ts
+++ b/packages/web/src/app/api/integrations/list-databases/route.ts
@@ -1,13 +1,9 @@
 // audit-exempt: read-only database list, no state changes
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const listDatabasesSchema = z.object({
-  url: z.string().url(),
-});
+import { listDatabasesSchema } from "@/lib/schemas/integrations";
 
 export const POST = withAdmin(async (request) => {
   const parsed = await parseRequestBody(listDatabasesSchema, request);

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -1,31 +1,14 @@
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { encrypt, decrypt } from "@/lib/encryption";
 import { deferAuditLog } from "@/lib/audit-deferred";
-import { odooCredentialsSchema, odooConnectionDataSchema } from "@/lib/integrations/odoo-schema";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { maskConnectionCredentials } from "@/lib/integrations/mask-credentials";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const createIntegrationSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("odoo"),
-    name: z.string().min(1).max(100),
-    description: z.string().max(500).default(""),
-    credentials: odooCredentialsSchema,
-    data: odooConnectionDataSchema.optional(),
-  }),
-  z.object({
-    type: z.literal("web-search"),
-    name: z.string().min(1).max(100),
-    description: z.string().max(500).default(""),
-    credentials: z.object({ apiKey: z.string().min(1) }),
-  }),
-]);
+import { createIntegrationSchema } from "@/lib/schemas/integrations";
 
 export const GET = withAdmin(async () => {
   const connections = await db.select().from(integrationConnections);

--- a/packages/web/src/app/api/integrations/sync-preview/route.ts
+++ b/packages/web/src/app/api/integrations/sync-preview/route.ts
@@ -1,21 +1,10 @@
 // audit-exempt: read-only preview, no state changes
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const syncPreviewSchema = z.object({
-  type: z.literal("odoo"),
-  credentials: z.object({
-    url: z.string().url(),
-    db: z.string().min(1),
-    login: z.string().min(1),
-    apiKey: z.string().min(1),
-    uid: z.number().int().positive(),
-  }),
-});
+import { syncPreviewSchema } from "@/lib/schemas/integrations";
 
 export const POST = withAdmin(async (request) => {
   const parsed = await parseRequestBody(syncPreviewSchema, request);

--- a/packages/web/src/app/api/integrations/test-credentials/route.ts
+++ b/packages/web/src/app/api/integrations/test-credentials/route.ts
@@ -1,28 +1,10 @@
 // audit-exempt: read-only credential test, no state changes
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { OdooClient } from "odoo-node";
 import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const testCredentialsSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("odoo"),
-    credentials: z.object({
-      url: z.string().url(),
-      db: z.string().min(1),
-      login: z.string().min(1),
-      apiKey: z.string().min(1),
-    }),
-  }),
-  z.object({
-    type: z.literal("web-search"),
-    credentials: z.object({
-      apiKey: z.string().min(1),
-    }),
-  }),
-]);
+import { testCredentialsSchema } from "@/lib/schemas/integrations";
 
 export const POST = withAdmin(async (request) => {
   const parsed = await parseRequestBody(testCredentialsSchema, request);

--- a/packages/web/src/app/api/invite/claim/route.ts
+++ b/packages/web/src/app/api/invite/claim/route.ts
@@ -4,7 +4,6 @@
 // row below, because a password change is security-sensitive regardless
 // of who triggers it.
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { hashPassword } from "better-auth/crypto";
 import { auth } from "@/lib/auth";
 import { db } from "@/db";
@@ -17,13 +16,8 @@ import { waitForAgentInRuntime } from "@/lib/wait-for-agent-in-runtime";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { validatePassword } from "@/lib/validate-password";
 import { parseRequestBody } from "@/lib/api-validation";
+import { claimInviteSchema } from "@/lib/schemas/invite";
 import { appendAuditLog } from "@/lib/audit";
-
-const claimInviteSchema = z.object({
-  token: z.string().min(1),
-  name: z.string().optional(),
-  password: z.string(),
-});
 
 export async function POST(request: NextRequest) {
   const parsed = await parseRequestBody(claimInviteSchema, request);

--- a/packages/web/src/app/api/settings/providers/route.ts
+++ b/packages/web/src/app/api/settings/providers/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse, after } from "next/server";
-import { z } from "zod";
 import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getSetting, deleteSetting } from "@/lib/settings";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
@@ -14,12 +13,7 @@ import {
   capMigratedAgents,
 } from "@/lib/provider-deletion";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const VALID_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
-
-const deleteProviderSchema = z.object({
-  provider: z.enum(VALID_PROVIDERS as [ProviderName, ...ProviderName[]]),
-});
+import { deleteProviderSchema } from "@/lib/schemas/providers";
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const isAdmin = session.user.role === "admin";

--- a/packages/web/src/app/api/settings/route.ts
+++ b/packages/web/src/app/api/settings/route.ts
@@ -1,15 +1,10 @@
 import { NextRequest, NextResponse, after } from "next/server";
-import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { getAllSettings, setSetting } from "@/lib/settings";
 import { getOrgTimezone, setOrgTimezone, isValidIanaTimezone } from "@/lib/settings-timezone";
 import { appendAuditLog } from "@/lib/audit";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const setSettingSchema = z.object({
-  key: z.string().min(1),
-  value: z.string(),
-});
+import { orgSettingSchema } from "@/lib/schemas/settings";
 
 export async function GET() {
   const sessionOrError = await requireAdmin();
@@ -27,7 +22,7 @@ export async function POST(request: NextRequest) {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  const parsed = await parseRequestBody(setSettingSchema, request);
+  const parsed = await parseRequestBody(orgSettingSchema, request);
   if ("error" in parsed) return parsed.error;
   const { key, value } = parsed.data;
 

--- a/packages/web/src/app/api/settings/telegram/route.ts
+++ b/packages/web/src/app/api/settings/telegram/route.ts
@@ -4,7 +4,6 @@
 // lib/telegram-pairing-security.ts — because that path is the brute-force
 // surface; the exemption covers success/unlink only.
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { resolvePairingCode } from "@/lib/telegram-pairing";
 import {
@@ -17,8 +16,7 @@ import { db } from "@/db";
 import { channelLinks } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const linkTelegramSchema = z.object({ code: z.string().min(1) });
+import { linkTelegramSchema } from "@/lib/schemas/telegram";
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const link = await db.query.channelLinks.findFirst({

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse, after } from "next/server";
-import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   validateProviderKey,
@@ -24,15 +23,8 @@ import { agents } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { appendAuditLog } from "@/lib/audit";
 import { parseRequestBody } from "@/lib/api-validation";
+import { setupProviderSchema } from "@/lib/schemas/providers";
 import { docsUrl } from "@/components/docs-link";
-
-const VALID_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
-
-const setupProviderSchema = z.object({
-  provider: z.enum(VALID_PROVIDERS as [ProviderName, ...ProviderName[]]),
-  url: z.string().min(1).optional(),
-  apiKey: z.string().min(1).optional(),
-});
 
 export async function POST(request: NextRequest) {
   const sessionOrError = await requireAdmin();

--- a/packages/web/src/app/api/setup/route.ts
+++ b/packages/web/src/app/api/setup/route.ts
@@ -1,11 +1,11 @@
 // audit-exempt: initial setup runs before any users exist, no actor to audit
 import { NextRequest, NextResponse } from "next/server";
-import { z } from "zod";
 import { createAdmin } from "@/lib/setup";
 import { validatePassword } from "@/lib/validate-password";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { markOpenClawConfigReady, isOpenClawConfigReady } from "@/lib/openclaw-config-ready";
 import { parseRequestBody } from "@/lib/api-validation";
+import { setupSchema } from "@/lib/schemas/setup";
 
 // Coalesces concurrent config-recovery retries into a single regeneration.
 // The recovery path is reachable without auth (the admin already exists), so a
@@ -15,17 +15,6 @@ import { parseRequestBody } from "@/lib/api-validation";
 // requests await it instead of starting their own. Module-scoped because a
 // Next.js route module is a per-process singleton.
 let recoveryInFlight: Promise<void> | null = null;
-
-const setupSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .transform((v) => v.trim())
-    .refine((v) => v.length > 0, "Name is required"),
-  email: z.string().email("A valid email address is required"),
-  password: z.string(),
-  browserTimezone: z.string().optional(),
-});
 
 export async function POST(request: NextRequest) {
   try {

--- a/packages/web/src/app/api/users/[userId]/groups/route.ts
+++ b/packages/web/src/app/api/users/[userId]/groups/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse, after } from "next/server";
-import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { db } from "@/db";
@@ -8,10 +7,7 @@ import { eq, inArray } from "drizzle-orm";
 import { appendAuditLog } from "@/lib/audit";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const updateUserGroupsSchema = z.object({
-  groupIds: z.array(z.string()),
-});
+import { updateUserGroupsSchema } from "@/lib/schemas/users";
 
 export async function PUT(
   request: NextRequest,

--- a/packages/web/src/app/api/users/[userId]/route.ts
+++ b/packages/web/src/app/api/users/[userId]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse, after } from "next/server";
-import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users, agents, sessions } from "@/db/schema";
@@ -9,10 +8,7 @@ import { deleteWorkspace } from "@/lib/workspace";
 import { appendAuditLog } from "@/lib/audit";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const updateUserSchema = z.object({
-  role: z.enum(["admin", "member"]),
-});
+import { updateUserSchema } from "@/lib/schemas/users";
 
 export async function PATCH(
   request: NextRequest,

--- a/packages/web/src/app/api/users/invite/route.ts
+++ b/packages/web/src/app/api/users/invite/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse, after } from "next/server";
-import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { createInvite } from "@/lib/invites";
 import { appendAuditLog, redactEmail } from "@/lib/audit";
@@ -8,15 +7,9 @@ import { getSeatUsage } from "@/lib/seat-usage";
 import { evaluateSeatPressure } from "@/lib/seat-grace";
 import { db } from "@/db";
 import { groups } from "@/db/schema";
-import { INVITE_ROLES } from "@/db/enums";
 import { inArray } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const inviteUserSchema = z.object({
-  email: z.string().email().optional(),
-  role: z.enum(INVITE_ROLES),
-  groupIds: z.array(z.string()).optional(),
-});
+import { inviteUserSchema } from "@/lib/schemas/users";
 
 export async function POST(request: NextRequest) {
   const sessionOrError = await requireAdmin();

--- a/packages/web/src/app/api/users/me/password/route.ts
+++ b/packages/web/src/app/api/users/me/password/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
-import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
@@ -12,14 +11,7 @@ import {
   PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MS,
   PASSWORD_CHANGE_RATE_LIMIT_WINDOW_MINUTES,
 } from "@/lib/password-change-rate-limiter";
-
-// Shape only — length/breach-list policy is enforced post-parse via
-// validatePassword() so the same rules apply to setup, invite-claim, and
-// password-change without drifting between routes.
-const changePasswordSchema = z.object({
-  currentPassword: z.string().min(1),
-  newPassword: z.string(),
-});
+import { changePasswordSchema } from "@/lib/schemas/settings";
 
 export const POST = withAuth(async (request, _ctx, session) => {
   const parsed = await parseRequestBody(changePasswordSchema, request);

--- a/packages/web/src/app/api/users/me/route.ts
+++ b/packages/web/src/app/api/users/me/route.ts
@@ -1,19 +1,11 @@
 // audit-exempt: users updating their own profile is a self-service action
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
-
-const updateMeSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .transform((v) => v.trim())
-    .refine((v) => v.length > 0, "Name is required"),
-});
+import { updateMeSchema } from "@/lib/schemas/settings";
 
 export const PATCH = withAuth(async (request, _ctx, session) => {
   const parsed = await parseRequestBody(updateMeSchema, request);

--- a/packages/web/src/app/invite/[token]/page.tsx
+++ b/packages/web/src/app/invite/[token]/page.tsx
@@ -20,6 +20,8 @@ import { CheckCircle2, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { PasswordInput } from "@/components/password-input";
 import { passwordSchema } from "@/lib/validate-password";
+import { apiPost, errorMessage } from "@/lib/api-client";
+import type { ClaimInviteInput } from "@/lib/schemas/invite";
 
 // The /invite/[token] page serves two flows that share the same token table
 // (#436): a brand-new user claiming an invite, and an existing user resetting
@@ -152,31 +154,20 @@ function ClaimForm({ token, type }: { token: string; type: InviteType }) {
   async function onSubmit(values: FormValues) {
     setLoading(true);
 
-    const body = isReset
+    const body: ClaimInviteInput = isReset
       ? { token, password: values.password }
       : { token, name: values.name, password: values.password };
 
     try {
-      const res = await fetch("/api/invite/claim", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        // Submit failures (expired link, server error) are system-level, not
-        // field-correctable, so they surface as a toast per the error-display
-        // policy. Field validation stays inline via <FormMessage>.
-        toast.error(
-          data.error || (isReset ? "Failed to reset password" : "Failed to create account")
-        );
-        return;
-      }
-
+      await apiPost<unknown, ClaimInviteInput>("/api/invite/claim", body);
       setSuccess(true);
-    } catch {
-      toast.error("Something went wrong. Please try again.");
+    } catch (e) {
+      // Submit failures (expired link, server error) are system-level, not
+      // field-correctable, so they surface as a toast per the error-display
+      // policy. Field validation stays inline via <FormMessage>.
+      toast.error(
+        errorMessage(e, isReset ? "Failed to reset password" : "Failed to create account")
+      );
     } finally {
       setLoading(false);
     }

--- a/packages/web/src/components/add-integration-dialog.tsx
+++ b/packages/web/src/components/add-integration-dialog.tsx
@@ -45,7 +45,35 @@ import {
   type OAuthProviderDescriptor,
   type OAuthProviderId,
 } from "@/lib/integrations/oauth-providers";
-import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, ApiError, errorMessage } from "@/lib/api-client";
+import type {
+  ListDatabasesInput,
+  TestCredentialsInput,
+  SyncPreviewInput,
+  CreateIntegrationInput,
+} from "@/lib/schemas/integrations";
+import type { OdooSyncResult, OdooSyncError } from "@/lib/integrations/odoo-sync";
+import { odooConnectionDataSchema, type OdooConnectionData } from "@/lib/integrations/odoo-schema";
+
+/**
+ * The probe routes answer 200 with `{ success: false, error }` for a credential
+ * failure and reserve non-2xx for a broken request, so both the body's verdict
+ * and a thrown ApiError have to be handled at each call site.
+ */
+type TestCredentialsResult = {
+  success?: boolean;
+  error?: string;
+  uid?: number;
+  version?: string;
+};
+
+/**
+ * `/api/integrations/sync-preview` returns `fetchOdooSchema`'s own result
+ * verbatim, so the client reuses that discriminated union rather than
+ * re-describing it. `import type` is erased at build time, so this does not
+ * drag `odoo-node` into the client bundle.
+ */
+type SyncPreviewResult = OdooSyncResult | OdooSyncError;
 import type { SaveOAuthRequest } from "@/lib/schemas/oauth-settings";
 
 interface OAuthConfigResponse {
@@ -546,7 +574,7 @@ export function AddIntegrationDialog({
     }>;
   } | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
-  const [syncData, setSyncData] = useState<unknown>(null);
+  const [syncData, setSyncData] = useState<OdooConnectionData | undefined>(undefined);
 
   // Done step
   const [connectionName, setConnectionName] = useState("");
@@ -581,7 +609,7 @@ export function AddIntegrationDialog({
     setConnecting(false);
     setSyncResult(null);
     setSyncError(null);
-    setSyncData(null);
+    setSyncData(undefined);
     setSaving(false);
     setConnectionName("");
     setDbFetchState("idle");
@@ -629,12 +657,10 @@ export function AddIntegrationDialog({
     setFetchedDatabases([]);
 
     try {
-      const res = await fetch("/api/integrations/list-databases", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url }),
-      });
-      const data = await res.json();
+      const data = await apiPost<{ success?: boolean; databases?: string[] }, ListDatabasesInput>(
+        "/api/integrations/list-databases",
+        { url }
+      );
 
       if (data.success && Array.isArray(data.databases) && data.databases.length > 0) {
         setFetchedDatabases(data.databases);
@@ -661,23 +687,20 @@ export function AddIntegrationDialog({
     setConnecting(true);
 
     try {
-      const testRes = await fetch("/api/integrations/test-credentials", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: selectedType,
+      const testData = await apiPost<TestCredentialsResult, TestCredentialsInput>(
+        "/api/integrations/test-credentials",
+        {
+          type: "odoo",
           credentials: {
             url: values.url,
             db: values.db,
             login: values.login,
             apiKey: values.apiKey,
           },
-        }),
-      });
+        }
+      );
 
-      const testData = await testRes.json();
-
-      if (!testRes.ok || !testData.success) {
+      if (!testData.success || testData.uid === undefined) {
         form.setError("root", {
           message: testData.error || "Connection test failed",
         });
@@ -685,13 +708,15 @@ export function AddIntegrationDialog({
         return;
       }
 
-      setConnectionResult({ uid: testData.uid, version: testData.version });
+      setConnectionResult({ uid: testData.uid, version: testData.version ?? "" });
       setConnecting(false);
       setStep("sync");
       // Trigger sync immediately — no useEffect needed
       runSyncPreview(testData.uid);
-    } catch {
-      form.setError("root", { message: "Connection test failed" });
+    } catch (e) {
+      form.setError("root", {
+        message: errorMessage(e, "Connection test failed"),
+      });
       setConnecting(false);
     }
   }
@@ -704,10 +729,9 @@ export function AddIntegrationDialog({
     try {
       const values = form.getValues();
 
-      const res = await fetch("/api/integrations/sync-preview", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const data = await apiPost<SyncPreviewResult, SyncPreviewInput>(
+        "/api/integrations/sync-preview",
+        {
           type: "odoo",
           credentials: {
             url: values.url,
@@ -716,20 +740,28 @@ export function AddIntegrationDialog({
             apiKey: values.apiKey,
             uid,
           },
-        }),
-      });
-
-      const data = await res.json();
+        }
+      );
 
       if (data.success) {
-        setSyncResult({ models: data.models, categories: data.categories ?? [] });
-        setSyncData(data.data);
+        // Validate the payload here rather than assert it. `fetchOdooSchema`
+        // types the probed field list as `unknown[]`, and this same blob is
+        // re-validated by POST /api/integrations against the very same schema —
+        // so a shape the parse rejects would have come back as a 400 two steps
+        // later, with nothing pointing at the sync that produced it.
+        const parsedData = odooConnectionDataSchema.safeParse(data.data);
+        if (!parsedData.success) {
+          setSyncError("Odoo returned a schema Pinchy could not read. Please retry the sync.");
+          return;
+        }
+        setSyncResult({ models: data.models, categories: data.categories });
+        setSyncData(parsedData.data);
         // Stay on sync step — user clicks "Continue" to proceed
       } else {
         setSyncError(data.error || "Schema sync failed");
       }
-    } catch {
-      setSyncError("Schema sync failed");
+    } catch (e) {
+      setSyncError(errorMessage(e, "Schema sync failed"));
     }
   }
 
@@ -738,40 +770,39 @@ export function AddIntegrationDialog({
   const [saving, setSaving] = useState(false);
 
   async function handleDone() {
+    // The done step is only reachable once the credential test returned a uid,
+    // so guard rather than default. `?? 0` would satisfy the type and then fail
+    // the route's `uid: z.number().int().positive()` as a 400 that reads like a
+    // credential problem — the whole point of typing the payload was to stop
+    // papering over a value at the boundary.
+    if (!connectionResult) {
+      toast.error("Connection details were lost. Please run the connection test again.");
+      return;
+    }
+
     setSaving(true);
     try {
       const values = form.getValues();
 
-      const res = await fetch("/api/integrations", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: selectedType,
-          name: connectionName,
-          description: "",
-          credentials: {
-            url: values.url,
-            db: values.db,
-            login: values.login,
-            apiKey: values.apiKey,
-            uid: connectionResult?.uid,
-          },
-          data: syncData,
-        }),
+      await apiPost<unknown, CreateIntegrationInput>("/api/integrations", {
+        type: "odoo",
+        name: connectionName,
+        description: "",
+        credentials: {
+          url: values.url,
+          db: values.db,
+          login: values.login,
+          apiKey: values.apiKey,
+          uid: connectionResult.uid,
+        },
+        data: syncData,
       });
-
-      if (!res.ok) {
-        const err = await res.json();
-        toast.error(err.error || "Failed to save integration");
-        setSaving(false);
-        return;
-      }
 
       toast.success("Integration ready");
       handleClose(false);
       onSuccess();
-    } catch {
-      toast.error("Failed to save integration");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to save integration"));
       setSaving(false);
     }
   }
@@ -784,18 +815,15 @@ export function AddIntegrationDialog({
 
     try {
       // 1. Test the API key
-      const testRes = await fetch("/api/integrations/test-credentials", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const testData = await apiPost<TestCredentialsResult, TestCredentialsInput>(
+        "/api/integrations/test-credentials",
+        {
           type: "web-search",
           credentials: { apiKey: values.apiKey },
-        }),
-      });
+        }
+      );
 
-      const testData = await testRes.json();
-
-      if (!testRes.ok || !testData.success) {
+      if (!testData.success) {
         webSearchForm.setError("root", {
           message: testData.error || "API key validation failed",
         });
@@ -804,31 +832,20 @@ export function AddIntegrationDialog({
       }
 
       // 2. Create the integration immediately
-      const createRes = await fetch("/api/integrations", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: "web-search",
-          name: "Brave Search",
-          description: "",
-          credentials: { apiKey: values.apiKey },
-        }),
+      await apiPost<unknown, CreateIntegrationInput>("/api/integrations", {
+        type: "web-search",
+        name: "Brave Search",
+        description: "",
+        credentials: { apiKey: values.apiKey },
       });
-
-      if (!createRes.ok) {
-        const err = await createRes.json();
-        webSearchForm.setError("root", {
-          message: err.error || "Failed to save integration",
-        });
-        setConnecting(false);
-        return;
-      }
 
       toast.success("Web Search connected");
       handleClose(false);
       onSuccess();
-    } catch {
-      webSearchForm.setError("root", { message: "Connection failed" });
+    } catch (e) {
+      webSearchForm.setError("root", {
+        message: errorMessage(e, "Connection failed"),
+      });
       setConnecting(false);
     }
   }

--- a/packages/web/src/components/agent-settings-access.tsx
+++ b/packages/web/src/components/agent-settings-access.tsx
@@ -12,9 +12,12 @@ import {
 } from "@/components/ui/select";
 import { EnterpriseFeatureCard } from "@/components/enterprise-feature-card";
 import type { LicenseState } from "@/lib/license-state";
+import type { AgentVisibility } from "@/db/enums";
 
 interface AccessValues {
-  visibility: string;
+  // Narrowed to the enum the agents table's CHECK constraint enforces, so the
+  // PATCH body this feeds type-checks against the route's own schema.
+  visibility: AgentVisibility;
   groupIds: string[];
 }
 
@@ -24,7 +27,7 @@ interface Group {
 }
 
 interface AgentSettingsAccessProps {
-  agent: { visibility: string };
+  agent: { visibility: AgentVisibility };
   currentGroupIds: string[];
   onChange: (values: AccessValues, isDirty: boolean) => void;
   isAdmin?: boolean;
@@ -93,7 +96,8 @@ export function AgentSettingsAccess({
   }, [visibility, selectedGroupIds, baselineVisibility, baselineGroupIds, onChange]);
 
   function handleVisibilityChange(value: string) {
-    setVisibility(value);
+    // Radix hands back a bare string; the SelectItems below are the enum.
+    setVisibility(value as AgentVisibility);
     if (value !== "restricted") {
       setSelectedGroupIds([]);
     }

--- a/packages/web/src/components/agent-settings-automation-create-dialog.tsx
+++ b/packages/web/src/components/agent-settings-automation-create-dialog.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, errorMessage } from "@/lib/api-client";
 import { AUTOMATION_MAX_SWEEP_WINDOW_DAYS } from "@/lib/schemas/automations";
 import type { AutomationConnectionOption, CreateAutomationInput } from "@/lib/schemas/automations";
 import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
@@ -25,10 +25,6 @@ import {
 /** Default sweep window (days) — mirrors the schema default so the form and the
  * server agree on what "leave it blank" means. */
 const DEFAULT_SWEEP_WINDOW_DAYS = 14;
-
-function errorMessage(e: unknown, fallback: string): string {
-  return e instanceof ApiError ? e.message : fallback;
-}
 
 /** Split a comma-separated input into trimmed, non-empty tokens. */
 function parseList(value: string): string[] {

--- a/packages/web/src/components/agent-settings-automations.tsx
+++ b/packages/web/src/components/agent-settings-automations.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
-import { apiGet, apiPatch, apiDelete, ApiError } from "@/lib/api-client";
+import { apiGet, apiPatch, apiDelete, errorMessage } from "@/lib/api-client";
 import type { AutomationListItem } from "@/lib/schemas/automations";
 import type { EmailWorkflowFilter } from "@/lib/email-workflows/types";
 import type { EmailWorkflowStatus } from "@/db/enums";
@@ -56,10 +56,6 @@ const STATUS_VARIANT: Record<EmailWorkflowStatus, "default" | "secondary" | "des
   pending: "secondary",
   error: "destructive",
 };
-
-function errorMessage(e: unknown, fallback: string): string {
-  return e instanceof ApiError ? e.message : fallback;
-}
 
 /**
  * The Automations tab: the review-and-activate surface for an agent's Inbox

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -28,7 +28,11 @@ import { AgentTelegramSettings } from "@/components/agent-telegram-settings";
 import { AgentSettingsAutomations } from "@/components/agent-settings-automations";
 import { useRestart } from "@/components/restart-provider";
 import { normalizeStarterPrompts } from "@/lib/schemas/starter-prompts";
+import { apiPatch, apiPut, apiDelete, ApiError, errorMessage } from "@/lib/api-client";
+import type { UpdateAgentInput, WriteAgentFileInput } from "@/lib/schemas/agents";
+import type { SetAgentIntegrationsInput } from "@/lib/schemas/agent-integrations";
 import type { AgentPluginConfig } from "@/db/schema";
+import type { AgentVisibility } from "@/db/enums";
 
 interface Agent {
   id: string;
@@ -41,7 +45,9 @@ interface Agent {
   starterPrompts: string[];
   avatarSeed: string | null;
   personalityPresetId: string | null;
-  visibility: string;
+  // Narrowed to the enum the agents table's CHECK constraint enforces, so the
+  // unified PATCH body below type-checks against the route's own schema.
+  visibility: AgentVisibility;
   groupIds: string[];
 }
 
@@ -89,7 +95,7 @@ interface PermissionsValues {
 }
 
 interface AccessValues {
-  visibility: string;
+  visibility: AgentVisibility;
   groupIds: string[];
 }
 
@@ -127,18 +133,20 @@ function DirtyDot() {
  * The body is the primary source; status is the fallback, because a proxy 502
  * or a crashed process answers with HTML or nothing at all. Never returns
  * empty — the caller renders this as the sole feedback for a failed save.
+ *
+ * The saves now reject with an `ApiError` rather than resolving to a Response,
+ * so the body has already been read: `ApiError.message` IS the route's `error`
+ * when it sent one. `errorMessage` falls back exactly when it did not, which
+ * is where the status belongs — a bare "Something went wrong" would throw away
+ * the one fact a body-less 502 still carries.
  */
-async function describeSaveFailure(response: Response): Promise<string> {
-  try {
-    const body: unknown = await response.json();
-    if (body && typeof body === "object" && "error" in body) {
-      const { error } = body as { error?: unknown };
-      if (typeof error === "string" && error.trim()) return error;
-    }
-  } catch {
-    // No JSON body (HTML error page, empty response, connection cut).
+function describeSaveFailure(reason: unknown): string {
+  if (reason instanceof ApiError) {
+    return errorMessage(reason, `Failed to save settings (HTTP ${String(reason.status)})`);
   }
-  return `Failed to save settings (HTTP ${String(response.status)})`;
+  // Not an ApiError: a network failure or an abort, whose own message is an
+  // internal string ("Failed to fetch"), never user-facing copy.
+  return "Failed to save settings";
 }
 
 export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }) {
@@ -310,10 +318,12 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
       // Integration saves must complete before the agent PATCH: the PATCH triggers
       // regenerateOpenClawConfig() which reads integration permissions from the DB.
       // Saving integrations first ensures the config reflects the latest state.
-      const integrationPromises: Promise<Response>[] = [];
+      const integrationPromises: Promise<unknown>[] = [];
 
-      // Build unified agent PATCH body
-      const agentPatch: Record<string, unknown> = {};
+      // Build unified agent PATCH body. Typed against the route's own schema,
+      // so a renamed field is a compile error here rather than a 400 nobody
+      // sees until the settings page silently stops saving one tab.
+      const agentPatch: UpdateAgentInput = {};
       if (dirtyTabs.has("general") && generalDraft.current) {
         agentPatch.name = generalDraft.current.name;
         agentPatch.tagline = generalDraft.current.tagline;
@@ -340,20 +350,15 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
         if (permissionsDraft.current.integrations.length > 0) {
           for (const integration of permissionsDraft.current.integrations) {
             integrationPromises.push(
-              fetch(`/api/agents/${agentId}/integrations`, {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(integration),
-              })
+              apiPut<unknown, SetAgentIntegrationsInput>(
+                `/api/agents/${agentId}/integrations`,
+                integration
+              )
             );
           }
         } else {
           // Clear all integration permissions when no connections are configured
-          integrationPromises.push(
-            fetch(`/api/agents/${agentId}/integrations`, {
-              method: "DELETE",
-            })
-          );
+          integrationPromises.push(apiDelete(`/api/agents/${agentId}/integrations`));
         }
       }
       if (dirtyTabs.has("access") && accessDraft.current) {
@@ -361,48 +366,43 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
         agentPatch.groupIds = accessDraft.current.groupIds;
       }
 
-      // Phase 1: Save integration permissions to DB (no config regen yet)
-      const integrationResults = await Promise.all(integrationPromises);
+      // Phase 1: Save integration permissions to DB (no config regen yet).
+      // allSettled, not all: a failed integration write must NOT skip phase 2 —
+      // that is how it behaved on raw fetch (which never rejects on a 4xx), and
+      // the partial save is reported below rather than silently dropped.
+      const integrationResults = await Promise.allSettled(integrationPromises);
 
       // Phase 2: Agent PATCH + file saves (PATCH triggers single config regen)
-      const otherPromises: Promise<Response>[] = [];
+      const otherPromises: Promise<unknown>[] = [];
 
       if (Object.keys(agentPatch).length > 0) {
         otherPromises.push(
-          fetch(`/api/agents/${agentId}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(agentPatch),
-          })
+          apiPatch<unknown, UpdateAgentInput>(`/api/agents/${agentId}`, agentPatch)
         );
       }
 
       if (dirtyTabs.has("personality") && personalityDraft.current) {
         otherPromises.push(
-          fetch(`/api/agents/${agentId}/files/SOUL.md`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ content: personalityDraft.current.soulContent }),
+          apiPut<unknown, WriteAgentFileInput>(`/api/agents/${agentId}/files/SOUL.md`, {
+            content: personalityDraft.current.soulContent,
           })
         );
       }
 
       if (dirtyTabs.has("instructions") && instructionsDraft.current !== null) {
         otherPromises.push(
-          fetch(`/api/agents/${agentId}/files/AGENTS.md`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ content: instructionsDraft.current }),
+          apiPut<unknown, WriteAgentFileInput>(`/api/agents/${agentId}/files/AGENTS.md`, {
+            content: instructionsDraft.current,
           })
         );
       }
 
-      const otherResults = await Promise.all(otherPromises);
+      const otherResults = await Promise.allSettled(otherPromises);
       const results = [...integrationResults, ...otherResults];
 
-      const failed = results.find((r) => !r.ok);
-      if (failed) {
-        toast.error(await describeSaveFailure(failed));
+      const firstFailure = results.find((r) => r.status === "rejected");
+      if (firstFailure) {
+        toast.error(describeSaveFailure(firstFailure.reason));
         return;
       }
 

--- a/packages/web/src/components/agent-telegram-settings.tsx
+++ b/packages/web/src/components/agent-telegram-settings.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { toast } from "sonner";
+import { apiPost, apiDelete } from "@/lib/api-client";
+import type { SetBotTokenInput } from "@/lib/schemas/telegram";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -152,24 +154,11 @@ export function AgentTelegramSettings({
     setError("");
 
     try {
-      const res = await fetch(`/api/agents/${agentId}/channels/telegram`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ botToken }),
-      });
+      const data = await apiPost<{ botUsername?: string | null }, SetBotTokenInput>(
+        `/api/agents/${agentId}/channels/telegram`,
+        { botToken }
+      );
 
-      if (!res.ok) {
-        let message = "Failed to connect";
-        try {
-          const data = await res.json();
-          if (data.error) message = data.error;
-        } catch {
-          // response body was not JSON
-        }
-        throw new Error(message);
-      }
-
-      const data = await res.json();
       setConnectedUsername(data.botUsername || null);
       setBotToken("");
       // A successful (re)connect clears the auto-disable marker server-side, so
@@ -194,14 +183,7 @@ export function AgentTelegramSettings({
     setError("");
 
     try {
-      const res = await fetch(`/api/agents/${agentId}/channels/telegram`, {
-        method: "DELETE",
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || "Failed to disconnect");
-      }
+      await apiDelete(`/api/agents/${agentId}/channels/telegram`);
 
       setConnectedUsername(null);
       triggerRestart();

--- a/packages/web/src/components/chat-session-mounts.tsx
+++ b/packages/web/src/components/chat-session-mounts.tsx
@@ -9,7 +9,7 @@ import {
   chatSessionKey,
   ChatSessionStoreContext,
 } from "@/components/chat-session-provider";
-import { apiPost, ApiError } from "@/lib/api-client";
+import { apiPost, errorMessage } from "@/lib/api-client";
 import { generateChatId } from "@/lib/chats/generate-chat-id";
 import { type SlashCommand } from "@/lib/slash-commands";
 import type { CompactSessionRequest, ResetSessionRequest } from "@/lib/schemas/sessions";
@@ -76,11 +76,7 @@ function ChatSessionInstance({
               );
               toast.success("Conversation compacted. It takes effect on your next message.");
             } catch (e) {
-              toast.error(
-                e instanceof ApiError
-                  ? e.message
-                  : "Couldn't compact the conversation. Please try again."
-              );
+              toast.error(errorMessage(e, "Couldn't compact the conversation. Please try again."));
             }
           })();
           break;
@@ -98,11 +94,7 @@ function ChatSessionInstance({
               onSessionReset();
               toast.success("Conversation reset — context cleared. Use New chat to keep a copy.");
             } catch (e) {
-              toast.error(
-                e instanceof ApiError
-                  ? e.message
-                  : "Couldn't reset the conversation. Please try again."
-              );
+              toast.error(errorMessage(e, "Couldn't reset the conversation. Please try again."));
             }
           })();
           break;

--- a/packages/web/src/components/connected-apps.tsx
+++ b/packages/web/src/components/connected-apps.tsx
@@ -22,7 +22,7 @@ import {
   type OAuthProviderId,
   type OAuthProviderDescriptor,
 } from "@/lib/integrations/oauth-providers";
-import { apiDelete, apiGet, ApiError } from "@/lib/api-client";
+import { apiGet, apiDelete, errorMessage } from "@/lib/api-client";
 
 interface OAuthAppState {
   configured: boolean;
@@ -128,7 +128,7 @@ export function ConnectedApps({ onConnectionsChanged }: { onConnectionsChanged?:
       await fetchStates();
       onConnectionsChanged?.();
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to reset app.");
+      toast.error(errorMessage(e, "Failed to reset app."));
     } finally {
       setResetting(false);
     }

--- a/packages/web/src/components/delete-agent-dialog.tsx
+++ b/packages/web/src/components/delete-agent-dialog.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { useRestart } from "@/components/restart-provider";
+import { apiDelete, errorMessage } from "@/lib/api-client";
 
 interface DeleteAgentDialogProps {
   agentId: string;
@@ -28,17 +29,12 @@ export function DeleteAgentDialog({ agentId, agentName }: DeleteAgentDialogProps
 
   async function handleDelete() {
     try {
-      const res = await fetch(`/api/agents/${agentId}`, { method: "DELETE" });
-      if (!res.ok) {
-        const data = await res.json();
-        setError(data.error || "Failed to delete agent");
-        return;
-      }
+      await apiDelete(`/api/agents/${agentId}`);
       triggerRestart();
       router.push("/");
       router.refresh();
-    } catch {
-      setError("Failed to delete agent");
+    } catch (e) {
+      setError(errorMessage(e, "Failed to delete agent"));
     }
   }
 

--- a/packages/web/src/components/dev-toolbar.tsx
+++ b/packages/web/src/components/dev-toolbar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Shield, ShieldOff } from "lucide-react";
+import { apiPost } from "@/lib/api-client";
 
 export function DevToolbar() {
   const [enterprise, setEnterprise] = useState<boolean | null>(null);
@@ -17,8 +18,7 @@ export function DevToolbar() {
   async function toggle() {
     setToggling(true);
     try {
-      const res = await fetch("/api/dev/enterprise-toggle", { method: "POST" });
-      const data = await res.json();
+      const data = await apiPost<{ enterprise: boolean }>("/api/dev/enterprise-toggle", undefined);
       setEnterprise(data.enterprise);
       // Reload to reflect enterprise state across the app
       window.location.reload();

--- a/packages/web/src/components/diagnostics-export-form.tsx
+++ b/packages/web/src/components/diagnostics-export-form.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
-import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, errorMessage } from "@/lib/api-client";
 import { chatTitle } from "@/lib/chats/chat-title";
 import { buildBundleFilename, downloadBundle } from "@/lib/diagnostics/download";
 import type { DiagnosticsExportRequest } from "@/lib/schemas/diagnostics";
@@ -175,8 +175,7 @@ export function DiagnosticsExportForm({
       onExported?.();
     } catch (e) {
       updateSubmitting(false);
-      const message =
-        e instanceof ApiError ? e.message : "Failed to generate diagnostics. Please try again.";
+      const message = errorMessage(e, "Failed to generate diagnostics. Please try again.");
       toast.error(message);
     }
   }

--- a/packages/web/src/components/imap-connect-step.tsx
+++ b/packages/web/src/components/imap-connect-step.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/select";
 import { Loader2, AlertTriangle, Eye, EyeOff } from "lucide-react";
 import { toast } from "sonner";
-import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, errorMessage } from "@/lib/api-client";
 import type { ImapTestInput, ImapCreateInput, ImapTestResult } from "@/lib/schemas/imap";
 
 interface AutodiscoverResponse {
@@ -247,7 +247,7 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
       result = await apiPost<ImapTestResult>("/api/integrations/imap/test", testBody);
     } catch (err) {
       setFlightStatus("failure");
-      setTestError(err instanceof ApiError ? err.message : "Connection test failed");
+      setTestError(errorMessage(err, "Connection test failed"));
       setServerSettingsExpanded(true);
       setUserExpanded(true);
       return;
@@ -280,7 +280,7 @@ export function ImapConnectStep({ onSuccess, onCancel, onBack }: ImapConnectStep
       onSuccess(connection);
     } catch (err) {
       setFlightStatus("failure");
-      setSaveError(err instanceof ApiError ? err.message : "Failed to create the connection");
+      setSaveError(errorMessage(err, "Failed to create the connection"));
     }
   }
 

--- a/packages/web/src/components/invite-dialog.tsx
+++ b/packages/web/src/components/invite-dialog.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { buildInviteUrl } from "@/lib/invite-url";
+import { apiPost, errorMessage } from "@/lib/api-client";
+import type { InviteUserInput } from "@/lib/schemas/users";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -101,26 +103,16 @@ export function InviteDialog({ open, onOpenChange }: InviteDialogProps) {
     setError(null);
     setCreating(true);
     try {
-      const res = await fetch("/api/users/invite", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          email: values.email,
-          role: values.role,
-          ...(selectedGroupIds.length > 0 ? { groupIds: selectedGroupIds } : {}),
-        }),
+      const data = await apiPost<{ token: string }, InviteUserInput>("/api/users/invite", {
+        email: values.email,
+        role: values.role,
+        ...(selectedGroupIds.length > 0 ? { groupIds: selectedGroupIds } : {}),
       });
-      if (res.ok) {
-        const data = await res.json();
-        setInviteLink(buildInviteUrl(window.location.origin, data.token));
-      } else {
-        const data = await res.json();
-        // Seat-cap 403s carry an actionable message (quote path, § 5) —
-        // prefer it over the terse error code.
-        setError(data.message || data.error || "Failed to create invite");
-      }
-    } catch {
-      setError("Failed to create invite");
+      setInviteLink(buildInviteUrl(window.location.origin, data.token));
+    } catch (e) {
+      // Seat-cap 403s carry an actionable message beside the terse headline
+      // (quote path, § 5); ApiError.message already joins the two.
+      setError(errorMessage(e, "Failed to create invite"));
     } finally {
       setCreating(false);
     }

--- a/packages/web/src/components/knowledge-reindex-section.tsx
+++ b/packages/web/src/components/knowledge-reindex-section.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { KnowledgeUnsearchableList } from "@/components/knowledge-unsearchable-list";
-import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, errorMessage } from "@/lib/api-client";
 import {
   appendProgressSample,
   estimateRemainingMs,
@@ -176,7 +176,7 @@ export function KnowledgeReindexSection({
     } catch (err) {
       // 409 (already running), 503 (embedder missing) and 500 all arrive here as
       // an ApiError whose message is the route's human-readable `error`.
-      toast.error(err instanceof ApiError ? err.message : "Reindex could not be started.");
+      toast.error(errorMessage(err, "Reindex could not be started."));
     } finally {
       setSubmitting(false);
     }

--- a/packages/web/src/components/new-agent-form.tsx
+++ b/packages/web/src/components/new-agent-form.tsx
@@ -65,6 +65,8 @@ interface ValidationResult {
 }
 
 import { AGENT_NAME_MAX_LENGTH } from "@/lib/agent-constants";
+import { apiPost, errorMessage } from "@/lib/api-client";
+import type { CreateAgentInput } from "@/lib/schemas/agents";
 
 const agentFormSchema = z.object({
   name: z
@@ -372,6 +374,12 @@ export function NewAgentForm() {
   }, [selectedTemplate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function onSubmit(values: AgentFormValues) {
+    // The form — and therefore this handler — only renders inside the
+    // "a template is selected" branch. Stated rather than asserted, because
+    // the create payload is typed against the route's schema and templateId is
+    // required there.
+    if (!selectedTemplate) return;
+
     setError(null);
     setSubmitting(true);
 
@@ -379,7 +387,7 @@ export function NewAgentForm() {
       // Enable workspace write by default so new agents can save files out of
       // the box. The API dedups this against the template's own allowedTools;
       // users can toggle it off later in Agent Settings → Permissions.
-      const body: Record<string, unknown> = {
+      const body: CreateAgentInput = {
         name: values.name.trim(),
         tagline: values.tagline?.trim() || null,
         templateId: selectedTemplate,
@@ -394,19 +402,10 @@ export function NewAgentForm() {
         body.connectionId = selectedConnectionId;
       }
 
-      const res = await fetch("/api/agents", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        setError(data.error || "Failed to create agent");
-        return;
-      }
-
-      const agent = await res.json();
+      const agent = await apiPost<{ id: string; warning?: string }, CreateAgentInput>(
+        "/api/agents",
+        body
+      );
       // #880 — the route creates the agent even when applying it to the OC
       // runtime fails, returning a non-blocking `warning` instead of a 500.
       // Surface it as a warning toast (sonner persists across the navigation
@@ -417,8 +416,8 @@ export function NewAgentForm() {
       triggerRestart();
       router.push(`/chat/${agent.id}`);
       router.refresh();
-    } catch {
-      setError("Failed to create agent");
+    } catch (e) {
+      setError(errorMessage(e, "Failed to create agent"));
     } finally {
       setSubmitting(false);
     }

--- a/packages/web/src/components/openai-compatible-provider-form.tsx
+++ b/packages/web/src/components/openai-compatible-provider-form.tsx
@@ -6,7 +6,7 @@ import { Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { apiPost, ApiError } from "@/lib/api-client";
+import { apiPost, ApiError, errorMessage } from "@/lib/api-client";
 import type { OpenClawModelDefinition } from "@/lib/openclaw-builtin-models";
 import type { UpsertOpenAiCompatibleProviderInput } from "@/lib/schemas/openai-compatible-provider";
 
@@ -123,7 +123,7 @@ export function OpenAiCompatibleProviderForm({ provider, onSaved, onCancel }: Fo
           }
         }
       }
-      toast.error(e instanceof ApiError ? e.message : "Could not save the provider.");
+      toast.error(errorMessage(e, "Could not save the provider."));
     } finally {
       setSaving(false);
     }

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -32,7 +32,8 @@ import {
   type ProviderListItem,
 } from "@/components/openai-compatible-provider-form";
 import type { ProviderName } from "@/lib/providers";
-import { apiGet, apiPatch, apiDelete, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, apiPatch, apiDelete, ApiError, errorMessage } from "@/lib/api-client";
+import type { SetupProviderInput, DeleteProviderInput } from "@/lib/schemas/providers";
 import type { DeleteOpenAiCompatibleInput } from "@/lib/schemas/openai-compatible-provider";
 import type { SetDefaultProviderInput } from "@/lib/schemas/provider-default";
 import type { DeletionPreviewResponse } from "@/lib/schemas/provider-deletion";
@@ -193,6 +194,28 @@ function renderStepWithLink(label: string, link: { text: string; url: string }) 
 }
 
 // Providers whose default models are always vision-capable
+/**
+ * `/api/setup/provider` answers a `docs` link alongside its 400. Validate the
+ * shape defensively — a route returning partial/malformed metadata must not
+ * break the inline error, and the href must be a real http(s) URL so a
+ * compromised or buggy route can never coax the client into rendering a
+ * `javascript:` anchor. An empty label would render an icon-only click target,
+ * which is worse than no link — treat it as "no docs".
+ */
+function readErrorDocs(body: unknown): { href: string; label: string } | null {
+  const docs = (body as { docs?: { href?: unknown; label?: unknown } } | null)?.docs;
+  if (
+    docs &&
+    typeof docs.href === "string" &&
+    /^https?:\/\//i.test(docs.href) &&
+    typeof docs.label === "string" &&
+    docs.label.length > 0
+  ) {
+    return { href: docs.href, label: docs.label };
+  }
+  return null;
+}
+
 const VISION_CAPABLE_PROVIDERS: ReadonlySet<ProviderName> = new Set([
   "anthropic",
   "openai",
@@ -291,8 +314,11 @@ function RemovalConsequence({ preview }: { preview: DeletionPreviewResponse | nu
  * the preflight and the DELETE agree by construction, see provider-deletion.ts.
  */
 function removalSummary(
+  // Optional on purpose — the guard below already handles a response that
+  // omitted the count, and the typed client now surfaces that possibility
+  // instead of hiding it behind an untyped `res.json()`.
   providerLabel: string,
-  migratedAgents: number,
+  migratedAgents: number | undefined,
   targetLabel: string | null
 ): string {
   const removed = `${providerLabel} removed.`;
@@ -460,7 +486,7 @@ export function ProviderKeyForm({
       toast.success("Default provider updated.");
       onSuccess();
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Could not set the default provider.");
+      toast.error(errorMessage(e, "Could not set the default provider."));
     } finally {
       setSettingDefault(false);
     }
@@ -487,7 +513,7 @@ export function ProviderKeyForm({
       void fetchCustomProviders();
       onSuccess();
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Could not remove the provider.");
+      toast.error(errorMessage(e, "Could not remove the provider."));
     } finally {
       setDeletingCustom(false);
     }
@@ -516,57 +542,16 @@ export function ProviderKeyForm({
         ? { provider, url: values.apiKey }
         : { provider, apiKey: values.apiKey };
 
-      const res = await fetch("/api/setup/provider", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        // Session expired — redirect to login
-        if (res.status === 401) {
-          window.location.href = "/login";
-          return;
-        }
-        let message = "Setup failed";
-        let docs: { href: string; label: string } | null = null;
-        try {
-          const data = await res.json();
-          if (data.error) message = data.error;
-          // Validate the docs shape defensively — a route that returns
-          // partial/malformed metadata shouldn't break the inline error, and
-          // the href must be a real http(s) URL so a compromised/buggy route
-          // can never coax the client into rendering a `javascript:` anchor.
-          // An empty label would render an icon-only click target, which is
-          // worse than no link — treat it as "no docs".
-          if (
-            data.docs &&
-            typeof data.docs.href === "string" &&
-            /^https?:\/\//i.test(data.docs.href) &&
-            typeof data.docs.label === "string" &&
-            data.docs.label.length > 0
-          ) {
-            docs = { href: data.docs.href, label: data.docs.label };
-          }
-        } catch {
-          // response body was not JSON; use default message
-        }
-        setErrorDocs(docs);
-        throw new Error(message);
-      }
+      const data = await apiPost<{ warning?: string }, SetupProviderInput>(
+        "/api/setup/provider",
+        body
+      );
 
       // #880 — the route persists the key even when applying it to the OC
       // runtime fails, and returns a non-blocking `warning` instead of a 500.
       // Surface it as a warning toast so the save still reads as successful.
-      let warning: string | undefined;
-      try {
-        const data = await res.json();
-        if (typeof data?.warning === "string" && data.warning.length > 0) {
-          warning = data.warning;
-        }
-      } catch {
-        // No/!JSON body — treat as a plain success.
-      }
+      const warning =
+        typeof data?.warning === "string" && data.warning.length > 0 ? data.warning : undefined;
 
       setValidationStatus("success");
       form.reset();
@@ -579,9 +564,16 @@ export function ProviderKeyForm({
       onSaved?.(provider, VISION_CAPABLE_PROVIDERS.has(provider));
       onSuccess(provider);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Setup failed";
+      // Session expired — redirect to login rather than showing an inline error.
+      if (err instanceof ApiError && err.status === 401) {
+        window.location.href = "/login";
+        return;
+      }
+      setErrorDocs(err instanceof ApiError ? readErrorDocs(err.body) : null);
+      // Not `err.message`: this catch now also sees a network TypeError, whose
+      // message ("Failed to fetch") is an internal string, not error copy.
       setValidationStatus("error");
-      setError(message);
+      setError(errorMessage(err, "Setup failed"));
     } finally {
       setLoading(false);
     }
@@ -981,15 +973,10 @@ export function ProviderKeyForm({
                       onClick={async () => {
                         setRemoving(true);
                         try {
-                          const res = await fetch("/api/settings/providers", {
-                            method: "DELETE",
-                            headers: { "Content-Type": "application/json" },
-                            body: JSON.stringify({ provider }),
-                          });
-                          const data = await res.json().catch(() => ({}));
-                          if (!res.ok) {
-                            throw new Error(data.error || "Failed to remove key");
-                          }
+                          const data = await apiDelete<
+                            { migratedAgents?: number },
+                            DeleteProviderInput
+                          >("/api/settings/providers", { provider });
                           toast.success(
                             removalSummary(
                               PROVIDERS[provider].name,

--- a/packages/web/src/components/settings-api-keys.tsx
+++ b/packages/web/src/components/settings-api-keys.tsx
@@ -33,7 +33,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
-import { apiGet, apiPost, apiDelete, ApiError, extractFieldErrors } from "@/lib/api-client";
+import { apiGet, apiPost, apiDelete, errorMessage, extractFieldErrors } from "@/lib/api-client";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { API_KEY_SCOPES, type ApiKeyScope } from "@/lib/api-key-scopes";
 import type { CreateApiKeyInput } from "@/lib/schemas/api-keys";
@@ -130,7 +130,7 @@ export function SettingsApiKeys() {
       // issues a "replacement" has just added a second live org credential
       // while the first is still valid and unlisted.
       setLoadError(true);
-      toast.error(e instanceof ApiError ? e.message : "Failed to load API keys");
+      toast.error(errorMessage(e, "Failed to load API keys"));
     } finally {
       setLoading(false);
     }
@@ -189,7 +189,7 @@ export function SettingsApiKeys() {
         setFieldErrors(fe);
         return;
       }
-      toast.error(e instanceof ApiError ? e.message : "Failed to create API key");
+      toast.error(errorMessage(e, "Failed to create API key"));
       return;
     }
 
@@ -208,7 +208,7 @@ export function SettingsApiKeys() {
       fetchKeys();
       toast.success("API key revoked.");
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to revoke API key");
+      toast.error(errorMessage(e, "Failed to revoke API key"));
     }
   }
 

--- a/packages/web/src/components/settings-context.tsx
+++ b/packages/web/src/components/settings-context.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { MarkdownEditor } from "@/components/markdown-editor";
-import { CONTEXT_CONTENT_MAX_LENGTH } from "@/lib/schemas/context";
+import { apiPut, errorMessage, extractFieldErrors } from "@/lib/api-client";
+import { CONTEXT_CONTENT_MAX_LENGTH, type ContextContentInput } from "@/lib/schemas/context";
 
 /**
  * Below this the counter stays hidden — a limit nobody is near is noise. From
@@ -20,25 +21,20 @@ function formatCount(value: number): string {
 
 /**
  * `parseRequestBody` answers a failed validation with `error: "Validation
- * failed"` and the actionable text in `details.fieldErrors`. Showing `error`
- * alone leaves the user with nothing to correct, so prefer the field error.
+ * failed"` and the actionable text in `details.fieldErrors` — here that is the
+ * "Context is too long" message. `ApiError.message` is built from `error` and
+ * `message` only, so `errorMessage()` alone would show "Validation failed" and
+ * leave the user with nothing to correct.
+ *
+ * This form has ONE field, so the field error is the message rather than an
+ * inline annotation — which is why it reads `extractFieldErrors` (the shared
+ * unwrapper #1087 consolidated) instead of growing a third private copy of it.
  */
-function readErrorMessage(data: unknown): string {
-  if (data && typeof data === "object") {
-    const { details, error } = data as {
-      details?: { fieldErrors?: Record<string, string[] | undefined> };
-      error?: unknown;
-    };
-
-    const fieldError = Object.values(details?.fieldErrors ?? {})
-      .flat()
-      .find((message): message is string => typeof message === "string" && message.length > 0);
-    if (fieldError) return fieldError;
-
-    if (typeof error === "string" && error.length > 0) return error;
-  }
-
-  return "Failed to save";
+function readErrorMessage(e: unknown): string {
+  const fieldError = Object.values(extractFieldErrors(e) ?? {}).find(
+    (message) => message.length > 0
+  );
+  return fieldError ?? errorMessage(e, "Failed to save");
 }
 
 interface SettingsContextProps {
@@ -89,28 +85,15 @@ function ContextSection({
     setFeedback(null);
 
     try {
-      const res = await fetch(apiUrl, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        setFeedback({
-          type: "error",
-          message: readErrorMessage(data),
-        });
-        return;
-      }
+      await apiPut<unknown, ContextContentInput>(apiUrl, { content });
 
       setSavedContent(content);
       setFeedback({
         type: "success",
         message: "Saved. Changes will apply to your next conversation.",
       });
-    } catch {
-      setFeedback({ type: "error", message: "Failed to save" });
+    } catch (e) {
+      setFeedback({ type: "error", message: readErrorMessage(e) });
     } finally {
       setSaving(false);
     }

--- a/packages/web/src/components/settings-groups.tsx
+++ b/packages/web/src/components/settings-groups.tsx
@@ -40,6 +40,7 @@ import {
   apiPut,
   apiDelete,
   ApiError,
+  errorMessage,
   extractFieldErrors,
 } from "@/lib/api-client";
 import type { CreateGroupInput } from "@/lib/schemas/groups";
@@ -171,7 +172,7 @@ export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsPro
         setFieldErrors(fe);
         return;
       }
-      toast.error(e instanceof ApiError ? e.message : "Failed to create group");
+      toast.error(errorMessage(e, "Failed to create group"));
       return;
     }
 
@@ -214,7 +215,7 @@ export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsPro
         setFieldErrors(fe);
         return;
       }
-      toast.error(e instanceof ApiError ? e.message : "Failed to update group");
+      toast.error(errorMessage(e, "Failed to update group"));
       return;
     }
 
@@ -243,7 +244,7 @@ export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsPro
       setDeleteGroupId(null);
       fetchData();
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to delete group");
+      toast.error(errorMessage(e, "Failed to delete group"));
     }
   }
 

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -17,7 +17,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
-import { apiDelete, ApiError } from "@/lib/api-client";
+import { apiPut, apiDelete, errorMessage } from "@/lib/api-client";
+import type { SetLicenseKeyInput } from "@/lib/schemas/enterprise";
 import type { LicenseInfo } from "@/lib/enterprise";
 import { PRICING_URL, PORTAL_URL, conversionLink } from "@/lib/conversion-links";
 import { formatLicenseDate } from "@/lib/format-date";
@@ -66,7 +67,7 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
       );
       await fetchStatus();
     } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to remove gated configuration");
+      toast.error(errorMessage(e, "Failed to remove gated configuration"));
     } finally {
       setRemovingGated(false);
     }
@@ -76,26 +77,19 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch("/api/enterprise/key", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key: keyInput.trim() }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        await fetchStatus();
-        setKeyInput("");
-        setShowInput(false);
-        window.dispatchEvent(new Event("license-updated"));
-        if (data.enterprise) {
-          onEnterpriseActivated?.();
-        }
-      } else {
-        const data = await res.json();
-        setError(data.error ?? "Failed to save license key");
+      const data = await apiPut<{ enterprise?: boolean }, SetLicenseKeyInput>(
+        "/api/enterprise/key",
+        { key: keyInput.trim() }
+      );
+      await fetchStatus();
+      setKeyInput("");
+      setShowInput(false);
+      window.dispatchEvent(new Event("license-updated"));
+      if (data.enterprise) {
+        onEnterpriseActivated?.();
       }
-    } catch {
-      setError("Failed to save license key");
+    } catch (e) {
+      setError(errorMessage(e, "Failed to save license key"));
     } finally {
       setSaving(false);
     }

--- a/packages/web/src/components/settings-profile.tsx
+++ b/packages/web/src/components/settings-profile.tsx
@@ -19,12 +19,16 @@ import {
 } from "@/components/ui/form";
 import { authClient } from "@/lib/auth-client";
 import { passwordSchema } from "@/lib/validate-password";
+import { apiPost, apiPatch, errorMessage } from "@/lib/api-client";
+import type { UpdateMeInput, ChangePasswordInput } from "@/lib/schemas/settings";
 
 const nameSchema = z.object({
   name: z.string().min(1, "Name is required"),
 });
 
-const changePasswordSchema = z
+// The FORM's shape, not the route's: `confirmPassword` never leaves the
+// browser. The payload is typed by ChangePasswordInput at the call site.
+const passwordFormSchema = z
   .object({
     currentPassword: z.string().min(1, "Current password is required"),
     newPassword: passwordSchema,
@@ -36,7 +40,7 @@ const changePasswordSchema = z
   });
 
 type NameFormValues = z.infer<typeof nameSchema>;
-type PasswordFormValues = z.infer<typeof changePasswordSchema>;
+type PasswordFormValues = z.infer<typeof passwordFormSchema>;
 
 interface SettingsProfileProps {
   userName: string;
@@ -59,7 +63,7 @@ export function SettingsProfile({ userName, onDirtyChange }: SettingsProfileProp
   }, [userName, nameForm]);
 
   const passwordForm = useForm<PasswordFormValues>({
-    resolver: zodResolver(changePasswordSchema),
+    resolver: zodResolver(passwordFormSchema),
     defaultValues: { currentPassword: "", newPassword: "", confirmPassword: "" },
   });
 
@@ -72,48 +76,34 @@ export function SettingsProfile({ userName, onDirtyChange }: SettingsProfileProp
 
   async function onNameSubmit(values: NameFormValues) {
     try {
-      const res = await fetch("/api/users/me", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: values.name }),
+      await apiPatch<unknown, UpdateMeInput>("/api/users/me", { name: values.name });
+      toast.success("Name updated");
+      nameForm.reset({ name: values.name });
+    } catch (e) {
+      nameForm.setError("root", {
+        message: errorMessage(e, "Failed to update name"),
       });
-      if (res.ok) {
-        toast.success("Name updated");
-        nameForm.reset({ name: values.name });
-      } else {
-        const data = await res.json();
-        nameForm.setError("root", { message: data.error || "Failed to update name" });
-      }
-    } catch {
-      nameForm.setError("root", { message: "Failed to update name" });
     }
   }
 
   async function onPasswordSubmit(values: PasswordFormValues) {
     try {
-      const res = await fetch("/api/users/me/password", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          currentPassword: values.currentPassword,
-          newPassword: values.newPassword,
-        }),
+      await apiPost<unknown, ChangePasswordInput>("/api/users/me/password", {
+        currentPassword: values.currentPassword,
+        newPassword: values.newPassword,
       });
-      if (res.ok) {
-        // Say what actually happened: the change revokes every session this
-        // user holds (revokeOtherSessions in the route), so their phone and
-        // second machine are signed out. This tab keeps working — the route
-        // forwards the reissued session cookie — which is exactly why the
-        // sign-out would otherwise go unnoticed until someone else's device
-        // asked for a password.
-        toast.success("Password updated. Your other devices have been signed out.");
-        passwordForm.reset();
-      } else {
-        const data = await res.json();
-        passwordForm.setError("root", { message: data.error || "Failed to change password" });
-      }
-    } catch {
-      passwordForm.setError("root", { message: "Failed to change password" });
+      // Say what actually happened: the change revokes every session this
+      // user holds (revokeOtherSessions in the route), so their phone and
+      // second machine are signed out. This tab keeps working — the route
+      // forwards the reissued session cookie — which is exactly why the
+      // sign-out would otherwise go unnoticed until someone else's device
+      // asked for a password.
+      toast.success("Password updated. Your other devices have been signed out.");
+      passwordForm.reset();
+    } catch (e) {
+      passwordForm.setError("root", {
+        message: errorMessage(e, "Failed to change password"),
+      });
     }
   }
 

--- a/packages/web/src/components/settings-security.tsx
+++ b/packages/web/src/components/settings-security.tsx
@@ -7,6 +7,17 @@ import { Button } from "@/components/ui/button";
 import { ShieldCheck, ShieldAlert, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { docsUrl } from "@/components/docs-link";
+import { apiPost, apiDelete, errorMessage } from "@/lib/api-client";
+
+/**
+ * POST answers `{ domain, restart }`; DELETE answers `{ removed, restart }`.
+ * Only `restart` is common, so `domain` is optional here and the lock branch
+ * is the only one that reads it.
+ */
+interface DomainLockResult {
+  domain?: string;
+  restart?: boolean;
+}
 
 interface DomainStatus {
   domain: string | null;
@@ -69,21 +80,21 @@ export function SettingsSecurity() {
   const handleLock = async () => {
     setLocking(true);
     try {
-      const res = await fetch("/api/settings/domain", { method: "POST" });
-      if (res.ok) {
-        const data = await res.json();
-        setStatus((prev) => (prev ? { ...prev, domain: data.domain } : prev));
-        toast.success(`Domain locked to ${data.domain}.`);
-        if (data.restart) {
-          setShowRestarting(true);
-          waitForRestart();
-        }
-      } else {
-        const data = await res.json();
-        toast.error(data.error || "Failed to lock domain");
+      const data = await apiPost<DomainLockResult>("/api/settings/domain", undefined);
+      // Resolve the locked domain once. Reading `data.domain` again below would
+      // interpolate `undefined` into the toast on the very response the `??`
+      // here concedes is possible — "Domain locked to undefined."
+      const lockedDomain = data.domain ?? status?.domain ?? null;
+      setStatus((prev) => (prev ? { ...prev, domain: lockedDomain } : prev));
+      toast.success(
+        lockedDomain ? `Domain locked to ${lockedDomain}.` : "Domain locked to this host."
+      );
+      if (data.restart) {
+        setShowRestarting(true);
+        waitForRestart();
       }
-    } catch {
-      toast.error("Failed to lock domain");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to lock domain"));
     } finally {
       setLocking(false);
     }
@@ -92,24 +103,18 @@ export function SettingsSecurity() {
   const handleRemove = async () => {
     setRemoving(true);
     try {
-      const res = await fetch("/api/settings/domain", { method: "DELETE" });
-      if (res.ok) {
-        const data = await res.json();
-        setStatus((prev) => (prev ? { ...prev, domain: null } : prev));
-        setShowRemoveConfirm(false);
-        toast.success("Domain lock removed");
-        if (data.restart) {
-          setShowRestarting(true);
-          waitForRestart();
-        } else {
-          router.refresh();
-        }
+      const data = await apiDelete<DomainLockResult>("/api/settings/domain");
+      setStatus((prev) => (prev ? { ...prev, domain: null } : prev));
+      setShowRemoveConfirm(false);
+      toast.success("Domain lock removed");
+      if (data.restart) {
+        setShowRestarting(true);
+        waitForRestart();
       } else {
-        const data = await res.json();
-        toast.error(data.error || "Failed to remove domain lock");
+        router.refresh();
       }
-    } catch {
-      toast.error("Failed to remove domain lock");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to remove domain lock"));
     } finally {
       setRemoving(false);
     }

--- a/packages/web/src/components/settings-users.tsx
+++ b/packages/web/src/components/settings-users.tsx
@@ -23,6 +23,8 @@ import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { buildInviteUrl } from "@/lib/invite-url";
 import { evaluateSeatPressure } from "@/lib/seat-grace";
 import { SALES_MAILTO, CALENDLY_URL } from "@/lib/conversion-links";
+import { apiPost, apiDelete, errorMessage } from "@/lib/api-client";
+import type { InviteUserInput } from "@/lib/schemas/users";
 
 interface SettingsUsersProps {
   currentUserId: string;
@@ -134,11 +136,13 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
   function handleRevoke(inviteId: string) {
     startRevokeTransition(async () => {
       applyOptimistic({ type: "removeInvite", id: inviteId });
-      const res = await fetch(`/api/users/invites/${inviteId}`, { method: "DELETE" });
-      // fetchUsers() re-introduces the optimistically-removed row on failure;
-      // surface why it flickered back instead of failing silently.
-      if (!res.ok) {
-        toast.error("Failed to revoke invite. Please try again.");
+      try {
+        await apiDelete(`/api/users/invites/${inviteId}`);
+      } catch (e) {
+        // fetchUsers() re-introduces the optimistically-removed row on failure;
+        // surface why it flickered back instead of failing silently. The route's
+        // own wording ("Invite not found") tells a stale list from an outage.
+        toast.error(errorMessage(e, "Failed to revoke invite. Please try again."));
       }
       fetchUsers();
     });
@@ -148,22 +152,21 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
     // Resend = revoke the old invite, then create a fresh one. Report which of
     // the two steps failed so the admin knows whether the old invite is still
     // live (revoke failed) or simply no replacement was issued (create failed).
-    const deleteRes = await fetch(`/api/users/invites/${item.id}`, { method: "DELETE" });
-    if (!deleteRes.ok) {
-      toast.error("Failed to revoke the old invite. Please try again.");
+    try {
+      await apiDelete(`/api/users/invites/${item.id}`);
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to revoke the old invite. Please try again."));
       fetchUsers();
       return;
     }
-    const res = await fetch("/api/users/invite", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: item.email || undefined, role: item.role }),
-    });
-    if (res.ok) {
-      const data = await res.json();
+    try {
+      const data = await apiPost<{ token: string }, InviteUserInput>("/api/users/invite", {
+        email: item.email || undefined,
+        role: item.role,
+      });
       setResetLink(buildInviteUrl(window.location.origin, data.token));
-    } else {
-      toast.error("Failed to create the new invite. Please try again.");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to create the new invite. Please try again."));
     }
     fetchUsers();
   }

--- a/packages/web/src/components/setup-form.tsx
+++ b/packages/web/src/components/setup-form.tsx
@@ -20,6 +20,8 @@ import { CheckCircle2, Loader2, AlertTriangle } from "lucide-react";
 import { PasswordInput } from "@/components/password-input";
 import { ReportIssueLink } from "@/components/report-issue-link";
 import { passwordSchema } from "@/lib/validate-password";
+import { apiPost, errorMessage } from "@/lib/api-client";
+import type { SetupInput } from "@/lib/schemas/setup";
 
 const setupSchema = z
   .object({
@@ -120,25 +122,20 @@ export function SetupForm() {
     setError("");
 
     try {
-      const res = await fetch("/api/setup", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: values.name,
-          email: values.email,
-          password: values.password,
-          browserTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        }),
+      await apiPost<unknown, SetupInput>("/api/setup", {
+        name: values.name,
+        email: values.email,
+        password: values.password,
+        browserTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || "Setup failed");
-      }
 
       setSuccess(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Setup failed");
+      // Not `err.message`: before the migration this catch only ever saw an
+      // Error this handler threw itself, so its message was curated copy. It
+      // now also sees a network TypeError, whose message is "Failed to fetch" —
+      // and this is the very first screen a new install shows.
+      setError(errorMessage(err, "Setup failed"));
     } finally {
       setLoading(false);
     }

--- a/packages/web/src/components/telegram-link-settings.tsx
+++ b/packages/web/src/components/telegram-link-settings.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { QRCodeSVG } from "qrcode.react";
+import { apiPost, apiDelete, errorMessage } from "@/lib/api-client";
+import type { LinkTelegramInput } from "@/lib/schemas/telegram";
 import { toast } from "sonner";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -113,23 +115,13 @@ export function TelegramLinkSettings({ isAdmin }: TelegramLinkSettingsProps) {
     setLinking(true);
     setLinkError("");
     try {
-      const res = await fetch("/api/settings/telegram", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code: code.trim() }),
-      });
-
-      if (res.ok) {
-        setCode("");
-        setLinkError("");
-        toast.success("Telegram account linked");
-        await fetchData();
-      } else {
-        const data = await res.json();
-        setLinkError(data.error || "Failed to link Telegram account");
-      }
-    } catch {
-      setLinkError("Failed to link Telegram account");
+      await apiPost<unknown, LinkTelegramInput>("/api/settings/telegram", { code: code.trim() });
+      setCode("");
+      setLinkError("");
+      toast.success("Telegram account linked");
+      await fetchData();
+    } catch (e) {
+      setLinkError(errorMessage(e, "Failed to link Telegram account"));
     } finally {
       setLinking(false);
     }
@@ -138,20 +130,12 @@ export function TelegramLinkSettings({ isAdmin }: TelegramLinkSettingsProps) {
   async function handleUnlink() {
     setUnlinking(true);
     try {
-      const res = await fetch("/api/settings/telegram", {
-        method: "DELETE",
-      });
-
-      if (res.ok) {
-        setPairingStep(1);
-        toast.success("Telegram account unlinked");
-        await fetchData();
-      } else {
-        const data = await res.json();
-        toast.error(data.error || "Failed to unlink Telegram account");
-      }
-    } catch {
-      toast.error("Failed to unlink Telegram account");
+      await apiDelete("/api/settings/telegram");
+      setPairingStep(1);
+      toast.success("Telegram account unlinked");
+      await fetchData();
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to unlink Telegram account"));
     } finally {
       setUnlinking(false);
     }
@@ -160,16 +144,11 @@ export function TelegramLinkSettings({ isAdmin }: TelegramLinkSettingsProps) {
   async function handleRemoveAll() {
     setRemovingAll(true);
     try {
-      const res = await fetch("/api/settings/telegram/all", { method: "DELETE" });
-      if (res.ok) {
-        toast.success("Telegram removed");
-        await fetchData();
-      } else {
-        const data = await res.json();
-        toast.error(data.error || "Failed to remove Telegram");
-      }
-    } catch {
-      toast.error("Failed to remove Telegram");
+      await apiDelete("/api/settings/telegram/all");
+      toast.success("Telegram removed");
+      await fetchData();
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to remove Telegram"));
     } finally {
       setRemovingAll(false);
     }

--- a/packages/web/src/components/timezone-settings.tsx
+++ b/packages/web/src/components/timezone-settings.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { apiPost, errorMessage } from "@/lib/api-client";
+import type { OrgSettingInput } from "@/lib/schemas/settings";
 import {
   Select,
   SelectContent,
@@ -66,19 +68,13 @@ export function TimezoneSettings() {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch("/api/settings", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key: "org.timezone", value: timezone }),
+      await apiPost<unknown, OrgSettingInput>("/api/settings", {
+        key: "org.timezone",
+        value: timezone,
       });
-      if (!res.ok) {
-        const data = await res.json();
-        setError(data.error || "Failed to save timezone");
-        return;
-      }
       toast.success("Settings saved");
-    } catch {
-      setError("Failed to save timezone");
+    } catch (e) {
+      setError(errorMessage(e, "Failed to save timezone"));
     } finally {
       setSaving(false);
     }

--- a/packages/web/src/components/user-detail-sheet.tsx
+++ b/packages/web/src/components/user-detail-sheet.tsx
@@ -32,6 +32,9 @@ import { Separator } from "@/components/ui/separator";
 import { StatusBadge } from "@/components/status-badge";
 import { toast } from "sonner";
 import type { UserListItem, UserGroup } from "@/lib/user-list";
+import type { UserRole } from "@/db/enums";
+import { apiPost, apiPut, apiPatch, apiDelete, ApiError, errorMessage } from "@/lib/api-client";
+import type { UpdateUserInput, UpdateUserGroupsInput } from "@/lib/schemas/users";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { buildInviteUrl } from "@/lib/invite-url";
 
@@ -119,25 +122,33 @@ export function UserDetailSheet({
       // results.every(ok), which reports a total failure on a partial success
       // and leaves the table out of sync with what actually persisted.
       const rolePromise = roleChanged
-        ? fetch(`/api/users/${user.id}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ role: selectedRole }),
-          })
+        ? apiPatch<unknown, UpdateUserInput>(`/api/users/${user.id}`, { role: selectedRole })
         : null;
 
       const groupsPromise = groupsChanged
-        ? fetch(`/api/users/${user.id}/groups`, {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ groupIds: [...selectedGroupIds] }),
+        ? apiPut<unknown, UpdateUserGroupsInput>(`/api/users/${user.id}/groups`, {
+            groupIds: [...selectedGroupIds],
           })
         : null;
 
-      const [roleRes, groupsRes] = await Promise.all([rolePromise, groupsPromise]);
+      // allSettled, not all: the two writes are independent, and `all` would
+      // discard the other outcome the moment one rejects — which is exactly
+      // the partial-success case this branch exists to report.
+      const [roleResult, groupsResult] = await Promise.allSettled([
+        rolePromise ?? Promise.resolve(),
+        groupsPromise ?? Promise.resolve(),
+      ]);
 
-      const roleOk = !rolePromise || (roleRes?.ok ?? false);
-      const groupsOk = !groupsPromise || (groupsRes?.ok ?? false);
+      const roleOk = !rolePromise || roleResult.status === "fulfilled";
+      const groupsOk = !groupsPromise || groupsResult.status === "fulfilled";
+      // The route's own wording ("Cannot change your own role", "License
+      // required — Adding users to groups requires an active license.") beats
+      // "Please try again", which tells the admin nothing they can act on.
+      const reason = [roleResult, groupsResult]
+        .map((r) =>
+          r.status === "rejected" && r.reason instanceof ApiError ? r.reason.message : null
+        )
+        .find((m): m is string => m !== null);
 
       if (roleOk && groupsOk) {
         toast("User updated");
@@ -152,49 +163,48 @@ export function UserDetailSheet({
         // re-applies the failed half. Use onRefresh (refetch-only), NOT onSaved
         // — the latter closes the sheet in the parent and would kill the retry.
         onRefresh?.();
-        toast.error(
-          !roleOk
-            ? "Group membership saved, but the role change failed. Please retry."
-            : "Role saved, but group membership could not be updated. Please retry."
-        );
+        const half = !roleOk
+          ? "Group membership saved, but the role change failed."
+          : "Role saved, but group membership could not be updated.";
+        toast.error(reason ? `${half} ${reason}` : `${half} Please retry.`);
         return;
       }
 
       // Total failure: nothing persisted, keep the sheet open.
-      toast.error("Failed to update user. Please try again.");
+      toast.error(reason ?? "Failed to update user. Please try again.");
     } finally {
       setSaving(false);
     }
   }
 
   async function handleResetPassword() {
-    const res = await fetch(`/api/users/${user.id}/reset`, { method: "POST" });
-    if (res.ok) {
-      const data = await res.json();
+    try {
+      const data = await apiPost<{ token: string }>(`/api/users/${user.id}/reset`, undefined);
       setResetLink(buildInviteUrl(window.location.origin, data.token));
-    } else {
-      toast.error("Failed to reset password");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to reset password"));
     }
   }
 
   async function handleDeactivate() {
-    const res = await fetch(`/api/users/${user.id}`, { method: "DELETE" });
-    setShowDeactivateConfirm(false);
-    if (res.ok) {
+    try {
+      await apiDelete(`/api/users/${user.id}`);
+      setShowDeactivateConfirm(false);
       onSaved();
       onOpenChange(false);
-    } else {
-      toast.error("Failed to deactivate user");
+    } catch (e) {
+      setShowDeactivateConfirm(false);
+      toast.error(errorMessage(e, "Failed to deactivate user"));
     }
   }
 
   async function handleReactivate() {
-    const res = await fetch(`/api/users/${user.id}/reactivate`, { method: "POST" });
-    if (res.ok) {
+    try {
+      await apiPost(`/api/users/${user.id}/reactivate`, undefined);
       onSaved();
       onOpenChange(false);
-    } else {
-      toast.error("Failed to reactivate user");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to reactivate user"));
     }
   }
 
@@ -217,7 +227,9 @@ export function UserDetailSheet({
             <Label htmlFor="role-select">Role</Label>
             <Select
               value={selectedRole}
-              onValueChange={setSelectedRole}
+              // Radix hands back a bare string; the only two values it can
+              // produce are the two SelectItems below, which are the role enum.
+              onValueChange={(v) => setSelectedRole(v as UserRole)}
               disabled={isOwnAccount || isDeactivated}
             >
               <SelectTrigger id="role-select">

--- a/packages/web/src/hooks/__tests__/use-integration-actions.test.ts
+++ b/packages/web/src/hooks/__tests__/use-integration-actions.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useIntegrationActions } from "../use-integration-actions";
+import { jsonResponse } from "@/test-helpers/fetch";
 
 // Mock sonner
 const mockToastSuccess = vi.fn();
@@ -26,10 +27,7 @@ describe("useIntegrationActions", () => {
 
   describe("testConnection", () => {
     it("sets testing state during the call", async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ success: true }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ success: true }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -50,10 +48,7 @@ describe("useIntegrationActions", () => {
     });
 
     it("shows success toast on successful test", async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ success: true }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ success: true }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -65,10 +60,7 @@ describe("useIntegrationActions", () => {
     });
 
     it("shows error toast when test fails", async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ success: false, error: "Auth failed" }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ success: false, error: "Auth failed" }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -94,10 +86,7 @@ describe("useIntegrationActions", () => {
 
   describe("syncSchema", () => {
     it("sets syncing state during the call", async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ success: true }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ success: true }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -116,10 +105,7 @@ describe("useIntegrationActions", () => {
     });
 
     it("calls onChange after successful sync", async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ success: true }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ success: true }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -132,10 +118,7 @@ describe("useIntegrationActions", () => {
     });
 
     it("shows error toast when sync fails", async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ success: false, error: "Permission denied" }),
-      });
+      mockFetch.mockResolvedValue(jsonResponse({ success: false, error: "Permission denied" }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -150,7 +133,7 @@ describe("useIntegrationActions", () => {
 
   describe("renameConnection", () => {
     it("calls PATCH with trimmed name", async () => {
-      mockFetch.mockResolvedValue({ ok: true });
+      mockFetch.mockResolvedValue(jsonResponse(undefined, { status: 200 }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -178,7 +161,7 @@ describe("useIntegrationActions", () => {
     });
 
     it("shows error toast on failure", async () => {
-      mockFetch.mockResolvedValue({ ok: false });
+      mockFetch.mockResolvedValue(jsonResponse(undefined, { status: 400 }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -192,7 +175,7 @@ describe("useIntegrationActions", () => {
 
   describe("deleteConnection", () => {
     it("calls DELETE and triggers onChange", async () => {
-      mockFetch.mockResolvedValue({ ok: true });
+      mockFetch.mockResolvedValue(jsonResponse(undefined, { status: 200 }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 
@@ -206,7 +189,7 @@ describe("useIntegrationActions", () => {
     });
 
     it("shows error toast on failure", async () => {
-      mockFetch.mockResolvedValue({ ok: false });
+      mockFetch.mockResolvedValue(jsonResponse(undefined, { status: 400 }));
 
       const { result } = renderHook(() => useIntegrationActions(mockOnChange));
 

--- a/packages/web/src/hooks/use-integration-actions.ts
+++ b/packages/web/src/hooks/use-integration-actions.ts
@@ -1,5 +1,16 @@
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
+import { apiPost, apiPatch, apiDelete, errorMessage } from "@/lib/api-client";
+import type { UpdateConnectionInput } from "@/lib/schemas/integration-edit";
+
+/**
+ * The test and sync routes deliberately answer 200 with `{ success: false }`
+ * for a *credential* failure — that is a diagnosis, not a request error — and
+ * reserve non-2xx for a genuinely broken request (404 unknown connection, 403).
+ * So both branches have to be handled: the body's own verdict, and the thrown
+ * ApiError.
+ */
+type ProbeResult = { success?: boolean; error?: string };
 
 /**
  * Hook for integration CRUD actions (test, sync, rename, delete).
@@ -14,15 +25,14 @@ export function useIntegrationActions(onChange: () => void) {
   const testConnection = useCallback(async (id: string) => {
     setTesting(id);
     try {
-      const res = await fetch(`/api/integrations/${id}/test`, { method: "POST" });
-      const data = await res.json();
+      const data = await apiPost<ProbeResult>(`/api/integrations/${id}/test`, undefined);
       if (data.success) {
         toast.success("Connection successful");
       } else {
         toast.error(data.error || "Connection test failed");
       }
-    } catch {
-      toast.error("Failed to test connection");
+    } catch (e) {
+      toast.error(errorMessage(e, "Failed to test connection"));
     } finally {
       setTesting(null);
     }
@@ -32,16 +42,15 @@ export function useIntegrationActions(onChange: () => void) {
     async (id: string) => {
       setSyncing(id);
       try {
-        const res = await fetch(`/api/integrations/${id}/sync`, { method: "POST" });
-        const data = await res.json();
+        const data = await apiPost<ProbeResult>(`/api/integrations/${id}/sync`, undefined);
         if (data.success) {
           toast.success("Schema synced successfully");
         } else {
           toast.error(data.error || "Schema sync failed");
         }
         onChange();
-      } catch {
-        toast.error("Failed to sync schema");
+      } catch (e) {
+        toast.error(errorMessage(e, "Failed to sync schema"));
       } finally {
         setSyncing(null);
       }
@@ -53,19 +62,13 @@ export function useIntegrationActions(onChange: () => void) {
     async (id: string, name: string) => {
       if (!name.trim()) return;
       try {
-        const res = await fetch(`/api/integrations/${id}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: name.trim() }),
+        await apiPatch<unknown, UpdateConnectionInput>(`/api/integrations/${id}`, {
+          name: name.trim(),
         });
-        if (res.ok) {
-          toast.success("Integration renamed");
-          onChange();
-        } else {
-          toast.error("Failed to rename integration");
-        }
-      } catch {
-        toast.error("Failed to rename integration");
+        toast.success("Integration renamed");
+        onChange();
+      } catch (e) {
+        toast.error(errorMessage(e, "Failed to rename integration"));
       }
     },
     [onChange]
@@ -74,15 +77,11 @@ export function useIntegrationActions(onChange: () => void) {
   const deleteConnection = useCallback(
     async (id: string) => {
       try {
-        const res = await fetch(`/api/integrations/${id}`, { method: "DELETE" });
-        if (res.ok) {
-          toast.success("Integration deleted");
-          onChange();
-        } else {
-          toast.error("Failed to delete integration");
-        }
-      } catch {
-        toast.error("Failed to delete integration");
+        await apiDelete(`/api/integrations/${id}`);
+        toast.success("Integration deleted");
+        onChange();
+      } catch (e) {
+        toast.error(errorMessage(e, "Failed to delete integration"));
       }
     },
     [onChange]

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -2,11 +2,56 @@ export class ApiError extends Error {
   constructor(
     public readonly status: number,
     message: string,
-    public readonly details?: unknown
+    public readonly details?: unknown,
+    /**
+     * The whole parsed error payload. The escape hatch for the routes that
+     * carry a field beyond `{ error, message, details }` — e.g.
+     * `/api/setup/provider` answers a `docs` link with its 400. Without it,
+     * such a caller would have to drop back to a raw `fetch` and hand-roll the
+     * error contract again, which is the drift this module exists to stop.
+     */
+    public readonly body?: unknown
   ) {
     super(message);
     this.name = "ApiError";
   }
+}
+
+const FALLBACK_MESSAGE = "Something went wrong. Please try again.";
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+/**
+ * The error contract routes actually use is `{ error, message?, details? }`,
+ * where `error` is a short headline and `message` — when present — is the
+ * sentence that tells the user what to do about it ("Your license includes 5
+ * seats… Remove an existing user or email sales@…"). Reading only `error`
+ * dropped that half on the floor, so the toast said "Seat limit reached" and
+ * nothing else. Join them; skip the join when a route sends the same text
+ * twice, so the toast never stutters.
+ */
+export function buildErrorMessage(error?: string, message?: string): string {
+  if (error && message && error !== message) return `${error} — ${message}`;
+  return error ?? message ?? FALLBACK_MESSAGE;
+}
+
+/**
+ * The server's own wording when it sent any, otherwise the caller's
+ * context-specific fallback.
+ *
+ * Prefer this over a bare `e.message` in a catch block. `ApiError.message`
+ * falls back to a deliberately generic sentence when the route sent no `error`
+ * or `message` at all (a bare 500, a proxy's HTML error page), and a component
+ * almost always knows something more useful than "Something went wrong" —
+ * "Failed to save timezone" at least says which action died. A non-ApiError
+ * (a network failure, an aborted request) gets the fallback for the same
+ * reason: its `message` is an internal string, not user-facing copy.
+ */
+export function errorMessage(e: unknown, fallback: string): string {
+  if (e instanceof ApiError && e.message !== FALLBACK_MESSAGE) return e.message;
+  return fallback;
 }
 
 async function send<R>(url: string, method: string, body?: unknown): Promise<R> {
@@ -22,14 +67,23 @@ async function send<R>(url: string, method: string, body?: unknown): Promise<R> 
   const parsedBody = rawBody.length > 0 ? safeParseJson(rawBody) : undefined;
 
   if (!res.ok) {
-    const errBody = (parsedBody ?? {}) as { error?: string; details?: unknown };
-    // The fallback message is surfaced to end users via toast. Keep it
-    // human-readable; the numeric status is still available on ApiError.status
-    // for logging and conditional handling.
+    const errBody = (parsedBody ?? {}) as {
+      error?: unknown;
+      message?: unknown;
+      details?: unknown;
+    };
+    // `asString` is not defensiveness for its own sake: a handful of routes
+    // put an OBJECT under `error` (`{ error: { message } }`), and passing that
+    // to `new Error(...)` shows the user "[object Object]". Fall back instead.
+    // The fallback is surfaced to end users via toast, so keep it a human
+    // sentence; the numeric status stays on ApiError.status for logging.
+    const error = asString(errBody.error);
+    const serverMessage = asString(errBody.message);
     throw new ApiError(
       res.status,
-      errBody.error ?? "Something went wrong. Please try again.",
-      errBody.details
+      buildErrorMessage(error, serverMessage),
+      errBody.details,
+      parsedBody
     );
   }
   return (parsedBody as R) ?? (undefined as R);

--- a/packages/web/src/lib/schemas/agents.ts
+++ b/packages/web/src/lib/schemas/agents.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { AGENT_NAME_MAX_LENGTH } from "@/lib/agent-constants";
 import { pluginConfigSchema } from "@/lib/domain-validation";
+import { starterPromptsSchema } from "@/lib/schemas/starter-prompts";
+import { AGENT_VISIBILITIES } from "@/db/enums";
 
 /**
  * Request schema for creating an agent. Shared between the session-authenticated
@@ -20,3 +22,33 @@ export const createAgentSchema = z.object({
   defaultAllowedTools: z.array(z.string()).optional(),
 });
 export type CreateAgentInput = z.infer<typeof createAgentSchema>;
+
+/**
+ * Request schema for `PATCH /api/agents/[agentId]`. Shared with
+ * `agent-settings-page-content.tsx`, which builds one unified patch body out
+ * of whichever settings tabs are dirty — the case where an untyped
+ * `Record<string, unknown>` hid a rename until a runtime 400.
+ */
+export const updateAgentSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(AGENT_NAME_MAX_LENGTH)
+    .refine((v) => v.trim().length > 0, "Name is required")
+    .optional(),
+  model: z.string().optional(),
+  allowedTools: z.array(z.string()).optional(),
+  pluginConfig: pluginConfigSchema.nullable().optional(),
+  greetingMessage: z.string().min(1, "Greeting message cannot be empty").optional(),
+  tagline: z.string().nullable().optional(),
+  starterPrompts: starterPromptsSchema.optional(),
+  avatarSeed: z.string().nullable().optional(),
+  personalityPresetId: z.string().nullable().optional(),
+  visibility: z.enum(AGENT_VISIBILITIES).optional(),
+  groupIds: z.array(z.string()).optional(),
+});
+export type UpdateAgentInput = z.input<typeof updateAgentSchema>;
+
+/** `PUT /api/agents/[agentId]/files/[filename]` — a workspace text file. */
+export const writeAgentFileSchema = z.object({ content: z.string() });
+export type WriteAgentFileInput = z.infer<typeof writeAgentFileSchema>;

--- a/packages/web/src/lib/schemas/context.ts
+++ b/packages/web/src/lib/schemas/context.ts
@@ -24,3 +24,7 @@ export const CONTEXT_TOO_LONG_MESSAGE = `Context is too long — the limit is ${
 export const contextContentSchema = z.object({
   content: z.string().max(CONTEXT_CONTENT_MAX_LENGTH, { message: CONTEXT_TOO_LONG_MESSAGE }),
 });
+
+/** The PUT body, so `settings-context.tsx` types its payload against the same
+ * shape the routes parse (AGENTS.md § "Shared Schemas And Typed Client"). */
+export type ContextContentInput = z.infer<typeof contextContentSchema>;

--- a/packages/web/src/lib/schemas/enterprise.ts
+++ b/packages/web/src/lib/schemas/enterprise.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+/**
+ * `PUT /api/enterprise/key` — activate a license key. Shared with
+ * `settings-license.tsx` (AGENTS.md § "Shared Schemas And Typed Client").
+ */
+export const setLicenseKeySchema = z.object({ key: z.string().min(1) });
+export type SetLicenseKeyInput = z.infer<typeof setLicenseKeySchema>;

--- a/packages/web/src/lib/schemas/integration-edit.ts
+++ b/packages/web/src/lib/schemas/integration-edit.ts
@@ -2,6 +2,21 @@ import { z } from "zod";
 
 import { senderNameSchema } from "@/lib/schemas/sender-name";
 
+// `PATCH /api/integrations/[connectionId]` — the connection envelope itself
+// (rename/describe/re-credential), as opposed to the per-type credential
+// shapes below. Shared with `use-integration-actions.ts` so a rename payload
+// cannot drift from what the route accepts. `.passthrough()` is deliberate:
+// the route merges unknown keys into the credential blob for types that
+// validate them separately.
+export const updateConnectionSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    description: z.string().max(500).optional(),
+    credentials: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+export type UpdateConnectionInput = z.infer<typeof updateConnectionSchema>;
+
 // All fields optional — empty string means "leave current value unchanged".
 // The submit handler filters out empty strings before sending the PATCH body.
 export const odooEditSchema = z.object({

--- a/packages/web/src/lib/schemas/integrations.ts
+++ b/packages/web/src/lib/schemas/integrations.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { odooCredentialsSchema, odooConnectionDataSchema } from "@/lib/integrations/odoo-schema";
+
+/**
+ * Request schemas for the integration-connect wizard's four routes, shared
+ * with `add-integration-dialog.tsx` (AGENTS.md § "Shared Schemas And Typed
+ * Client"). `@/lib/integrations/odoo-schema` imports nothing but zod, so it is
+ * safe in a client bundle.
+ */
+
+/** `POST /api/integrations/list-databases` — probe an Odoo host for db names. */
+export const listDatabasesSchema = z.object({
+  url: z.string().url(),
+});
+export type ListDatabasesInput = z.infer<typeof listDatabasesSchema>;
+
+/** `POST /api/integrations/test-credentials` — probe before anything is saved. */
+export const testCredentialsSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("odoo"),
+    credentials: z.object({
+      url: z.string().url(),
+      db: z.string().min(1),
+      login: z.string().min(1),
+      apiKey: z.string().min(1),
+    }),
+  }),
+  z.object({
+    type: z.literal("web-search"),
+    credentials: z.object({
+      apiKey: z.string().min(1),
+    }),
+  }),
+]);
+export type TestCredentialsInput = z.infer<typeof testCredentialsSchema>;
+
+/** `POST /api/integrations/sync-preview` — read the Odoo schema, save nothing. */
+export const syncPreviewSchema = z.object({
+  type: z.literal("odoo"),
+  credentials: z.object({
+    url: z.string().url(),
+    db: z.string().min(1),
+    login: z.string().min(1),
+    apiKey: z.string().min(1),
+    uid: z.number().int().positive(),
+  }),
+});
+export type SyncPreviewInput = z.infer<typeof syncPreviewSchema>;
+
+/** `POST /api/integrations` — create the connection with everything at once. */
+export const createIntegrationSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("odoo"),
+    name: z.string().min(1).max(100),
+    description: z.string().max(500).default(""),
+    credentials: odooCredentialsSchema,
+    data: odooConnectionDataSchema.optional(),
+  }),
+  z.object({
+    type: z.literal("web-search"),
+    name: z.string().min(1).max(100),
+    description: z.string().max(500).default(""),
+    credentials: z.object({ apiKey: z.string().min(1) }),
+  }),
+]);
+/** Pre-parse shape — `description` has a default the caller may omit. */
+export type CreateIntegrationInput = z.input<typeof createIntegrationSchema>;

--- a/packages/web/src/lib/schemas/invite.ts
+++ b/packages/web/src/lib/schemas/invite.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * `POST /api/invite/claim` — redeem an invite or a password-reset link. Shared
+ * with the claim page (AGENTS.md § "Shared Schemas And Typed Client").
+ *
+ * `name` is optional because the reset branch has no name to set; `password`
+ * is shape-only, with the length/breach-list policy enforced post-parse via
+ * `validatePassword()`.
+ */
+export const claimInviteSchema = z.object({
+  token: z.string().min(1),
+  name: z.string().optional(),
+  password: z.string(),
+});
+export type ClaimInviteInput = z.infer<typeof claimInviteSchema>;

--- a/packages/web/src/lib/schemas/providers.ts
+++ b/packages/web/src/lib/schemas/providers.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { PROVIDERS, type ProviderName } from "@/lib/providers";
+
+/**
+ * Request schemas for the built-in provider routes, shared with
+ * `provider-key-form.tsx` (AGENTS.md § "Shared Schemas And Typed Client").
+ *
+ * `@/lib/providers` is a const table plus one pure URL helper — no database,
+ * no settings — so it is safe in a client bundle, and the form already imports
+ * `ProviderName` from it.
+ */
+const VALID_PROVIDERS = Object.keys(PROVIDERS) as [ProviderName, ...ProviderName[]];
+
+/** `POST /api/setup/provider` — save an API key or a local-runtime URL. */
+export const setupProviderSchema = z.object({
+  provider: z.enum(VALID_PROVIDERS),
+  url: z.string().min(1).optional(),
+  apiKey: z.string().min(1).optional(),
+});
+export type SetupProviderInput = z.infer<typeof setupProviderSchema>;
+
+/** `DELETE /api/settings/providers` — remove a configured provider. */
+export const deleteProviderSchema = z.object({
+  provider: z.enum(VALID_PROVIDERS),
+});
+export type DeleteProviderInput = z.infer<typeof deleteProviderSchema>;

--- a/packages/web/src/lib/schemas/settings.ts
+++ b/packages/web/src/lib/schemas/settings.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+/**
+ * Request schemas for the settings- and self-service routes, shared with their
+ * client counterparts so a rename on either side is a compile error rather
+ * than a runtime 400 (AGENTS.md § "Shared Schemas And Typed Client").
+ *
+ * These are the ROUTE's shapes. The forms keep their own schemas where the
+ * form is not the payload — `settings-profile.tsx` validates a
+ * `confirmPassword` field that is deliberately never sent.
+ */
+
+/** `POST /api/settings` — one org-level key/value setting. */
+export const orgSettingSchema = z.object({
+  key: z.string().min(1),
+  value: z.string(),
+});
+export type OrgSettingInput = z.infer<typeof orgSettingSchema>;
+
+// The org- and user-level context PUTs (`/api/settings/context`,
+// `/api/users/me/context`) are NOT here: they share `contextContentSchema`
+// in `@/lib/schemas/context`, which also carries the length cap and its
+// message. One shape, one file — a second definition here would be exactly
+// the drift this directory exists to prevent.
+
+/** `PATCH /api/users/me` — the signed-in user's own display name. */
+export const updateMeSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .transform((v) => v.trim())
+    .refine((v) => v.length > 0, "Name is required"),
+});
+/**
+ * The INPUT type, not the output: `transform` makes `z.infer` the post-parse
+ * shape, which is what the route reads. A client body is pre-parse, so it must
+ * be typed with `z.input` or the trim would look required of the caller.
+ */
+export type UpdateMeInput = z.input<typeof updateMeSchema>;
+
+/**
+ * `POST /api/users/me/password` — shape only. The length/breach-list policy is
+ * enforced post-parse via `validatePassword()` so setup, invite-claim and
+ * password-change cannot drift apart.
+ */
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: z.string(),
+});
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;

--- a/packages/web/src/lib/schemas/setup.ts
+++ b/packages/web/src/lib/schemas/setup.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * `POST /api/setup` — the first-run admin. Shared with `setup-form.tsx`
+ * (AGENTS.md § "Shared Schemas And Typed Client").
+ *
+ * `password` is shape-only: the length/breach-list policy is enforced
+ * post-parse via `validatePassword()`, so setup, invite-claim and
+ * password-change cannot drift apart.
+ */
+export const setupSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .transform((v) => v.trim())
+    .refine((v) => v.length > 0, "Name is required"),
+  email: z.string().email("A valid email address is required"),
+  password: z.string(),
+  browserTimezone: z.string().optional(),
+});
+/** Pre-parse shape — `name` is trimmed by the schema, not by the caller. */
+export type SetupInput = z.input<typeof setupSchema>;

--- a/packages/web/src/lib/schemas/telegram.ts
+++ b/packages/web/src/lib/schemas/telegram.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+/**
+ * `POST /api/settings/telegram` — redeem a pairing code. Shared with
+ * `telegram-link-settings.tsx` (AGENTS.md § "Shared Schemas And Typed Client").
+ */
+export const linkTelegramSchema = z.object({ code: z.string().min(1) });
+export type LinkTelegramInput = z.infer<typeof linkTelegramSchema>;
+
+/**
+ * `POST /api/agents/[agentId]/channels/telegram` — connect an agent's bot.
+ * Shared with `agent-telegram-settings.tsx`.
+ */
+export const setBotTokenSchema = z.object({
+  botToken: z.string().min(1),
+});
+export type SetBotTokenInput = z.infer<typeof setBotTokenSchema>;

--- a/packages/web/src/lib/schemas/users.ts
+++ b/packages/web/src/lib/schemas/users.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { INVITE_ROLES } from "@/db/enums";
+
+/**
+ * Request schemas for the user-management routes, shared with the admin UI
+ * (`invite-dialog.tsx`, `settings-users.tsx`, `user-detail-sheet.tsx`) so a
+ * payload rename is a compile error rather than a runtime 400 (AGENTS.md
+ * § "Shared Schemas And Typed Client").
+ *
+ * `@/db/enums` carries no database import — it is the const list the CHECK
+ * constraints are generated from — so it is safe in a client bundle.
+ */
+
+/** `POST /api/users/invite` */
+export const inviteUserSchema = z.object({
+  email: z.string().email().optional(),
+  role: z.enum(INVITE_ROLES),
+  groupIds: z.array(z.string()).optional(),
+});
+export type InviteUserInput = z.infer<typeof inviteUserSchema>;
+
+/** `PATCH /api/users/[userId]` — role change only. */
+export const updateUserSchema = z.object({
+  role: z.enum(["admin", "member"]),
+});
+export type UpdateUserInput = z.infer<typeof updateUserSchema>;
+
+/** `PUT /api/users/[userId]/groups` — full replace of the user's memberships. */
+export const updateUserGroupsSchema = z.object({
+  groupIds: z.array(z.string()),
+});
+export type UpdateUserGroupsInput = z.infer<typeof updateUserGroupsSchema>;

--- a/packages/web/src/lib/user-list.ts
+++ b/packages/web/src/lib/user-list.ts
@@ -1,3 +1,5 @@
+import type { UserRole, InviteRole } from "@/db/enums";
+
 export interface UserGroup {
   id: string;
   name: string;
@@ -9,7 +11,7 @@ export type UserListItem =
       id: string;
       name: string;
       email: string;
-      role: string;
+      role: UserRole;
       status: "active" | "deactivated";
       groups: UserGroup[];
     }
@@ -17,17 +19,21 @@ export type UserListItem =
       kind: "invite";
       id: string;
       email: string | null;
-      role: string;
+      role: InviteRole;
       status: "pending" | "expired";
       createdAt: string;
       groups: UserGroup[];
     };
 
+// The role columns are constrained by a database CHECK derived from the same
+// consts (db/enums.ts), and schema-hardening.integration.test.ts reads that
+// constraint back from Postgres — so narrowing the response type here is a
+// guarantee the server actually holds, not an assumption.
 interface ApiUser {
   id: string;
   name: string;
   email: string;
-  role: string;
+  role: UserRole;
   banned: boolean;
   groups?: UserGroup[];
 }
@@ -35,7 +41,7 @@ interface ApiUser {
 interface ApiInvite {
   id: string;
   email: string | null;
-  role: string;
+  role: InviteRole;
   type: string;
   createdAt: string;
   expiresAt: string;

--- a/packages/web/src/test-helpers/fetch.ts
+++ b/packages/web/src/test-helpers/fetch.ts
@@ -1,0 +1,28 @@
+/**
+ * Response stubs for tests that spy on `global.fetch`.
+ *
+ * Every component that mutates goes through `@/lib/api-client`, whose `send()`
+ * reads the body with `res.text()` and derives `ok` from the status. A
+ * hand-rolled `{ ok: true, json: async () => x } as Response` satisfies neither,
+ * and the failure is a rejected promise deep inside the helper rather than an
+ * assertion that names the missing method — which is exactly why this lives in
+ * one place: the next change to how api-client reads a response is a one-line
+ * fix here instead of a sweep across ~250 inline literals (AGENTS.md § "Web
+ * Test Files Are Type-Checked").
+ *
+ * Deliberately a stub rather than a real `new Response(...)`: a real Response
+ * body can be read only once, so a mock reused across calls
+ * (`mockResolvedValue`, not `…Once`) would throw "Body already read" on the
+ * second one. These are re-readable.
+ */
+export function jsonResponse(body?: unknown, init: { status?: number } = {}): Response {
+  const status = init.status ?? 200;
+  const text = body === undefined ? "" : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+    json: async () => (text.length > 0 ? JSON.parse(text) : undefined),
+    headers: new Headers(text.length > 0 ? { "content-type": "application/json" } : {}),
+  } as unknown as Response;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      '@typescript-eslint/parser':
+        specifier: ^8.62.1
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -12052,8 +12055,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.12
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -12075,7 +12078,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -12086,22 +12089,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12112,7 +12115,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Closes #1075.

## What was wrong

AGENTS.md § "Shared Schemas And Typed Client" has promised since it was written that payload↔schema drift is a compile-time error rather than a runtime 400. Nothing enforced it, and the tree drifted the other way: **43 mutating raw `fetch` calls across 19 files**, three of them next to an `apiPost` import in the same file. `JSON.stringify(anything)` type-checks, so nothing was ever red.

The cost was not only the missing type. `send()` reads the route's error contract and raises an `ApiError` carrying the server's own wording; a hand-rolled `if (!res.ok)` almost always threw that away — `settings-users.tsx` showed "Failed to revoke invite. Please try again." while the route answered "Invite not found". And the contract itself was read wrong: several routes answer `{ error: "<headline>", message: "<what to do about it>" }` (users/invite's seat cap, the group-membership licence gate) and api-client read only `error`.

## What changed

- **`api-client`** joins `error` + `message`, refuses to stringify a non-string `error` (which rendered as `[object Object]`), and exposes the whole parsed payload as `ApiError.body` — `/api/setup/provider` answers a `docs` link with its 400, and without that escape hatch it would have to stay on raw `fetch`.
- **`errorMessage(e, "<fallback>")`** prefers the server's wording, falls back to the component's own when the route sent none. Two files had already grown a private copy of this before it was extracted.
- **All 43 call sites migrated**, plus **20 route schemas** moved into `src/lib/schemas/<feature>.ts` and imported from both sides.
- **`pinchy/no-raw-fetch-mutation`** is the guard (28 unit tests). Exemption is `// raw-fetch-exempt: <reason>` on the statement itself, never file-wide — the blind spot #1060 closed in `require-audit-log`. It takes a written reason rather than an issue number: a skip *defers* work, "this call cannot use the helper" *asserts a fact*.
- **`src/test-helpers/fetch.ts`** centralises the Response stub. `send()` reads `res.text()`, which `{ ok, json } as Response` does not have.

## Drift the typing surfaced

Four cases that were invisible before, each narrowed at its source (the DB `CHECK` constraints in `db/enums.ts` are the evidence) rather than cast at the boundary:

| Where | Was | Is |
|---|---|---|
| `user-list.ts`, `agent-settings-access.tsx`, `agent-settings-page-content.tsx` | `role` / `visibility` as bare `string` into an enum column | `UserRole` / `AgentVisibility` |
| `agent-settings-page-content.tsx` | `agentPatch: Record<string, unknown>` | `UpdateAgentInput` |
| `new-agent-form.tsx` | `templateId` could be `null` at the call site | explicit guard |

Two behaviour fixes fell out of the migration: `user-detail-sheet.tsx` and `agent-settings-page-content.tsx` used `Promise.all` over raw fetches, which with a rejecting helper would discard the other outcome — exactly the partial-success case those branches exist to report. Both now use `allSettled` and name the failing half's reason.

## Verification

- `pnpm -C packages/web test` — 10973 passed, 0 failed
- `pnpm -C packages/web typecheck`, `pnpm -C packages/web lint` (0 errors), `pnpm test:scripts` (894), `pnpm format:check`, `pnpm build`
- Rule verified by **canary**, not by reading it: a raw mutating fetch goes red, the exemption comment clears it, removing both is green again.

## Not done here

Item 2 of the issue is complete only for the routes with a client counterpart in this change. Routes whose inline schema has no client caller were left alone — moving those would be churn without the pairing that makes the shared file worth having.