### PR TITLE
fix(plugins): unify drifted credential-client copies across odoo/email/web

### DIFF
--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -1406,6 +1406,49 @@ describe("email_send", () => {
     });
   });
 
+  it("does not re-send when the failure merely contains the digits 401 (pinchy#1077)", async () => {
+    // The pre-#1077 matcher tested `msg.includes("401")` over the whole
+    // error message, so any provider error carrying those digits — a quota
+    // figure, a size, a message id — was classified as an auth failure.
+    // withAuthRetry then invalidated the adapter and replayed the entire
+    // closure, and for email_send that closure IS the send: the recipient
+    // gets the mail twice.
+    //
+    // Asserted on the tool, not on isAuthError: the unit test proves the
+    // matcher rejects the string, this proves the send is not repeated.
+    mockSend.mockRejectedValue(new Error("Recipient mailbox is 401 MB over quota"));
+
+    const configWithSend: PluginConfig = {
+      ...testConfig,
+      agents: {
+        "agent-1": {
+          connectionId: "conn-1",
+          permissions: { email: ["read", "draft", "send"] },
+        },
+      },
+    };
+    const tools = createApi(configWithSend);
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Sent Subject",
+      body: "Sent body text",
+    });
+
+    // Read the count, THEN reset, THEN assert. `vi.clearAllMocks()` in
+    // beforeEach clears recorded calls but keeps a standing implementation
+    // (and any unconsumed `…Once`), so a rejection left behind here would
+    // surface as a failure in whichever later test calls send without its
+    // own setup. Resetting before the assertions means a red assertion
+    // cannot skip the cleanup and turn one failure into several.
+    const sendCalls = mockSend.mock.calls.length;
+    mockSend.mockReset();
+
+    expect(result.isError).toBe(true);
+    expect(sendCalls).toBe(1);
+  });
+
   it("reports a direct send honestly when the adapter returns messageId: null (Graph's 202-with-no-location case) instead of fabricating an empty id", async () => {
     mockSend.mockResolvedValue({ messageId: null });
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -3719,6 +3719,83 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
     expect(mockSearchRead).toHaveBeenCalledTimes(2);
   });
 
+  it("refetches after a connection hot-swap instead of serving the previous connection's client (pinchy#1077)", async () => {
+    mockSearchRead.mockResolvedValue({
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
+
+    // A hot swap re-points the SAME agent at a different integration
+    // connection; the agentId does not change. Keying the client cache on
+    // agentId alone therefore kept the OLD connection's OdooClient — and
+    // with it the old Odoo instance's credentials — serving tool calls for
+    // up to CREDENTIAL_CACHE_TTL_MS after the swap.
+    //
+    // This asserts the behaviour, not the helper: credentialCacheKey's own
+    // unit test can only prove that two strings differ, which stays true
+    // even if index.ts goes back to caching on `agentId`.
+    const agentConfigs: Record<string, AgentOdooConfig> = {
+      [agentId]: { ...agentConfig, connectionId: "conn-before-swap" },
+    };
+    const tools = createApi(agentConfigs);
+
+    await findTool(tools, "odoo_read", agentId)!.execute("call-1", {
+      model: "sale.order",
+      filters: [],
+    });
+
+    agentConfigs[agentId] = { ...agentConfig, connectionId: "conn-after-swap" };
+
+    await findTool(tools, "odoo_read", agentId)!.execute("call-2", {
+      model: "sale.order",
+      filters: [],
+    });
+
+    const credentialUrls = fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .filter((url) => url.includes("/credentials"));
+    expect(credentialUrls).toHaveLength(2);
+    expect(credentialUrls[0]).toContain("conn-before-swap");
+    expect(credentialUrls[1]).toContain("conn-after-swap");
+  });
+
+  it("does not replay a create when the failure merely contains the digits 401 (pinchy#1077)", async () => {
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+    // The pre-#1077 matcher tested `msg.includes("401")` over the whole
+    // error message, so an amount or record id that happened to contain
+    // those digits was classified as an auth failure. withAuthRetry then
+    // invalidated the client and replayed the ENTIRE closure — including
+    // `client.create`, which is not idempotent. The second create is a
+    // duplicate record nobody asked for.
+    //
+    // Asserted on the tool, not on isAuthError: the unit test proves the
+    // matcher rejects the string, this proves the write is not repeated.
+    mockCreate.mockRejectedValue(new Error("Invalid value 401.00 for field credit_limit"));
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      model: "res.partner",
+      values: { name: "New Partner" },
+    });
+
+    // Read the count, THEN reset, THEN assert. `vi.clearAllMocks()` in
+    // beforeEach clears recorded calls but keeps a standing implementation
+    // (and any unconsumed `…Once`), so a rejection left behind here would
+    // surface as a failure in whichever later test calls create without its
+    // own setup — odoo_attach_file creates ir.attachment rows through this
+    // same mock. Resetting before the assertions means a red assertion
+    // cannot skip the cleanup and turn one failure into several.
+    const createCalls = mockCreate.mock.calls.length;
+    mockCreate.mockReset();
+
+    expect(result.isError).toBe(true);
+    expect(createCalls).toBe(1);
+  });
+
   it("POSTs report-auth-failure when retry-once also returns an auth error", async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/packages/web/src/__tests__/lib/plugin-credential-client-drift.test.ts
+++ b/packages/web/src/__tests__/lib/plugin-credential-client-drift.test.ts
@@ -27,12 +27,24 @@
  * passes.
  */
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const PLUGINS_DIR = resolve(import.meta.dirname, "../../../../plugins");
 const REFERENCE_PLUGIN = "pinchy-odoo";
-const COPY_PLUGINS = ["pinchy-email", "pinchy-web"];
+
+// Discovered, not listed. A literal list is a gate that reports on what it
+// looks at rather than on what it should: the fourth plugin to copy
+// credential-client.ts would drift unwatched while this file stayed green —
+// the failure shape AGENTS.md names in § "A Hand-Maintained List That Mirrors
+// Code Will Be Wrong". The floor below is what keeps a broken walk from
+// passing on an empty corpus.
+const PLUGINS_WITH_A_COPY = readdirSync(PLUGINS_DIR)
+  .filter((entry) => entry.startsWith("pinchy-"))
+  .filter((plugin) => existsSync(resolve(PLUGINS_DIR, plugin, "credential-client.ts")))
+  .sort();
+
+const COPY_PLUGINS = PLUGINS_WITH_A_COPY.filter((plugin) => plugin !== REFERENCE_PLUGIN);
 
 function readCopy(plugin: string): string {
   return readFileSync(resolve(PLUGINS_DIR, plugin, "credential-client.ts"), "utf-8");
@@ -40,6 +52,17 @@ function readCopy(plugin: string): string {
 
 describe("credential-client drift guard", () => {
   const reference = readCopy(REFERENCE_PLUGIN);
+
+  it("finds every plugin that carries a copy, including ones added later", () => {
+    // Asserted against the plugins known to carry a copy rather than against
+    // the length of a literal defined above — the latter is a tautology that
+    // a typo'd path would not fail. Adding a copy to a fourth plugin should
+    // extend this list; it must never shrink silently.
+    expect(PLUGINS_WITH_A_COPY).toEqual(
+      expect.arrayContaining(["pinchy-email", "pinchy-odoo", "pinchy-web"])
+    );
+    expect(COPY_PLUGINS.length).toBeGreaterThanOrEqual(2);
+  });
 
   it("the reference copy is not empty and exports the shared surface", () => {
     // A guard that compares three unreadable files to each other passes on an


### PR DESCRIPTION
## Summary

- Extracts the credential-fetch / auth-retry building blocks (`isAuthError`, `reportAuthFailure`, the 5-min credential/client cache, `withAuthRetry`'s matcher) that were near-copied across `pinchy-odoo`, `pinchy-email`, and `pinchy-web` into a single `credential-client.ts`, copied byte-identically into each plugin directory (bundle isolation — same rationale as `normalizeTableHtml` / docx-table-html across `pinchy-files` and the web composer). Pinned by a new textual drift guard: `packages/web/src/__tests__/lib/credential-client-drift.test.ts`.
- Unifies the auth-error matcher (`isAuthError`) to the union of all three plugins' previously-independent phrase lists, and makes the `401` check precise: it now requires a real HTTP-401 envelope (`"Graph 401:"`, `"(401)"`, `"HTTP 401"`, `"401 Unauthorized"`, `"status code 401"`) instead of a bare substring match. Before this, a benign amount or record id containing the digits `401` (e.g. an invoice total of `401.00`, a record id of `401`) could be misclassified as an auth failure, causing `withAuthRetry` to invalidate the cached client/adapter and **replay the entire closure — including a non-idempotent write** (`odoo_create`'s `client.create`, `email_send`'s `adapter.send`) — a second time.
- Unifies the credential/client cache key to `agentId:connectionId` everywhere a per-agent cache exists. `pinchy-odoo` previously keyed on `agentId` alone, so after a connection hot-swap the old client could stay cached for up to 5 minutes. `pinchy-email` already used `agentId:connectionId`; `pinchy-web`'s single-entry cache is deliberately left un-keyed (documented in the code) because the Brave key is instance-wide by design — that is not a drift, it's a different, intentional cache shape.

`fetchCredentials()` itself stays per-plugin: each plugin fetches a differently-shaped credential object (Odoo: `{url, db, uid, apiKey}`; email: OAuth-or-IMAP dispatch on a `type` field; Brave: `{apiKey}`) with its own SecretRef-shape assertion (#209), and unifying that is out of scope.

Closes #1077

## `withAuthRetry` callsite audit (non-idempotent writes)

Per the issue's request to check every `withAuthRetry` callsite for replayed non-idempotent operations, here's what I found:

- **`pinchy-odoo`**: the only genuinely non-idempotent operations reachable through `withAuthRetry` are the three `client.create(...)` calls (`odoo_create`, the `mail.activity` create inside `odoo_schedule_activity`, and `ir.attachment` create inside `odoo_attach_file`). In every case, `client.create(...)` is the terminal statement of its closure — nothing else runs afterward that could produce a second false-positive-triggered replay within the same attempt. Everything else wrapped in `withAuthRetry` (`searchRead`, `write`, `unlink`, `callMethod` for confirm/reconcile/undo-reconciliation) is either naturally idempotent (a `write` with the same values) or fails loudly on a second application (Odoo state-transition guards reject an already-confirmed/already-reconciled record) rather than silently duplicating.
- **`pinchy-email`**: `email_send` (`adapter.send`) and `email_draft` (`adapter.draft`) are the non-idempotent writes; both are single-call closures.
- **`pinchy-web`**: no non-idempotent writes reachable through `withAuthRetry` (search/fetch are read-only).

I did not restructure these closures to physically separate "credential refresh" from "the write" — that would be a materially larger, riskier change touching heavily-commented, already-tested write-verification logic (`#720`/`#721` duplicate-guard + read-back verification in `odoo_create`) for marginal additional safety. Given that a real Odoo/OAuth auth failure is rejected at the RPC/HTTP layer *before* the write executes server-side, the precise-matcher fix removes the practical risk this issue raises: a false-positive can no longer be triggered by ordinary response data, so the replay path is (in practice) only ever taken for a genuine, not-yet-persisted auth failure. Flagging this here as an explicit, deliberate scope boundary rather than silently declaring the callsite audit "done."

## Test plan

- [x] New drift guard: `packages/web/src/__tests__/lib/credential-client-drift.test.ts` — 3 tests, pins all three `credential-client.ts` copies to be byte-identical modulo comments/whitespace.
- [x] New behavior tests (duplicated per plugin, same rationale as the source duplication — each package's own `pnpm test:plugins` run exercises its own copy): `credential-client.test.ts` in `pinchy-odoo/__tests__/`, `pinchy-email/__tests__/`, and `pinchy-web/` (29 tests each) — cover `isAuthError`'s legitimate phrases, the precise HTTP-401 envelopes, the explicit "bare 401 in unrelated data must NOT match" cases from the issue, `credentialCacheKey`'s hot-swap-safety property, and `reportAuthFailure`'s POST shape/truncation/best-effort-swallow behavior.
- [x] All pre-existing plugin tests (`pinchy-odoo` 482, `pinchy-email` 396, `pinchy-web` 129) still pass unchanged against the new matcher — confirms no regression in real-world auth-failure detection (e.g. `"Access Denied: invalid api key"`, `"HTTP 401: Invalid Credentials"`, `"401 Unauthorized"` all still match via their textual substrings independent of the tightened 401-envelope check).

### Gates (from repo root)

- `pnpm typecheck:plugins` — all 9 plugin packages typecheck cleanly.
- `pnpm -C packages/web` test-file typecheck (`tsc --noEmit -p tsconfig.typecheck.json`) — clean.
- `pnpm test:plugins` — pinchy-odoo 482/482, pinchy-email 396/396, pinchy-web 129/129, all other plugins unchanged and passing.
- `pnpm test:related` — 661/661 passed.
- `pnpm format:check` — clean.
- `pnpm test` (full suite) — 780 test files passed / 4 skipped, 11090 tests passed / 18 skipped.

`Docs-not-needed: internal plugin refactor, no user-facing change` trailer is on the commit (no product-behavior or API-shape change).