### PR TITLE
test: cover the helpers the #1087 sweep left untested

### DIFF
--- a/packages/web/src/__tests__/components/edit-credentials-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/edit-credentials-dialog.test.tsx
@@ -257,6 +257,58 @@ describe("EditCredentialsDialog", () => {
         });
       });
     });
+
+    it("shows a generic message, not the raw error, when the save fails opaquely", async () => {
+      // The non-ApiError branch of the shared save path (#1087): a transport
+      // failure carries no server-authored message, and its text is an
+      // internal detail rather than something to render at a user. Only the
+      // ApiError branch was covered before the copies were collapsed.
+      const user = userEvent.setup();
+      vi.mocked(apiPatch).mockRejectedValue(new Error("ECONNRESET"));
+
+      render(
+        <EditCredentialsDialog
+          connection={webSearchConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      await user.type(screen.getByLabelText("API Key"), "new-brave-key");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("ECONNRESET")).not.toBeInTheDocument();
+      expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it("re-enables Save after a failed attempt so the user can retry", async () => {
+      // The `finally` that clears `saving` is the one line of the shared save
+      // path with no visible success counterpart — lose it and the dialog
+      // strands the user on a spinner after a transient failure.
+      const user = userEvent.setup();
+      vi.mocked(apiPatch).mockRejectedValue(new ApiError(502, "Upstream is down"));
+
+      render(
+        <EditCredentialsDialog
+          connection={webSearchConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      await user.type(screen.getByLabelText("API Key"), "new-brave-key");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Upstream is down")).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
   });
 
   describe("Google integration", () => {
@@ -307,6 +359,30 @@ describe("EditCredentialsDialog", () => {
       await waitFor(() => {
         expect(assignMock).toHaveBeenCalledWith("https://accounts.google.com/oauth?code=xxx");
       });
+    });
+
+    it("shows a generic message when starting the OAuth redirect fails opaquely", async () => {
+      // The reconnect branch shares `credentialErrorMessage` with the three
+      // credential forms since #1087, but reaches it from apiPost rather than
+      // apiPatch — and it was the branch with no failure test at all.
+      const user = userEvent.setup();
+      vi.mocked(apiPost).mockRejectedValue(new Error("ECONNRESET"));
+
+      render(
+        <EditCredentialsDialog
+          connection={googleConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "Reconnect via Google" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("ECONNRESET")).not.toBeInTheDocument();
     });
   });
 

--- a/packages/web/src/__tests__/hooks/office-document-adapter.test.ts
+++ b/packages/web/src/__tests__/hooks/office-document-adapter.test.ts
@@ -27,6 +27,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import mammoth from "mammoth";
 import { OfficeDocumentAttachmentAdapter } from "@/hooks/use-ws-runtime";
 import { CLIENT_MAX_ATTACHMENT_SIZE_BYTES } from "@/lib/limits";
+import { oversizeAttachmentError } from "@/lib/attachment-size-check";
 
 function fakeDocxFile({ size, name = "briefing.docx" }: { size: number; name?: string }): File {
   return {
@@ -92,6 +93,22 @@ describe("OfficeDocumentAttachmentAdapter.add", () => {
       name: "huge.docx",
     });
     await expect(adapter.add({ file })).rejects.toThrow(/huge\.docx/);
+  });
+
+  it("rejects in the shared wording, not a second sentence for the same refusal", async () => {
+    // Until #1087 this adapter re-implemented the size check it already
+    // imported, and answered with "The limit is N MB." while every other
+    // attachment path said "The maximum is N MB." — one rejection, two
+    // sentences, depending on which file the user happened to drop. The two
+    // loose regexes above pass against either, so the exact string is what
+    // holds the paths together.
+    const adapter = new OfficeDocumentAttachmentAdapter();
+    const size = CLIENT_MAX_ATTACHMENT_SIZE_BYTES + 1024 * 1024;
+    const file = fakeDocxFile({ size, name: "huge.docx" });
+
+    await expect(adapter.add({ file })).rejects.toThrow(
+      oversizeAttachmentError({ name: "huge.docx", type: file.type, size })!
+    );
   });
 });
 

--- a/packages/web/src/__tests__/lib/chats/load-chat-agent.test.ts
+++ b/packages/web/src/__tests__/lib/chats/load-chat-agent.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for the chat-page preamble the #1087 sweep single-sourced out of
+ * `/chat/[agentId]`, its `[chatId]` child and the read-only `telegram` mirror.
+ *
+ * The three page components are server components the route suites exercise
+ * through their rendered output, so what they pin is "this page rendered".
+ * The decisions that live here are different ones and none of them is visible
+ * in that output: that a denied read answers 404 rather than 403 (a member
+ * must not learn a hidden agent exists), that `canEdit` is the same predicate
+ * the write routes enforce rather than a second spelling of it, and that the
+ * group lookups are skipped when they cannot change the answer.
+ *
+ * `@/lib/agent-access` stays REAL on purpose — the visibility facts these
+ * cases rest on are the point, and mocking `assertAgentAccess` would turn
+ * every access assertion below into a restatement of the mock.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const notFoundMock = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+vi.mock("next/navigation", () => ({ notFound: () => notFoundMock() }));
+
+const whereMock = vi.fn();
+vi.mock("@/db", () => ({
+  db: { select: () => ({ from: () => ({ where: (...args: unknown[]) => whereMock(...args) }) }) },
+}));
+
+vi.mock("@/lib/require-auth", () => ({ requireAuth: vi.fn() }));
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: vi.fn().mockResolvedValue([]),
+  getAgentGroupIds: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/enterprise", () => ({ getLicenseState: vi.fn().mockResolvedValue("paid") }));
+vi.mock("@/lib/avatar", () => ({
+  getAgentAvatarSvg: vi.fn(
+    (agent: { avatarSeed: string | null; name: string }) =>
+      `data:image/svg+xml;utf8,${agent.avatarSeed ?? agent.name}`
+  ),
+}));
+
+import { requireAuth } from "@/lib/require-auth";
+import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
+import { getLicenseState } from "@/lib/enterprise";
+import { loadChatAgentName, loadChatPageAgent } from "@/lib/chats/load-chat-agent";
+
+const agentRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "agent-1",
+  name: "Smithers",
+  ownerId: null,
+  isPersonal: false,
+  visibility: "all",
+  avatarSeed: "seed-1",
+  ...overrides,
+});
+
+/** The single `.where(...)` every load in this module ends with. */
+function dbReturns(rows: unknown[]) {
+  whereMock.mockResolvedValue(rows);
+}
+
+function signedInAs(id: string, role: string) {
+  vi.mocked(requireAuth).mockResolvedValue({ user: { id, role } } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getUserGroupIds).mockResolvedValue([]);
+  vi.mocked(getAgentGroupIds).mockResolvedValue([]);
+  vi.mocked(getLicenseState).mockResolvedValue("paid");
+});
+
+describe("loadChatAgentName", () => {
+  it("returns the agent's name for the tab title", async () => {
+    dbReturns([{ name: "Smithers" }]);
+    await expect(loadChatAgentName("agent-1")).resolves.toBe("Smithers");
+  });
+
+  it("returns undefined for an unknown agent instead of 404-ing", async () => {
+    // generateMetadata has no way to answer 404; the callers fall back to a
+    // generic title. A notFound() here would take the page down with it.
+    dbReturns([]);
+    await expect(loadChatAgentName("ghost")).resolves.toBeUndefined();
+    expect(notFoundMock).not.toHaveBeenCalled();
+  });
+
+  it("does not require a session — the name is not the secret, the chat is", async () => {
+    dbReturns([{ name: "Smithers" }]);
+    await loadChatAgentName("agent-1");
+    expect(requireAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe("loadChatPageAgent", () => {
+  it("answers 404 when no agent matches the id", async () => {
+    signedInAs("user-1", "member");
+    dbReturns([]);
+    await expect(loadChatPageAgent("ghost")).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  it("answers 404 — not 403 — when the read gate denies access", async () => {
+    // A member opening someone else's personal agent must not learn it exists.
+    signedInAs("other-user", "member");
+    dbReturns([agentRow({ isPersonal: true, ownerId: "owner-user" })]);
+    await expect(loadChatPageAgent("agent-1")).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+
+  it("returns the agent and its avatar for a permitted read", async () => {
+    signedInAs("user-1", "member");
+    dbReturns([agentRow()]);
+
+    const { agent, userId, userRole, avatarUrl } = await loadChatPageAgent("agent-1");
+
+    expect(agent.id).toBe("agent-1");
+    expect(userId).toBe("user-1");
+    expect(userRole).toBe("member");
+    expect(avatarUrl).toBe("data:image/svg+xml;utf8,seed-1");
+  });
+
+  it("grants canEdit to the owner of a personal agent", async () => {
+    signedInAs("user-1", "member");
+    dbReturns([agentRow({ isPersonal: true, ownerId: "user-1" })]);
+    await expect(loadChatPageAgent("agent-1")).resolves.toMatchObject({ canEdit: true });
+  });
+
+  it("grants canEdit to an admin on a shared agent", async () => {
+    signedInAs("admin-user", "admin");
+    dbReturns([agentRow()]);
+    await expect(loadChatPageAgent("agent-1")).resolves.toMatchObject({ canEdit: true });
+  });
+
+  it("withholds canEdit from a member on a shared agent they can read", async () => {
+    // The UI must not offer an edit the write routes refuse.
+    signedInAs("user-1", "member");
+    dbReturns([agentRow()]);
+    await expect(loadChatPageAgent("agent-1")).resolves.toMatchObject({ canEdit: false });
+  });
+
+  it("lets a member into a restricted agent they share a group with", async () => {
+    signedInAs("user-1", "member");
+    dbReturns([agentRow({ visibility: "restricted" })]);
+    vi.mocked(getUserGroupIds).mockResolvedValue(["group-a"]);
+    vi.mocked(getAgentGroupIds).mockResolvedValue(["group-a"]);
+
+    await expect(loadChatPageAgent("agent-1")).resolves.toMatchObject({ canEdit: false });
+  });
+
+  it("keeps a member out of a restricted agent they share no group with", async () => {
+    signedInAs("user-1", "member");
+    dbReturns([agentRow({ visibility: "restricted" })]);
+    vi.mocked(getUserGroupIds).mockResolvedValue(["group-a"]);
+    vi.mocked(getAgentGroupIds).mockResolvedValue(["group-b"]);
+
+    await expect(loadChatPageAgent("agent-1")).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  it("skips both group lookups when they cannot change the answer", async () => {
+    // The common case is one query. This is the reason the preamble reads the
+    // way it does, and nothing else in the suite would notice it regressing.
+    signedInAs("user-1", "member");
+    dbReturns([agentRow({ visibility: "all" })]);
+
+    await loadChatPageAgent("agent-1");
+
+    expect(getUserGroupIds).not.toHaveBeenCalled();
+    expect(getAgentGroupIds).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/format-date.test.ts
+++ b/packages/web/src/__tests__/lib/format-date.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { formatLicenseDate } from "@/lib/format-date";
+
+/**
+ * `formatLicenseDate` was single-sourced from three byte-identical copies in
+ * the #1087 sweep (the enterprise banner, the cliff dialog, the settings
+ * license card) and landed without a test of its own. The three components
+ * assert their rendered strings, so the format used to be pinned three times
+ * indirectly — and after the consolidation, nowhere.
+ *
+ * The fixtures use midday UTC on purpose. `toLocaleDateString` renders in the
+ * machine's zone, so a midnight-UTC input reads as the previous day west of
+ * Greenwich: the test would pass in CI (UTC) and fail on a laptop in New York,
+ * which would be a property of the fixture rather than of the function.
+ */
+describe("formatLicenseDate", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("formats an ISO date as 'Mon D, YYYY'", () => {
+    expect(formatLicenseDate("2026-08-15T12:00:00.000Z")).toBe("Aug 15, 2026");
+  });
+
+  it("writes a single-digit day without a leading zero", () => {
+    expect(formatLicenseDate("2026-01-05T12:00:00.000Z")).toBe("Jan 5, 2026");
+  });
+
+  it("names the month rather than numbering it", () => {
+    expect(formatLicenseDate("2026-09-08T12:00:00.000Z")).toBe("Sep 8, 2026");
+  });
+
+  it("asks for en-US explicitly rather than taking the machine's locale", () => {
+    // Asserted on the call, not on the output, because the output cannot see
+    // this: a runner whose default locale is already en-US — CI's is — renders
+    // the same string either way, so dropping the argument would stay green
+    // here and turn "Sep 8, 2026" into "8.9.2026" on a de-AT admin's browser.
+    // The locale is load-bearing: these three surfaces quote a contractual
+    // renewal date back at an admin, and 8/9 vs 9/8 is a real ambiguity.
+    const spy = vi.spyOn(Date.prototype, "toLocaleDateString");
+
+    formatLicenseDate("2026-09-08T12:00:00.000Z");
+
+    expect(spy).toHaveBeenCalledWith("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  });
+});

--- a/packages/web/src/__tests__/lib/schemas/sender-name.test.ts
+++ b/packages/web/src/__tests__/lib/schemas/sender-name.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { senderNameSchema } from "@/lib/schemas/sender-name";
+import { imapCreateSchema } from "@/lib/schemas/imap";
+import { imapEditSchema } from "@/lib/schemas/integration-edit";
+
+/**
+ * The From-header display-name guard, single-sourced in the #1087 sweep from
+ * two byte-identical copies (create and edit) — and left without a test of its
+ * own, which is the wrong half to leave untested: this `.refine` is a header
+ * injection barrier, and a schema that silently loses it still looks validated
+ * at every call site.
+ *
+ * The last two cases assert the *composition* rather than the rule again: both
+ * schemas must keep applying it, because "shared" is a claim about the import,
+ * not about the field.
+ */
+describe("senderNameSchema", () => {
+  it("accepts an ordinary display name", () => {
+    expect(senderNameSchema.safeParse("Support Team").success).toBe(true);
+  });
+
+  it("rejects a CR/LF header-injection attempt with a message that names the reason", () => {
+    const parsed = senderNameSchema.safeParse("Support\r\nBcc: evil@example.com");
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]?.message).toBe("Sender name must not contain line breaks");
+    }
+  });
+
+  it("rejects a bare LF as well as a full CRLF", () => {
+    expect(senderNameSchema.safeParse("Support\nBcc: evil@example.com").success).toBe(false);
+    expect(senderNameSchema.safeParse("Support\rBcc: evil@example.com").success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(senderNameSchema.safeParse("").success).toBe(false);
+  });
+
+  it("accepts exactly 200 characters and rejects 201", () => {
+    expect(senderNameSchema.safeParse("a".repeat(200)).success).toBe(true);
+    expect(senderNameSchema.safeParse("a".repeat(201)).success).toBe(false);
+  });
+
+  it("still guards the create schema's senderName field", () => {
+    const parsed = imapCreateSchema.safeParse({
+      imapHost: "imap.example.com",
+      imapPort: 993,
+      smtpHost: "smtp.example.com",
+      smtpPort: 587,
+      username: "user@example.com",
+      password: "secret",
+      security: "tls",
+      senderName: "Bad\r\nBcc: evil@example.com",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("still guards the edit schema's senderName field", () => {
+    expect(imapEditSchema.safeParse({ senderName: "Bad\r\nBcc: evil@example.com" }).success).toBe(
+      false
+    );
+    expect(imapEditSchema.safeParse({ senderName: "Support Team" }).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed, and why the diff shrank

This branch was a **second, independent run** at the #1087 duplication sweep. The first one landed as [#1123](https://github.com/heypinchy/pinchy/pull/1123) while this was open, so every consolidation here already exists on `main` — under different names, and in each diverging spot in a better form:

| this branch | main (#1123) | why main's wins |
| --- | --- | --- |
| `requireManageableAgent` | `resolveWorkflowAgent` | runs the **read** gate before the manage-scope gate, so 404 and 403 mean what they say |
| `loadChatPageAgent` (`chat-page-shell.ts`) | `loadChatPageAgent` (`chats/load-chat-agent.ts`) | derives `canEdit` from `canWriteAgent` instead of restating the predicate; adds `loadChatAgentName` |
| `formatLicenseDate` (`format-license-date.ts`) | `formatLicenseDate` (`format-date.ts`) | carries the reasoning for the pinned locale |
| `resolveUsageFilter` | `parseUsageFilter` | already unit-tested, incl. the fake-timer bound on `since` |

Resolving 24 conflicting files in this branch's favour would be a regression dressed as a merge resolution. The refactor is therefore **dropped in favour of main's**, and the branch keeps only what main does *not* have.

## What stays: the missing test coverage

Five extracted helpers landed with no tests of their own. Their callers covered them indirectly *before* extraction; afterwards, nothing did.

- **`formatLicenseDate`** — the format, plus the pinned `"en-US"`. The locale is asserted **on the call, not the output**: a runner whose default locale is already en-US renders the same string either way, so dropping the argument stays green in CI and turns `Sep 8, 2026` into `8.9.2026` on a de-AT admin's screen. Fixtures use midday UTC so the day does not shift west of Greenwich.
- **`senderNameSchema`** — the CR/LF header-injection barrier, and that **both** the create and the edit schema still apply it. "Shared" is a claim about the import, not about the field.
- **`loadChatPageAgent` / `loadChatAgentName`** — that a denied read answers **404, not 403** (a member must not learn a hidden agent exists), that the metadata loader deliberately needs no session, and that the group lookups are skipped when they cannot change the answer. None of the three is visible in the pages' rendered output. `@/lib/agent-access` stays **real** so the visibility facts are facts.
- **The office adapter's oversize rejection** — pinned to the shared helper's sentence. The two existing regexes (`/too large/i`, `/huge\.docx/`) pass against the wording it used to re-implement.
- **The credential dialog's opaque-failure branch**, on both the PATCH forms and the OAuth reconnect — that a transport error's text is not rendered at the user, and that Save is re-enabled so a retry is possible.

## Test plan

- [x] **Canary-verified, all six**: broke the implementation, watched the test fail on that exact assertion, reverted. The first attempt at the locale test did **not** go red — that is why it now asserts the call.
- [x] Full `pnpm test`: **828 files passed, 4 skipped; 11981 tests passed, 18 skipped**.
- [x] `pnpm -C packages/web typecheck` clean · `lint` 0 errors · `prettier --check .` clean.
- [x] Net test addition; nothing removed.

Refs #1087