### PR TITLE
fix(agents): guard the second config push, and the loop that pushes it

### DIFF
--- a/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
@@ -84,15 +84,24 @@ vi.mock("@/lib/provider-models", () => ({
     },
   ]),
 }));
-vi.mock("@/db", () => ({
-  db: {
-    insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
-    delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
-    select: vi.fn().mockImplementation(() => ({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
-    })),
-  },
-}));
+vi.mock("@/db", () => {
+  const insert = vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+  const del = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+  return {
+    db: {
+      insert,
+      delete: del,
+      // Group assignment runs inside a transaction; hand the callback a tx that
+      // behaves like db so the route's writes resolve.
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ insert, delete: del })
+      ),
+      select: vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+      })),
+    },
+  };
+});
 vi.mock("@/db/schema", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/db/schema")>();
   return { ...actual };
@@ -101,6 +110,8 @@ vi.mock("@/db/schema", async (importOriginal) => {
 import { auth } from "@/lib/auth";
 import { updateAgent, AgentRuntimeUpdateError } from "@/lib/agents";
 import { appendAuditLog } from "@/lib/audit";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
 import { db } from "@/db";
 
 function mockAgent(agent: Record<string, unknown>) {
@@ -315,5 +326,130 @@ describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", 
     await flushAfter();
 
     expect(appendAuditLog).not.toHaveBeenCalled();
+  });
+});
+
+// The handler pushes the runtime config from TWO places, and the tests above
+// cover only the first. `updateAgent` pushes for the fields it owns; the tail
+// of the handler pushes again for `allowedTools` / `pluginConfig`, because
+// those change the generated openclaw.json without changing the agents row in a
+// way updateAgent regenerates for.
+//
+// That second call went in unguarded, so it still escaped as a framework 500
+// with no `error` field — on a PERMISSION change, which is the change #1095
+// actually broke. And it sat AFTER the success audit registration: `after()`
+// cannot be cancelled once queued, so the row was written anyway, claiming
+// `outcome: "success"` for a request that answered 500.
+describe("PATCH /api/agents/[agentId] — the permission-change config push", () => {
+  let PATCH: typeof import("@/app/api/agents/[agentId]/route").PATCH;
+
+  const EXISTING = {
+    id: "agent-1",
+    name: "Penny",
+    model: "old",
+    allowedTools: [],
+    isPersonal: false,
+    ownerId: null,
+  };
+
+  function patchTools() {
+    return new NextRequest("http://localhost/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ allowedTools: ["email_read"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  async function patchToolsWithFailingPush() {
+    adminSession();
+    mockAgent(EXISTING);
+    vi.mocked(updateAgent).mockResolvedValueOnce({
+      ...EXISTING,
+      allowedTools: ["email_read"],
+    } as never);
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(eaccesOnToolsFile());
+
+    const res = await PATCH(patchTools(), { params: Promise.resolve({ agentId: "agent-1" }) });
+    await flushAfter();
+    return res;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/agents/[agentId]/route");
+    PATCH = mod.PATCH;
+  });
+
+  it("answers the same readable error as the other push site", async () => {
+    const res = await patchToolsWithFailingPush();
+
+    expect(res.status).toBe(500);
+    const { error } = (await res.json()) as { error: string };
+    expect(error).toMatch(/saved/i);
+    expect(error).toContain("EACCES");
+  });
+
+  it("writes ONE audit row for the request, and it says failure", async () => {
+    await patchToolsWithFailingPush();
+
+    const rows = vi
+      .mocked(appendAuditLog)
+      .mock.calls.map(([entry]) => entry)
+      .filter((entry) => entry.eventType === "agent.updated");
+
+    // Two rows disagreeing about one request is worse than no row: whichever
+    // an analyst reads first is as likely to be the wrong one.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcome).toBe("failure");
+    expect(rows[0].detail).toMatchObject({
+      changes: { allowedTools: { to: ["email_read"] } },
+      runtimeUpdate: { applied: false },
+    });
+  });
+
+  it("still recalculates the Telegram allow-stores", async () => {
+    // They mirror group and visibility rows that are already committed, and
+    // they ran before the push until this early return existed. Skipping them
+    // would leave the store enforcing an access rule the database dropped —
+    // a drift introduced by the error path rather than by the error.
+    adminSession();
+    mockAgent(EXISTING);
+    vi.mocked(updateAgent).mockResolvedValueOnce({
+      ...EXISTING,
+      allowedTools: ["email_read"],
+    } as never);
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(eaccesOnToolsFile());
+
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/agents/agent-1", {
+        method: "PATCH",
+        body: JSON.stringify({ allowedTools: ["email_read"], groupIds: [] }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      { params: Promise.resolve({ agentId: "agent-1" }) }
+    );
+
+    expect(res.status).toBe(500);
+    expect(recalculateTelegramAllowStores).toHaveBeenCalled();
+  });
+
+  it("still answers 200 and audits success when the push works", async () => {
+    adminSession();
+    mockAgent(EXISTING);
+    vi.mocked(updateAgent).mockResolvedValueOnce({
+      ...EXISTING,
+      allowedTools: ["email_read"],
+    } as never);
+
+    const res = await PATCH(patchTools(), { params: Promise.resolve({ agentId: "agent-1" }) });
+    await flushAfter();
+
+    expect(res.status).toBe(200);
+    const rows = vi
+      .mocked(appendAuditLog)
+      .mock.calls.map(([entry]) => entry)
+      .filter((entry) => entry.eventType === "agent.updated");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].outcome).toBe("success");
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config-tools-md.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-tools-md.test.ts
@@ -115,7 +115,7 @@ vi.mock("@/lib/provider-models", () => ({
   getDefaultModel: vi.fn(async () => "anthropic/claude-haiku-4-5-20251001"),
 }));
 
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync, rmSync } from "fs";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { db } from "@/db";
 import { mockJoinedPermissionsDb } from "@/test-helpers/db-mock";
@@ -436,5 +436,117 @@ describe("regenerateOpenClawConfig TOOLS.md mailbox context", () => {
     const config = getWrittenConfig();
     expect(config.plugins?.entries?.["pinchy-email"]).toBeUndefined();
     expect(config.agents.list.find((a) => a.id === "plain")).toBeDefined();
+  });
+});
+
+describe("regenerateOpenClawConfig — an unwritable workspace is not fatal (#1095)", () => {
+  // writeFileReclaiming repairs the case where the FILE is root-owned: the
+  // directory entry can be replaced via rename, which the directory's owner is
+  // allowed to do. It says so itself, and it names the case it cannot repair —
+  // when the DIRECTORY is what Pinchy may not write, the temp write is denied
+  // too and the error propagates. That needs root, and root only arrives on the
+  // OpenClaw-side tick, which reaches an instance when its image is upgraded.
+  //
+  // Until then this loop decides the blast radius. Unguarded, one agent's EACCES
+  // aborts regenerateOpenClawConfig BEFORE the openclaw.json write — so the
+  // symptom is not "one agent's TOOLS.md is stale" but every agent's runtime
+  // config frozen and pinchy-email absent. That is #1095 as it actually shipped.
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStore.clear();
+    mockedReadFileSync.mockImplementation((p) => {
+      const path = String(p);
+      const stored = fileStore.get(path);
+      if (stored !== undefined) return stored;
+      if (path.endsWith("openclaw.json")) return JSON.stringify(gatewayConfig);
+      const err = new Error(`ENOENT: no such file or directory, open '${path}'`);
+      (err as NodeJS.ErrnoException).code = "ENOENT";
+      throw err;
+    });
+  });
+
+  /**
+   * Model a root-owned workspace DIRECTORY: every write under it is denied,
+   * including the sibling temp file writeFileReclaiming falls back to. Denying
+   * only TOOLS.md would let the reclaim rescue it and prove nothing.
+   */
+  function denyWritesUnder(agentId: string): void {
+    const dir = `/openclaw-config/workspaces/${agentId}/`;
+    const write = vi.mocked(writeFileSync);
+    const passthrough = write.getMockImplementation();
+    write.mockImplementation(((p: unknown, ...rest: unknown[]) => {
+      if (String(p).startsWith(dir)) {
+        const err = new Error(`EACCES: permission denied, open '${String(p)}'`);
+        (err as NodeJS.ErrnoException).code = "EACCES";
+        throw err;
+      }
+      return (passthrough as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as never);
+  }
+
+  it("still pushes openclaw.json — with pinchy-email — when one workspace is locked", async () => {
+    const conn = emailConnection("conn-locked", { name: "Locked Mailbox" });
+    mockDb([agentRow("hermes")], [emailPermission("hermes", conn, "read")]);
+    denyWritesUnder("hermes");
+
+    await expect(regenerateOpenClawConfig()).resolves.not.toThrow();
+
+    // The point of the whole change: the grant the user just made reaches the
+    // runtime even though the file explaining it could not be written.
+    const config = getWrittenConfig();
+    expect(config.plugins?.entries?.["pinchy-email"]).toBeDefined();
+    expect(config.agents.list.find((a) => a.id === "hermes")).toBeDefined();
+  });
+
+  it("names the agent and quotes the errno rather than failing silently", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const conn = emailConnection("conn-locked", { name: "Locked Mailbox" });
+    mockDb([agentRow("hermes")], [emailPermission("hermes", conn, "read")]);
+    denyWritesUnder("hermes");
+
+    await regenerateOpenClawConfig();
+
+    const relevant = warn.mock.calls.map((c) => String(c[0])).find((m) => m.includes("TOOLS.md"));
+    expect(relevant).toBeDefined();
+    expect(relevant).toContain("hermes");
+    // A warning that hides the errno is the log line that cost #1095 two days.
+    expect(relevant).toContain("EACCES");
+    warn.mockRestore();
+  });
+
+  it("keeps every OTHER agent's TOOLS.md when one workspace is locked", async () => {
+    const locked = emailConnection("conn-locked", { name: "Locked Mailbox" });
+    const fine = emailConnection("conn-fine", { name: "Fine Mailbox" });
+    mockDb(
+      [agentRow("hermes"), agentRow("iris")],
+      [emailPermission("hermes", locked, "read"), emailPermission("iris", fine, "read")]
+    );
+    denyWritesUnder("hermes");
+
+    await regenerateOpenClawConfig();
+
+    expect(fileStore.get(toolsMdPath("hermes"))).toBeUndefined();
+    expect(fileStore.get(toolsMdPath("iris"))).toContain("conn-fine@example.com");
+  });
+
+  it("survives an unwritable REMOVAL too", async () => {
+    // writeToolsFile DELETES TOOLS.md for an agent with no mailbox. rmSync's
+    // `force` swallows ENOENT, never EACCES.
+    const rm = vi.mocked(rmSync);
+    const passthrough = rm.getMockImplementation();
+    rm.mockImplementation(((p: unknown, ...rest: unknown[]) => {
+      if (String(p) === toolsMdPath("plain")) {
+        const err = new Error(`EACCES: permission denied, unlink '${String(p)}'`);
+        (err as NodeJS.ErrnoException).code = "EACCES";
+        throw err;
+      }
+      return (passthrough as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as never);
+    mockDb([agentRow("plain")], []);
+
+    await expect(regenerateOpenClawConfig()).resolves.not.toThrow();
+
+    expect(getWrittenConfig().agents.list.find((a) => a.id === "plain")).toBeDefined();
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -21,6 +21,14 @@ import { updateAgentSchema } from "@/lib/schemas/agents";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
+/** What an `agent.updated` row carries, success or failure. */
+type AgentUpdateDetail = UpdateDetail & {
+  allowedGroups?: {
+    added: { id: string; name: string }[];
+    removed: { id: string; name: string }[];
+  };
+};
+
 export const GET = withAuth<RouteContext>(async (_req, { params }, session) => {
   const { agentId } = await params;
 
@@ -203,38 +211,54 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   //     forbids, and `outcome: "failure"` exists for precisely this shape.
   //   anything else → the write itself failed, nothing persisted. Claiming it
   //     was saved would stop the user retrying a change that never landed.
+  /**
+   * The answer a failed config push owes the caller.
+   *
+   * TWO sites in this handler push the runtime config — `updateAgent` for the
+   * fields it owns, and the tail of this handler for `allowedTools` /
+   * `pluginConfig`. They share this so they cannot drift into two different
+   * stories about the same failure, and so the second one cannot be forgotten
+   * the way it was: it went in unguarded, which left a permission change — the
+   * exact change #1095 broke — answering a blank Next.js 500.
+   *
+   * `detail` is null when there is nothing auditable to record.
+   */
+  function runtimeUpdateFailed(err: unknown, detail: AgentUpdateDetail | null): NextResponse {
+    const cause = err instanceof Error ? err.message : String(err);
+    console.error(`[agents] config regeneration failed for agent ${agentId}:`, err);
+    if (detail) {
+      after(() =>
+        appendAuditLog({
+          actorType: "user",
+          actorId: session.user.id!,
+          eventType: "agent.updated",
+          resource: `agent:${agentId}`,
+          // safeProviderError, not the raw string: an uncapped field would
+          // trip truncateDetail, which replaces the WHOLE detail with a
+          // summary blob rather than trimming the offender — taking
+          // `changes` with it, on the one row whose value is recording what
+          // changed. It also scrubs addresses, and this path exists because
+          // of TOOLS.md, the file carrying an agent's mailbox context.
+          detail: { ...detail, runtimeUpdate: { applied: false, error: safeProviderError(cause) } },
+          outcome: "failure",
+        })
+      );
+    }
+    return NextResponse.json(
+      { error: `Settings were saved, but the agent runtime was not updated: ${cause}` },
+      { status: 500 }
+    );
+  }
+
   let agent: typeof existingAgent;
   try {
     agent = Object.keys(data).length > 0 ? await updateAgent(agentId, data) : existingAgent;
   } catch (err) {
-    const cause = err instanceof Error ? err.message : String(err);
-
     if (err instanceof AgentRuntimeUpdateError) {
-      console.error(`[agents] config regeneration failed for agent ${agentId}:`, err);
-      if (Object.keys(changes).length > 0) {
-        after(() =>
-          appendAuditLog({
-            actorType: "user",
-            actorId: session.user.id!,
-            eventType: "agent.updated",
-            resource: `agent:${agentId}`,
-            // safeProviderError, not the raw string: an uncapped field would
-            // trip truncateDetail, which replaces the WHOLE detail with a
-            // summary blob rather than trimming the offender — taking
-            // `changes` with it, on the one row whose value is recording what
-            // changed. It also scrubs addresses, and this path exists because
-            // of TOOLS.md, the file carrying an agent's mailbox context.
-            detail: { changes, runtimeUpdate: { applied: false, error: safeProviderError(cause) } },
-            outcome: "failure",
-          })
-        );
-      }
-      return NextResponse.json(
-        { error: `Settings were saved, but the agent runtime was not updated: ${cause}` },
-        { status: 500 }
-      );
+      return runtimeUpdateFailed(err, Object.keys(changes).length > 0 ? { changes } : null);
     }
 
+    const cause = err instanceof Error ? err.message : String(err);
     console.error(`[agents] update failed for agent ${agentId}:`, err);
     return NextResponse.json({ error: `Could not update the agent: ${cause}` }, { status: 500 });
   }
@@ -270,12 +294,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   }
 
   // Build audit detail with group diffs
-  const auditDetail: UpdateDetail & {
-    allowedGroups?: {
-      added: { id: string; name: string }[];
-      removed: { id: string; name: string }[];
-    };
-  } = { changes };
+  const auditDetail: AgentUpdateDetail = { changes };
 
   if (body.groupIds !== undefined && session.user.role === "admin") {
     const newIds = body.groupIds;
@@ -298,7 +317,36 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     }
   }
 
-  if (Object.keys(changes).length > 0 || auditDetail.allowedGroups) {
+  const hasAuditableChange = Object.keys(changes).length > 0 || Boolean(auditDetail.allowedGroups);
+
+  // Recalculate Telegram allow-from stores when visibility or groups change.
+  // Above the push, where it has always run: the rows it mirrors are already
+  // committed, so a failed push must not skip it and leave the store enforcing
+  // an access rule the database no longer has.
+  if (body.visibility !== undefined || body.groupIds !== undefined) {
+    await recalculateTelegramAllowStores();
+  }
+
+  // Rebuild OpenClaw config when tool permissions or plugin config change — these
+  // fields affect the generated openclaw.json (e.g. write_paths for pinchy_write).
+  //
+  // Guarded like the push inside updateAgent, and for the same reason: this is
+  // the one a PERMISSION change rides on, which is the change #1095 actually
+  // broke. Unguarded it escaped as a blank 500.
+  //
+  // Ordered BEFORE the audit registration, which is the other half of the bug.
+  // `after()` cannot be cancelled once queued, so a success row registered
+  // first would still be written after this fails — one request leaving two
+  // rows that disagree, with the wrong one claiming `outcome: "success"`.
+  if (data.allowedTools !== undefined || data.pluginConfig !== undefined) {
+    try {
+      await regenerateOpenClawConfig();
+    } catch (err) {
+      return runtimeUpdateFailed(err, hasAuditableChange ? auditDetail : null);
+    }
+  }
+
+  if (hasAuditableChange) {
     after(() =>
       appendAuditLog({
         actorType: "user",
@@ -309,17 +357,6 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
         outcome: "success",
       })
     );
-  }
-
-  // Recalculate Telegram allow-from stores when visibility or groups change
-  if (body.visibility !== undefined || body.groupIds !== undefined) {
-    await recalculateTelegramAllowStores();
-  }
-
-  // Rebuild OpenClaw config when tool permissions or plugin config change — these
-  // fields affect the generated openclaw.json (e.g. write_paths for pinchy_write).
-  if (data.allowedTools !== undefined || data.pluginConfig !== undefined) {
-    await regenerateOpenClawConfig();
   }
 
   return NextResponse.json(agent);

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -394,32 +394,50 @@ export async function regenerateOpenClawConfig() {
   // Agents without email connections get their TOOLS.md actively removed so
   // no stale mailbox identity survives a permission revocation.
   // The shared display order also dedupes ops merged across permission rows.
+  //
+  // Per-agent and non-fatal, exactly like the ensureWorkspace loop above and
+  // for the same reason — same volume, same cross-uid failure mode. This one
+  // was not guarded, and #1095 is what that costs: a single EACCES on one
+  // agent's root-owned TOOLS.md aborted this function BEFORE it pushed
+  // openclaw.json, so the symptom was not a stale bootstrap file but every
+  // agent save failing and pinchy-email missing from the runtime entirely.
+  // Trading one agent's mailbox context for every agent's config is never the
+  // right trade. The reclaim path in writeToolsFile should stop the EACCES
+  // happening at all; this is what keeps its failure proportionate if it does.
   for (const agent of liveAgents) {
-    const emailData = emailPermsByAgent.get(agent.id);
-    if (!emailData) {
-      writeToolsFile(agent.id, []);
-      continue;
-    }
-    if (emailData.connectionIds.size > 1) {
-      // Surface the silent first-wins pick (see the aggregation note above)
-      // so operators notice when an agent carries more than one email
-      // connection in the DB — the UI prevents this today, but the data
-      // model does not.
+    try {
+      const emailData = emailPermsByAgent.get(agent.id);
+      if (!emailData) {
+        writeToolsFile(agent.id, []);
+        continue;
+      }
+      if (emailData.connectionIds.size > 1) {
+        // Surface the silent first-wins pick (see the aggregation note above)
+        // so operators notice when an agent carries more than one email
+        // connection in the DB — the UI prevents this today, but the data
+        // model does not.
+        console.warn(
+          `[openclaw-config] Agent ${agent.name} (${agent.id}) has ${String(emailData.connectionIds.size)} email connections; pinchy-email serves only the first one (${emailData.connectionId}), and TOOLS.md lists exactly that connection.`
+        );
+      }
+      const conn = emailData.connection;
+      const connData =
+        conn.data && typeof conn.data === "object" ? (conn.data as { emailAddress?: string }) : {};
+      const grantedOps = emailData.ops.get("email") ?? [];
+      writeToolsFile(agent.id, [
+        {
+          address: connData.emailAddress || conn.name,
+          label: conn.name,
+          operations: EMAIL_OPERATION_DISPLAY_ORDER.filter((op) => grantedOps.includes(op)),
+        },
+      ]);
+    } catch (err) {
       console.warn(
-        `[openclaw-config] Agent ${agent.name} (${agent.id}) has ${String(emailData.connectionIds.size)} email connections; pinchy-email serves only the first one (${emailData.connectionId}), and TOOLS.md lists exactly that connection.`
+        `[openclaw-config] Could not write TOOLS.md for agent ${agent.name} (${agent.id}): ${
+          err instanceof Error ? err.message : String(err)
+        }. The agent keeps its previous mailbox context; every other agent's config is unaffected.`
       );
     }
-    const conn = emailData.connection;
-    const connData =
-      conn.data && typeof conn.data === "object" ? (conn.data as { emailAddress?: string }) : {};
-    const grantedOps = emailData.ops.get("email") ?? [];
-    writeToolsFile(agent.id, [
-      {
-        address: connData.emailAddress || conn.name,
-        label: conn.name,
-        operations: EMAIL_OPERATION_DISPLAY_ORDER.filter((op) => grantedOps.includes(op)),
-      },
-    ]);
   }
 
   // Pattern A from CLAUDE.md "Secrets Handling": secret pair for each LLM


### PR DESCRIPTION
Follow-up to #1128, which fixed #1095. **This PR originally duplicated that work** — #1128 landed first and solved the same incident, generally better. Rebased onto it and reduced to what it left open: two places that still trade a whole regeneration for one agent's file, both in the shape the incident actually had.

## The permission-change config push was unguarded

`PATCH /api/agents/:id` pushes the runtime config from **two** sites: `updateAgent` for the fields it owns, and the tail of the handler for `allowedTools` / `pluginConfig`, which change the generated `openclaw.json` without changing the row in a way `updateAgent` regenerates for.

#1128 guarded the first. The second still escaped as a framework 500 with no `error` field — on a **permission change**, which is the change #1095 actually broke.

And it sat *after* the success audit registration. `after()` cannot be cancelled once queued, so the row was written anyway, claiming `outcome: "success"` for a request that answered 500. `reference/api.mdx` already promises a readable cause and an `agent.updated` row with `outcome: failure` for this case; on that path the code did the opposite.

Both sites now share one `runtimeUpdateFailed`, so they cannot drift into two stories about one failure, and the push moved above the audit registration so one request leaves one row.

## The TOOLS.md loop decides the blast radius

`writeFileReclaiming` repairs a root-owned **file** without root — and names the case it cannot repair: when the **directory** is what Pinchy may not write, the temp write is denied too and the error propagates. That case needs the OpenClaw-side tick, which reaches an instance when its image is upgraded.

Until then this loop is what bounds the damage, and unguarded it aborts `regenerateOpenClawConfig` *before* `openclaw.json` is written. That is #1095 exactly: not a stale bootstrap file, but every agent's runtime config frozen and `pinchy-email` gone from the plugin list. `ensureWorkspace` 100 lines above makes this argument already and catches per agent; this loop did not.

## Deliberately not added

A drift guard pinning the shell chown list to `BOOTSTRAP_FILENAMES`. The two legitimately differ — `BOOTSTRAP_FILENAMES` is OpenClaw's bootstrap-loading list, used for size budgeting and documented as a superset of what Pinchy writes — so that pin would encode a false invariant. With `writeFileReclaiming` in place a missing filename there is no longer fatal anyway; the load-bearing half is the directory chown, which #1128 already covers and tests.

## Verification

Both fixes verified by canary against `origin/main` rather than by reading: reverting either file to main's version turns the new tests red (4 and 3 respectively).

One test is a regression guard rather than a fix — main does **not** skip the Telegram allow-store recalculation, and this keeps it that way now that the push can return early.

Gates: full suite 11681 passed / 0 failed, `test:scripts` 1116/0, typecheck (incl. tests), eslint 0 errors, `prettier --check .` whole-tree, `next build`.

No docs change: `reference/api.mdx` already documents both 500 shapes and the failure audit row. This makes the second push site honour what is already written rather than changing the contract.
