### PR TITLE
fix(plugins): odoo_delete takes refs, not raw ids, and names what it deleted (#1078)

### DIFF
--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -127,9 +127,15 @@ When you connect Odoo and grant an agent access to it, Pinchy automatically enab
 | **Reconcile payment**     | `odoo_reconcile`           | Match a posted bill/invoice against a bank transaction or payment, and verify the result on the document       | Read & Write          |
 | **Update records**        | `odoo_write`               | Modify existing records                                                                                        | Read & Write          |
 | **Attach file**           | `odoo_attach_file`         | Attach an uploaded file to an existing record as `ir.attachment`                                               | Read & Write          |
-| **Delete records**        | `odoo_delete`              | Delete records                                                                                                 | Full                  |
+| **Delete records**        | `odoo_delete`              | Delete records the agent has read — it takes the references `odoo_read` returns, never raw record IDs          | Full                  |
 
 For example, setting an agent to "Read-only" enables the five read-shaped tools. "Read & Write" adds create, the three activity tools (schedule / complete / reschedule), the governed action tools (confirm order, apply inventory, validate picking, mark MO done, set approval), write, and attach-file. "Full" adds delete.
+
+:::caution[Delete only reaches records the agent looked up]
+Deleting is the one thing in Odoo we cannot undo for you, so `odoo_delete` does not accept record IDs. It takes the opaque reference (`_pinchy_ref`) that `odoo_read` and `odoo_create` hand back — which an agent can only hold for a record it actually retrieved, on this connection, of this model. A number the model invented on its own is refused before it reaches Odoo, and so is a reference belonging to a different model than the one being deleted.
+
+The audit entry names what went: the model, how many records, and their IDs with display names — read from Odoo in the moment before the delete, because afterwards nothing can look them up again. A bulk delete lists the first 20 and says how many more it stands for, so the row stays inside the audit size budget without ever implying it listed everything.
+:::
 
 :::note[Cross-company write protection]
 For multi-company Odoo databases, the `pinchy-odoo` plugin refuses to write a record whose embedded `_pinchy_ref` company tag disagrees with the company implied by the relation chain (top-level field only). This prevents a class of silent cross-company mistakes — for example, applying a Company A fiscal position to a partner that lives under Company B. See [Connect Odoo → Multi-company databases](/guides/connect-odoo/#multi-company-databases) for the full story.

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -24,6 +24,8 @@ Pinchy logs event types across several categories:
 
 Each tool execution produces **one audit entry** — logged when the tool call completes (end phase only). The detail includes the tool name, parameters, and result. Start events are received but not persisted.
 
+Some tools curate that detail instead of logging their raw parameters, because the parameters are either sensitive or meaningless on their own: `pinchy_write` records the path and a content hash rather than the file body, and `odoo_delete` records the model plus the IDs and display names of what it removed rather than the opaque references it was handed. Deletes get this treatment because their evidence is perishable — once the row is gone, nothing can resolve an ID back to a name.
+
 ## Event Status
 
 Every entry in the audit log — not just tool calls — carries a status that

--- a/docs/src/content/docs/concepts/integrations.mdx
+++ b/docs/src/content/docs/concepts/integrations.mdx
@@ -148,7 +148,7 @@ When granting an agent access to an Odoo connection, you choose an access level:
 | **Full**         | read & write set + delete                           | Full CRUD — use with caution |
 | **Custom**       | You pick individual tools                           | Fine-grained control         |
 
-Each level maps directly to the Odoo tools that get enabled for the agent. See [Agent Permissions](/concepts/agent-permissions/#odoo-tools) for the full tool list, including the per-tool IDs and the cross-company write protection that applies to all Odoo agents regardless of level.
+Each level maps directly to the Odoo tools that get enabled for the agent. See [Agent Permissions](/concepts/agent-permissions/#odoo-tools) for the full tool list, including the per-tool IDs, the cross-company write protection that applies to all Odoo agents regardless of level, and why **Full** still confines a delete to records the agent has actually read.
 
 ### What happens when Odoo permissions change
 

--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -77,6 +77,8 @@ A connection alone doesn't give any agent access. You need to explicitly grant i
 
 Each level maps directly to the Odoo tools that get enabled for the agent. See [Agent Permissions](/concepts/agent-permissions/) for the full tool list.
 
+Granting **Full** does not mean the agent can delete anything it can name: `odoo_delete` only accepts the references a read hands back, so a delete is confined to records the agent actually looked up. See [Delete only reaches records the agent looked up](/concepts/agent-permissions/#odoo-tools).
+
 ## 5. Test it
 
 Open the agent's chat and try a few queries:

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -199,6 +199,14 @@ So after upgrading, a Knowledge Base agent finds nothing until you reindex it: o
 
 The `ollama pull bge-m3` step from the v0.9.0 notes no longer applies. If nothing else on your machine uses that model, you can remove it.
 
+#### Deleting in Odoo now requires reading the record first
+
+`odoo_delete` no longer takes record IDs. It takes the opaque references (`_pinchy_ref`) that `odoo_read` and `odoo_create` hand back, so an agent can only delete a record it actually retrieved — from this connection, on the model it says it is deleting. Every other Odoo write tool already worked this way; delete, the one that cannot be undone, was the exception.
+
+Nothing to configure, and agents pick this up on their own from the tool description. Two things are worth checking if you granted **Full** Odoo access to an agent: it needs **read** on any model it deletes from, since that is where a reference comes from (the only other source is the `odoo_create` that made the record), and if you wrote your own instructions telling an agent to call `odoo_delete` with `ids`, update them to read the records first and pass `targets`.
+
+Delete entries in the audit trail now carry the model, the record IDs and the display names, read from Odoo immediately before the delete. See [Agent Permissions → Odoo tools](/concepts/agent-permissions/#odoo-tools).
+
 ### Upgrade notes
 
 The standard flow applies:

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -57,6 +57,9 @@ import plugin, {
   ODOO_AGGREGATE_TRUNCATION_HINT,
   ODOO_READ_DEFAULT_LIMIT,
   ODOO_READ_LIMIT_CAP,
+  ODOO_DELETE_DETAIL_LABEL_CAP,
+  ODOO_DELETE_DETAIL_BUDGET_BYTES,
+  buildDeleteAuditDetail,
 } from "../index";
 
 const MOVE_FIELDS: OdooField[] = [
@@ -3361,47 +3364,295 @@ describe("odoo_write", () => {
   });
 });
 
-describe("odoo_delete", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+describe("buildDeleteAuditDetail (pinchy#1078)", () => {
+  const entries = (n: number, label: (i: number) => string) =>
+    Array.from({ length: n }, (_, i) => ({ id: i + 1, label: label(i + 1) }));
+
+  const bytes = (detail: unknown) => Buffer.byteLength(JSON.stringify(detail), "utf8");
+
+  it("lists every record when they fit", () => {
+    const detail = buildDeleteAuditDetail(
+      "res.partner",
+      entries(3, (i) => `Partner ${i}`)
+    );
+
+    expect(detail).toEqual({
+      model: "res.partner",
+      count: 3,
+      deleted: [
+        { id: 1, label: "Partner 1" },
+        { id: 2, label: "Partner 2" },
+        { id: 3, label: "Partner 3" },
+      ],
+    });
   });
 
-  it("deletes records on a permitted model", async () => {
-    mockUnlink.mockResolvedValue(true);
+  it("caps the list for readability and says how many it left out", () => {
+    const detail = buildDeleteAuditDetail(
+      "res.partner",
+      entries(40, (i) => `Partner ${i}`)
+    );
 
-    // Add delete permission for this test
-    const configWithDelete = {
-      ...agentConfig,
-      permissions: {
-        ...testPermissions,
-        "res.partner": ["read", "write", "create", "delete"],
-      },
-    };
-    const tools = createApi({ [agentId]: configWithDelete });
-    const tool = findTool(tools, "odoo_delete", agentId)!;
+    expect(detail.count).toBe(40);
+    expect(detail.deleted).toHaveLength(ODOO_DELETE_DETAIL_LABEL_CAP);
+    expect(detail.deletedTruncated).toBe(40 - ODOO_DELETE_DETAIL_LABEL_CAP);
+  });
 
-    const result = await tool.execute("call-1", {
+  // The count cap alone does NOT bound the byte size: an Odoo display_name has
+  // no length limit, so twenty long ones would pass a count check and blow
+  // AGENTS.md's 2048-byte detail budget.
+  it("stays inside the byte budget even when every display name is long", () => {
+    const long = "INV/2026/00042 — Müller Maschinenbau GmbH & Co. KG [Helmcraft GmbH]".repeat(6);
+    const detail = buildDeleteAuditDetail(
+      "account.move",
+      entries(40, () => long)
+    );
+
+    expect(bytes(detail)).toBeLessThanOrEqual(ODOO_DELETE_DETAIL_BUDGET_BYTES);
+    expect(bytes(detail)).toBeLessThan(2048);
+    // Whatever it had to drop is still accounted for.
+    expect((detail.deleted as unknown[]).length + (detail.deletedTruncated as number)).toBe(40);
+  });
+
+  it("clips a single pathological name instead of dropping the record", () => {
+    const detail = buildDeleteAuditDetail("account.move", [{ id: 1, label: "x".repeat(5000) }]);
+
+    const deleted = detail.deleted as Array<{ id: number; label: string }>;
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0].id).toBe(1);
+    expect(deleted[0].label.length).toBeLessThan(200);
+    expect(deleted[0].label.endsWith("…")).toBe(true);
+    expect(detail.deletedTruncated).toBeUndefined();
+  });
+});
+
+// pinchy#1078: odoo_delete is the most destructive tool in the plugin and was
+// the ONE writing tool that took raw `ids: number[]` — no ref, no shape check,
+// no read-back. A hallucinated `ids: [40]` deleted a record the model had never
+// read. It now speaks the same opaque-ref language as every other governed
+// tool: `targets: _pinchy_ref[]`, so a delete is only reachable for a record
+// the model has demonstrably read, on this connection, of this model.
+describe("odoo_delete", () => {
+  const deleteConfig = {
+    ...agentConfig,
+    permissions: {
+      ...testPermissions,
+      "res.partner": ["read", "write", "create", "delete"],
+    },
+  };
+
+  function partnerRef(id: number, label: string, connectionId = "conn-test-1") {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId,
       model: "res.partner",
-      ids: [5, 6],
+      id,
+      label,
+    });
+  }
+
+  function deleteTool(config: AgentOdooConfig = deleteConfig) {
+    return findTool(createApi({ [agentId]: config }), "odoo_delete", agentId)!;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+    mockUnlink.mockResolvedValue(true);
+    mockSearchRead.mockResolvedValue([]);
+  });
+
+  it("deletes the records its targets decode to", async () => {
+    mockSearchRead.mockResolvedValue([
+      { id: 5, display_name: "Müller GmbH" },
+      { id: 6, display_name: "Huber KG" },
+    ]);
+
+    const result = await deleteTool().execute("call-1", {
+      model: "res.partner",
+      targets: [partnerRef(5, "Müller GmbH"), partnerRef(6, "Huber KG")],
     });
 
     const data = JSON.parse(result.content[0].text);
     expect(data.success).toBe(true);
+    expect(data.deleted).toEqual([
+      { id: 5, label: "Müller GmbH" },
+      { id: 6, label: "Huber KG" },
+    ]);
     expect(mockUnlink).toHaveBeenCalledWith("res.partner", [5, 6]);
   });
 
-  it("denies delete on model without delete permission", async () => {
-    const tools = createApi({ [agentId]: agentConfig });
-    const tool = findTool(tools, "odoo_delete", agentId)!;
+  // AGENTS.md: "Include resource names in delete-event details because deleted
+  // rows may no longer be queryable." The audit route merges result.details into
+  // the audit row, so the names have to be read BEFORE the unlink — afterwards
+  // there is nothing left to read.
+  it("carries model, ids and names into the audit details", async () => {
+    mockSearchRead.mockResolvedValue([{ id: 5, display_name: "Müller GmbH" }]);
 
-    const result = await tool.execute("call-2", {
+    const result = await deleteTool().execute("call-2", {
       model: "res.partner",
-      ids: [1],
+      targets: [partnerRef(5, "Müller GmbH")],
+    });
+
+    expect(result.details).toEqual({
+      model: "res.partner",
+      count: 1,
+      deleted: [{ id: 5, label: "Müller GmbH" }],
+    });
+    // The name read has to happen while the record still exists.
+    expect(mockSearchRead.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUnlink.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("falls back to the ref's own signed label when the name read fails", async () => {
+    mockSearchRead.mockRejectedValue(new Error("AccessError: permission denied"));
+
+    const result = await deleteTool().execute("call-3", {
+      model: "res.partner",
+      targets: [partnerRef(5, "Müller GmbH")],
+    });
+
+    // A failed label lookup must not block the delete the user asked for — the
+    // ref itself carries a signed label from the read that minted it.
+    expect(mockUnlink).toHaveBeenCalledWith("res.partner", [5]);
+    expect(result.details).toEqual({
+      model: "res.partner",
+      count: 1,
+      deleted: [{ id: 5, label: "Müller GmbH" }],
+    });
+  });
+
+  it("refuses raw numeric ids and names the ref parameter to use instead", async () => {
+    const result = await deleteTool().execute("call-4", {
+      model: "res.partner",
+      ids: [40],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Raw numeric IDs are not accepted");
+    expect(result.content[0].text).toContain("targets");
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it("refuses a ref minted for another Odoo connection", async () => {
+    const result = await deleteTool().execute("call-5", {
+      model: "res.partner",
+      targets: [partnerRef(5, "Müller GmbH", "conn-other")],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("does not belong to this Odoo connection");
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  // The permission check reads `model`; a ref pointing somewhere else would
+  // unlink on a model the agent was never granted delete on.
+  it("refuses a target whose ref points at a different model", async () => {
+    const otherModelRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "sale.order",
+      id: 5,
+      label: "S00005",
+    });
+
+    const result = await deleteTool().execute("call-6", {
+      model: "res.partner",
+      targets: [otherModelRef],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("sale.order");
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it("refuses a corrupted ref with a re-fetch instruction", async () => {
+    const result = await deleteTool().execute("call-7", {
+      model: "res.partner",
+      targets: ["pinchy_ref:v1:not-a-real-token"],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/could not be decoded/);
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a missing targets list", {}],
+    ["a bare string instead of a list", { targets: "pinchy_ref:v1:abc" }],
+    ["an empty list", { targets: [] }],
+    ["a list holding a number", { targets: [5] }],
+  ])("refuses %s", async (_label, extra) => {
+    const result = await deleteTool().execute("call-8", { model: "res.partner", ...extra });
+
+    expect(result.isError).toBe(true);
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it("rejects the {item: …} array-serialization artifact", async () => {
+    const result = await deleteTool().execute("call-9", {
+      model: "res.partner",
+      targets: { item: partnerRef(5, "Müller GmbH") },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('{"item": …}');
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates repeated targets so the audit detail counts records, not calls", async () => {
+    mockSearchRead.mockResolvedValue([{ id: 5, display_name: "Müller GmbH" }]);
+    const ref = partnerRef(5, "Müller GmbH");
+
+    const result = await deleteTool().execute("call-10", {
+      model: "res.partner",
+      targets: [ref, ref],
+    });
+
+    expect(mockUnlink).toHaveBeenCalledWith("res.partner", [5]);
+    expect(result.details).toMatchObject({ count: 1 });
+  });
+
+  // AGENTS.md: "Keep audit detail under 2048 bytes. Summarize bulk operations."
+  it("summarizes a bulk delete instead of listing every name", async () => {
+    const ids = Array.from({ length: 40 }, (_, i) => i + 1);
+    mockSearchRead.mockResolvedValue(ids.map((id) => ({ id, display_name: `Partner ${id}` })));
+
+    const result = await deleteTool().execute("call-11", {
+      model: "res.partner",
+      targets: ids.map((id) => partnerRef(id, `Partner ${id}`)),
+    });
+
+    const details = result.details as Record<string, unknown>;
+    expect(mockUnlink).toHaveBeenCalledWith("res.partner", ids);
+    expect(details.count).toBe(40);
+    expect(details.deleted).toHaveLength(ODOO_DELETE_DETAIL_LABEL_CAP);
+    expect(details.deletedTruncated).toBe(40 - ODOO_DELETE_DETAIL_LABEL_CAP);
+    expect(JSON.stringify(details).length).toBeLessThan(2048);
+  });
+
+  it("denies delete on a model without delete permission before decoding anything", async () => {
+    const result = await deleteTool(agentConfig).execute("call-12", {
+      model: "res.partner",
+      targets: [partnerRef(1, "Müller GmbH")],
     });
 
     expect(result.content[0].text).toContain("Permission denied");
     expect(result.isError).toBe(true);
     expect(mockUnlink).not.toHaveBeenCalled();
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("tells the model in its description that only refs are accepted", () => {
+    const tool = deleteTool();
+    const schema = tool.parameters as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(tool.description).toMatch(/_pinchy_ref/);
+    expect(schema.properties.ids).toBeUndefined();
+    expect(schema.required).toEqual(["model", "targets"]);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -3424,6 +3424,26 @@ describe("buildDeleteAuditDetail (pinchy#1078)", () => {
     expect(deleted[0].label.endsWith("…")).toBe(true);
     expect(detail.deletedTruncated).toBeUndefined();
   });
+
+  // A UTF-16 slice can cut a surrogate pair in half. JSON.stringify then emits a
+  // lone `\ud83d`, and audit_log.detail is jsonb — Postgres rejects the row with
+  // "Unicode low surrogate must follow a high surrogate", so the delete happens
+  // and its audit entry does not. An emoji in a res.partner.category name is the
+  // everyday way to land on that boundary.
+  it("clips on a code-point boundary so the detail stays valid JSON for jsonb", () => {
+    // The 120-char clip keeps 119 code points, so put the emoji exactly there.
+    const label = `${"x".repeat(118)}😀${"y".repeat(50)}`;
+    const detail = buildDeleteAuditDetail("res.partner.category", [{ id: 1, label }]);
+
+    const json = JSON.stringify(detail);
+    expect(json).not.toMatch(/\\ud[89ab][0-9a-f]{2}/i);
+    // Round-tripping is what Postgres does; a lone surrogate survives it, so
+    // assert on the code units directly as well.
+    const clipped = (detail.deleted as Array<{ label: string }>)[0].label;
+    for (const unit of [...clipped].map((c) => c.codePointAt(0)!)) {
+      expect(unit >= 0xd800 && unit <= 0xdfff).toBe(false);
+    }
+  });
 });
 
 // pinchy#1078: odoo_delete is the most destructive tool in the plugin and was
@@ -3630,6 +3650,65 @@ describe("odoo_delete", () => {
     expect(details.deleted).toHaveLength(ODOO_DELETE_DETAIL_LABEL_CAP);
     expect(details.deletedTruncated).toBe(40 - ODOO_DELETE_DETAIL_LABEL_CAP);
     expect(JSON.stringify(details).length).toBeLessThan(2048);
+
+    // Only the audit ROW is capped. The tool result the model reads is the full
+    // set — a shortened list here is how an agent ends up telling the user it
+    // deleted twenty when it deleted forty.
+    const data = JSON.parse(result.content[0].text);
+    expect(data.count).toBe(40);
+    expect(data.deleted).toHaveLength(40);
+    expect(data.deleted.at(-1)).toEqual({ id: 40, label: "Partner 40" });
+
+    // And the name read is scoped to what the detail can print: reading 40
+    // display names to log 20 is payload nobody sees.
+    expect(mockSearchRead).toHaveBeenCalledTimes(1);
+    expect(mockSearchRead.mock.calls[0][1]).toEqual([
+      ["id", "in", ids.slice(0, ODOO_DELETE_DETAIL_LABEL_CAP)],
+    ]);
+  });
+
+  // The plugin comment claims an agent granted delete but not read still
+  // deletes, falling back to the ref's signed label. Nothing proved it, and the
+  // fallback is what keeps a forensic nicety from inventing a new way for the
+  // user's actual request to fail.
+  it("still deletes when the agent has delete but not read on the model", async () => {
+    const deleteOnly = {
+      ...agentConfig,
+      permissions: { ...testPermissions, "res.partner": ["delete"] },
+    };
+
+    const result = await deleteTool(deleteOnly).execute("call-13", {
+      model: "res.partner",
+      targets: [partnerRef(5, "Müller GmbH")],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockUnlink).toHaveBeenCalledWith("res.partner", [5]);
+    expect(mockSearchRead).not.toHaveBeenCalled();
+    expect(result.details).toEqual({
+      model: "res.partner",
+      count: 1,
+      deleted: [{ id: 5, label: "Müller GmbH" }],
+    });
+  });
+
+  // #404 / the 2026-06-25 false-success incident: the shape to refuse is an
+  // outcome=success audit row whose detail names records as deleted that are
+  // still in Odoo. Real Odoo returns True or raises, so this is the edge — but
+  // it is the edge that produces a lie rather than an error.
+  it("reports a failure when Odoo does not confirm the unlink", async () => {
+    mockUnlink.mockResolvedValue(false);
+
+    const result = await deleteTool().execute("call-14", {
+      model: "res.partner",
+      targets: [partnerRef(5, "Müller GmbH")],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/did not confirm the delete/i);
+    // errorResult curates `{error}` only, which is what keeps the audit route
+    // from suppressing params — forensics need to see what was attempted.
+    expect(Object.keys(result.details as Record<string, unknown>)).toEqual(["error"]);
   });
 
   it("denies delete on a model without delete permission before decoding anything", async () => {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2173,6 +2173,73 @@ function clampOptionalLimit(limit: unknown): number | undefined {
  */
 export const ODOO_READ_RESULT_BUDGET_CHARS = 30000;
 
+/**
+ * How many `{id, label}` pairs a delete lists in its audit detail. A reader
+ * drilling into a bulk delete wants to recognize what went, not to scroll a
+ * hundred names — the exact set is `count` plus the tool params.
+ */
+export const ODOO_DELETE_DETAIL_LABEL_CAP = 20;
+
+/**
+ * Byte ceiling for that detail. AGENTS.md caps an audit `detail` at 2048
+ * bytes; the tool-use audit route merges its own fields (toolName, success,
+ * toolCallId, durationMs) on top of ours, so ours has to fit with room left.
+ *
+ * This is the real bound, and {@link ODOO_DELETE_DETAIL_LABEL_CAP} is not:
+ * a cap on how many labels we list says nothing about how long an Odoo
+ * `display_name` is. An invoice's runs to "INV/2026/00042 — Müller
+ * Maschinenbau GmbH & Co. KG [Helmcraft GmbH]" and there is no upper bound in
+ * the schema, so twenty of them can pass a count check and still blow the byte
+ * budget. Counting is the readability rule; this is the one that holds.
+ */
+export const ODOO_DELETE_DETAIL_BUDGET_BYTES = 1400;
+
+/** Per-label clip, so one pathological display_name cannot crowd out the rest. */
+const DELETE_LABEL_MAX_CHARS = 120;
+
+function deleteDetailShape(
+  model: string,
+  count: number,
+  shown: Array<{ id: number; label: string }>
+): Record<string, unknown> {
+  const truncated = count - shown.length;
+  return {
+    model,
+    count,
+    deleted: shown,
+    ...(truncated > 0 ? { deletedTruncated: truncated } : {}),
+  };
+}
+
+/**
+ * Build the audit detail for a delete: the model, how many records went, and
+ * as many `{id, label}` pairs as fit both caps above.
+ *
+ * `deletedTruncated` is not decoration. A list shortened in silence reads as
+ * "that was all of them", which is the one claim an append-only audit row must
+ * never make on its own.
+ */
+export function buildDeleteAuditDetail(
+  model: string,
+  deleted: Array<{ id: number; label: string }>
+): Record<string, unknown> {
+  const shown: Array<{ id: number; label: string }> = [];
+  for (const entry of deleted.slice(0, ODOO_DELETE_DETAIL_LABEL_CAP)) {
+    const label =
+      entry.label.length > DELETE_LABEL_MAX_CHARS
+        ? `${entry.label.slice(0, DELETE_LABEL_MAX_CHARS - 1)}…`
+        : entry.label;
+    const candidate = [...shown, { id: entry.id, label }];
+    const size = Buffer.byteLength(
+      JSON.stringify(deleteDetailShape(model, deleted.length, candidate)),
+      "utf8"
+    );
+    if (size > ODOO_DELETE_DETAIL_BUDGET_BYTES) break;
+    shown.push(candidate[candidate.length - 1]);
+  }
+  return deleteDetailShape(model, deleted.length, shown);
+}
+
 export const ODOO_READ_TRUNCATION_HINT =
   "Result truncated to fit the model's context budget: the first `returned` of " +
   "`total` matching records (in order) are included. To make the result smaller, " +
@@ -2755,6 +2822,43 @@ const plugin = {
         }
       }
       return { ok: true, verified: true };
+    }
+
+    /**
+     * pinchy#1078: read the display names of the records a delete is about to
+     * remove — BEFORE the unlink, because afterwards there is nothing left to
+     * read and AGENTS.md requires a delete's audit detail to name what it
+     * deleted ("deleted rows may no longer be queryable").
+     *
+     * Best-effort on purpose. The caller already holds a signed label per
+     * target (every `_pinchy_ref` carries the display name of the read that
+     * minted it), so a missing entry degrades to that instead of to nothing.
+     * Turning a failed name lookup into a failed delete would invent a new way
+     * for the user's actual request to fail, and would do it over a forensic
+     * nicety — so an agent granted delete but not read still deletes, with the
+     * ref's label in the audit row.
+     */
+    async function readDeleteLabels(
+      agentId: string,
+      config: AgentOdooConfig,
+      model: string,
+      ids: number[]
+    ): Promise<Map<number, string>> {
+      const labels = new Map<number, string>();
+      if (!checkPermission(config.permissions, model, "read")) return labels;
+      try {
+        const res = await withAuthRetry(agentId, config, (client) =>
+          client.searchRead(model, [["id", "in", ids]], { fields: ["id", "display_name"] })
+        );
+        for (const record of getSearchReadRecords(res)) {
+          const id = recordId(record);
+          const label = recordText(record, "display_name");
+          if (id !== null && label !== null && label.length > 0) labels.set(id, label);
+        }
+      } catch {
+        return labels;
+      }
+      return labels;
     }
 
     // Shared implementation of the list-models tool body. Reused by the
@@ -4654,37 +4758,129 @@ const plugin = {
         return {
           name: "odoo_delete",
           label: "Odoo Delete",
-          description: "Delete records from Odoo.",
+          description:
+            "Permanently delete records from Odoo. Pass the `_pinchy_ref` of every record to delete in `targets` (from `odoo_read` or `odoo_create`) — raw numeric IDs are NOT accepted, so you can only delete records you have actually looked up. Deleting cannot be undone: read the records first, show the user what you are about to remove, and delete only after they confirm.",
           parameters: {
             type: "object",
             properties: {
-              model: { type: "string", description: "Odoo model name" },
-              ids: {
+              model: {
+                type: "string",
+                description:
+                  "Odoo model name. Every ref in `targets` must point at a record of this model.",
+              },
+              targets: {
                 type: "array",
-                items: { type: "number" },
-                description: "IDs of records to delete",
+                items: { type: "string" },
+                description:
+                  'Opaque `_pinchy_ref` values of the records to delete, from `odoo_read` or `odoo_create`. Each is a token starting with `pinchy_ref:v1:` — do NOT construct strings like `"<model>,<id>"` and do NOT pass raw numeric IDs.',
               },
             },
-            required: ["model", "ids"],
+            required: ["model", "targets"],
           },
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             try {
-              const model = params.model as string;
+              const model = params.model;
+              if (typeof model !== "string" || model.trim().length === 0) {
+                return errorResult(
+                  new Error(
+                    "`model` is required: pass the Odoo model name of the records to delete."
+                  )
+                );
+              }
               if (!checkPermission(config.permissions, model, "delete")) {
                 return permissionDenied("delete", model);
               }
 
+              // pinchy#1078: raw ids were how a hallucinated delete reached
+              // Odoo. `ids: [40]` needs no prior read, so nothing tied a delete
+              // to a record the model had actually seen — while every other
+              // governed write tool already spoke refs. Refusing loudly (rather
+              // than quietly accepting ids alongside targets) is the whole
+              // point: a silent fallback is a one-parameter route back to the
+              // hole this closes.
+              if (params.ids !== undefined) {
+                return errorResult(
+                  new Error(
+                    "Raw numeric IDs are not accepted for odoo_delete. Read the records with " +
+                      "`odoo_read` first and pass the `_pinchy_ref` each one carries in `targets` — " +
+                      "that is what keeps a delete to records that were actually looked up."
+                  )
+                );
+              }
+              // The `{item: …}` array-serialization artifact reaches `targets`
+              // exactly as it reaches `values` elsewhere (see hasItemWrappedArray);
+              // caught here so the model gets the actionable shape error rather
+              // than a decode failure per element.
+              if (hasItemWrappedArray(params.targets)) {
+                throw itemWrappedError("targets");
+              }
+
+              const targets = params.targets;
+              if (
+                !Array.isArray(targets) ||
+                targets.length === 0 ||
+                !targets.every((t) => typeof t === "string" && t.length > 0)
+              ) {
+                return errorResult(
+                  new Error(
+                    "`targets` is required: pass a non-empty array of `_pinchy_ref` strings " +
+                      "(from `odoo_read` or `odoo_create`), one per record to delete."
+                  )
+                );
+              }
+
+              // Decode everything before touching Odoo, so a mixed batch with
+              // one bad ref deletes nothing at all. The map also dedupes: the
+              // same ref twice is one record, and the audit detail should count
+              // records rather than mentions.
+              const labelByRef = new Map<number, string>();
+              for (const target of targets as string[]) {
+                const decoded = decodeTargetRef(config.connectionId, target, "targets");
+                // The permission check above read `model`; a ref pointing
+                // elsewhere would unlink on a model this agent may never delete.
+                if (decoded.model !== model) {
+                  return errorResult(
+                    new Error(
+                      `\`targets\` must all be ${model} refs — one of them points at ` +
+                        `${decoded.model}. Re-read the records you mean with \`odoo_read\` on ` +
+                        `${model} and pass those refs.`
+                    )
+                  );
+                }
+                if (!labelByRef.has(decoded.id)) labelByRef.set(decoded.id, decoded.label);
+              }
+              const ids = [...labelByRef.keys()];
+
+              // Names first — after the unlink there is nothing left to read.
+              const freshLabels = await readDeleteLabels(agentId, config, model, ids);
+
               const success = await withAuthRetry(agentId, config, (client) =>
-                client.unlink(model, params.ids as number[])
+                client.unlink(model, ids)
               );
 
+              const deleted = ids.map((id) => ({
+                id,
+                label: freshLabels.get(id) ?? labelByRef.get(id) ?? `${model}#${id}`,
+              }));
+              const details = buildDeleteAuditDetail(model, deleted);
+
               return {
-                content: [{ type: "text", text: JSON.stringify({ success }) }],
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      success,
+                      count: deleted.length,
+                      deleted: details.deleted,
+                    }),
+                  },
+                ],
+                details,
               };
             } catch (error) {
               return errorResult(error, {
                 operation: "delete",
-                model: params.model as string,
+                model: typeof params.model === "string" ? params.model : undefined,
               });
             }
           },

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2174,9 +2174,22 @@ function clampOptionalLimit(limit: unknown): number | undefined {
 export const ODOO_READ_RESULT_BUDGET_CHARS = 30000;
 
 /**
- * How many `{id, label}` pairs a delete lists in its audit detail. A reader
- * drilling into a bulk delete wants to recognize what went, not to scroll a
- * hundred names — the exact set is `count` plus the tool params.
+ * How many `{id, label}` pairs a delete lists in its audit detail.
+ *
+ * Read this together with what the audit route does: curated details suppress
+ * `detail.params` (`curatesNonErrorFields` in `api/internal/audit/tool-use`),
+ * so this list plus `count` IS the audit row's record of the delete — the
+ * `targets` the tool was called with are not kept beside it. That is the right
+ * trade (the refs are opaque tokens; a name is what a reader can act on), but
+ * it means the cap is a real limit and not a display preference: a delete of
+ * more than this many records leaves Pinchy knowing how many went and naming
+ * the first {@link ODOO_DELETE_DETAIL_LABEL_CAP}, with `deletedTruncated`
+ * saying so out loud.
+ *
+ * Raising it does not fix that — {@link ODOO_DELETE_DETAIL_BUDGET_BYTES} binds
+ * first, and AGENTS.md's 2048-byte detail rule is what that budget serves
+ * ("Summarize bulk operations"). The full set lives in the tool result the
+ * model receives, which is complete by construction.
  */
 export const ODOO_DELETE_DETAIL_LABEL_CAP = 20;
 
@@ -2196,6 +2209,29 @@ export const ODOO_DELETE_DETAIL_BUDGET_BYTES = 1400;
 
 /** Per-label clip, so one pathological display_name cannot crowd out the rest. */
 const DELETE_LABEL_MAX_CHARS = 120;
+
+/**
+ * Clip a label to {@link DELETE_LABEL_MAX_CHARS} **code points**, not UTF-16
+ * units.
+ *
+ * `String.prototype.slice` counts units, so a boundary landing inside a
+ * surrogate pair — an emoji in a `res.partner.category` name is the everyday
+ * case — leaves a lone high surrogate. `JSON.stringify` faithfully encodes it
+ * as `\ud83d`, and Postgres then refuses the whole row:
+ *
+ *   ERROR: invalid input syntax for type json
+ *   DETAIL: Unicode low surrogate must follow a high surrogate.
+ *
+ * `audit_log.detail` is `jsonb`, so that is a failed INSERT for a delete that
+ * has already happened — the exact evidence-loss this detail exists to
+ * prevent, caused by the code meant to prevent it. Iterating the string yields
+ * whole code points.
+ */
+function clipDeleteLabel(label: string): string {
+  const points = Array.from(label);
+  if (points.length <= DELETE_LABEL_MAX_CHARS) return label;
+  return `${points.slice(0, DELETE_LABEL_MAX_CHARS - 1).join("")}…`;
+}
 
 function deleteDetailShape(
   model: string,
@@ -2225,11 +2261,7 @@ export function buildDeleteAuditDetail(
 ): Record<string, unknown> {
   const shown: Array<{ id: number; label: string }> = [];
   for (const entry of deleted.slice(0, ODOO_DELETE_DETAIL_LABEL_CAP)) {
-    const label =
-      entry.label.length > DELETE_LABEL_MAX_CHARS
-        ? `${entry.label.slice(0, DELETE_LABEL_MAX_CHARS - 1)}…`
-        : entry.label;
-    const candidate = [...shown, { id: entry.id, label }];
+    const candidate = [...shown, { id: entry.id, label: clipDeleteLabel(entry.label) }];
     const size = Buffer.byteLength(
       JSON.stringify(deleteDetailShape(model, deleted.length, candidate)),
       "utf8"
@@ -2830,9 +2862,11 @@ const plugin = {
      * read and AGENTS.md requires a delete's audit detail to name what it
      * deleted ("deleted rows may no longer be queryable").
      *
-     * Best-effort on purpose. The caller already holds a signed label per
-     * target (every `_pinchy_ref` carries the display name of the read that
-     * minted it), so a missing entry degrades to that instead of to nothing.
+     * Best-effort on purpose, and called with only the ids the detail can show.
+     * The caller already holds a signed label per target (every `_pinchy_ref`
+     * carries the display name of the read that minted it), so an id this never
+     * reaches — or one the read did not return — degrades to that, not to
+     * nothing.
      * Turning a failed name lookup into a failed delete would invent a new way
      * for the user's actual request to fail, and would do it over a forensic
      * nicety — so an agent granted delete but not read still deletes, with the
@@ -4852,7 +4886,16 @@ const plugin = {
               const ids = [...labelByRef.keys()];
 
               // Names first — after the unlink there is nothing left to read.
-              const freshLabels = await readDeleteLabels(agentId, config, model, ids);
+              // Only the ids the audit detail can actually show are worth a
+              // round trip: everything past the cap falls back to the ref's own
+              // label anyway, so reading 500 names to print 20 would be pure
+              // payload.
+              const freshLabels = await readDeleteLabels(
+                agentId,
+                config,
+                model,
+                ids.slice(0, ODOO_DELETE_DETAIL_LABEL_CAP)
+              );
 
               const success = await withAuthRetry(agentId, config, (client) =>
                 client.unlink(model, ids)
@@ -4862,16 +4905,39 @@ const plugin = {
                 id,
                 label: freshLabels.get(id) ?? labelByRef.get(id) ?? `${model}#${id}`,
               }));
+
+              // A falsy `unlink` must not be reported as a delete. Odoo returns
+              // True or raises, so this is the defensive edge — but the shape it
+              // guards against is the one this repo has been bitten by before
+              // (#404, the false-success incident): an outcome=success audit row
+              // whose detail names records as deleted that are still there.
+              // errorResult keeps `details` to `{error}` only, so the route
+              // retains the params and forensics can see what was attempted.
+              if (!success) {
+                return errorResult(
+                  new Error(
+                    `Odoo did not confirm the delete of ${deleted.length} ${model} record(s) ` +
+                      `(unlink returned ${JSON.stringify(success)}). Nothing is recorded as ` +
+                      `deleted; re-read the records to see what is still there.`
+                  ),
+                  { operation: "delete", model }
+                );
+              }
+
               const details = buildDeleteAuditDetail(model, deleted);
 
               return {
                 content: [
                   {
                     type: "text",
+                    // The FULL list, not the audit detail's capped one. The
+                    // budget that caps `details` is the audit row's, and handing
+                    // the model a silently shortened list is how it ends up
+                    // telling the user it deleted twenty when it deleted forty.
                     text: JSON.stringify({
                       success,
                       count: deleted.length,
-                      deleted: details.deleted,
+                      deleted,
                     }),
                   },
                 ],

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -6,6 +6,7 @@ import {
   waitForOdooMock,
   resetOdooMock,
   seedOdooRecords,
+  getOdooRecords,
   login,
   createOdooConnection,
   setAgentPermissions,
@@ -30,6 +31,8 @@ import {
   FAKE_OLLAMA_ODOO_RECONCILE_REF_TRIGGER,
   FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_TRIGGER,
   FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_FILENAME,
+  FAKE_OLLAMA_ODOO_DELETE_REF_TRIGGER,
+  FAKE_OLLAMA_ODOO_DELETE_REF_MODEL,
   FAKE_OLLAMA_ODOO_DUP_BILL_REF,
   FAKE_OLLAMA_ODOO_CREATE_DUP_BLOCK_TRIGGER,
   FAKE_OLLAMA_ODOO_CREATE_DUP_OVERRIDE_TRIGGER,
@@ -383,6 +386,15 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
       { id: 9401, name: "MO/E2E-0001", state: "confirmed" },
     ]);
     await seedOdooRecords("purchase.order", [{ id: 9501, name: "P0E2E-01", state: "draft" }]);
+    // pinchy#1078 (odoo_delete): its own model, touched by no other probe — a
+    // delete probe sharing a model would remove the row another probe reads,
+    // making the suite order-dependent. TWO rows: odoo_read returns the first,
+    // so the probe deletes 9901 and 9902 proves the unlink was scoped to the
+    // ref it was given rather than to the whole model.
+    await seedOdooRecords(FAKE_OLLAMA_ODOO_DELETE_REF_MODEL, [
+      { id: 9901, name: "E2E Tag (delete target)" },
+      { id: 9902, name: "E2E Tag (must survive)" },
+    ]);
     // Reconcile (payment counterpart): a POSTED bill with one open payable line,
     // plus a payment whose journal entry has a matching open line on the SAME
     // account. js_assign_outstanding_line (the mock handler added for this)
@@ -478,6 +490,8 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
       { model: "account.move.line", operation: "write" },
       { model: "account.payment", operation: "read" },
       { model: "ir.attachment", operation: "create" },
+      { model: FAKE_OLLAMA_ODOO_DELETE_REF_MODEL, operation: "read" },
+      { model: FAKE_OLLAMA_ODOO_DELETE_REF_MODEL, operation: "delete" },
     ]);
 
     // 7. Allow odoo_list_models (happy-path probe), odoo_read (failure probe +
@@ -499,6 +513,7 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
           "odoo_set_approval",
           "odoo_reconcile",
           "odoo_attach_file",
+          "odoo_delete",
           "odoo_create",
         ],
       },
@@ -826,6 +841,23 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
         await expect(readyChip).toBeVisible({ timeout: 20_000 });
       },
     });
+  });
+
+  test("odoo_delete dispatches on a runtime-minted _pinchy_ref", async ({ page }, testInfo) => {
+    // pinchy#1078. Round 1 reads res.partner.category (target ref), round 2
+    // deletes on that ref alone — the tool no longer accepts raw ids, so this
+    // chain is the ONLY way a delete can reach Odoo at all.
+    await runRefDispatchProbe(page, testInfo, {
+      trigger: FAKE_OLLAMA_ODOO_DELETE_REF_TRIGGER,
+      eventType: "tool.odoo_delete",
+      message: "delete the tag",
+    });
+
+    // outcome=success only proves the plugin was happy. Read the mock back: the
+    // targeted row is gone and its neighbour is not, which is what "scoped to
+    // the ref it was given" means.
+    const remaining = await getOdooRecords(FAKE_OLLAMA_ODOO_DELETE_REF_MODEL);
+    expect(remaining.map((r) => r.id)).toEqual([9902]);
   });
 
   // ── Deterministic vendor-bill duplicate guard (pinchy#721) ────────────────

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -1295,6 +1295,13 @@ const ODOO_RECONCILE_REF_TRIGGER = "E2E_ODOO_RECONCILE_REF";
 const ODOO_RECONCILE_REF_RESPONSE = "Reconciled via ref: coverage probe complete.";
 const ODOO_ATTACH_FILE_REF_TRIGGER = "E2E_ODOO_ATTACH_FILE_REF";
 const ODOO_ATTACH_FILE_REF_RESPONSE = "File attached via ref: coverage probe complete.";
+// pinchy#1078: odoo_delete no longer takes raw ids, so its dispatch is now a
+// ref chain like every other governed write — read the record, reuse the
+// `_pinchy_ref` it returns. The model it deletes on (res.partner.category) is
+// touched by no other probe, so the row it removes cannot starve one.
+const ODOO_DELETE_REF_TRIGGER = "E2E_ODOO_DELETE_REF";
+const ODOO_DELETE_REF_RESPONSE = "Record deleted via ref: coverage probe complete.";
+const ODOO_DELETE_REF_MODEL = "res.partner.category";
 
 // The filename the odoo_attach_file probe attaches. The E2E spec uploads this
 // exact fixture via the composer (landing it in the agent's uploads/ dir) before
@@ -1380,6 +1387,13 @@ const REF_DISPATCH_PROBES: RefDispatchProbe[] = [
     toolName: "odoo_attach_file",
     buildArgs: (refs) => ({ targetRef: refs[0], filename: ODOO_ATTACH_FILE_REF_FILENAME }),
     response: ODOO_ATTACH_FILE_REF_RESPONSE,
+  },
+  {
+    trigger: ODOO_DELETE_REF_TRIGGER,
+    reads: [ODOO_DELETE_REF_MODEL],
+    toolName: "odoo_delete",
+    buildArgs: (refs) => ({ model: ODOO_DELETE_REF_MODEL, targets: [refs[0]] }),
+    response: ODOO_DELETE_REF_RESPONSE,
   },
 ];
 
@@ -2248,6 +2262,8 @@ export const FAKE_OLLAMA_ODOO_SET_APPROVAL_REF_TRIGGER = ODOO_SET_APPROVAL_REF_T
 export const FAKE_OLLAMA_ODOO_RECONCILE_REF_TRIGGER = ODOO_RECONCILE_REF_TRIGGER;
 export const FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_TRIGGER = ODOO_ATTACH_FILE_REF_TRIGGER;
 export const FAKE_OLLAMA_ODOO_ATTACH_FILE_REF_FILENAME = ODOO_ATTACH_FILE_REF_FILENAME;
+export const FAKE_OLLAMA_ODOO_DELETE_REF_TRIGGER = ODOO_DELETE_REF_TRIGGER;
+export const FAKE_OLLAMA_ODOO_DELETE_REF_MODEL = ODOO_DELETE_REF_MODEL;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_TRIGGER = ODOO_CREATE_NESTED_LINES_TRIGGER;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_RESPONSE = ODOO_CREATE_NESTED_LINES_RESPONSE;
 export const FAKE_OLLAMA_ODOO_DUP_BILL_REF = ODOO_DUP_BILL_REF;

--- a/packages/web/src/__tests__/lib/odoo-ref-tool-e2e-coverage.test.ts
+++ b/packages/web/src/__tests__/lib/odoo-ref-tool-e2e-coverage.test.ts
@@ -40,6 +40,9 @@ const REF_BASED_ODOO_TOOLS = [
   "odoo_set_approval",
   "odoo_reconcile",
   "odoo_attach_file",
+  // pinchy#1078: odoo_delete joined the ref-based tools when its raw
+  // `ids: number[]` became `targets: _pinchy_ref[]`.
+  "odoo_delete",
 ] as const;
 
 // Ref-based odoo tools that do NOT yet have an E2E dispatch test, each with a
@@ -64,7 +67,7 @@ const PENDING_E2E: Record<string, string> = {};
  * Two shapes carry a `_pinchy_ref` input:
  *   1. `recordActionFactory({ ... name: "odoo_x" ... })` — the shared factory
  *      for record-action tools (confirm_order, validate_picking, …).
- *   2. An inline schema property named target / targetRef / invoice /
+ *   2. An inline schema property named target / targets / targetRef / invoice /
  *      counterpart, whose owning tool is the nearest following `name: "odoo_x"`.
  */
 function detectRefToolNames(source: string): Set<string> {
@@ -74,7 +77,11 @@ function detectRefToolNames(source: string): Set<string> {
     names.add(m[1]);
   }
 
-  const refProp = /\b(?:target|targetRef|invoice|counterpart):\s*\{/g;
+  // `targets` (plural, pinchy#1078's odoo_delete) is listed explicitly: the
+  // alternation is ordered, and while JS backtracking would reach it anyway,
+  // spelling it out is what tells the next reader that a multi-ref parameter
+  // counts here too.
+  const refProp = /\b(?:targets|target|targetRef|invoice|counterpart):\s*\{/g;
   for (const m of source.matchAll(refProp)) {
     const after = source.slice(m.index ?? 0);
     const nameMatch = after.match(/name:\s*"(odoo_[a-z_]+)"/);

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -174,7 +174,7 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
   {
     id: "odoo_delete",
     label: "Odoo: Delete records",
-    description: "Delete records from Odoo",
+    description: "Delete records the agent has read from Odoo — cannot be undone",
     category: "powerful",
     integration: "odoo",
   },


### PR DESCRIPTION
Closes #1078.

## The finding

Every writing Odoo tool makes the model prove it has read a record before it can act on it — an opaque, signed `_pinchy_ref` rather than an integer. The most destructive one was the exception: `odoo_delete` took `ids: number[]` straight through to `unlink`, with no shape validation, no `{item: …}` check, and nothing tying the call to a record the model had actually seen. A hallucinated `ids: [40]` deleted record 40. The duplicate and read-back governance from #720/#721 stopped short of delete.

One correction to the issue's framing, since it changes nothing about the fix: `odoo_write` also takes raw `ids`. The "Raw numeric IDs are not accepted" guard the issue quotes governs relation **field values**, not the `ids` argument. Delete still deserves the stricter contract on its own merits — it is the one operation nothing downstream can verify or undo — but this PR deliberately does not change `odoo_write`, whose read-after-write verification (#720) covers a different risk.

## What changed

**`targets: _pinchy_ref[]` replaces `ids`.** Raw ids are refused with a message naming what to do instead, rather than quietly accepted alongside `targets` — a lenient fallback would be a one-parameter route back to the same hole. Every ref is decoded before Odoo is touched at all, so a mixed batch with one bad ref deletes nothing, and each must belong to this connection **and** to the model the permission check just cleared (otherwise a ref could unlink on a model the agent was never granted delete on). `hasItemWrappedArray` covers the `{item: …}` serialization artifact.

**The audit row names what went.** AGENTS.md asks a delete to record resource names because the rows are gone by the time anyone reads it; the plugin logged `{success: true}`. It now reads display names in the moment before the unlink and records model, count and `{id, label}` pairs. That read is best-effort: every ref already carries a signed label from the read that minted it, so a failed lookup degrades to that rather than turning a forensic nicety into a failed delete.

**The size bound is bytes, not entries.** An Odoo `display_name` has no length limit, so twenty long ones pass a count check and still blow the 2048-byte detail budget. `buildDeleteAuditDetail` clips each label, fills to a byte budget, and reports `deletedTruncated` — a list shortened in silence reads as "that was all of them".

## Coverage

- 23 unit tests in `packages/plugins/pinchy-odoo/__tests__/tools.test.ts` (raw-id refusal, cross-connection ref, cross-model ref, corrupted ref, shape cases, `{item: …}`, dedup, read-before-unlink ordering, label fallback) plus four on `buildDeleteAuditDetail` proving the byte bound against long names.
- `odoo_delete` joins `REF_DISPATCH_PROBES` and the ref-tool coverage guard; its detector now recognises a plural `targets` parameter. The E2E probe deletes on its own model (`res.partner.category`, touched by no other probe), seeded with two rows, and asserts the second survives — `outcome=success` only proves the plugin was happy, not that the unlink was scoped to the ref it was given.

## Docs

Permissions reference, Connect Odoo, Integrations, and a breaking-change note in the open upgrade section. The `review-docs` pass caught three things worth naming: my own upgrade note claimed a delete requires read permission (a ref can also come from the `odoo_create` that made the record); my permissions note implied every name is listed (a bulk delete lists 20 and says how many more); and `audit-trail.mdx`'s "the detail includes the parameters" was already wrong for curated tools and is now wrong for one more, so it says which tools curate and why.

`upgrading.mdx:959` ("`odoo_write`, `odoo_delete` are unchanged") is left alone deliberately — it is a released section, and it was true of that release.

## Verification

`pnpm test` (10935 passed), `pnpm test:plugins`, `pnpm test:scripts` (913), `pnpm typecheck:plugins`, `pnpm -C packages/web typecheck`, `pnpm -C packages/web lint` (0 errors), `pnpm build`, `pnpm format:check`, and the docs build with `check:anchors` + `check:rendered`. The Odoo E2E probe runs in CI's `odoo-e2e` job.

## Follow-up: reviewing the above against its own claims

Four defects in the first commit, fixed in `5218e48c`:

- **A clipped `display_name` could make the audit INSERT fail.** The per-label clip counted UTF-16 units, so a boundary inside a surrogate pair left a lone high surrogate; `JSON.stringify` emits `\ud83d` and Postgres refuses the row (`Unicode low surrogate must follow a high surrogate` — reproduced against pg17, `audit_log.detail` is `jsonb`). The delete lands, its evidence does not — via the code written to preserve that evidence. An emoji in a `res.partner.category` name is the everyday way there. Clipping iterates code points now.
- **A falsy `unlink` was reported as a delete.** `details.deleted` on an `outcome=success` row would have named records as deleted that are still in Odoo — the #404 shape. Real Odoo returns True or raises, so it is the edge; it is also the edge that produces a lie rather than an error. Now `errorResult`, whose `{error}`-only details keep the params for forensics.
- **The tool result handed the model the audit-capped list.** The cap serves the 2048-byte row, not the model. Content carries the full set; the cap stays where the budget is.
- **A comment claimed a guarantee the audit route removes** — "the exact set is `count` plus the tool params", but curated details suppress `detail.params`. The capped list plus `count` *is* the row, and raising the cap does not change that (the byte budget binds first). Said plainly, and the pre-unlink name read now fetches only the ids the detail can print.

Each fix is canaried: reverted against the pre-fix code, the new test goes red, restored.
