### PR TITLE
fix(security): sign the development license with a key production rejects (#1083)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,13 +476,23 @@ jobs:
       - name: Verify private key matches public key
         env:
           PINCHY_LICENSE_PRIVATE_KEY: ${{ secrets.PINCHY_LICENSE_PRIVATE_KEY }}
+          # "true" on a fork PR, "false" on a same-repo PR, empty on push and
+          # merge_group. Only the first case legitimately has no secrets.
+          FORK_PR: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          # Fork PRs get no secrets; a missing key must read as "cannot verify
-          # here", not as a red check on every outside contribution. Runs with
-          # the secret on same-repo PRs, merge queue and main.
+          # A fork PR carries no secrets by design, so "cannot verify here" must
+          # not read as a red check on every outside contribution. Anywhere else
+          # the secret is supposed to be present, and its absence means this
+          # check has been silently switched off — which is the one outcome a
+          # security check may never report as green. Skip on a fork, fail
+          # otherwise.
           if [ -z "$PINCHY_LICENSE_PRIVATE_KEY" ]; then
-            echo "::notice::PINCHY_LICENSE_PRIVATE_KEY not available (fork PR or unset secret) — skipping keypair verification."
-            exit 0
+            if [ "$FORK_PR" = "true" ]; then
+              echo "::notice::Fork PR carries no secrets — keypair verification cannot run here."
+              exit 0
+            fi
+            echo "::error::PINCHY_LICENSE_PRIVATE_KEY is unset on a run that should have it (event=${GITHUB_EVENT_NAME}). The keypair check cannot verify anything; restore the repository secret rather than letting this pass."
+            exit 1
           fi
           npm install jose
           node -e "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,19 +477,31 @@ jobs:
         env:
           PINCHY_LICENSE_PRIVATE_KEY: ${{ secrets.PINCHY_LICENSE_PRIVATE_KEY }}
         run: |
+          # Fork PRs get no secrets; a missing key must read as "cannot verify
+          # here", not as a red check on every outside contribution. Runs with
+          # the secret on same-repo PRs, merge queue and main.
+          if [ -z "$PINCHY_LICENSE_PRIVATE_KEY" ]; then
+            echo "::notice::PINCHY_LICENSE_PRIVATE_KEY not available (fork PR or unset secret) — skipping keypair verification."
+            exit 0
+          fi
           npm install jose
           node -e "
             const jose = require('jose');
             const fs = require('fs');
-            const src = fs.readFileSync('packages/web/src/lib/enterprise.ts', 'utf8');
-            const pubMatch = src.match(/-----BEGIN PUBLIC KEY-----[\s\S]+?-----END PUBLIC KEY-----/);
-            if (!pubMatch) { console.error('❌ Public key not found in enterprise.ts'); process.exit(1); }
+            const src = fs.readFileSync('packages/web/src/lib/license-keys.ts', 'utf8');
+            // Anchor on the PRODUCTION const: the file also carries the
+            // development public key, and a first-match regex would happily
+            // verify against the wrong one if the declarations were reordered.
+            const idx = src.indexOf('PRODUCTION_PUBLIC_KEY');
+            if (idx === -1) { console.error('❌ PRODUCTION_PUBLIC_KEY not found in license-keys.ts'); process.exit(1); }
+            const pubMatch = src.slice(idx).match(/-----BEGIN PUBLIC KEY-----[\s\S]+?-----END PUBLIC KEY-----/);
+            if (!pubMatch) { console.error('❌ Public key PEM not found after PRODUCTION_PUBLIC_KEY in license-keys.ts'); process.exit(1); }
             (async () => {
               const priv = await jose.importPKCS8(process.env.PINCHY_LICENSE_PRIVATE_KEY, 'ES256');
               const pub = await jose.importSPKI(pubMatch[0], 'ES256');
               const jwt = await new jose.SignJWT({test: true}).setProtectedHeader({alg: 'ES256'}).sign(priv);
               await jose.jwtVerify(jwt, pub);
-              console.log('✅ Keypair verified: private key matches public key in enterprise.ts');
+              console.log('✅ Keypair verified: private key matches PRODUCTION_PUBLIC_KEY in license-keys.ts');
             })();
           "
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,11 +445,18 @@ Development should use Docker Compose because the app depends on PostgreSQL, Ope
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
-With a development enterprise key:
+That stack is **already** an enterprise install: `docker-compose.dev.yml` defaults `PINCHY_ENTERPRISE_KEY` to the development license (`DEV_LICENSE_TOKEN`, `packages/web/src/lib/license-keys.ts`). It is signed by a key only a non-production build trusts, so committing it unlocks nothing on anyone's install — which is the point, and the fix for #1083. The production-signed token that used to sit there did unlock every install, and no test could see it, because a valid key makes every test pass.
+
+To see the community experience instead, set the variable to something empty — Compose only substitutes its default when the variable is **unset**, not when it is empty:
 
 ```bash
-PINCHY_ENTERPRISE_KEY=dev-enterprise docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+PINCHY_ENTERPRISE_KEY= docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
+
+Two rules keep this honest, both guarded by `packages/web/src/__tests__/security/committed-license-tokens.test.ts`:
+
+- **No token in the tracked tree may verify against the production key.** The guard asks jose directly rather than going through `validateLicense`, so it fires even on a token our own policy would reject — the question is whether we signed it, not whether we would grant it.
+- **The development subject is never honoured under the production key** (`DEV_LICENSE_SUBJECT`, `packages/web/src/lib/license.ts`). That rule, not the rotation of any key, is what revokes the token in this repository's history — it is in every clone and every fork and cannot be un-published. Changing the string un-revokes it; a test pins the value for exactly that reason.
 
 Production-style run:
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,12 @@ services:
     environment:
       - DATABASE_URL=postgresql://pinchy:pinchy_dev@db:5432/pinchy
       - BETTER_AUTH_SECRET=dev-secret-do-not-use-in-production
-      - PINCHY_ENTERPRISE_KEY=${PINCHY_ENTERPRISE_KEY-eyJhbGciOiJFUzI1NiJ9.eyJ0eXBlIjoicGFpZCIsImZlYXR1cmVzIjpbImVudGVycHJpc2UiXSwiaXNzIjoiaGV5cGluY2h5LmNvbSIsInN1YiI6InBpbmNoeS1kZXYiLCJpYXQiOjE3NzM0ODUyMzQsImV4cCI6MjA4ODg0NTIzNH0.h6stBWDrHP2LnXBv18RDk9_y71_b8FvFU6IodCBJkldlLoW6uxX6P7Hr_SL8OM-jhaNqUu7BIMaTYvbqW28buA}
+      # The development license — signed by the DEVELOPMENT key, which only a
+      # non-production build trusts (see src/lib/license-keys.ts). Committing
+      # it is safe for exactly that reason; the production-signed token that
+      # used to sit here was not (#1083). Kept byte-identical to
+      # `DEV_LICENSE_TOKEN` by committed-license-tokens.test.ts.
+      - PINCHY_ENTERPRISE_KEY=${PINCHY_ENTERPRISE_KEY-eyJhbGciOiJFUzI1NiJ9.eyJ0eXBlIjoicGFpZCIsImZlYXR1cmVzIjpbImVudGVycHJpc2UiXSwiaXNzIjoiaGV5cGluY2h5LmNvbSIsInN1YiI6InBpbmNoeS1kZXYiLCJpYXQiOjE3NzM0ODUyMzQsImV4cCI6NDkyNzA4NTIzNH0.x6YibNzmaMdiWJb4GjksKqfvJ1y-Tu0cv-iSZWdPW5fPQIzzJyed4b8oMlBbdQN_CkRFOisjYe9Q75PC6OEZxA}
     volumes:
       - ./packages/web:/app/packages/web
       - /app/packages/web/node_modules

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -207,6 +207,14 @@ Nothing to configure, and agents pick this up on their own from the tool descrip
 
 Delete entries in the audit trail now carry the model, the record IDs and the display names, read from Odoo immediately before the delete. See [Agent Permissions → Odoo tools](/concepts/agent-permissions/#odoo-tools).
 
+#### A license key that didn't come from us stops working
+
+Development builds ship a license key so contributors can exercise enterprise features on their own machine. Until this release that key was signed the same way real customer licenses are, so anyone reading the source could paste it into **Settings → License** and unlock the paid tier on any install.
+
+Development licenses now carry their own signature, which release builds do not accept, and the old key is refused outright. If your install was activated with a key that did not come from us, enterprise features switch off on this upgrade: Groups, agent access control and basic RBAC return to their community behaviour. Nothing is deleted — your groups and permission settings are still there, and they come back the moment a valid key is entered.
+
+Keys we issued are unaffected. Nothing about them changed, and there is nothing to re-enter.
+
 ### Upgrade notes
 
 The standard flow applies:

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -211,7 +211,7 @@ Delete entries in the audit trail now carry the model, the record IDs and the di
 
 Development builds ship a license key so contributors can exercise enterprise features on their own machine. Until this release that key was signed the same way real customer licenses are, so anyone reading the source could paste it into **Settings → License** and unlock the paid tier on any install.
 
-Development licenses now carry their own signature, which release builds do not accept, and the old key is refused outright. If your install was activated with a key that did not come from us, enterprise features switch off on this upgrade: Groups, agent access control and basic RBAC return to their community behaviour. Nothing is deleted — your groups and permission settings are still there, and they come back the moment a valid key is entered.
+Development licenses now carry their own signature, which release builds do not accept, and the old key is refused outright. If your install was activated with that key, it lands in the same state as an [expired license](/guides/enterprise-setup/#what-happens-when-a-license-expires) on this upgrade: management features lock, and **your existing access restrictions stay enforced** — restricted agents stay restricted, group-based access keeps working. A refused key never widens access. Nothing is deleted, and everything reactivates the moment a valid key is entered.
 
 Keys we issued are unaffected. Nothing about them changed, and there is nothing to re-enter.
 

--- a/packages/web/src/__tests__/lib/enterprise.test.ts
+++ b/packages/web/src/__tests__/lib/enterprise.test.ts
@@ -250,9 +250,11 @@ describe("the shipped development license", () => {
     const mod = await import("@/lib/enterprise");
     const status = await mod.getLicenseStatus();
     expect(status.active).toBe(false);
-    // Not "expired" either — a production install must not recognise it at all.
-    expect(status.expired).toBeUndefined();
     expect(status.org).toBeUndefined();
+    // The production key never saw this signature, so there is nothing to
+    // refuse: an unknown key is the community case, exactly as it was before
+    // anyone entered one.
+    expect(await mod.getLicenseState()).toBe("community");
   });
 });
 

--- a/packages/web/src/__tests__/lib/enterprise.test.ts
+++ b/packages/web/src/__tests__/lib/enterprise.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach, beforeAll } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import * as jose from "jose";
@@ -218,6 +218,41 @@ describe("validateLicenseToken", () => {
 
       expect(viaValidate).toEqual(viaStatus);
     }
+  });
+});
+
+// #1083. The development license is committed — that is deliberate, and it is
+// only safe because a production build does not trust the key that signed it.
+// These two tests are the pair that makes it safe; drop either and the repo is
+// back to shipping a key that unlocks paid features on any install.
+describe("the shipped development license", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("unlocks enterprise outside production", async () => {
+    const { DEV_LICENSE_TOKEN } = await import("@/lib/license-keys");
+    process.env.PINCHY_ENTERPRISE_KEY = DEV_LICENSE_TOKEN;
+
+    const mod = await import("@/lib/enterprise");
+    // No key argument: the real production key plus the development ring,
+    // exactly as a running app resolves it.
+    const status = await mod.getLicenseStatus();
+    expect(status.active).toBe(true);
+    expect(status.org).toBe("pinchy-dev");
+  });
+
+  it("unlocks nothing in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const { DEV_LICENSE_TOKEN } = await import("@/lib/license-keys");
+    process.env.PINCHY_ENTERPRISE_KEY = DEV_LICENSE_TOKEN;
+
+    const mod = await import("@/lib/enterprise");
+    const status = await mod.getLicenseStatus();
+    expect(status.active).toBe(false);
+    // Not "expired" either — a production install must not recognise it at all.
+    expect(status.expired).toBeUndefined();
+    expect(status.org).toBeUndefined();
   });
 });
 

--- a/packages/web/src/__tests__/lib/license.test.ts
+++ b/packages/web/src/__tests__/lib/license.test.ts
@@ -292,12 +292,40 @@ describe("the development subject", () => {
     const token = await createTokenFor(DEV_LICENSE_SUBJECT);
     const status = await validateLicense(token, testPublicKeyPem);
     expect(status.active).toBe(false);
-    expect(status.expired).toBeUndefined();
+    expect(status.features).toEqual([]);
   });
 
-  it("is not reported as expired either, once past exp", async () => {
-    // Otherwise a production install would surface "your license expired" for
-    // the dev subject — an honest-looking hint that the token is recognised.
+  it("is refused without leaking its claims", async () => {
+    // No org, no date. The key did not expire — it was refused — so nothing
+    // may print an expiry for it. The banner's expired copy degrades to the
+    // dateless form, which is exactly what happened.
+    const { validateLicense, DEV_LICENSE_SUBJECT } = await import("@/lib/license");
+    const token = await createTokenFor(DEV_LICENSE_SUBJECT);
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.org).toBeUndefined();
+    expect(status.type).toBeUndefined();
+    expect(status.expiresAt).toBeUndefined();
+    expect(status.maxUsers).toBe(0);
+  });
+
+  it("refuses rather than falling back to community, so access never widens", async () => {
+    // The one that matters. INACTIVE derives the "community" state, and
+    // `effectiveVisibility` widens `restricted` to `all` there — so a refused
+    // key would publish agents somebody deliberately restricted. A license
+    // verdict must never widen access (pricing concept § 5).
+    const { validateLicense, DEV_LICENSE_SUBJECT } = await import("@/lib/license");
+    const { deriveLicenseState } = await import("@/lib/license-state");
+    const { effectiveVisibility } = await import("@/lib/agent-access");
+
+    const token = await createTokenFor(DEV_LICENSE_SUBJECT);
+    const status = await validateLicense(token, testPublicKeyPem);
+    const state = deriveLicenseState(status, new Date());
+
+    expect(state).toBe("expired");
+    expect(effectiveVisibility("restricted", state)).toBe("restricted");
+  });
+
+  it("is refused past its exp too", async () => {
     const { validateLicense, DEV_LICENSE_SUBJECT } = await import("@/lib/license");
     vi.useFakeTimers();
     try {
@@ -305,7 +333,6 @@ describe("the development subject", () => {
       vi.setSystemTime(Date.now() + 1500);
       const status = await validateLicense(token, testPublicKeyPem);
       expect(status.active).toBe(false);
-      expect(status.expired).toBeUndefined();
       expect(status.org).toBeUndefined();
     } finally {
       vi.useRealTimers();

--- a/packages/web/src/__tests__/lib/license.test.ts
+++ b/packages/web/src/__tests__/lib/license.test.ts
@@ -262,3 +262,69 @@ describe("validateLicense", () => {
     }
   });
 });
+
+// The revocation half of #1083. `testPrivateKey` stands in for the production
+// key here: the rule under test is "this key signed it, and the subject is the
+// development one" — which is precisely the shape of the token that shipped in
+// this repository's history and cannot be un-published.
+describe("the development subject", () => {
+  // `createTestToken` pins `sub` to "test-org" via .setSubject(), which wins
+  // over a `sub` in the payload — so this suite signs its own.
+  async function createTokenFor(subject: string, expiresIn = "365d") {
+    return new jose.SignJWT({ type: "paid", features: ["enterprise"] })
+      .setProtectedHeader({ alg: "ES256" })
+      .setIssuer("heypinchy.com")
+      .setSubject(subject)
+      .setIssuedAt()
+      .setExpirationTime(expiresIn)
+      .sign(testPrivateKey);
+  }
+
+  it("pins the subject string that revokes the leaked token", async () => {
+    const { DEV_LICENSE_SUBJECT } = await import("@/lib/license");
+    // Not decoration: the token in this repository's history carries exactly
+    // this `sub`. Change the string and that token is honoured again.
+    expect(DEV_LICENSE_SUBJECT).toBe("pinchy-dev");
+  });
+
+  it("is never honoured by default", async () => {
+    const { validateLicense, DEV_LICENSE_SUBJECT } = await import("@/lib/license");
+    const token = await createTokenFor(DEV_LICENSE_SUBJECT);
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.active).toBe(false);
+    expect(status.expired).toBeUndefined();
+  });
+
+  it("is not reported as expired either, once past exp", async () => {
+    // Otherwise a production install would surface "your license expired" for
+    // the dev subject — an honest-looking hint that the token is recognised.
+    const { validateLicense, DEV_LICENSE_SUBJECT } = await import("@/lib/license");
+    vi.useFakeTimers();
+    try {
+      const token = await createTokenFor(DEV_LICENSE_SUBJECT, "1s");
+      vi.setSystemTime(Date.now() + 1500);
+      const status = await validateLicense(token, testPublicKeyPem);
+      expect(status.active).toBe(false);
+      expect(status.expired).toBeUndefined();
+      expect(status.org).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("is honoured when the caller opts in (the development key ring)", async () => {
+    const { validateLicense, DEV_LICENSE_SUBJECT } = await import("@/lib/license");
+    const token = await createTokenFor(DEV_LICENSE_SUBJECT);
+    const status = await validateLicense(token, testPublicKeyPem, { honourDevSubject: true });
+    expect(status.active).toBe(true);
+    expect(status.org).toBe(DEV_LICENSE_SUBJECT);
+  });
+
+  it("does not affect any other subject", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTokenFor("acme-gmbh");
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.active).toBe(true);
+    expect(status.org).toBe("acme-gmbh");
+  });
+});

--- a/packages/web/src/__tests__/security/committed-license-tokens.test.ts
+++ b/packages/web/src/__tests__/security/committed-license-tokens.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+//
+// packages/web/src/__tests__/security/committed-license-tokens.test.ts
+//
+// Guard for the license material this repository ships.
+//
+// Until v0.9 the dev stack was unlocked by a license signed with the
+// PRODUCTION key (exp 2088), committed in two places. It was NODE_ENV-gated
+// only at the route that installs it — the string itself was a working
+// enterprise key, and pasting it into Settings → License unlocked paid
+// features on any install (#1083). Nothing was red: the token was valid, so
+// every test that used it passed, which is exactly the point.
+//
+// The fix is structural (a development keypair no production build trusts,
+// plus a validator that never honours the dev subject under the production
+// key). This guard is the tripwire that keeps it structural: the moment a
+// production-signed token lands anywhere in the tracked tree again, CI fails
+// here, naming the file.
+//
+// It asks jose directly rather than going through `validateLicense`, so it
+// still fires on a token the validator's own policy would reject. The question
+// is "did our production key sign this?", not "would we grant it today".
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import * as jose from "jose";
+import { DEV_LICENSE_TOKEN, PRODUCTION_PUBLIC_KEY } from "@/lib/license-keys";
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+
+/** Three base64url segments — the shape of a compact JWS. */
+const JWT_RE = "eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+";
+
+function git(args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+function trackedFileCount(): number {
+  return git(["ls-files"]).split("\n").filter(Boolean).length;
+}
+
+/**
+ * Every JWT-shaped string in the tracked tree, with the file it came from.
+ * `-I` skips binaries; `git grep` exits 1 on "no matches", which is a legal
+ * (if, here, impossible) answer rather than a failure.
+ */
+function jwtCandidates(): Array<{ file: string; token: string }> {
+  let out: string;
+  try {
+    out = git(["grep", "-I", "--no-color", "-o", "-E", JWT_RE, "--", "."]);
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    if (status === 1) return [];
+    throw err;
+  }
+  return out
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const sep = line.indexOf(":");
+      return { file: line.slice(0, sep), token: line.slice(sep + 1) };
+    });
+}
+
+/**
+ * Did the production key sign this? jose verifies the signature BEFORE it
+ * validates claims, so a claim-level rejection (expired, wrong issuer) still
+ * proves authenticity — which is the property that matters for a token sitting
+ * in a public repository.
+ */
+async function signedByProductionKey(token: string): Promise<boolean> {
+  const key = await jose.importSPKI(PRODUCTION_PUBLIC_KEY, "ES256");
+  try {
+    await jose.jwtVerify(token, key);
+    return true;
+  } catch (err) {
+    return (
+      err instanceof jose.errors.JWTExpired || err instanceof jose.errors.JWTClaimValidationFailed
+    );
+  }
+}
+
+describe("no production-signed license is committed", () => {
+  it("scans a real corpus", () => {
+    // A walker that finds nothing passes in silence; assert it found the repo.
+    expect(trackedFileCount()).toBeGreaterThan(500);
+  });
+
+  it("finds no token the production key signed", async () => {
+    const offenders: string[] = [];
+    for (const { file, token } of jwtCandidates()) {
+      if (await signedByProductionKey(token)) offenders.push(file);
+    }
+    expect(
+      offenders,
+      "A license signed by the PRODUCTION key is committed. Anyone who can read " +
+        "this repository can paste it into Settings → License and unlock paid " +
+        "features on their own install — and it cannot be un-published. Sign " +
+        "development licenses with the DEVELOPMENT key instead (see #1083 and " +
+        "src/lib/license-keys.ts)."
+    ).toEqual([]);
+  });
+});
+
+describe("the development license", () => {
+  it("is signed by the development key and not the production one", async () => {
+    expect(await signedByProductionKey(DEV_LICENSE_TOKEN)).toBe(false);
+  });
+
+  it("is the same string docker-compose.dev.yml defaults to", () => {
+    // Compose cannot import a TS constant, so the copy there is pinned here.
+    // Drift is silent otherwise: the dev stack keeps booting, just without
+    // enterprise features, and nothing says why.
+    const compose = readFileSync(join(REPO_ROOT, "docker-compose.dev.yml"), "utf-8");
+    const match = compose.match(/PINCHY_ENTERPRISE_KEY=\$\{PINCHY_ENTERPRISE_KEY-([^}]+)\}/);
+    expect(match, "docker-compose.dev.yml no longer defaults PINCHY_ENTERPRISE_KEY").not.toBeNull();
+    expect(match![1]).toBe(DEV_LICENSE_TOKEN);
+  });
+});

--- a/packages/web/src/__tests__/security/committed-license-tokens.test.ts
+++ b/packages/web/src/__tests__/security/committed-license-tokens.test.ts
@@ -5,11 +5,12 @@
 // Guard for the license material this repository ships.
 //
 // Until v0.9 the dev stack was unlocked by a license signed with the
-// PRODUCTION key (exp 2088), committed in two places. It was NODE_ENV-gated
-// only at the route that installs it — the string itself was a working
-// enterprise key, and pasting it into Settings → License unlocked paid
-// features on any install (#1083). Nothing was red: the token was valid, so
-// every test that used it passed, which is exactly the point.
+// PRODUCTION key (valid to 2036-03-11 — the issue said 2088, which is the
+// epoch value 2088845234), committed in two places. It was NODE_ENV-gated only
+// at the route that installs it — the string itself was a working enterprise
+// key, and pasting it into Settings → License unlocked paid features on any
+// install (#1083). Nothing was red: the token was valid, so every test that
+// used it passed, which is exactly the point.
 //
 // The fix is structural (a development keypair no production build trusts,
 // plus a validator that never honours the dev subject under the production
@@ -20,6 +21,22 @@
 // It asks jose directly rather than going through `validateLicense`, so it
 // still fires on a token the validator's own policy would reject. The question
 // is "did our production key sign this?", not "would we grant it today".
+//
+// What it does NOT cover, stated so nobody reads the green check as more:
+//
+//   - **The tracked tree, never the history.** A token committed and removed
+//     again lives on in every clone, and no CI check can retract it — which is
+//     why the revocation is a validator rule rather than a scrub. History was
+//     audited once, on 2026-08-05, by extracting every JWT-shaped string from
+//     `git log --all -p` and verifying each against the production key:
+//     exactly ONE has ever existed, `sub=pinchy-dev`, i.e. the token above,
+//     and `DEV_LICENSE_SUBJECT` revokes it. The other two hits are test
+//     fixtures we never signed. Re-run that scan if the revocation rule is
+//     ever narrowed — it is the evidence that the rule is sufficient.
+//   - **One line at a time.** `git grep` matches per line (all matches on a
+//     line, verified — not just the first), so a token split across lines or
+//     assembled by concatenation is invisible to it. Writing one that way to
+//     dodge the guard is a deliberate act, and review owns that case.
 import { describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";

--- a/packages/web/src/app/api/dev/enterprise-toggle/route.ts
+++ b/packages/web/src/app/api/dev/enterprise-toggle/route.ts
@@ -1,10 +1,8 @@
 import { NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { clearLicenseCache, isEnterprise } from "@/lib/enterprise";
+import { DEV_LICENSE_TOKEN } from "@/lib/license-keys";
 import { setSetting, deleteSetting } from "@/lib/settings";
-
-const DEV_ENTERPRISE_KEY =
-  "eyJhbGciOiJFUzI1NiJ9.eyJ0eXBlIjoicGFpZCIsImZlYXR1cmVzIjpbImVudGVycHJpc2UiXSwiaXNzIjoiaGV5cGluY2h5LmNvbSIsInN1YiI6InBpbmNoeS1kZXYiLCJpYXQiOjE3NzM0ODUyMzQsImV4cCI6MjA4ODg0NTIzNH0.h6stBWDrHP2LnXBv18RDk9_y71_b8FvFU6IodCBJkldlLoW6uxX6P7Hr_SL8OM-jhaNqUu7BIMaTYvbqW28buA";
 
 // audit-exempt: dev-only endpoint, not available in production
 export async function POST() {
@@ -24,7 +22,7 @@ export async function POST() {
   if (wasEnabled) {
     await deleteSetting("enterprise_key");
   } else {
-    await setSetting("enterprise_key", DEV_ENTERPRISE_KEY, true);
+    await setSetting("enterprise_key", DEV_LICENSE_TOKEN, true);
   }
 
   clearLicenseCache();

--- a/packages/web/src/lib/enterprise.ts
+++ b/packages/web/src/lib/enterprise.ts
@@ -1,6 +1,7 @@
 import { getSetting } from "@/lib/settings";
 import { validateLicense, type LicenseStatus } from "@/lib/license";
 import { deriveLicenseState, type LicenseState } from "@/lib/license-state";
+import { DEVELOPMENT_PUBLIC_KEY, PRODUCTION_PUBLIC_KEY } from "@/lib/license-keys";
 
 export type { LicenseStatus, LicenseType } from "@/lib/license";
 export type { LicenseState } from "@/lib/license-state";
@@ -18,13 +19,6 @@ export interface LicenseInfo {
   seatsUsed: number;
   hasGatedConfig: boolean;
 }
-
-// Production public key (ES256 / P-256)
-// Generated with: npx tsx scripts/generate-license.ts --generate-keypair
-const PRODUCTION_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaPYaiLnn7Z+EUywhGX4vOitboyzJ
-ce3W+NnSsTlbVzMRnXALwqra86Orhk9Sl4UWKEuebwltk+3OIuVy33oTWA==
------END PUBLIC KEY-----`;
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -51,6 +45,41 @@ export function isKeyFromEnv(): boolean {
 }
 
 /**
+ * Whether a license signed by the DEVELOPMENT key is honoured.
+ *
+ * False in production, which is the whole point: the development license is
+ * committed to this repository, so anything that honours it is unlocked for
+ * everyone who can read the repository (#1083). A dev stack (`next dev`, the
+ * E2E web server) runs outside production and honours it.
+ *
+ * Read per call rather than captured at module load — NODE_ENV is stubbed per
+ * test, and a module-level constant would freeze whatever the first import saw.
+ */
+function developmentLicensesHonoured(): boolean {
+  return process.env.NODE_ENV !== "production";
+}
+
+/**
+ * Validate against the key ring rather than a single key: the production key
+ * always, the development key only where development licenses are honoured.
+ *
+ * Order matters. The production key is asked first and its verdict wins when
+ * it recognises the token at all (`active` or the authentic-but-`expired`
+ * case), so a real customer license can never be re-read under the dev key.
+ */
+async function validateAgainstKeyRing(
+  token: string,
+  productionKeyPem: string
+): Promise<LicenseStatus> {
+  const status = await validateLicense(token, productionKeyPem);
+  if (status.active || status.expired) return status;
+  if (!developmentLicensesHonoured()) return status;
+
+  const dev = await validateLicense(token, DEVELOPMENT_PUBLIC_KEY, { honourDevSubject: true });
+  return dev.active || dev.expired ? dev : status;
+}
+
+/**
  * Validate a candidate token without storing it or touching the cache.
  *
  * This is the entry point for "would this key work?", which is a different
@@ -64,12 +93,18 @@ export function isKeyFromEnv(): boolean {
  * copy of it. The route decides with this function what the app then reads
  * through that one; a change to how a token is verified must reach both or the
  * route would accept a key the app treats as community.
+ *
+ * That invariant is why the key ring lives HERE and not in `getLicenseStatus`
+ * (#1083). Put it one level down and the two diverge in the other direction:
+ * on a dev stack the route would reject the development license while the app
+ * honours it — the same class of bug, arriving as "your key is invalid" for a
+ * key that demonstrably works.
  */
 export async function validateLicenseToken(
   token: string,
   publicKeyPem: string = PRODUCTION_PUBLIC_KEY
 ): Promise<LicenseStatus> {
-  return validateLicense(token, publicKeyPem);
+  return validateAgainstKeyRing(token, publicKeyPem);
 }
 
 /**

--- a/packages/web/src/lib/license-keys.ts
+++ b/packages/web/src/lib/license-keys.ts
@@ -1,0 +1,64 @@
+/**
+ * The license material this build ships: the public keys a license may be
+ * verified against, and the development license itself.
+ *
+ * Kept in a module of its own, with no imports, so the guards in
+ * `__tests__/security/committed-license-tokens.test.ts` can read the
+ * production key without pulling in `@/lib/settings` (and with it the DB).
+ *
+ * See AGENTS.md § "Secret Handling" — none of this is secret. A public key is
+ * public by construction, and the development token below unlocks nothing that
+ * a production install honours (#1083).
+ */
+
+/**
+ * Production public key (ES256 / P-256).
+ * Generated with: npx tsx scripts/generate-license.ts --generate-keypair
+ *
+ * The matching private key is held by us and appears nowhere in this
+ * repository. Every customer license verifies against this key.
+ */
+export const PRODUCTION_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaPYaiLnn7Z+EUywhGX4vOitboyzJ
+ce3W+NnSsTlbVzMRnXALwqra86Orhk9Sl4UWKEuebwltk+3OIuVy33oTWA==
+-----END PUBLIC KEY-----`;
+
+/**
+ * Development public key (ES256 / P-256).
+ *
+ * Trusted ONLY outside production — see `developmentLicensesHonoured` in
+ * `@/lib/enterprise`. This is the structural half of the fix for #1083: the
+ * dev license a self-hoster can lift out of this repository is signed by a key
+ * their install does not trust, so pasting it into Settings → License does
+ * nothing.
+ *
+ * The matching private key is deliberately NOT committed. Nothing at runtime
+ * needs it, and a private key in the tree is the shape of the bug this replaces.
+ * To mint a new development license (the current one runs to 2126, so this
+ * should stay theoretical):
+ *
+ *   npx tsx scripts/generate-license.ts --generate-keypair > /tmp/dev-license.pem
+ *   PINCHY_LICENSE_PRIVATE_KEY="$(cat /tmp/dev-license.pem)" \
+ *     npx tsx scripts/generate-license.ts --org pinchy-dev --type paid --days 36500
+ *
+ * Then replace this key, replace `DEV_LICENSE_TOKEN` below, and replace the
+ * `PINCHY_ENTERPRISE_KEY` default in `docker-compose.dev.yml` — the drift guard
+ * in `__tests__/security/committed-license-tokens.test.ts` fails if the last
+ * one is forgotten.
+ */
+export const DEVELOPMENT_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEP8GjpWN6BapAFGpJWt4aYZcHrSxE
+ZBn4RRZ7nTILUQ33aQER5Atgmpj3p6NfI78KwcAw+CkrgcZ/1skRdvmhhQ==
+-----END PUBLIC KEY-----`;
+
+/**
+ * The development license, signed by the development key above and issued to
+ * `DEV_LICENSE_SUBJECT`. Unlocks enterprise features on a developer's own
+ * stack and nowhere else.
+ *
+ * `docker-compose.dev.yml` ships the same string as the `PINCHY_ENTERPRISE_KEY`
+ * default; Compose cannot import, so that copy is pinned by a drift guard
+ * rather than by the type system.
+ */
+export const DEV_LICENSE_TOKEN =
+  "eyJhbGciOiJFUzI1NiJ9.eyJ0eXBlIjoicGFpZCIsImZlYXR1cmVzIjpbImVudGVycHJpc2UiXSwiaXNzIjoiaGV5cGluY2h5LmNvbSIsInN1YiI6InBpbmNoeS1kZXYiLCJpYXQiOjE3NzM0ODUyMzQsImV4cCI6NDkyNzA4NTIzNH0.x6YibNzmaMdiWJb4GjksKqfvJ1y-Tu0cv-iSZWdPW5fPQIzzJyed4b8oMlBbdQN_CkRFOisjYe9Q75PC6OEZxA";

--- a/packages/web/src/lib/license.ts
+++ b/packages/web/src/lib/license.ts
@@ -26,6 +26,23 @@ export interface LicenseStatus {
 
 const INACTIVE: LicenseStatus = { active: false, features: [], ver: 1, maxUsers: 0 };
 
+/**
+ * Authentic signature, refused by policy.
+ *
+ * Distinct from INACTIVE because the difference is load-bearing downstream:
+ * `deriveLicenseState` reads `expired` and answers "expired" rather than
+ * "community", and `effectiveVisibility` widens `restricted` to `all` in the
+ * community state alone. An install that refuses its key must not thereby
+ * publish agents somebody deliberately restricted — a license verdict never
+ * widens access (pricing concept § 5).
+ *
+ * Carries no claims on purpose: the key did not expire, so nothing may print a
+ * date for it. The banner's expired copy degrades to "Your license period
+ * ended. Existing access restrictions remain enforced; management features are
+ * locked." — which is exactly what happened.
+ */
+const REFUSED: LicenseStatus = { active: false, expired: true, features: [], ver: 1, maxUsers: 0 };
+
 const ISSUER = "heypinchy.com";
 
 /**
@@ -85,17 +102,15 @@ function readClaims(payload: jose.JWTPayload): Omit<LicenseStatus, "active" | "e
 }
 
 /**
- * Whether this key may grant anything for these claims at all — checked on the
- * valid and the expired path alike, so an expired dev license cannot leak its
- * subject into the UI as "expired" under the production key either.
+ * Whether this key refuses these claims outright — checked on the valid and
+ * the expired path alike, so a dev license past its exp is refused under the
+ * production key too rather than surfacing its claims.
  */
-function grantable(
+function refused(
   claims: Omit<LicenseStatus, "active" | "expired">,
   options: ValidateLicenseOptions
 ): boolean {
-  if (!claims.features.includes("enterprise")) return false;
-  if (claims.org === DEV_LICENSE_SUBJECT && !options.honourDevSubject) return false;
-  return true;
+  return claims.org === DEV_LICENSE_SUBJECT && !options.honourDevSubject;
 }
 
 /**
@@ -116,7 +131,8 @@ export async function validateLicense(
     });
 
     const claims = readClaims(payload);
-    if (!grantable(claims, options)) return INACTIVE;
+    if (!claims.features.includes("enterprise")) return INACTIVE;
+    if (refused(claims, options)) return REFUSED;
 
     return { active: true, ...claims };
   } catch (err) {
@@ -128,7 +144,8 @@ export async function validateLicense(
       const payload = jose.decodeJwt(token);
       if (payload.iss !== ISSUER) return INACTIVE;
       const claims = readClaims(payload);
-      if (!grantable(claims, options)) return INACTIVE;
+      if (!claims.features.includes("enterprise")) return INACTIVE;
+      if (refused(claims, options)) return REFUSED;
       return { active: false, expired: true, ...claims };
     }
     return INACTIVE;

--- a/packages/web/src/lib/license.ts
+++ b/packages/web/src/lib/license.ts
@@ -28,6 +28,31 @@ const INACTIVE: LicenseStatus = { active: false, features: [], ver: 1, maxUsers:
 
 const ISSUER = "heypinchy.com";
 
+/**
+ * Subject reserved for the development license this repository ships (in
+ * `docker-compose.dev.yml` and the dev toolbar's toggle route).
+ *
+ * Two rules hang off it, and together they are the fix for #1083:
+ *
+ *   - the development key signs licenses for this subject and no other;
+ *   - the PRODUCTION key never honours it.
+ *
+ * The second rule is what revokes the production-signed dev token this
+ * repository shipped until v0.9. That token cannot be un-published — it is in
+ * the history of every clone and every fork, and it verified against the key
+ * every install trusts — so revoking it has to happen here, in the validator.
+ * Changing this string un-revokes it; a test pins the value for that reason.
+ */
+export const DEV_LICENSE_SUBJECT = "pinchy-dev";
+
+export interface ValidateLicenseOptions {
+  /**
+   * Honour a license issued to `DEV_LICENSE_SUBJECT`. Only the development key
+   * passes this — under the production key such a license is always inactive.
+   */
+  honourDevSubject?: boolean;
+}
+
 function readClaims(payload: jose.JWTPayload): Omit<LicenseStatus, "active" | "expired"> {
   const features = (payload.features as string[]) ?? [];
   const ver = typeof payload.ver === "number" ? payload.ver : 1;
@@ -60,10 +85,28 @@ function readClaims(payload: jose.JWTPayload): Omit<LicenseStatus, "active" | "e
 }
 
 /**
+ * Whether this key may grant anything for these claims at all — checked on the
+ * valid and the expired path alike, so an expired dev license cannot leak its
+ * subject into the UI as "expired" under the production key either.
+ */
+function grantable(
+  claims: Omit<LicenseStatus, "active" | "expired">,
+  options: ValidateLicenseOptions
+): boolean {
+  if (!claims.features.includes("enterprise")) return false;
+  if (claims.org === DEV_LICENSE_SUBJECT && !options.honourDevSubject) return false;
+  return true;
+}
+
+/**
  * Validate a JWT license token against a public key.
  * Pure function — no side effects, no caching.
  */
-export async function validateLicense(token: string, publicKeyPem: string): Promise<LicenseStatus> {
+export async function validateLicense(
+  token: string,
+  publicKeyPem: string,
+  options: ValidateLicenseOptions = {}
+): Promise<LicenseStatus> {
   if (!token) return INACTIVE;
 
   try {
@@ -73,7 +116,7 @@ export async function validateLicense(token: string, publicKeyPem: string): Prom
     });
 
     const claims = readClaims(payload);
-    if (!claims.features.includes("enterprise")) return INACTIVE;
+    if (!grantable(claims, options)) return INACTIVE;
 
     return { active: true, ...claims };
   } catch (err) {
@@ -85,7 +128,7 @@ export async function validateLicense(token: string, publicKeyPem: string): Prom
       const payload = jose.decodeJwt(token);
       if (payload.iss !== ISSUER) return INACTIVE;
       const claims = readClaims(payload);
-      if (!claims.features.includes("enterprise")) return INACTIVE;
+      if (!grantable(claims, options)) return INACTIVE;
       return { active: false, expired: true, ...claims };
     }
     return INACTIVE;

--- a/packages/web/src/lib/license.ts
+++ b/packages/web/src/lib/license.ts
@@ -49,10 +49,16 @@ const ISSUER = "heypinchy.com";
  * Subject reserved for the development license this repository ships (in
  * `docker-compose.dev.yml` and the dev toolbar's toggle route).
  *
- * Two rules hang off it, and together they are the fix for #1083:
+ * Two rules hang off it, and together they are the fix for #1083. Only the
+ * second is enforced here — say which is which, because a comment that claims
+ * coverage the code lacks is how the unbounded Gmail fetch survived a review
+ * (AGENTS.md § "Every plugin `fetch()` passes a signal"):
  *
- *   - the development key signs licenses for this subject and no other;
- *   - the PRODUCTION key never honours it.
+ *   - CONVENTION: we mint development licenses for this subject and no other.
+ *     Nothing checks it, and nothing needs to — the development private key is
+ *     not published, so no one else can mint under that key at all.
+ *   - ENFORCED: the PRODUCTION key never honours this subject, on the valid and
+ *     the expired path alike.
  *
  * The second rule is what revokes the production-signed dev token this
  * repository shipped until v0.9. That token cannot be un-published — it is in


### PR DESCRIPTION
Closes #1083.

## The finding

`packages/web/src/app/api/dev/enterprise-toggle/route.ts` and `docker-compose.dev.yml` shipped the **same license token signed with the production key**, valid until **2036-03-11** (the issue said exp 2088 — that is the epoch value `2088845234`, which is 2036). Only the route that installs it was `NODE_ENV`-gated; the string itself was a working enterprise key, so `PUT /api/enterprise/key` accepted it on any install.

Nothing was ever red about it. A valid key makes every test pass — that is exactly why it survived.

## What this does

**1. A development keypair.** The dev license is now signed by a key that `developmentLicensesHonoured()` consults only outside production. Committing it is safe for that reason. The private half is deliberately **not** committed: nothing at runtime needs it, and a private key in the tree is the shape of the bug being replaced. Regeneration is documented in `license-keys.ts`; the token runs to 2126.

**2. The revocation.** Rotating the production keypair would have invalidated **every customer license**, so instead the production key never honours `DEV_LICENSE_SUBJECT` (`"pinchy-dev"`) — on the valid and the expired path alike. That rule, not a rotation, is what kills a token that is in every clone and every fork and cannot be un-published. A test pins the string, because changing it un-revokes the token.

Verified by reproduction rather than by reading: through the real validator the old token reads `active=false`, and `active=true` with the rule forced off.

**3. A refused key fails closed** (second commit — found by the `review-docs` pass). Returning `INACTIVE` derived the *community* state, where `effectiveVisibility` maps `restricted` → `all`. An install running the leaked key would have **published every agent somebody had deliberately restricted** on upgrade. An authentic-but-refused signature now returns `expired: true` with no claims: management locks, restrictions stay enforced, and the banner degrades to its dateless copy instead of printing "Your license period ended on 11 March 2036".

**4. The tripwire.** `committed-license-tokens.test.ts` fails if any JWT in the tracked tree verifies against the production key, and names the file. It asks jose directly rather than going through `validateLicense`, so it fires even on a token our own policy would reject — the question is whether *we signed it*, not whether we would grant it. It also pins the `docker-compose.dev.yml` copy against `DEV_LICENSE_TOKEN`.

## Residual, stated rather than hidden

A self-hoster can still run their install outside production mode. That degrades the app visibly and is a code-level change in spirit — and under AGPL a determined operator can always patch the validator. The licence is a control, not a boundary. What changes here is that **pasting a string no longer works**, which was the whole of the exposure.

## Also

`AGENTS.md` § Commands claimed `PINCHY_ENTERPRISE_KEY=dev-enterprise` was how you get a dev enterprise key. It is not a valid token, so that command turned enterprise *off* — the dev stack has shipped a license by default all along.

## Verification

Canaried in both directions rather than reasoned about:

- re-introducing the old token into a tracked file → tree guard red, naming the file
- forcing `developmentLicensesHonoured()` to `true` → "unlocks nothing in production" red
- returning `INACTIVE` instead of `REFUSED` → `expected 'community' to be 'expired'`

Gates: `pnpm test` (776 files, 10953 tests), `pnpm test:scripts` (913), `typecheck`, `lint` (0 errors), `format:check`, `pnpm build`, docs build + `check:anchors` + `check:rendered`.