### PR TITLE
refactor(openclaw-config): extract email-agent-config from build.ts

### DIFF
--- a/packages/web/src/__tests__/lib/integrations/email-connection-types-drift.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/email-connection-types-drift.test.ts
@@ -21,7 +21,10 @@ import { resolve } from "node:path";
 const CALL_SITES = [
   "../../../app/api/templates/route.ts",
   "../../../components/agent-settings-permissions.tsx",
-  "../../../lib/openclaw-config/build.ts",
+  // Extracted from build.ts (openclaw-config monolith split, #1072): the
+  // email-permission aggregation that reads EMAIL_CONNECTION_TYPES now lives
+  // here, so build.ts itself no longer imports the constant directly.
+  "../../../lib/openclaw-config/email-agent-config.ts",
   "../../../components/settings-integrations.tsx",
 ] as const;
 

--- a/packages/web/src/__tests__/lib/openclaw-config/email-agent-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/email-agent-config.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateEmailPermissionsByAgent,
+  buildEmailAgentConfigs,
+  type JoinedPermissionRow,
+} from "@/lib/openclaw-config/email-agent-config";
+
+/**
+ * Minimal integration_connections fixture. Only the fields the two functions
+ * under test actually read (`type`, `id`, `name`, `data`) are meaningful;
+ * the rest are present to satisfy the schema-derived type and deliberately
+ * carry a plausible-looking encrypted-credentials string so the "no plaintext
+ * secret in output" test below has something real to check against.
+ */
+function makeConnection(
+  overrides: Partial<JoinedPermissionRow["integration_connections"]> = {}
+): JoinedPermissionRow["integration_connections"] {
+  return {
+    id: "conn-1",
+    type: "google",
+    name: "Gmail",
+    description: "",
+    credentials: "ENCRYPTED:super-secret-refresh-token",
+    data: null,
+    status: "active",
+    lastError: null,
+    lastErrorAt: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as JoinedPermissionRow["integration_connections"];
+}
+
+function makePermission(
+  overrides: Partial<JoinedPermissionRow["agent_connection_permissions"]> = {}
+): JoinedPermissionRow["agent_connection_permissions"] {
+  return {
+    id: "perm-1",
+    agentId: "agent-1",
+    connectionId: "conn-1",
+    model: "email",
+    operation: "read",
+    ...overrides,
+  } as JoinedPermissionRow["agent_connection_permissions"];
+}
+
+function row(
+  permOverrides: Partial<JoinedPermissionRow["agent_connection_permissions"]> = {},
+  connOverrides: Partial<JoinedPermissionRow["integration_connections"]> = {}
+): JoinedPermissionRow {
+  return {
+    agent_connection_permissions: makePermission(permOverrides),
+    integration_connections: makeConnection(connOverrides),
+  };
+}
+
+describe("aggregateEmailPermissionsByAgent", () => {
+  it("ignores connections that are not an email provider type", () => {
+    const rows: JoinedPermissionRow[] = [
+      row({ agentId: "agent-1", connectionId: "odoo-conn" }, { id: "odoo-conn", type: "odoo" }),
+    ];
+
+    const result = aggregateEmailPermissionsByAgent(rows);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("accepts every EMAIL_CONNECTION_TYPES member (google, microsoft, imap)", () => {
+    const rows: JoinedPermissionRow[] = [
+      row({ agentId: "agent-google" }, { type: "google" }),
+      row({ agentId: "agent-microsoft" }, { type: "microsoft" }),
+      row({ agentId: "agent-imap" }, { type: "imap" }),
+    ];
+
+    const result = aggregateEmailPermissionsByAgent(rows);
+
+    expect(new Set(result.keys())).toEqual(
+      new Set(["agent-google", "agent-microsoft", "agent-imap"])
+    );
+  });
+
+  it("merges operations across multiple permission rows for the same agent+model", () => {
+    const rows: JoinedPermissionRow[] = [
+      row({ agentId: "agent-1", model: "email", operation: "read" }),
+      row({ agentId: "agent-1", model: "email", operation: "draft" }),
+    ];
+
+    const result = aggregateEmailPermissionsByAgent(rows);
+
+    expect(result.get("agent-1")?.ops.get("email")).toEqual(["read", "draft"]);
+  });
+
+  it("keeps the FIRST-seen connection for connectionId/connection but tracks all connectionIds (LATENT FIRST-WINS)", () => {
+    const rows: JoinedPermissionRow[] = [
+      row(
+        { agentId: "agent-1", connectionId: "conn-first" },
+        { id: "conn-first", name: "First Inbox" }
+      ),
+      row(
+        { agentId: "agent-1", connectionId: "conn-second" },
+        { id: "conn-second", name: "Second Inbox" }
+      ),
+    ];
+
+    const result = aggregateEmailPermissionsByAgent(rows);
+    const agentData = result.get("agent-1");
+
+    expect(agentData?.connectionId).toBe("conn-first");
+    expect(agentData?.connection.id).toBe("conn-first");
+    expect(agentData?.connectionIds).toEqual(new Set(["conn-first", "conn-second"]));
+  });
+
+  it("returns an empty map for no rows", () => {
+    expect(aggregateEmailPermissionsByAgent([]).size).toBe(0);
+  });
+});
+
+describe("buildEmailAgentConfigs", () => {
+  it("derives email_* read tools from a plain 'read' operation", () => {
+    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+      row({ agentId: "agent-1", model: "email", operation: "read" }),
+    ]);
+
+    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+
+    expect(configs["agent-1"].tools).toEqual([
+      "email_list",
+      "email_read",
+      "email_search",
+      "email_get_attachment",
+    ]);
+  });
+
+  it("grants the same read toolset for legacy 'search'/'list' aliases without a 'read' row", () => {
+    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+      row({ agentId: "agent-1", model: "email", operation: "search" }),
+    ]);
+
+    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+
+    expect(configs["agent-1"].tools).toEqual([
+      "email_list",
+      "email_read",
+      "email_search",
+      "email_get_attachment",
+    ]);
+  });
+
+  it("adds draft/send tools only when explicitly granted, never implied by read", () => {
+    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+      row({ agentId: "agent-1", model: "email", operation: "read" }),
+      row({ agentId: "agent-1", model: "email", operation: "draft" }),
+    ]);
+
+    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+
+    expect(configs["agent-1"].tools).toContain("email_draft");
+    expect(configs["agent-1"].tools).not.toContain("email_send");
+  });
+
+  it("emits an empty tools array when the agent has no 'email' model ops", () => {
+    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+      row({ agentId: "agent-1", model: "some-other-model", operation: "read" }),
+    ]);
+
+    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+
+    expect(configs["agent-1"].tools).toEqual([]);
+    // The unrelated model's ops are still surfaced in `permissions` even
+    // though they don't map to any tool.
+    expect(configs["agent-1"].permissions).toEqual({ "some-other-model": ["read"] });
+  });
+
+  it("returns an empty object for an empty aggregation", () => {
+    expect(buildEmailAgentConfigs(new Map())).toEqual({});
+  });
+
+  it("carries connectionId + permissions per agent, keyed by model", () => {
+    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+      row({ agentId: "agent-1", connectionId: "conn-1", model: "email", operation: "read" }),
+    ]);
+
+    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+
+    expect(configs["agent-1"].connectionId).toBe("conn-1");
+    expect(configs["agent-1"].permissions).toEqual({ email: ["read"] });
+  });
+
+  it("never leaks the connection's encrypted credentials into the emitted plugin config", () => {
+    // Security-relevant edge: emailAgentConfigs feeds directly into
+    // plugins.entries.pinchy-email.config.agents in build.ts. The plugin
+    // fetches credentials itself via the internal API — the emitted config
+    // must carry no more than connectionId/permissions/tools.
+    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+      row(
+        { agentId: "agent-1", connectionId: "conn-1", model: "email", operation: "read" },
+        { credentials: "ENCRYPTED:super-secret-refresh-token" }
+      ),
+    ]);
+
+    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+    const serialized = JSON.stringify(configs);
+
+    expect(Object.keys(configs["agent-1"]).sort()).toEqual([
+      "connectionId",
+      "permissions",
+      "tools",
+    ]);
+    expect(serialized).not.toContain("super-secret-refresh-token");
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/email-agent-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/email-agent-config.test.ts
@@ -4,13 +4,17 @@ import {
   buildEmailAgentConfigs,
   type JoinedPermissionRow,
 } from "@/lib/openclaw-config/email-agent-config";
+import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
+import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
 
 /**
  * Minimal integration_connections fixture. Only the fields the two functions
  * under test actually read (`type`, `id`, `name`, `data`) are meaningful;
- * the rest are present to satisfy the schema-derived type and deliberately
- * carry a plausible-looking encrypted-credentials string so the "no plaintext
- * secret in output" test below has something real to check against.
+ * the rest are spelled out because the fixture is checked against the
+ * schema-derived type — no `as` cast, so a new NOT NULL column shows up here
+ * as a compile error instead of an absent field the code reads as undefined.
+ * `credentials` deliberately carries a plausible-looking encrypted string so
+ * the "no plaintext secret in output" test below has something real to check.
  */
 function makeConnection(
   overrides: Partial<JoinedPermissionRow["integration_connections"]> = {}
@@ -28,7 +32,7 @@ function makeConnection(
     createdAt: new Date("2026-01-01T00:00:00Z"),
     updatedAt: new Date("2026-01-01T00:00:00Z"),
     ...overrides,
-  } as JoinedPermissionRow["integration_connections"];
+  };
 }
 
 function makePermission(
@@ -41,7 +45,7 @@ function makePermission(
     model: "email",
     operation: "read",
     ...overrides,
-  } as JoinedPermissionRow["agent_connection_permissions"];
+  };
 }
 
 function row(
@@ -65,17 +69,19 @@ describe("aggregateEmailPermissionsByAgent", () => {
     expect(result.size).toBe(0);
   });
 
-  it("accepts every EMAIL_CONNECTION_TYPES member (google, microsoft, imap)", () => {
-    const rows: JoinedPermissionRow[] = [
-      row({ agentId: "agent-google" }, { type: "google" }),
-      row({ agentId: "agent-microsoft" }, { type: "microsoft" }),
-      row({ agentId: "agent-imap" }, { type: "imap" }),
-    ];
+  // Driven off EMAIL_CONNECTION_TYPES itself, not a hand-written copy of it:
+  // a fourth email provider added to the constant is then covered here the
+  // moment it lands, instead of leaving a test whose name claims "every
+  // member" while it checks three.
+  it("accepts every EMAIL_CONNECTION_TYPES member", () => {
+    const rows: JoinedPermissionRow[] = EMAIL_CONNECTION_TYPES.map((type) =>
+      row({ agentId: `agent-${type}` }, { type })
+    );
 
     const result = aggregateEmailPermissionsByAgent(rows);
 
     expect(new Set(result.keys())).toEqual(
-      new Set(["agent-google", "agent-microsoft", "agent-imap"])
+      new Set(EMAIL_CONNECTION_TYPES.map((type) => `agent-${type}`))
     );
   });
 
@@ -131,22 +137,38 @@ describe("buildEmailAgentConfigs", () => {
     ]);
   });
 
-  it("grants the same read toolset for legacy 'search'/'list' aliases without a 'read' row", () => {
-    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
-      row({ agentId: "agent-1", model: "email", operation: "search" }),
-    ]);
+  // Every alias in EMAIL_READ_OPERATIONS, not just "search": a legacy
+  // list-only agent (pre-#328 rows, no accompanying "read") must derive the
+  // same toolset, and deriving the cases from the constant keeps a future
+  // alias from slipping past a hand-written pair.
+  it.each(EMAIL_READ_OPERATIONS.filter((op) => op !== "read"))(
+    "grants the same read toolset for the legacy '%s' alias without a 'read' row",
+    (operation) => {
+      const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+        row({ agentId: "agent-1", model: "email", operation }),
+      ]);
 
-    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+      const configs = buildEmailAgentConfigs(emailPermsByAgent);
 
-    expect(configs["agent-1"].tools).toEqual([
-      "email_list",
-      "email_read",
-      "email_search",
-      "email_get_attachment",
-    ]);
+      expect(configs["agent-1"].tools).toEqual([
+        "email_list",
+        "email_read",
+        "email_search",
+        "email_get_attachment",
+      ]);
+    }
+  );
+
+  // The half a derived test cannot see: drop "list" from the constant and the
+  // case above simply vanishes rather than going red. Nothing else in the repo
+  // pins the alias list, so a legacy list-only agent losing every email tool
+  // would ship silently.
+  it("keeps the legacy read aliases in EMAIL_READ_OPERATIONS", () => {
+    expect(EMAIL_READ_OPERATIONS).toContain("search");
+    expect(EMAIL_READ_OPERATIONS).toContain("list");
   });
 
-  it("adds draft/send tools only when explicitly granted, never implied by read", () => {
+  it("adds draft tools only when explicitly granted, never implied by read", () => {
     const emailPermsByAgent = aggregateEmailPermissionsByAgent([
       row({ agentId: "agent-1", model: "email", operation: "read" }),
       row({ agentId: "agent-1", model: "email", operation: "draft" }),
@@ -156,6 +178,21 @@ describe("buildEmailAgentConfigs", () => {
 
     expect(configs["agent-1"].tools).toContain("email_draft");
     expect(configs["agent-1"].tools).not.toContain("email_send");
+  });
+
+  // The other half of the same rule: send is the most consequential grant in
+  // the set, so it gets its own pin rather than only ever being asserted
+  // absent above.
+  it("adds email_send only when 'send' is granted, and not email_draft with it", () => {
+    const emailPermsByAgent = aggregateEmailPermissionsByAgent([
+      row({ agentId: "agent-1", model: "email", operation: "read" }),
+      row({ agentId: "agent-1", model: "email", operation: "send" }),
+    ]);
+
+    const configs = buildEmailAgentConfigs(emailPermsByAgent);
+
+    expect(configs["agent-1"].tools).toContain("email_send");
+    expect(configs["agent-1"].tools).not.toContain("email_draft");
   });
 
   it("emits an empty tools array when the agent has no 'email' model ops", () => {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -13,11 +13,7 @@ import {
   channelLinks,
 } from "@/db/schema";
 import { getSetting, getSettingsByPrefix } from "@/lib/settings";
-import {
-  computeAllowedTools,
-  getEmailToolsForOperations,
-  EMAIL_OPERATION_DISPLAY_ORDER,
-} from "@/lib/tool-registry";
+import { computeAllowedTools, EMAIL_OPERATION_DISPLAY_ORDER } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
 import {
   TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
@@ -65,7 +61,7 @@ import { resolveDefaultVisionModelChain } from "./default-media-models";
 import { resolveChatModelFallbackChain } from "./chat-model-fallback";
 import { deepMerge } from "./deep-merge";
 import { buildGatewayBlock } from "./gateway";
-import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
+import { aggregateEmailPermissionsByAgent, buildEmailAgentConfigs } from "./email-agent-config";
 
 /**
  * Public docs URL configuration for the bundled `pinchy-docs` plugin.
@@ -317,76 +313,12 @@ export async function regenerateOpenClawConfig() {
   // fan-out fix, v0.9.0 release verification).
   const allPermissions = await loadAgentConnectionPermissions(db);
 
-  // Aggregate email permissions per agent. LATENT FIRST-WINS BEHAVIOR: the
-  // pinchy-email plugin config supports exactly ONE connectionId per agent
-  // (additionalProperties: false in its manifest) and the UI offers a single
-  // Select, so `connectionId`/`connection` stick to the FIRST email-type
-  // connection seen while `ops` merge across ALL of them. `connectionIds`
-  // exists purely to detect and warn about the multi-connection case.
-  const EMAIL_PROVIDER_TYPES = new Set<string>(EMAIL_CONNECTION_TYPES);
-  const emailPermsByAgent = new Map<
-    string,
-    {
-      connectionId: string;
-      connection: typeof integrationConnections.$inferSelect;
-      connectionIds: Set<string>;
-      ops: Map<string, string[]>;
-    }
-  >();
-
-  for (const row of allPermissions) {
-    const perm = row.agent_connection_permissions;
-    const conn = row.integration_connections;
-
-    if (!EMAIL_PROVIDER_TYPES.has(conn.type)) continue;
-
-    if (!emailPermsByAgent.has(perm.agentId)) {
-      emailPermsByAgent.set(perm.agentId, {
-        connectionId: perm.connectionId,
-        connection: conn,
-        connectionIds: new Set(),
-        ops: new Map(),
-      });
-    }
-    const agentPerms = emailPermsByAgent.get(perm.agentId)!;
-    agentPerms.connectionIds.add(perm.connectionId);
-
-    if (!agentPerms.ops.has(perm.model)) {
-      agentPerms.ops.set(perm.model, []);
-    }
-    agentPerms.ops.get(perm.model)!.push(perm.operation);
-  }
-
-  // Per-agent pinchy-email plugin config (emitted into plugins.entries further
-  // down). Unlike Odoo, email config does NOT include decrypted credentials —
-  // only connectionId + permissions. The plugin fetches credentials at runtime
-  // via the internal API (API-callback pattern).
-  const emailAgentConfigs: Record<
-    string,
-    { connectionId: string; permissions: Record<string, string[]>; tools: string[] }
-  > = {};
-  for (const [agentId, data] of emailPermsByAgent) {
-    const permissions: Record<string, string[]> = {};
-    for (const [model, ops] of data.ops) {
-      permissions[model] = ops;
-    }
-    // Derive tool names from granted email operations. OpenClaw uses this
-    // array to know which plugin-registered tool factories to call for this
-    // agent — without it, no factory is called and no tools are available.
-    // Delegated to tool-registry's getEmailToolsForOperations — the same
-    // ops→tools mapping the permission UI uses, where "read" includes
-    // email_search (matching the plugin's own gate: email_search checks the
-    // "read" permission). A hand-rolled mapping here previously required a
-    // separate "search" operation the UI never writes, silently stripping
-    // email_search from every UI-configured agent.
-    const emailOps = data.ops.get("email") ?? [];
-    const tools = getEmailToolsForOperations(emailOps);
-    emailAgentConfigs[agentId] = {
-      connectionId: data.connectionId,
-      permissions,
-      tools,
-    };
-  }
+  // Aggregate email permissions per agent, then derive the per-agent
+  // pinchy-email plugin config (emitted into plugins.entries further down).
+  // See email-agent-config.ts for the LATENT FIRST-WINS BEHAVIOR rationale
+  // and why email config carries no decrypted credentials.
+  const emailPermsByAgent = aggregateEmailPermissionsByAgent(allPermissions);
+  const emailAgentConfigs = buildEmailAgentConfigs(emailPermsByAgent);
 
   // Materialize each agent's TOOLS.md mailbox context from the SAME
   // aggregation that feeds the pinchy-email plugin config above, so the

--- a/packages/web/src/lib/openclaw-config/email-agent-config.ts
+++ b/packages/web/src/lib/openclaw-config/email-agent-config.ts
@@ -1,0 +1,115 @@
+import type { agentConnectionPermissions, integrationConnections } from "@/db/schema";
+import { getEmailToolsForOperations } from "@/lib/tool-registry";
+import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
+
+/**
+ * Connection types the pinchy-email plugin serves. Pulled out to a set once so
+ * membership checks below are O(1).
+ */
+const EMAIL_PROVIDER_TYPES = new Set<string>(EMAIL_CONNECTION_TYPES);
+
+export type JoinedPermissionRow = {
+  agent_connection_permissions: typeof agentConnectionPermissions.$inferSelect;
+  integration_connections: typeof integrationConnections.$inferSelect;
+};
+
+/**
+ * Per-agent aggregation of every email-type connection permission row.
+ *
+ * LATENT FIRST-WINS BEHAVIOR: the pinchy-email plugin config supports exactly
+ * ONE connectionId per agent (`additionalProperties: false` in its manifest)
+ * and the UI offers a single Select, so `connectionId`/`connection` stick to
+ * the FIRST email-type connection seen while `ops` merge across ALL of them.
+ * `connectionIds` exists purely to detect and warn about the multi-connection
+ * case.
+ */
+export interface EmailPermissionsForAgent {
+  connectionId: string;
+  connection: typeof integrationConnections.$inferSelect;
+  connectionIds: Set<string>;
+  ops: Map<string, string[]>;
+}
+
+/**
+ * Groups joined agent-connection-permission rows by agent, keeping only rows
+ * whose connection is an email-type integration (see `EMAIL_CONNECTION_TYPES`).
+ * Pure: no DB access, no I/O — `allPermissions` is expected to already be
+ * loaded (see `loadAgentConnectionPermissions` in build.ts).
+ */
+export function aggregateEmailPermissionsByAgent(
+  allPermissions: JoinedPermissionRow[]
+): Map<string, EmailPermissionsForAgent> {
+  const emailPermsByAgent = new Map<string, EmailPermissionsForAgent>();
+
+  for (const row of allPermissions) {
+    const perm = row.agent_connection_permissions;
+    const conn = row.integration_connections;
+
+    if (!EMAIL_PROVIDER_TYPES.has(conn.type)) continue;
+
+    if (!emailPermsByAgent.has(perm.agentId)) {
+      emailPermsByAgent.set(perm.agentId, {
+        connectionId: perm.connectionId,
+        connection: conn,
+        connectionIds: new Set(),
+        ops: new Map(),
+      });
+    }
+    const agentPerms = emailPermsByAgent.get(perm.agentId)!;
+    agentPerms.connectionIds.add(perm.connectionId);
+
+    if (!agentPerms.ops.has(perm.model)) {
+      agentPerms.ops.set(perm.model, []);
+    }
+    agentPerms.ops.get(perm.model)!.push(perm.operation);
+  }
+
+  return emailPermsByAgent;
+}
+
+/** Per-agent pinchy-email plugin config, emitted into `plugins.entries.pinchy-email.config.agents`. */
+export interface EmailAgentConfig {
+  connectionId: string;
+  permissions: Record<string, string[]>;
+  tools: string[];
+}
+
+/**
+ * Builds the per-agent pinchy-email plugin config from the aggregation above.
+ * Unlike Odoo, email config does NOT include decrypted credentials — only
+ * connectionId + permissions. The plugin fetches credentials at runtime via
+ * the internal API (API-callback pattern).
+ *
+ * Pure: takes the already-aggregated map, returns a plain object. No DB
+ * access, no secret reads.
+ */
+export function buildEmailAgentConfigs(
+  emailPermsByAgent: Map<string, EmailPermissionsForAgent>
+): Record<string, EmailAgentConfig> {
+  const emailAgentConfigs: Record<string, EmailAgentConfig> = {};
+
+  for (const [agentId, data] of emailPermsByAgent) {
+    const permissions: Record<string, string[]> = {};
+    for (const [model, ops] of data.ops) {
+      permissions[model] = ops;
+    }
+    // Derive tool names from granted email operations. OpenClaw uses this
+    // array to know which plugin-registered tool factories to call for this
+    // agent — without it, no factory is called and no tools are available.
+    // Delegated to tool-registry's getEmailToolsForOperations — the same
+    // ops→tools mapping the permission UI uses, where "read" includes
+    // email_search (matching the plugin's own gate: email_search checks the
+    // "read" permission). A hand-rolled mapping here previously required a
+    // separate "search" operation the UI never writes, silently stripping
+    // email_search from every UI-configured agent.
+    const emailOps = data.ops.get("email") ?? [];
+    const tools = getEmailToolsForOperations(emailOps);
+    emailAgentConfigs[agentId] = {
+      connectionId: data.connectionId,
+      permissions,
+      tools,
+    };
+  }
+
+  return emailAgentConfigs;
+}


### PR DESCRIPTION
Part of #1072

## Summary

`regenerateOpenClawConfig` in `packages/web/src/lib/openclaw-config/build.ts` is a ~1700-line function that builds the entire OpenClaw config. #1072 sanctions extracting it one section per PR, behavior-pinned by the existing `openclaw-config.test.ts` suite (8.6k lines). This PR extracts the first section.

**Section chosen: the email-permission aggregation → `pinchy-email` plugin config** (out of the issue's candidates: `buildProvidersBlock`, `buildPluginEntries`, `buildEmailAgentConfigs`, `buildAgentsBlock`).

Why this one first: it has the fewest entanglements.
- Its only input is `allPermissions`, already loaded by `loadAgentConnectionPermissions` before this code runs — no DB access or secret reads inside the extracted logic itself.
- Its output (`emailAgentConfigs`) feeds exactly one downstream site: `plugins.entries.pinchy-email.config.agents`.
- `buildProvidersBlock` mutates a shared `providerSecrets` bundle and needs several live network fetches (Ollama, custom-provider model discovery) threaded through it. `buildAgentsBlock` and `buildPluginEntries` both interleave multiple shared accumulator variables (`pluginConfigs`, `contextPluginAgents`, `knowledgePluginAgents`) across the same loop. Those need more restructuring to pull apart safely and are left for follow-up PRs.

## What changed

- New `packages/web/src/lib/openclaw-config/email-agent-config.ts`:
  - `aggregateEmailPermissionsByAgent(allPermissions)` — pure, groups joined permission rows by agent for email-type connections (the LATENT FIRST-WINS behavior is preserved verbatim, including the multi-connection `connectionIds` tracking).
  - `buildEmailAgentConfigs(emailPermsByAgent)` — pure, derives the per-agent `{ connectionId, permissions, tools }` config (no credentials — the plugin fetches those itself via the internal API).
- `build.ts` now calls both functions instead of inlining the loops. The TOOLS.md side effect (`writeToolsFile`) stays in the orchestrator, reading the same aggregation map.
- `build.ts`: 1937 → 1869 lines (−68), measured after the rebase onto `main`.
- Updated `email-connection-types-drift.test.ts`'s call-site list to point at the new module (import-path-only change, no assertion touched) — that's where the `EMAIL_CONNECTION_TYPES` import now actually lives.
- New `packages/web/src/__tests__/lib/openclaw-config/email-agent-config.test.ts` — 15 focused unit tests: aggregation across connection types, operation merging, first-wins connection selection, legacy `search`/`list` alias handling in tool derivation, draft and send each granted only when asked for and never implied by read, and a security-relevant check that the emitted plugin config never carries the connection's encrypted credentials.

## Behavior

Unchanged. The 240 pre-existing `openclaw-config.test.ts` cases pass unmodified (verified red→green: confirmed they were green *before* the extraction, then green again *after*, with a canary removal of the new module producing the expected import-not-found failure for the new test file).

## Test plan

- [x] `pnpm -C packages/web exec vitest run src/__tests__/lib/openclaw-config.test.ts` — 240 passed (baseline unchanged)
- [x] `pnpm -C packages/web exec vitest run src/__tests__/lib/openclaw-config/email-agent-config.test.ts` — 12 passed (new)
- [x] `pnpm test:related` — 54 files / 1009 passed
- [x] `pnpm -C packages/web lint` — 0 errors (pre-existing warning count unchanged)
- [x] `pnpm -C packages/web typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test` (full suite) — 777 passed / 4 skipped test files, 11012 passed / 18 skipped tests (pre-existing skips)
- [x] Pre-push `pnpm build` — succeeded


---

**Rebased onto `main`** (was 260 commits behind; rebase applied cleanly, no conflicts) and re-verified there: full `pnpm test` 11969 passed / 18 skipped, `tsc -p tsconfig.typecheck.json` clean, `eslint` 0 errors, `prettier --check .` clean, pre-push `next build` succeeded.

**Review follow-up commit** (test-only, no production change): the two fixture builders dropped their `as` casts so a schema change fails the typecheck gate instead of compiling; the "every EMAIL_CONNECTION_TYPES member" case is now mapped from the constant rather than a hand-copied list; the alias case, previously named for `search`/`list` but only exercising `search`, is now one case per alias in `EMAIL_READ_OPERATIONS` plus a pin that both legacy aliases stay in it; and `send` got the counterpart assertion to `draft`.
