### PR TITLE
docs: close four Diataxis gaps found in the 2026-08-04 repo review

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Pinchy wraps OpenClaw into something enterprises can trust:
 | Odoo ERP integration                     |       ❌       |              ❌               |      connectors      |      **✅**       |
 | Open source                              |       ✅       |              ❌               |      fair-code       | **✅ (AGPL-3.0)** |
 
-Honest caveats: Pinchy is young, the integration list is short (Odoo, email — Gmail & Microsoft 365, Telegram, web search, documents), there is no compliance certification yet, and granular RBAC is on the roadmap.
+Honest caveats: Pinchy is young, the integration list is short (Odoo, email — Gmail, Microsoft 365 & IMAP, Telegram, web search, documents), there is no compliance certification yet, and granular RBAC is on the roadmap.
 
 ## Quick Start
 
@@ -85,7 +85,7 @@ That is the whole thing: no build step, pre-built images on GHCR. Pair it with a
 
 ## Status
 
-> Pinchy is in early development. The core is working — setup, auth, multi-user, agent chat, permissions, knowledge base agents, and audit trail. We're building the enterprise features (granular RBAC, plugin marketplace, cross-channel workflows) next.
+> Pinchy is in early development. The core is working — setup, auth, multi-user, agent chat, permissions, knowledge base agents, Telegram, Odoo, web search, email automations, usage dashboard, and audit trail. We're building granular RBAC, a plugin marketplace, and more channel integrations next.
 
 ### What works today
 
@@ -97,19 +97,25 @@ That is the whole thing: no build step, pre-built images on GHCR. Pair it with a
 - **Agent settings** — Configure name, model, system prompt, and tool permissions per agent
 - **Knowledge Base agents** — Create agents with scoped read-only access to specific directories
 - **Context management** — Per-user personal context and organization-wide context, editable in Settings
-- **Email integration** — Connect Gmail or Microsoft 365 mailboxes via OAuth; agents can read, search, draft, and send email with per-agent permissions
+- **Email integration** — Connect Gmail, Microsoft 365, or IMAP mailboxes; agents can read, search, draft, and send email with per-agent permissions
+- **Email automations** — Standing workflows that let an agent act on matching incoming mail on its own, proposed disabled and enabled only by a human review
+- **Odoo integration** — Scoped, permission-aware access to a connected Odoo ERP, with 20+ pre-built agent templates
+- **Web Search** — Give agents live web access via the Brave Search API, with per-agent domain allow/deny lists
+- **Telegram channel** — Chat with agents from Telegram; one bot per agent, accounts linked via a pairing code, same permissions and audit trail as the web UI
+- **Usage & Costs Dashboard** — Track token usage, estimated costs, and cache savings per agent and user
+- **Groups & agent access control** — Restrict which users can see a given agent by group membership (Enterprise)
+- **HTTPS & Domain Lock** — Reject requests whose `Host` header doesn't match the configured domain
 - **Smithers onboarding** — New users get an onboarding interview where Smithers learns about them through conversation
-- **Provider management** — Configure API keys for Anthropic, OpenAI, and Google
+- **Provider management** — Configure API keys for Anthropic, OpenAI, Google, or any OpenAI-compatible/local Ollama endpoint
 - **Docker Compose deployment** — Single command to run the full stack
-- **Audit trail** — Cryptographic audit logging with HMAC-signed entries, integrity verification, and CSV export
+- **Audit trail** — Cryptographic audit logging with HMAC-signed entries, integrity verification, and CSV/PDF export
 - **CI pipeline** — Automated linting, testing, and security auditing
 
 ### What's coming
 
-- Full RBAC with team-scoped permissions
+- Granular RBAC with custom, team-scoped roles (today's Enterprise tier ships Groups and agent access control, not custom roles)
 - Plugin marketplace for agent tools
-- Cross-channel workflows (email, Slack)
-- Admin dashboard with usage analytics
+- More channel integrations (e.g. Slack)
 
 Follow our progress on [the blog](https://heypinchy.com/blog/building-pinchy-in-public) and [LinkedIn](https://linkedin.com/in/clemenshelm).
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -157,6 +157,10 @@ export default defineConfig({
           label: "Guides",
           items: [
             {
+              label: "Your First Governed Agent",
+              slug: "guides/first-governed-agent",
+            },
+            {
               label: "Create a Knowledge Base Agent",
               slug: "guides/create-knowledge-base-agent",
             },
@@ -211,6 +215,10 @@ export default defineConfig({
                   slug: "guides/connect-email-imap",
                 },
               ],
+            },
+            {
+              label: "Set Up Email Automations",
+              slug: "guides/email-automations",
             },
             { label: "Connect Odoo", slug: "guides/connect-odoo" },
             { label: "Upload Files in Chat", slug: "guides/file-uploads" },
@@ -303,6 +311,10 @@ export default defineConfig({
           label: "Reference",
           items: [
             { label: "API Reference", slug: "reference/api" },
+            {
+              label: "Environment Variables",
+              slug: "reference/environment-variables",
+            },
             {
               label: "Agent Provisioning API",
               slug: "reference/agent-provisioning-api",

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -149,6 +149,8 @@ The Automations tab is where an agent's **email workflows** live — standing ru
 
 You'll see this tab on your personal Smithers and, as an admin, on shared agents that can read email. It's gated the same way the underlying API is: you can manage automations on a personal agent you own; admins can manage them on any agent, shared or personal.
 
+For a task-oriented walkthrough of creating and enabling one, see [Set Up Email Automations](/guides/email-automations/).
+
 ### Create an automation
 
 Click **New automation** and fill in:

--- a/docs/src/content/docs/guides/email-automations.mdx
+++ b/docs/src/content/docs/guides/email-automations.mdx
@@ -1,0 +1,76 @@
+---
+title: Set Up Email Automations
+description: Give an agent a standing rule to act on incoming mail on its own — propose, review, and enable an email workflow.
+---
+
+An automation is a standing rule that lets an agent act on incoming mail without anyone opening a chat. You describe a trigger (which mail it fires on) and an instruction (what to do with each match); Pinchy checks the connected mailboxes on a short, fixed schedule and runs the instruction once per new matching message.
+
+This guide walks through creating, reviewing, and enabling one. For the full field-by-field reference, see [Agent Settings → Automations](/concepts/agent-settings/#automations-tab).
+
+## Prerequisites
+
+- A mailbox connected via [Connect Email](/guides/connect-email/) — Gmail, Microsoft 365, or IMAP.
+- The agent you're automating needs **Read messages** access to that mailbox, granted in **Agent Settings → Permissions**. See [Agent Permissions → Email tools](/concepts/agent-permissions/#email-tools).
+- You can manage automations on a **personal agent you own**. Automations on a **shared agent** are admin-only.
+
+## Step 1: Open the Automations tab
+
+Open the agent's chat, click the gear icon, and select the **Automations** tab.
+
+## Step 2: Describe the trigger and the task
+
+Click **New automation** and fill in the form:
+
+- **Name** — a short label, e.g. "File supplier invoices."
+- **Instruction** — what the agent should do with each matching mail, in plain words, e.g. "Draft a supplier bill in Odoo from the attached invoice." It runs with this agent's own permissions and tools — it can only do what the agent is already allowed to do, nothing more.
+- **Trigger** — narrow which mail fires the workflow: sender addresses (**From**), recipient domain (**To domain**), words in the subject (**Subject contains**), whether it has an attachment and of what type, and a **Folder**. Every filled-in field must match — leave them all blank to watch the entire mailbox.
+- **Mailboxes** — which connected mailboxes to watch. Only mailboxes this agent is permitted to read appear here.
+- **Look back (days)** — how far back each pass re-checks for mail it may have missed. Default 14, and it can go up to 365.
+
+A workflow watches only mail that arrives **after** it's created — attaching it to an old, busy mailbox never retroactively processes years of history.
+
+## Step 3: Review before enabling
+
+Click **Create automation**. It appears in the tab's list as **Pending** — proposed, but not yet running.
+
+This is deliberate: Pinchy never activates a workflow on its own. Before flipping it on, read the trigger and instruction the way the tab renders them — in plain words, not raw filters — and ask whether you'd trust this agent to act on every message that matches, unsupervised. A trigger that's too loose (no filters at all) hands the agent every message in the mailbox; an instruction with a real side effect (drafting a bill, moving money, replying to a customer) deserves a second read before you turn it on.
+
+## Step 4: Enable it
+
+Click **Enable**. The workflow starts running on Pinchy's next check of the connected mailboxes — usually within about a minute. Its status flips from **Pending** to **Active** once a clean pass completes, or to **Error** if the last run hit a problem (bad credentials, an unreachable mailbox).
+
+**Disable** pauses a workflow without deleting it — flip it back on whenever you want. **Delete** removes it for good.
+
+## Step 5: Check what it did
+
+A workflow's run happens in an isolated context per email — it never shows up in your normal chat with the agent, so you won't see it appear in the conversation history. To see what an automation actually did:
+
+- Open [Audit Trail](/concepts/audit-trail/) and filter by the agent. Every tool call a run makes — drafting an email, creating an Odoo record, whatever the instruction asked for — is logged the same way a manual chat action would be, as a `tool.<toolName>` entry.
+- Check the **Status** badge in the Automations tab. **Error** means the last pass failed outright (credentials, connectivity) rather than the agent simply finding nothing to do — "no new matching mail" still reports **Active**.
+
+Each pass tracks exactly which messages it has already handled, so a message is never processed twice — and this tracking never relies on the read/unread state you see in your own inbox, so marking something read (or unread) doesn't affect it either way.
+
+## A worked example: filing supplier invoices
+
+Putting it together, a common first automation:
+
+- **Name**: File supplier invoices
+- **Instruction**: Draft a supplier bill in Odoo from the attached invoice.
+- **Trigger**: Has an attachment, attachment type `application/pdf`, folder `Inbox`
+- **Mailboxes**: your accounts-payable inbox
+- **Look back (days)**: 14 (the default)
+
+This needs the agent to also have Odoo write access — see [Connect Odoo](/guides/connect-odoo/) if that's not set up yet.
+
+## Limits worth knowing
+
+- Up to 50 mailboxes per workflow — in practice, as many mailboxes as the agent can read.
+- Look-back window is capped at 365 days.
+- Each agent works with exactly one mailbox per email connection; if a team needs several mailboxes watched independently, that's one agent (and one set of automations) per mailbox. See [Connect Email](/guides/connect-email/#the-app-and-the-mailboxes-are-two-different-things).
+
+## See also
+
+- [Agent Settings → Automations](/concepts/agent-settings/#automations-tab) — the full tab and field reference.
+- [Connect Email](/guides/connect-email/) — connecting a mailbox in the first place.
+- [Agent Permissions](/concepts/agent-permissions/#email-tools) — what Read/Draft/Send each grant.
+- [Audit Trail](/concepts/audit-trail/) — reading and exporting what an agent (or an automation) did.

--- a/docs/src/content/docs/guides/first-governed-agent.mdx
+++ b/docs/src/content/docs/guides/first-governed-agent.mdx
@@ -1,0 +1,99 @@
+---
+title: Your First Governed Agent
+description: A hands-on tutorial — create a shared agent, scope its permissions, invite a teammate, and read what happened in the audit trail.
+---
+
+import { Badge } from "@astrojs/starlight/components";
+
+Anyone can wire an LLM to a chat window. Pinchy's job starts after that: deciding exactly what an agent may do, letting more than one person work with it safely, and keeping a record that survives an argument about who did what.
+
+This tutorial builds all three, in order, on a Pinchy instance you already have running. By the end you'll have created a shared agent, watched its permission allow-list change its behavior in real time, generated an invite for a teammate, and read the resulting trail in the audit log.
+
+## Prerequisites
+
+- Pinchy is running and you've completed the [Quick Start](/getting-started/) — you're signed in as the first admin, and a provider is configured.
+- About 10 minutes.
+
+Nothing here needs Odoo, email, or any other integration. Everything runs with what Pinchy ships out of the box.
+
+## Step 1: Create a shared agent
+
+Personal agents (your own Smithers) are private and have no Permissions tab — there's nothing to share, so nothing to scope. To see governance in action you need a **shared** agent.
+
+1. Click **New Agent** in the sidebar.
+2. Pick the **Custom Agent** template — it starts with the fewest defaults, which makes the next step easier to see.
+3. Name it something you'll recognize, e.g. **Filing Clerk**.
+4. Click **Create**.
+
+Pinchy creates the agent and restarts the OpenClaw runtime to activate it — this takes a few seconds, and any other active chats reconnect automatically.
+
+## Step 2: Look at what it can do
+
+Open the new agent's chat and click the **gear icon** to open **Agent Settings**, then select the **Permissions** tab.
+
+![Agent Permissions — tool allow-list with directory scoping](/screenshots/agent-settings-permissions.png)
+
+Pinchy uses an **allow-list**: a new agent has no tools until you grant them. The only exceptions are reading its own workspace (always on, so it can see what you upload) and **Write files** (`pinchy_write`), which every new agent gets by default so it can save notes and exports right away.
+
+That's it — no shell access, no arbitrary file access, no web access. If you don't see a Web Search or Odoo section here, that's not a bug: those sections only appear once a matching connection exists in **Settings → Integrations**. An agent can't be granted a capability nothing has been connected for.
+
+## Step 3: Watch it use the one thing it's allowed to do
+
+Go back to the chat and ask:
+
+```
+Save a short note to your workbench with today's date.
+```
+
+The agent uses `pinchy_write` — the tool the Permissions tab showed as already on — to save the file into its own workspace and tells you it did. This is the only kind of side effect this agent can currently have on your Pinchy instance.
+
+## Step 4: Narrow it further
+
+Now take that capability away and watch the behavior change immediately — no code, no restart of Pinchy itself, just a permission flip.
+
+1. Open **Agent Settings → Permissions** again.
+2. Uncheck **Write files**.
+3. Click **Save & Restart**. A confirmation dialog lists the pending change and warns that active chats briefly disconnect while the OpenClaw runtime picks up the new allow-list.
+
+Ask the agent to save another note. Without `pinchy_write` in its allow-list, it can no longer write to its workspace — either it tells you directly that it doesn't have that capability, or the attempt is rejected before anything is written. Either way, nothing gets saved. That's the allow-list working exactly as designed: **nothing is permitted until it's explicitly granted**, and taking a grant away takes effect immediately.
+
+Turn **Write files** back on and **Save & Restart** if you want the agent to stay useful for later — the point was watching the flip, not leaving it disabled.
+
+## Step 5: Invite a teammate
+
+Governance matters most once more than one person is involved. Generate an invite the same way you would for a real teammate:
+
+1. Go to **Settings → Users**.
+2. Click **Invite User**.
+3. Leave the email blank (so nobody has to actually claim it for this tutorial) or fill in a real address, choose the **Member** role, and click **Create Invite**.
+4. Copy the generated link.
+
+![User management showing active users and pending invites](/screenshots/user-management.png)
+
+You don't need to actually claim the invite to continue — the point of this step is what happens next. When someone does claim it, they get their own personal Smithers, complete a short onboarding interview, and can see any shared agent you've made available to them — including the Filing Clerk you just built, restricted to exactly the tools you gave it.
+
+## Step 6: Read the audit trail
+
+Every action from the last five steps left a trace. As an admin, open **Audit Trail** from the sidebar.
+
+![Audit trail showing diverse events from users and agents](/screenshots/audit-trail.png)
+
+You should see, newest first:
+
+- `user.invited` — the invite you just created, with your admin identity as the actor.
+- `agent.updated` — twice, once for each permission flip in Step 4, each entry recording the old and new tool list.
+- `tool.pinchy_write` — from Step 3, with the tool name, its parameters, and its result.
+- `agent.created` — from Step 1, when the Filing Clerk was born.
+
+Use the **Event Type** filter to isolate `agent.updated` and confirm both permission changes are there with a full before/after diff — not just "something changed." Click any row to see its full detail, including the cryptographic signature Pinchy checks to detect tampering: every entry is HMAC-signed and the table is append-only, so this trail can't be quietly edited later, by an agent or anyone else.
+
+## What you've built
+
+A shared agent whose capabilities you explicitly control, a teammate you can bring into that scope, and a signed record of every step — the three pieces that make "an AI agent with real permissions" something you can actually run a business on, not just a demo.
+
+## Next steps
+
+- [Agent Permissions](/concepts/agent-permissions/) — the full tool catalogue, including integration tools once you connect one.
+- [Audit Trail](/concepts/audit-trail/) — every event type Pinchy logs, plus exporting and verifying the trail.
+- [User Management](/guides/user-management/) — roles, deactivation, and the rest of the invite lifecycle.
+- [Groups](/concepts/groups/) <Badge text="Enterprise" variant="note" /> — restrict which users can even see a given agent, on top of what it's allowed to do.

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -50,6 +50,8 @@ Only port **7777** is exposed to the host. OpenClaw and PostgreSQL are only reac
 
 Almost no configuration is needed to get started: session key, encryption key, HMAC signing key, and the database password are auto-generated on first start and persisted in Docker volumes so they survive restarts. The one value you set yourself is `PINCHY_VERSION` — the Compose file refuses to start without a pinned version. See the [Getting Started](/getting-started/) guide.
 
+See [Environment Variables](/reference/environment-variables/) for every variable the stack reads, in one place.
+
 #### Optional: production hardening
 
 For production deployments, extend the `.env` file to pin your own secrets instead of relying on auto-generated ones:

--- a/docs/src/content/docs/reference/environment-variables.mdx
+++ b/docs/src/content/docs/reference/environment-variables.mdx
@@ -1,0 +1,76 @@
+---
+title: Environment Variables
+description: Every environment variable Pinchy's Docker Compose stack reads — secrets, ports, resource limits, and licensing — in one place.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Pinchy needs almost none of this to start. A fresh install only sets `PINCHY_VERSION`; everything below is optional, and Pinchy fills in a safe default or auto-generates a secret when a variable is left unset. This page collects every variable the shipped `docker-compose.yml` reads, in one place, since the guides that explain _why_ you'd set one are otherwise spread across [Installation](/installation/), [Customizing Your Deployment](/guides/customizing-deployment/), [Hardening](/guides/hardening/), and [Enterprise Setup](/guides/enterprise-setup/).
+
+Set any of these in a `.env` file next to your `docker-compose.yml` — Docker Compose reads it automatically on every `docker compose up`.
+
+<Aside type="note">
+  Docker Compose only forwards a variable into a container if it's listed in
+  that service's `environment:` block in `docker-compose.yml`. Setting a name in
+  `.env` that isn't referenced there has no effect — see the [known
+  gaps](#known-gaps) section below for two variables where this currently
+  matters.
+</Aside>
+
+## Required
+
+| Variable         | Default                                    | What it does                                                                                       |
+| ---------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `PINCHY_VERSION` | none — Compose refuses to start without it | Pins the image tag for the `pinchy` and `openclaw` services. See [Quick Start](/getting-started/). |
+
+## Secrets
+
+These four are auto-generated on first start and persisted in the `pinchy-secrets` Docker volume if you don't set them. Pin them explicitly for production so a lost volume doesn't strand encrypted data — see [Hardening](/guides/hardening/) and [VPS Deployment → Pin your secrets](/guides/vps-deployment/#deploy-pinchy). Generate a value with `openssl rand -hex 32`.
+
+| Variable             | Default                              | What it does                                                                                                                                                                                                                                                                               |
+| -------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DB_PASSWORD`        | auto-generated (`pinchy_dev` in dev) | PostgreSQL password for the `pinchy` database user.                                                                                                                                                                                                                                        |
+| `BETTER_AUTH_SECRET` | auto-generated                       | Signs user sessions (Better Auth).                                                                                                                                                                                                                                                         |
+| `ENCRYPTION_KEY`     | auto-generated                       | Encrypts stored LLM provider API keys at rest (AES-256-GCM). Losing it makes every stored key permanently unreadable.                                                                                                                                                                      |
+| `AUDIT_HMAC_SECRET`  | auto-generated                       | Signs every audit trail entry with HMAC-SHA256. See [Audit Trail → Multi-instance deployments](/concepts/audit-trail/#multi-instance-deployments). **Currently not forwarded by the shipped `docker-compose.yml`** — see [known gaps](#known-gaps) below before relying on this in `.env`. |
+
+## Networking
+
+| Variable      | Default          | What it does                                                                                                                                                                                                        |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PINCHY_PORT` | `127.0.0.1:7777` | The host interface/port the `pinchy` container binds to. Accepts `HOST_PORT` or `HOST_IP:HOST_PORT` — never include the container port. See [Installation → Port configuration](/installation/#port-configuration). |
+
+## Licensing
+
+| Variable                | Default                        | What it does                                                                                                                                                               |
+| ----------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PINCHY_ENTERPRISE_KEY` | unset (no enterprise features) | License key for Groups, agent access control, and basic RBAC. Can also be entered via **Settings → License** in the UI. See [Enterprise Setup](/guides/enterprise-setup/). |
+
+## Resource limits
+
+All six are overridable so you never need to edit `docker-compose.yml` itself. Defaults add up to roughly 4 GB of memory ceiling across the three containers. See [Customizing Your Deployment → Resource limits and health checks](/guides/customizing-deployment/#resource-limits-and-health-checks) for sizing guidance, including the memory a knowledge-base reindex of Office documents needs.
+
+| Variable             | Default | Caps                                                               |
+| -------------------- | ------- | ------------------------------------------------------------------ |
+| `PINCHY_MEM_LIMIT`   | `1g`    | Memory for the `pinchy` container (web UI, API, WebSocket bridge). |
+| `PINCHY_CPUS`        | `1.5`   | CPU cores for `pinchy`.                                            |
+| `OPENCLAW_MEM_LIMIT` | `2g`    | Memory for the `openclaw` container (agent runtime, model calls).  |
+| `OPENCLAW_CPUS`      | `2`     | CPU cores for `openclaw`.                                          |
+| `DB_MEM_LIMIT`       | `1g`    | Memory for the `db` container (PostgreSQL 17).                     |
+| `DB_CPUS`            | `1`     | CPU cores for `db`.                                                |
+
+## Known gaps
+
+Two variables listed (commented out) in `.env.example` don't currently do what their name suggests. Both are tracked in [#1113](https://github.com/heypinchy/pinchy/issues/1113) rather than fixed silently, since resolving either is a code change, not a docs change:
+
+- **`AUDIT_HMAC_SECRET`** — the application does read this from its process environment, but the shipped `docker-compose.yml` doesn't list it in the `pinchy` service's `environment:` block, so a value set in `.env` alone never reaches the container. If you need a pinned audit HMAC secret today, add it via a `docker-compose.override.yml` instead (see [Customizing Your Deployment → Recipe 1](/guides/customizing-deployment/#recipe-1-extra-environment-variables)):
+
+  ```yaml
+  # docker-compose.override.yml
+  services:
+    pinchy:
+      environment:
+        - AUDIT_HMAC_SECRET=your-generated-hex-string
+  ```
+
+- **`PINCHY_ADMIN_EMAIL`** / **`PINCHY_ADMIN_PASSWORD`** — not read by the running application. The supported way to recover a lost admin password is the `pnpm reset-admin` CLI command — see [User Management → Emergency admin password reset](/guides/user-management/#emergency-admin-password-reset-cli).

--- a/scripts/lib/env-var-doc-coverage.mjs
+++ b/scripts/lib/env-var-doc-coverage.mjs
@@ -1,0 +1,68 @@
+/**
+ * Drift guard for `docs/src/content/docs/reference/environment-variables.mdx`
+ * (#1082): every variable named in the root `.env.example` must appear on the
+ * consolidated reference page, so the two can't quietly drift apart the way
+ * the env-var docs did before that page existed — scattered across
+ * installation/customizing-deployment/enterprise-setup, with no single place
+ * that had to list every variable to stay correct.
+ *
+ * Deliberately narrow: `.env.example` is the file an operator actually opens,
+ * and it is small and stable enough that a whole-word mention check is
+ * reliable. It does not additionally scan every `docker-compose*.yml` for
+ * `${VAR}` references — that set includes CI/test-only overlays
+ * (docker-compose.eval.yml, docker-compose.integration.yml, …) with variables
+ * no end-user reference page should document, and drawing the line between
+ * "user-facing" and "test-infra" compose vars is a judgement call a script
+ * can't make reliably. The six resource-limit variables from the base
+ * `docker-compose.yml` are documented on the page by hand instead, alongside
+ * the `.env.example` set this guard checks.
+ */
+
+/**
+ * Pulls every variable name `.env.example` mentions, whether it's live
+ * (`PINCHY_VERSION=v0.8.0`) or commented out as an optional example
+ * (`# DB_PASSWORD=`). Both are things a reader might set, so both need a
+ * home on the reference page.
+ *
+ * @param {string} source contents of .env.example
+ * @returns {string[]} sorted, deduplicated variable names
+ */
+export function extractEnvExampleVars(source) {
+  const names = new Set();
+  for (const line of source.split("\n")) {
+    const m = /^#?\s*([A-Z][A-Z0-9_]*)=/.exec(line);
+    if (m) names.add(m[1]);
+  }
+  return [...names].sort();
+}
+
+/**
+ * Whether a doc page names an identifier as a whole word — same rule as
+ * `mentions()` in docs-coverage.mjs, duplicated rather than imported so this
+ * guard has no dependency on that module's exemption tables. `PINCHY_PORT`
+ * must not be satisfied by a page that only mentions `PINCHY_PORT_OLD` or
+ * similar.
+ *
+ * @param {string} mdx
+ * @param {string} id
+ * @returns {boolean}
+ */
+function mentions(mdx, id) {
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?<![\\w])${escaped}(?![\\w])`).test(mdx);
+}
+
+/**
+ * @param {string[]} vars from {@link extractEnvExampleVars}
+ * @param {string} mdx contents of reference/environment-variables.mdx
+ * @returns {string[]} problems (empty = ok)
+ */
+export function findUndocumentedEnvVars(vars, mdx) {
+  return vars
+    .filter((v) => !mentions(mdx, v))
+    .map(
+      (v) =>
+        `"${v}" is in .env.example but not documented in ` +
+        `docs/src/content/docs/reference/environment-variables.mdx`,
+    );
+}

--- a/scripts/lib/env-var-doc-coverage.test.mjs
+++ b/scripts/lib/env-var-doc-coverage.test.mjs
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  extractEnvExampleVars,
+  findUndocumentedEnvVars,
+} from "./env-var-doc-coverage.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const REFERENCE_PAGE = join(
+  REPO_ROOT,
+  "docs/src/content/docs/reference/environment-variables.mdx",
+);
+
+// ── pure logic ────────────────────────────────────────────────────────────
+
+test("extractEnvExampleVars reads a live assignment", () => {
+  assert.deepEqual(extractEnvExampleVars("PINCHY_VERSION=v0.8.0\n"), [
+    "PINCHY_VERSION",
+  ]);
+});
+
+test("extractEnvExampleVars reads a commented-out optional line", () => {
+  assert.deepEqual(extractEnvExampleVars("# DB_PASSWORD=\n"), ["DB_PASSWORD"]);
+});
+
+test("extractEnvExampleVars ignores a comment that isn't a variable", () => {
+  assert.deepEqual(
+    extractEnvExampleVars(
+      "# Generate with: openssl rand -hex 32\n# ─────────────\n",
+    ),
+    [],
+  );
+});
+
+test("extractEnvExampleVars deduplicates and sorts", () => {
+  assert.deepEqual(
+    extractEnvExampleVars(
+      "# PINCHY_PORT=0.0.0.0:7777\nPINCHY_PORT=127.0.0.1\nDB_PASSWORD=x\n",
+    ),
+    ["DB_PASSWORD", "PINCHY_PORT"],
+  );
+});
+
+test("findUndocumentedEnvVars does not accept a longer variable as the shorter one", () => {
+  // PINCHY_PORT must not be satisfied by a page that only mentions
+  // PINCHY_PORT_OLD or a substring match on a longer identifier.
+  const problems = findUndocumentedEnvVars(
+    ["PINCHY_PORT"],
+    "`PINCHY_PORT_OLD` is deprecated.",
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /PINCHY_PORT/);
+});
+
+test("findUndocumentedEnvVars is quiet when the page names the variable", () => {
+  assert.deepEqual(
+    findUndocumentedEnvVars(
+      ["DB_PASSWORD"],
+      "Set `DB_PASSWORD` for production.",
+    ),
+    [],
+  );
+});
+
+test("findUndocumentedEnvVars points at the reference page", () => {
+  const problems = findUndocumentedEnvVars(
+    ["ENCRYPTION_KEY"],
+    "no mention here",
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /environment-variables\.mdx/);
+});
+
+// ── the repo itself ───────────────────────────────────────────────────────
+
+test("every .env.example variable is documented on the environment variables reference page", () => {
+  const vars = extractEnvExampleVars(
+    readFileSync(join(REPO_ROOT, ".env.example"), "utf8"),
+  );
+  // Guard the guard: a broken walker that finds nothing would pass silently.
+  assert.ok(
+    vars.length > 5,
+    `expected the full variable set, found ${vars.length}`,
+  );
+  const mdx = readFileSync(REFERENCE_PAGE, "utf8");
+  assert.deepEqual(findUndocumentedEnvVars(vars, mdx), []);
+});


### PR DESCRIPTION
## Summary

Implements the four findings from the 2026-08-04 repo review (#1082):

1. **Tutorial gap** — added `guides/first-governed-agent.mdx`, "Your First Governed Agent": create a shared agent, flip its permission allow-list live and watch the behavior change, generate a teammate invite, and read the resulting audit trail. Diataxis tutorial quadrant (learner does every step; no Odoo/email/Telegram required — works on any Pinchy instance right after Quick Start). Added as the first entry under **Guides** in the sidebar.
2. **No consolidated env-var/compose reference** — added `reference/environment-variables.mdx`, sourced directly from `.env.example` + `docker-compose.yml`. Added a drift guard (`scripts/lib/env-var-doc-coverage.mjs` + test, wired into `pnpm test:scripts`) that fails if a `.env.example` variable stops being documented on that page — same whole-word-match pattern `docs-coverage.mjs` already uses for routes/audit-events/tools. Scoped to `.env.example` only, not every `docker-compose*.yml` (see "Deviations" below).
3. **Automations guide** — added `guides/email-automations.mdx`, a task-oriented how-to (create → review → enable → check what ran), cross-linked from the existing `concepts/agent-settings.mdx` reference subsection, which stays as the field-by-field reference.
4. **README status drift** — "What works today" now lists Telegram, Odoo, web search, automations, usage dashboard, groups, and domain lock; "What's coming" no longer lists shipped items (email automations, usage analytics).

## A finding surfaced while researching #2, filed rather than fixed inline

Cross-checking `.env.example` against `docker-compose.yml` line by line turned up two real gaps, both filed as [#1113](https://github.com/heypinchy/pinchy/issues/1113):

- `AUDIT_HMAC_SECRET` is read by the app (`packages/web/src/lib/encryption.ts`) and three existing docs pages tell operators to set it in `.env`, but the shipped `docker-compose.yml`'s `pinchy` service `environment:` block never lists it — so on the packaged Compose flow, setting it in `.env` is currently a silent no-op (unlike `DB_PASSWORD`/`BETTER_AUTH_SECRET`/`ENCRYPTION_KEY`/`PINCHY_ENTERPRISE_KEY`, which all are listed there).
- `PINCHY_ADMIN_EMAIL`/`PINCHY_ADMIN_PASSWORD` are in `.env.example` but read nowhere in `packages/web/src` — the actual admin-recovery mechanism shipped is the `pnpm reset-admin` CLI.

The new reference page documents both honestly (with a workaround for the HMAC case via `docker-compose.override.yml`) instead of repeating the existing, inaccurate claim. Did not touch `docker-compose.yml`/`.env.example` themselves — that's a behavior change with its own testing burden, out of scope for a docs PR.

## Deviations from the brief

- The env-var drift guard checks `.env.example` only, not every `docker-compose*.yml`. The wider set includes CI/test-only overlays (`docker-compose.eval.yml`, `docker-compose.integration.yml`, …) with variables no end-user reference page should document (`OLLAMA_CLOUD_API_KEY`, `PINCHY_BUILD_SHA`, `OPENCLAW_IMAGE`, …), and drawing the "user-facing vs. test-infra" line reliably in a script felt like exactly the "wobbly check" the brief said to skip rather than ship. The six resource-limit variables from the base `docker-compose.yml` are documented on the page by hand alongside the `.env.example` set the guard checks.
- Opened tracking issue #1113 instead of silently fixing or silently repeating the `AUDIT_HMAC_SECRET`/`PINCHY_ADMIN_*` gaps (see above).

## Test plan

- [x] `pnpm -C docs test` — 42 passed
- [x] `pnpm -C docs build` — 70 pages built (73 incl. non-page routes), no errors
- [x] `pnpm -C docs check:anchors` — 73 pages checked, no broken internal links
- [x] `pnpm -C docs check:rendered` — 73 pages checked, every table rendered
- [x] `pnpm test:scripts` — 921 passed (incl. new `env-var-doc-coverage.test.mjs`, docs-coverage, docs-consistency)
- [x] `pnpm format:check` — clean
- [x] `pnpm test:related` — reports nothing in the vitest-covered surface changed (docs/README/scripts/lib aren't in that graph); full `pnpm test` not run, per the brief's own conditional
- [x] Red→green demonstrated for the new guard by transiently redacting a variable from the reference page and confirming the test fails, then restoring it

Closes #1082