### PR TITLE
fix(pinchy-email): precheck IMAP message size before full RFC822 fetch

### DIFF
--- a/docs/src/content/docs/guides/connect-email-imap.mdx
+++ b/docs/src/content/docs/guides/connect-email-imap.mdx
@@ -132,8 +132,8 @@ When email permissions are granted, the agent gets access to these tools — the
 | Tool                   | Permission required | Description                                                                                                                                                                               |
 | ---------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `email_list`           | Read                | List emails from a folder (INBOX, SENT, DRAFTS, TRASH, SPAM; defaults to INBOX). Supports filtering by read status.                                                                       |
-| `email_read`           | Read                | Read the full content of a specific email by ID. Lists any attachments with their IDs. Looks up the message in INBOX (see the limitation above).                                          |
-| `email_get_attachment` | Read                | Download an email attachment into the agent's workspace. Looks up the message in INBOX (see the limitation above).                                                                        |
+| `email_read`           | Read                | Read the full content of a specific email by ID. Lists any attachments with their IDs. Opens the message's own folder automatically.                                                      |
+| `email_get_attachment` | Read                | Download an email attachment into the agent's workspace. Opens the message's own folder automatically.                                                                                    |
 | `email_search`         | Read                | Search emails using structured fields: `from`, `to`, `subject`, `text`, `unread`, `sinceDays`, `folder`, `limit` (e.g. `{ from: "user@example.com", subject: "invoice", sinceDays: 7 }`). |
 | `email_draft`          | Draft               | Create a draft email. Saved directly to the mailbox's Drafts folder over IMAP.                                                                                                            |
 | `email_send`           | Send                | Send an email immediately over SMTP. Can also send replies with `replyTo`.                                                                                                                |
@@ -161,6 +161,12 @@ The server didn't respond in time — usually a network issue or an incorrect ho
 **"Blocked: this host resolves to a private network address"**
 
 See [Mail servers on your own network](#mail-servers-on-your-own-network) below.
+
+**"Message … is too large to fetch"**
+
+IMAP has no way to hand over a single attachment on its own — the whole message comes down in one piece, attachments included — so an agent reading a message loads all of it into memory at once. To keep one oversized message from taking the agent down with it, we check the size the server reports before downloading and refuse anything over 50 MB. That's the message as it travels, which is roughly a third larger than the files inside it, so a mail carrying an attachment at the 25 MB cap still comes through.
+
+The message itself is fine, and `email_list` and `email_search` still show its sender, subject and date. Only its body and attachments are out of reach. Gmail and Microsoft 365 have no equivalent limit — they can fetch one attachment at a time.
 
 ---
 

--- a/docs/src/content/docs/guides/connect-email.mdx
+++ b/docs/src/content/docs/guides/connect-email.mdx
@@ -38,7 +38,7 @@ An agent with read access can also download an email's attachments into its own 
 
 A few operational details worth knowing:
 
-- **Size cap**: attachments over 25 MB are rejected — the same cap `odoo_attach_file` uses, so anything the agent downloads here is always small enough to hand off downstream.
+- **Size cap**: attachments over 25 MB are rejected — the same cap `odoo_attach_file` uses, so anything the agent downloads here is always small enough to hand off downstream. On an [IMAP mailbox](/guides/connect-email-imap/#troubleshooting) there's a second, coarser limit: the protocol only hands over whole messages, so one over 50 MB is refused before it's downloaded and neither its body nor its attachments can be read.
 - **Filename sanitization**: the sender picks the attachment's original filename, so Pinchy sanitizes it before saving — stripping path separators and unsafe characters — rather than trusting it outright. International characters are kept intact (an `Abschätzung.pdf` stays `Abschätzung.pdf`) and normalized to a consistent Unicode form, so the agent can read the file back reliably afterward.
 - **Collision handling**: if a file with that name already exists in the agent's workspace, Pinchy appends `-1`, `-2`, and so on rather than overwriting anything.
 - **Use the returned filename**: because sanitization or a collision suffix can change the name, always use the filename the tool actually returns — not the original attachment name — for any hand-off to another tool, such as `odoo_attach_file`.

--- a/packages/plugins/pinchy-email/__tests__/imap-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/imap-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   tlsModeForPort,
   encodeMessageId,
   decodeMessageId,
+  MAX_MESSAGE_BYTES,
   type ImapAdapterOptions,
 } from "../imap-adapter.js";
 
@@ -367,6 +368,107 @@ describe("ImapAdapter#getAttachment", () => {
 
     const adapter = new ImapAdapter(opts);
     await expect(adapter.getAttachment("999", "whatever")).rejects.toThrow("message 999 not found");
+  });
+});
+
+describe("ImapAdapter fetchParsed message-size precheck (#1093)", () => {
+  // IMAP has no cheap way to learn a SINGLE attachment's size before
+  // download (see the note above ImapAdapter#getAttachment), but it CAN
+  // learn the whole message's declared byte count via RFC822.SIZE before
+  // paying for the full `{ source: true }` fetch that materializes every
+  // attachment's bytes. Both read() and getAttachment() share fetchParsed(),
+  // so a message-level precheck protects both call sites.
+  function mockSizedMessage(size: number) {
+    mockClient.fetchOne
+      .mockReset()
+      .mockImplementation(async (_uid: number, query: Record<string, unknown>) => {
+        if (query.size) {
+          return { uid: 42, size, flags: new Set(["\\Seen"]) };
+        }
+        return {
+          source: Buffer.from(buildMultipartFixture()),
+          flags: new Set(["\\Seen"]),
+        };
+      });
+  }
+
+  it("rejects an oversized message by RFC822.SIZE via read(), without ever fetching the source", async () => {
+    mockSizedMessage(50 * 1024 * 1024);
+
+    const adapter = new ImapAdapter(opts);
+    await expect(adapter.read("42")).rejects.toThrow(/too large.*50\.0 MB.*max allowed is 25 MB/is);
+
+    expect(mockClient.fetchOne).toHaveBeenCalledWith(
+      42,
+      { size: true, flags: true },
+      { uid: true }
+    );
+    // The whole point: never download the full message body once its
+    // declared size already exceeds the cap.
+    expect(mockClient.fetchOne).not.toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ source: true }),
+      { uid: true }
+    );
+  });
+
+  it("rejects an oversized message by RFC822.SIZE via getAttachment(), without ever fetching the source", async () => {
+    mockSizedMessage(50 * 1024 * 1024);
+
+    const adapter = new ImapAdapter(opts);
+    await expect(adapter.getAttachment("42", "whatever")).rejects.toThrow(
+      /too large.*50\.0 MB.*max allowed is 25 MB/is
+    );
+    expect(mockClient.fetchOne).not.toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ source: true }),
+      { uid: true }
+    );
+  });
+
+  // The pair below is the actual boundary. "a size under the cap is allowed"
+  // says nothing about where the cut sits — a `>=` typo would pass it — so
+  // these pin the exact threshold from both sides, mirroring the Graph/Gmail
+  // boundary tests in PR #1094.
+  it("allows a message whose RFC822.SIZE is EXACTLY MAX_MESSAGE_BYTES", async () => {
+    mockSizedMessage(MAX_MESSAGE_BYTES);
+
+    const adapter = new ImapAdapter(opts);
+    const result = await adapter.read("42");
+    expect(result.subject).toBe("Quarterly report attached");
+  });
+
+  it("rejects a message ONE byte over MAX_MESSAGE_BYTES", async () => {
+    mockSizedMessage(MAX_MESSAGE_BYTES + 1);
+
+    const adapter = new ImapAdapter(opts);
+    await expect(adapter.read("42")).rejects.toThrow(/too large/i);
+  });
+
+  it("falls through to the full fetch when RFC822.SIZE is absent — a missing signal must not block a legal message", async () => {
+    mockClient.fetchOne
+      .mockReset()
+      .mockImplementation(async (_uid: number, query: Record<string, unknown>) => {
+        if (query.size) {
+          // No `size` field at all on the size-check response.
+          return { uid: 42, flags: new Set(["\\Seen"]) };
+        }
+        return {
+          source: Buffer.from(buildMultipartFixture()),
+          flags: new Set(["\\Seen"]),
+        };
+      });
+
+    const adapter = new ImapAdapter(opts);
+    const result = await adapter.read("42");
+    expect(result.subject).toBe("Quarterly report attached");
+  });
+
+  it("falls through to the existing not-found error when the size-check fetchOne itself returns false", async () => {
+    mockClient.fetchOne.mockReset().mockResolvedValue(false);
+
+    const adapter = new ImapAdapter(opts);
+    await expect(adapter.read("999")).rejects.toThrow("message 999 not found");
   });
 });
 

--- a/packages/plugins/pinchy-email/__tests__/imap-adapter.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/imap-adapter.test.ts
@@ -9,6 +9,7 @@ import {
   MAX_MESSAGE_BYTES,
   type ImapAdapterOptions,
 } from "../imap-adapter.js";
+import { MAX_ATTACHMENT_BYTES } from "../email-adapter.js";
 
 // Shared mock SMTP transport for send() tests. Created inside vi.hoisted() so
 // it's visible to the vi.mock("nodemailer", ...) factory below, which vitest
@@ -378,12 +379,12 @@ describe("ImapAdapter fetchParsed message-size precheck (#1093)", () => {
   // paying for the full `{ source: true }` fetch that materializes every
   // attachment's bytes. Both read() and getAttachment() share fetchParsed(),
   // so a message-level precheck protects both call sites.
-  function mockSizedMessage(size: number) {
+  function mockSizedMessage(size: number, uid = 42) {
     mockClient.fetchOne
       .mockReset()
       .mockImplementation(async (_uid: number, query: Record<string, unknown>) => {
         if (query.size) {
-          return { uid: 42, size, flags: new Set(["\\Seen"]) };
+          return { uid, size, flags: new Set(["\\Seen"]) };
         }
         return {
           source: Buffer.from(buildMultipartFixture()),
@@ -392,17 +393,26 @@ describe("ImapAdapter fetchParsed message-size precheck (#1093)", () => {
       });
   }
 
+  // The cap is derived from MAX_ATTACHMENT_BYTES rather than restating 25 MB,
+  // and the factor is the load-bearing part: RFC822.SIZE counts bytes on the
+  // wire, MAX_ATTACHMENT_BYTES counts decoded ones, and base64 costs 4/3 plus
+  // CRLF folding (~1.37×). A message cap set to the attachment cap would
+  // refuse a 20 MB PDF that the Gmail and Graph paths both deliver.
+  it("leaves wire-format room for an attachment at the full decoded cap", () => {
+    expect(MAX_MESSAGE_BYTES).toBeGreaterThan(MAX_ATTACHMENT_BYTES * 1.37);
+  });
+
   it("rejects an oversized message by RFC822.SIZE via read(), without ever fetching the source", async () => {
-    mockSizedMessage(50 * 1024 * 1024);
+    mockSizedMessage(MAX_MESSAGE_BYTES * 2);
 
     const adapter = new ImapAdapter(opts);
-    await expect(adapter.read("42")).rejects.toThrow(/too large.*50\.0 MB.*max allowed is 25 MB/is);
-
-    expect(mockClient.fetchOne).toHaveBeenCalledWith(
-      42,
-      { size: true, flags: true },
-      { uid: true }
+    // Names the message, its size and the limit — and what still works, since
+    // there is nothing the caller can retry.
+    await expect(adapter.read("42")).rejects.toThrow(
+      /message 42 is too large.*100\.0 MB.*limit is 50\.0 MB.*email_search/is
     );
+
+    expect(mockClient.fetchOne).toHaveBeenCalledWith(42, { size: true }, { uid: true });
     // The whole point: never download the full message body once its
     // declared size already exceeds the cap.
     expect(mockClient.fetchOne).not.toHaveBeenCalledWith(
@@ -413,17 +423,28 @@ describe("ImapAdapter fetchParsed message-size precheck (#1093)", () => {
   });
 
   it("rejects an oversized message by RFC822.SIZE via getAttachment(), without ever fetching the source", async () => {
-    mockSizedMessage(50 * 1024 * 1024);
+    mockSizedMessage(MAX_MESSAGE_BYTES * 2);
 
     const adapter = new ImapAdapter(opts);
-    await expect(adapter.getAttachment("42", "whatever")).rejects.toThrow(
-      /too large.*50\.0 MB.*max allowed is 25 MB/is
-    );
+    await expect(adapter.getAttachment("42", "whatever")).rejects.toThrow(/too large/i);
     expect(mockClient.fetchOne).not.toHaveBeenCalledWith(
       42,
       expect.objectContaining({ source: true }),
       { uid: true }
     );
+  });
+
+  // The precheck runs after mailboxOpen and must address the SAME uid the
+  // source fetch would: a folder-encoded id carries a non-INBOX mailbox, and
+  // pricing the wrong mailbox's uid 42 would gate on an unrelated message.
+  it("prices the decoded uid in the message's own mailbox for a folder-encoded id", async () => {
+    mockSizedMessage(MAX_MESSAGE_BYTES * 2, 7);
+
+    const adapter = new ImapAdapter(opts);
+    await expect(adapter.read(encodeMessageId("Sent Items", 7))).rejects.toThrow(/too large/i);
+
+    expect(mockClient.mailboxOpen).toHaveBeenCalledWith("Sent Items");
+    expect(mockClient.fetchOne).toHaveBeenCalledWith(7, { size: true }, { uid: true });
   });
 
   // The pair below is the actual boundary. "a size under the cap is allowed"

--- a/packages/plugins/pinchy-email/email-adapter.ts
+++ b/packages/plugins/pinchy-email/email-adapter.ts
@@ -91,6 +91,19 @@ export function truncateEmailBody(body: string, max: number = EMAIL_BODY_MAX_CHA
   );
 }
 
+/**
+ * The largest attachment `email_get_attachment` will write to a workspace, in
+ * DECODED bytes — 25 MB matches `odoo_attach_file`'s own cap (see
+ * packages/plugins/pinchy-odoo/index.ts), so anything saved here is always
+ * small enough to hand off downstream.
+ *
+ * It lives here rather than in index.ts because an adapter needs it too:
+ * imap-adapter.ts derives its wire-level `MAX_MESSAGE_BYTES` from it, and
+ * index.ts importing from an adapter — or either file keeping its own 25 MB
+ * literal — is how the two numbers drift apart.
+ */
+export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
 // Shared by every adapter: the canonical-name validation and error message are
 // identical across providers, only the provider-specific value for each
 // folder differs (Gmail label IDs vs Graph well-known folder names). Sharing

--- a/packages/plugins/pinchy-email/imap-adapter.ts
+++ b/packages/plugins/pinchy-email/imap-adapter.ts
@@ -141,6 +141,31 @@ export function resolveFolders(mailboxes: ImapMailbox[]): Partial<Record<Folder,
 const DEFAULT_LIMIT = 20;
 const MS_PER_DAY = 86_400_000;
 
+// 25 MB — matches the MAX_ATTACHMENT_BYTES cap in index.ts (itself matching
+// odoo_attach_file's own limit downstream). Unlike Graph (Content-Length on
+// the attachment response) and Gmail (the part-listing `size` field), IMAP
+// has no cheap way to learn a SINGLE attachment's size before download —
+// see the note above ImapAdapter#getAttachment. It CAN learn the whole
+// message's declared byte count via RFC822.SIZE (client.fetchOne(uid,
+// { size: true })) before paying for the full `{ source: true }` fetch that
+// downloads and parses every attachment's bytes into memory (#1093).
+//
+// This is a coarser, conservative gate than the sibling adapters': it
+// rejects a message whose TOTAL declared size already exceeds the cap, even
+// when the specific attachment being requested would itself fit (e.g. a
+// 30 MB message with a 1 KB attachment among several larger ones). Fixing
+// that would mean matching a BODYSTRUCTURE part to the attachment identity
+// mailparser assigns from `parsed.attachments` — real work with a real risk
+// of mismatching, tracked as a possible follow-up in #1093's own analysis
+// rather than attempted here. This precheck closes the OOM for BOTH read()
+// and getAttachment(), since they share fetchParsed().
+//
+// Best-effort like the sibling adapters' prechecks: a missing/false
+// RFC822.SIZE just falls through to the real fetch — index.ts's own
+// post-download length check on getAttachment's returned buffer remains the
+// authoritative guard for that path.
+export const MAX_MESSAGE_BYTES = 25 * 1024 * 1024;
+
 // Maps the structured SearchOptions DSL to an imapflow SearchObject. Pure and
 // deterministic: `now` is supplied by the caller (never read internally via
 // Date.now()/new Date()) so `sinceDays` resolves to an exact, testable date.
@@ -409,6 +434,24 @@ export class ImapAdapter implements EmailAdapter {
   ): Promise<{ parsed: ParsedMail; unread: boolean }> {
     const decoded = decodeMessageId(id);
     await client.mailboxOpen(decoded.mailboxPath);
+
+    // Precheck RFC822.SIZE before paying for `{ source: true }` below, which
+    // downloads and fully parses the ENTIRE message — every attachment's
+    // bytes included — into memory. See MAX_MESSAGE_BYTES above for why this
+    // is message-level rather than per-attachment, and why it's best-effort.
+    const sizeCheck = await client.fetchOne(
+      decoded.uid,
+      { size: true, flags: true },
+      { uid: true }
+    );
+    if (sizeCheck && sizeCheck.size != null && sizeCheck.size > MAX_MESSAGE_BYTES) {
+      const declaredMb = (sizeCheck.size / 1024 / 1024).toFixed(1);
+      const maxMb = (MAX_MESSAGE_BYTES / 1024 / 1024).toFixed(0);
+      throw new Error(
+        `Message too large to download: ${declaredMb} MB, max allowed is ${maxMb} MB.`
+      );
+    }
+
     const msg = await client.fetchOne(decoded.uid, { source: true, flags: true }, { uid: true });
     if (!msg || !msg.source) {
       throw new Error(`message ${id} not found`);

--- a/packages/plugins/pinchy-email/imap-adapter.ts
+++ b/packages/plugins/pinchy-email/imap-adapter.ts
@@ -4,7 +4,7 @@ import { simpleParser } from "mailparser";
 import type { AddressObject, ParsedMail } from "mailparser";
 import nodemailer from "nodemailer";
 import MailComposer from "nodemailer/lib/mail-composer/index.js";
-import { stripHtml } from "./email-adapter.js";
+import { MAX_ATTACHMENT_BYTES, stripHtml } from "./email-adapter.js";
 import type {
   EmailAdapter,
   EmailAttachment,
@@ -141,30 +141,28 @@ export function resolveFolders(mailboxes: ImapMailbox[]): Partial<Record<Folder,
 const DEFAULT_LIMIT = 20;
 const MS_PER_DAY = 86_400_000;
 
-// 25 MB — matches the MAX_ATTACHMENT_BYTES cap in index.ts (itself matching
-// odoo_attach_file's own limit downstream). Unlike Graph (Content-Length on
-// the attachment response) and Gmail (the part-listing `size` field), IMAP
-// has no cheap way to learn a SINGLE attachment's size before download —
-// see the note above ImapAdapter#getAttachment. It CAN learn the whole
-// message's declared byte count via RFC822.SIZE (client.fetchOne(uid,
-// { size: true })) before paying for the full `{ source: true }` fetch that
-// downloads and parses every attachment's bytes into memory (#1093).
+// Bounds what fetchParsed() will pull over the wire. `{ source: true }`
+// downloads the ENTIRE RFC822 message — every attachment's bytes included —
+// and hands it to mailparser, so without a cap a single huge message can
+// exhaust the plugin's memory (#1093). Graph (Content-Length) and Gmail (the
+// part-listing `size` field) can price one attachment before downloading it;
+// IMAP can only price the whole message, via RFC822.SIZE. So this gate is
+// coarser: a message over the cap is refused even when the attachment
+// actually being requested is 1 KB. Matching a BODYSTRUCTURE node back to the
+// id mailparser assigns in `parsed.attachments` is the finer fix, tracked in
+// #1093 rather than attempted here. Both read() and getAttachment() go
+// through fetchParsed(), so one gate covers both.
 //
-// This is a coarser, conservative gate than the sibling adapters': it
-// rejects a message whose TOTAL declared size already exceeds the cap, even
-// when the specific attachment being requested would itself fit (e.g. a
-// 30 MB message with a 1 KB attachment among several larger ones). Fixing
-// that would mean matching a BODYSTRUCTURE part to the attachment identity
-// mailparser assigns from `parsed.attachments` — real work with a real risk
-// of mismatching, tracked as a possible follow-up in #1093's own analysis
-// rather than attempted here. This precheck closes the OOM for BOTH read()
-// and getAttachment(), since they share fetchParsed().
+// TWICE MAX_ATTACHMENT_BYTES, and the factor is the point: RFC822.SIZE counts
+// bytes on the wire while MAX_ATTACHMENT_BYTES counts DECODED ones. base64
+// inflates an attachment to ~1.37× (4/3 plus CRLF folding) and the message
+// carries headers and a body on top, so a cap equal to MAX_ATTACHMENT_BYTES
+// would refuse a 20 MB PDF that the Gmail and Graph paths both deliver.
 //
-// Best-effort like the sibling adapters' prechecks: a missing/false
-// RFC822.SIZE just falls through to the real fetch — index.ts's own
-// post-download length check on getAttachment's returned buffer remains the
-// authoritative guard for that path.
-export const MAX_MESSAGE_BYTES = 25 * 1024 * 1024;
+// Best-effort, like the sibling adapters' prechecks: a missing RFC822.SIZE
+// falls straight through to the real fetch, and index.ts's post-download
+// check on the returned buffer stays the authoritative per-attachment guard.
+export const MAX_MESSAGE_BYTES = MAX_ATTACHMENT_BYTES * 2;
 
 // Maps the structured SearchOptions DSL to an imapflow SearchObject. Pure and
 // deterministic: `now` is supplied by the caller (never read internally via
@@ -435,20 +433,24 @@ export class ImapAdapter implements EmailAdapter {
     const decoded = decodeMessageId(id);
     await client.mailboxOpen(decoded.mailboxPath);
 
-    // Precheck RFC822.SIZE before paying for `{ source: true }` below, which
+    // Price the message before paying for `{ source: true }` below, which
     // downloads and fully parses the ENTIRE message — every attachment's
-    // bytes included — into memory. See MAX_MESSAGE_BYTES above for why this
-    // is message-level rather than per-attachment, and why it's best-effort.
-    const sizeCheck = await client.fetchOne(
-      decoded.uid,
-      { size: true, flags: true },
-      { uid: true }
-    );
+    // bytes included — into memory. This costs one extra FETCH round-trip on
+    // every read: asking for RFC822.SIZE is the only way to learn a message's
+    // size without downloading it, and a combined fetch would already have
+    // paid for the body. See MAX_MESSAGE_BYTES above for why the gate is
+    // message-level rather than per-attachment, and why it's best-effort.
+    const sizeCheck = await client.fetchOne(decoded.uid, { size: true }, { uid: true });
     if (sizeCheck && sizeCheck.size != null && sizeCheck.size > MAX_MESSAGE_BYTES) {
       const declaredMb = (sizeCheck.size / 1024 / 1024).toFixed(1);
-      const maxMb = (MAX_MESSAGE_BYTES / 1024 / 1024).toFixed(0);
+      const maxMb = (MAX_MESSAGE_BYTES / 1024 / 1024).toFixed(1);
+      // There is nothing to retry here, so say what still works instead of
+      // leaving the model to guess: list/search read envelopes, not bodies,
+      // and are unaffected by the message's size.
       throw new Error(
-        `Message too large to download: ${declaredMb} MB, max allowed is ${maxMb} MB.`
+        `Message ${id} is too large to fetch: ${declaredMb} MB on the wire, and the limit ` +
+          `is ${maxMb} MB. Its sender, subject and date are still available through ` +
+          `email_list and email_search.`
       );
     }
 
@@ -586,6 +588,13 @@ export class ImapAdapter implements EmailAdapter {
     return { messageId };
   }
 
+  // No per-attachment size precheck is possible here, unlike Graph and Gmail:
+  // by the time fetchParsed() returns, mailparser has already decoded every
+  // part. Learning one part's size beforehand would mean walking BODYSTRUCTURE
+  // and matching a node back to the id mailparser assigns below — see #1093.
+  // The message-level gate in fetchParsed() (MAX_MESSAGE_BYTES) is what bounds
+  // this path; index.ts's post-download `data.length` check stays the
+  // authoritative per-attachment guard.
   async getAttachment(
     messageId: string,
     attachmentId: string

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile, access, chown } from "node:fs/promises";
 import { basename } from "node:path";
 import type { EmailAdapter, EmailSummary, Folder } from "./email-adapter.js";
-import { truncateEmailBody } from "./email-adapter.js";
+import { MAX_ATTACHMENT_BYTES, truncateEmailBody } from "./email-adapter.js";
 import { checkPermission, type Permissions } from "./permissions.js";
 import {
   putHandle,
@@ -34,9 +34,10 @@ const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
 const DELIVERY_UID = 999;
 const DELIVERY_GID = 999;
 
-// 25 MB matches odoo_attach_file's own cap (see packages/plugins/pinchy-odoo/index.ts),
-// so anything saved here is always small enough to hand off downstream.
-const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+// MAX_ATTACHMENT_BYTES is imported from email-adapter.ts, which owns it: the
+// 25 MB literal used to sit here AND in imap-adapter.ts, with a comment
+// claiming the two stayed in sync and nothing that would notice if they
+// stopped.
 
 // The two Pinchy-internal calls this plugin makes (credentials fetch,
 // auth-failure report) are bounded inside credential-client.ts. The mailbox


### PR DESCRIPTION
## Summary

- `ImapAdapter.getAttachment`/`.read` share `fetchParsed()`, which downloads the ENTIRE RFC822 message via `client.fetchOne(uid, { source: true, ... })` and hands it whole to `mailparser.simpleParser` — every attachment's bytes materialize in memory before any size check can fire. Graph and Gmail already precheck a declared attachment size before download; IMAP had no equivalent.
- Adds a `RFC822.SIZE` precheck (`client.fetchOne(uid, { size: true, flags: true }, { uid: true })`) ahead of the full `{ source: true }` fetch in `fetchParsed()`. A message whose declared size already exceeds `MAX_MESSAGE_BYTES` (25 MB, matching `index.ts`'s `MAX_ATTACHMENT_BYTES`) is rejected before it is downloaded — protecting both `read()` and `getAttachment()` since they share the fetch path.
- Best-effort like the sibling adapters' checks: a missing/false `RFC822.SIZE` falls straight through to the real fetch; `index.ts`'s post-download length check on `getAttachment`'s returned buffer stays the authoritative guard for that path.

## Approach chosen (SIZE vs BODYSTRUCTURE)

Went with the **RFC822.SIZE precheck**, per the issue's own proposed-follow-up analysis: it's a coarser, message-level gate — it rejects a message whose *total* declared size exceeds the cap even if the specific requested attachment would itself fit (e.g. a 30 MB message with a 1 KB attachment among larger ones). The finer BODYSTRUCTURE-per-part approach would require matching a BODYSTRUCTURE node to the attachment identity `mailparser` assigns from `parsed.attachments` (`a.contentId ?? a.cid ?? String(i)`), which is real work with real risk of mismatching (rejecting a legitimate small attachment, or worse, letting an oversized one through). That's left as a possible future follow-up rather than attempted here, matching the issue's own scoping.

This PR was branched directly off `origin/main` and does not depend on/stack on #1094 (fix/attachment-size-precheck), which was still open at the time this was written — so `MAX_ATTACHMENT_BYTES` was not yet available as a shared export from `email-adapter.ts`. The IMAP cap is defined independently as `MAX_MESSAGE_BYTES` in `imap-adapter.ts` (same 25 MB value).

## Tests added

`packages/plugins/pinchy-email/__tests__/imap-adapter.test.ts`, new `describe("ImapAdapter fetchParsed message-size precheck (#1093)")`:

- `rejects an oversized message by RFC822.SIZE via read(), without ever fetching the source`
- `rejects an oversized message by RFC822.SIZE via getAttachment(), without ever fetching the source`
- `allows a message whose RFC822.SIZE is EXACTLY MAX_MESSAGE_BYTES`
- `rejects a message ONE byte over MAX_MESSAGE_BYTES`
- `falls through to the full fetch when RFC822.SIZE is absent — a missing signal must not block a legal message`
- `falls through to the existing not-found error when the size-check fetchOne itself returns false`

Red → green: all 6 failed before the implementation (3 genuinely red — the boundary/oversized-rejection assertions; 3 were already green because they describe pre-existing fallback behavior), then passed once `fetchParsed()`'s precheck was added. Full `imap-adapter.test.ts` suite: 102/102 passing. Full `pinchy-email` plugin suite: 373/373 passing.

## Test plan

- [x] `pnpm typecheck:plugins` — all 9 plugin packages typecheck cleanly
- [x] `pnpm test:plugins` — all plugin suites pass (pinchy-email: 373/373)
- [x] `pnpm test:related` — 235/235 passing
- [x] `pnpm format:check` — clean
- [x] `pnpm test` (full suite, machine-wide lock) — 776 files / 11006 tests passed, 4 files / 18 tests skipped (pre-existing, unrelated)

Closes #1093