### PR TITLE
perf(audit): total on page 1 only, reltuples estimate, secret-read cache

### DIFF
--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1703,6 +1703,10 @@ Retrieve a paginated, filterable audit log. **Admin only.**
 
 `outcome` is one of `"success"` or `"failure"`. `error` is `null` for successes and a short error message for failures (e.g. `"seat_cap"` on a blocked invite). Both fields are part of the HMAC-signed v2 row shape.
 
+`total` is only present in the response for `page=1`. A request for `page > 1` omits the field entirely rather than recomputing it — the audit log is append-only and can grow unbounded, so counting it on every page view is wasteful once a client already has the number from its page-1 fetch. Callers that page through results should keep the `total` from their first response and not expect it on later pages.
+
+On an unfiltered `page=1` request, `total` is an **estimate** read from Postgres's own planner statistics (`pg_class.reltuples`) rather than an exact `count(*)`, so it may lag slightly behind the true row count (bounded below by the number of entries the same response returns). Any filtered request (`eventType`, `actorId`, `from`, `to`, or `status`) still gets an exact count.
+
 **Errors:**
 
 - `401` — not authenticated

--- a/packages/web/src/__tests__/api/audit-route.integration.test.ts
+++ b/packages/web/src/__tests__/api/audit-route.integration.test.ts
@@ -1,0 +1,104 @@
+// Real-DB integration test for GET /api/audit's total-count optimization
+// (part of #1076): total is only (re)computed on page 1, and an unfiltered
+// page-1 request reads pg_class.reltuples instead of an exact count(*).
+//
+// The unit tests in audit-route.test.ts mock db.select/db.execute entirely,
+// which proves the branching logic but not that the raw
+// `SELECT reltuples::bigint AS estimate FROM pg_class WHERE oid = ...`
+// actually runs against real Postgres — a typo in that literal SQL string
+// would still pass every mocked test. This is that guardrail.
+//
+// Only auth is mocked (Better Auth cookies on a NextRequest are not the thing
+// under test); the DB reads are real.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return { ...actual, getSession: vi.fn() };
+});
+
+import { getSession } from "@/lib/auth";
+import { appendAuditLog } from "@/lib/audit";
+import { GET } from "@/app/api/audit/route";
+import { makeNextRequest } from "@/test-helpers/route";
+
+function asAdmin() {
+  vi.mocked(getSession).mockResolvedValue({
+    user: { id: "admin-1", role: "admin" },
+  } as unknown as Awaited<ReturnType<typeof getSession>>);
+}
+
+async function appendLoginRow(actorId: string) {
+  await appendAuditLog({
+    actorType: "user",
+    actorId,
+    eventType: "auth.login",
+    resource: `user:${actorId}`,
+    outcome: "success",
+  });
+}
+
+async function appendConfigChangedRow(actorId: string) {
+  await appendAuditLog({
+    actorType: "user",
+    actorId,
+    eventType: "config.changed",
+    detail: { key: "test" },
+    outcome: "success",
+  });
+}
+
+async function get(url: string) {
+  const response = await GET(makeNextRequest(url));
+  return { status: response.status, body: await response.json() };
+}
+
+describe("GET /api/audit (integration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asAdmin();
+  });
+
+  it("computes a real total (via pg_class.reltuples) on an unfiltered page-1 request", async () => {
+    await appendLoginRow("user-1");
+    await appendLoginRow("user-2");
+    await appendLoginRow("user-3");
+
+    const { status, body } = await get("http://localhost/api/audit");
+
+    expect(status).toBe(200);
+    expect(body.entries).toHaveLength(3);
+    // reltuples is a planner ESTIMATE, refreshed by ANALYZE — on a table this
+    // small and this freshly written to, it can legitimately read anywhere
+    // from 0 up. The floor against the page's own entry count is exactly
+    // what keeps this assertion true regardless of autovacuum timing: the
+    // route must never report fewer than what it is already returning.
+    expect(body.total).toBeGreaterThanOrEqual(3);
+  });
+
+  it("omits total on page 2 — no recomputation past page 1", async () => {
+    await appendLoginRow("user-1");
+    await appendLoginRow("user-2");
+
+    const { status, body } = await get("http://localhost/api/audit?page=2&limit=1");
+
+    expect(status).toBe(200);
+    expect("total" in body).toBe(false);
+  });
+
+  it("computes an exact count for a filtered page-1 request", async () => {
+    await appendLoginRow("user-1");
+    await appendConfigChangedRow("user-2");
+
+    const { status, body } = await get("http://localhost/api/audit?eventType=auth.login");
+
+    expect(status).toBe(200);
+    expect(body.entries).toHaveLength(1);
+    expect(body.total).toBe(1);
+  });
+});

--- a/packages/web/src/__tests__/api/audit-route.test.ts
+++ b/packages/web/src/__tests__/api/audit-route.test.ts
@@ -18,14 +18,19 @@ const mockEntriesLeftJoin2 = vi.fn().mockReturnValue({ leftJoin: mockEntriesLeft
 const mockEntriesLeftJoin1 = vi.fn().mockReturnValue({ leftJoin: mockEntriesLeftJoin2 });
 const mockEntriesFrom = vi.fn().mockReturnValue({ leftJoin: mockEntriesLeftJoin1 });
 
-// Build chainable mock for count query: select().from().where()
+// Build chainable mock for the FILTERED count query: select().from().where()
 const mockCountWhere = vi.fn();
 const mockCountFrom = vi.fn().mockReturnValue({ where: mockCountWhere });
+
+// The UNFILTERED path reads pg_class.reltuples via db.execute(sql`...`)
+// instead of a select().from().where() chain — see rawTotalForPage1 in
+// app/api/audit/route.ts.
+const mockExecute = vi.fn();
 
 const mockSelect = vi.fn();
 
 vi.mock("@/db", () => ({
-  db: { select: mockSelect },
+  db: { select: mockSelect, execute: mockExecute },
 }));
 
 vi.mock("@/db/schema", () => ({
@@ -123,14 +128,31 @@ describe("GET /api/audit", () => {
     },
   ];
 
-  function setupMocks(entries = sampleEntries, total = entries.length) {
+  // Total is only computed on page 1, and takes one of two shapes: an exact
+  // count (filtered — a second db.select call) or a reltuples estimate
+  // (unfiltered — db.execute). "none" is page > 1, where total isn't
+  // computed at all. Queuing a `mockReturnValueOnce`/`mockResolvedValueOnce`
+  // that the code path never consumes would leak into the NEXT test (these
+  // are FIFO queues that `vi.clearAllMocks()` does not drain), so the mode
+  // must match exactly what the request under test will actually trigger —
+  // never "queue both, harmlessly".
+  type TotalMode = "estimate" | "exact" | "none";
+
+  function setupMocks(
+    entries = sampleEntries,
+    total = entries.length,
+    totalMode: TotalMode = "estimate"
+  ) {
     // First call: entries query (with leftJoin chain)
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(entries);
 
-    // Second call: count query
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: total }]);
+    if (totalMode === "exact") {
+      mockSelect.mockReturnValueOnce({ from: mockCountFrom });
+      mockCountWhere.mockResolvedValueOnce([{ count: total }]);
+    } else if (totalMode === "estimate") {
+      mockExecute.mockResolvedValueOnce([{ estimate: total }]);
+    }
   }
 
   beforeEach(async () => {
@@ -204,7 +226,8 @@ describe("GET /api/audit", () => {
   });
 
   it("supports custom page and limit parameters", async () => {
-    setupMocks([], 100);
+    // page > 1: total isn't (re)computed at all.
+    setupMocks([], 100, "none");
 
     const request = new NextRequest("http://localhost:7777/api/audit?page=3&limit=20");
     const response = await GET(request);
@@ -259,7 +282,7 @@ describe("GET /api/audit", () => {
   });
 
   it("supports eventType filter parameter", async () => {
-    setupMocks([sampleEntries[0]], 1);
+    setupMocks([sampleEntries[0]], 1, "exact");
 
     const request = new NextRequest("http://localhost:7777/api/audit?eventType=auth.login");
     const response = await GET(request);
@@ -274,7 +297,7 @@ describe("GET /api/audit", () => {
 
   it("supports actorId filter parameter (matches raw id when no pseudonym found)", async () => {
     mockResolveActorIdMatchSet.mockResolvedValueOnce(["user-1"]);
-    setupMocks([sampleEntries[0]], 1);
+    setupMocks([sampleEntries[0]], 1, "exact");
 
     const request = new NextRequest("http://localhost:7777/api/audit?actorId=user-1");
     const response = await GET(request);
@@ -290,7 +313,7 @@ describe("GET /api/audit", () => {
     // match both, or an admin filtering by a known user id would silently
     // miss half that user's history.
     mockResolveActorIdMatchSet.mockResolvedValueOnce(["user-1", "pseudo-abc"]);
-    setupMocks([sampleEntries[0]], 1);
+    setupMocks([sampleEntries[0]], 1, "exact");
 
     const request = new NextRequest("http://localhost:7777/api/audit?actorId=user-1");
     const response = await GET(request);
@@ -308,7 +331,7 @@ describe("GET /api/audit", () => {
 
   it("supports from and to date range filters", async () => {
     const { gte, lte } = await import("drizzle-orm");
-    setupMocks([]);
+    setupMocks([], 0, "exact");
 
     const request = new NextRequest(
       "http://localhost:7777/api/audit?from=2026-02-01T00:00:00Z&to=2026-02-28T23:59:59Z"
@@ -322,7 +345,7 @@ describe("GET /api/audit", () => {
 
   it("sets to-date to end of UTC day when only a date string is provided", async () => {
     const { lte } = await import("drizzle-orm");
-    setupMocks([]);
+    setupMocks([], 0, "exact");
 
     const request = new NextRequest("http://localhost:7777/api/audit?to=2026-03-03");
     const response = await GET(request);
@@ -343,6 +366,75 @@ describe("GET /api/audit", () => {
     const body = await response.json();
     expect(body.entries).toHaveLength(0);
     expect(body.total).toBe(0);
+  });
+
+  // ── Total: page 1 only, reltuples estimate for the unfiltered case ─────
+  //
+  // See rawTotalForPage1 in app/api/audit/route.ts. Total is only ever
+  // recomputed on page 1: a deep page (Previous/Next) reuses the total the
+  // page-1 fetch already put in client state (audit-log-table.tsx), and an
+  // unfiltered page-1 request reads pg_class.reltuples instead of running a
+  // full-table count(*).
+
+  it("does not compute a total at all on page > 1 — no exact count, no estimate query", async () => {
+    // Only the entries select is queued; queuing a count/estimate mock here
+    // would mean the route consumed one, which is exactly what this test
+    // must disprove.
+    mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
+    mockEntriesOffset.mockResolvedValueOnce(sampleEntries);
+
+    const request = new NextRequest("http://localhost:7777/api/audit?page=2");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    // JSON.stringify drops an undefined property entirely — the client must
+    // see no `total` key at all, not `total: null` or `total: 0`.
+    expect("total" in body).toBe(false);
+    expect(mockSelect).toHaveBeenCalledTimes(1); // entries only
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("uses the pg_class.reltuples estimate directly when it exceeds the page's own entry count", async () => {
+    mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
+    mockEntriesOffset.mockResolvedValueOnce(sampleEntries); // 2 entries
+    mockExecute.mockResolvedValueOnce([{ estimate: 500_000 }]);
+
+    const request = new NextRequest("http://localhost:7777/api/audit");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.total).toBe(500_000);
+    // Unfiltered: no exact count(*) — just the one entries select.
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("floors a stale/zero reltuples estimate at the page's own entry count", async () => {
+    // pg_class.reltuples reads 0 on a table that has never been ANALYZEd yet
+    // (a brand-new install) even though rows exist — the response must never
+    // undercount below what it is already returning.
+    mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
+    mockEntriesOffset.mockResolvedValueOnce(sampleEntries); // 2 entries
+    mockExecute.mockResolvedValueOnce([{ estimate: 0 }]);
+
+    const request = new NextRequest("http://localhost:7777/api/audit");
+    const response = await GET(request);
+
+    const body = await response.json();
+    expect(body.total).toBe(sampleEntries.length);
+  });
+
+  it("computes an exact count for a filtered page-1 request instead of the reltuples estimate", async () => {
+    setupMocks([sampleEntries[0]], 1, "exact");
+
+    const request = new NextRequest("http://localhost:7777/api/audit?eventType=auth.login");
+    const response = await GET(request);
+
+    const body = await response.json();
+    expect(body.total).toBe(1);
+    // Filtered path never touches pg_class — that's the unfiltered shortcut.
+    expect(mockExecute).not.toHaveBeenCalled();
   });
 
   it("resolves actorName from users table", async () => {
@@ -370,8 +462,7 @@ describe("GET /api/audit", () => {
     mockEntriesOffset.mockResolvedValueOnce(entriesWithName);
 
     // Second call: count query
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -406,8 +497,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(keyEntry);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -443,8 +533,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(keyEntry);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -481,8 +570,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(userEntry);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -532,8 +620,7 @@ describe("GET /api/audit", () => {
     mockEntriesOffset.mockResolvedValueOnce(entriesWithAgentResource);
 
     // Second call: count query
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -563,8 +650,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(entries);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -594,8 +680,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(entries);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -617,8 +702,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(entries);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -640,8 +724,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(entries);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -693,8 +776,7 @@ describe("GET /api/audit", () => {
     ];
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(entries);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 2 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 2 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -708,14 +790,14 @@ describe("GET /api/audit", () => {
   });
 
   it("filters by status=failure when query param is set", async () => {
-    setupMocks([], 0);
+    setupMocks([], 0, "exact");
     const req = new NextRequest("http://localhost/api/audit?status=failure");
     await GET(req);
     expect(eq).toHaveBeenCalledWith("outcome", "failure");
   });
 
   it("filters by status=success when query param is set", async () => {
-    setupMocks([], 0);
+    setupMocks([], 0, "exact");
     const req = new NextRequest("http://localhost/api/audit?status=success");
     await GET(req);
     expect(eq).toHaveBeenCalledWith("outcome", "success");
@@ -743,8 +825,7 @@ describe("GET /api/audit", () => {
 
     mockSelect.mockReturnValueOnce({ from: mockEntriesFrom });
     mockEntriesOffset.mockResolvedValueOnce(entries);
-    mockSelect.mockReturnValueOnce({ from: mockCountFrom });
-    mockCountWhere.mockResolvedValueOnce([{ count: 1 }]);
+    mockExecute.mockResolvedValueOnce([{ estimate: 1 }]);
 
     const req = new NextRequest("http://localhost/api/audit");
     const res = await GET(req);
@@ -756,14 +837,14 @@ describe("GET /api/audit", () => {
   it("returns 400 for an invalid 'from' date instead of crashing the query", async () => {
     // new Date("notadate") is an Invalid Date; pushed into a timestamp bound it
     // makes drizzle throw a RangeError at serialization → an unhandled 500.
-    setupMocks();
+    // No setupMocks(): the route returns 400 before any db call, and queuing
+    // an unconsumed mock here would leak into the next test's first call.
     const req = new NextRequest("http://localhost/api/audit?from=notadate");
     const res = await GET(req);
     expect(res.status).toBe(400);
   });
 
   it("returns 400 for an invalid 'to' date", async () => {
-    setupMocks();
     const req = new NextRequest("http://localhost/api/audit?to=garbage");
     const res = await GET(req);
     expect(res.status).toBe(400);

--- a/packages/web/src/__tests__/components/audit-log-table.test.tsx
+++ b/packages/web/src/__tests__/components/audit-log-table.test.tsx
@@ -441,6 +441,46 @@ describe("AuditLogTable", () => {
     });
   });
 
+  it("keeps the page-1 total when a later page's response omits it", async () => {
+    // The server only (re)computes `total` on page 1 (see app/api/audit's
+    // rawTotalForPage1) — a page > 1 response has no `total` key at all.
+    // The component must keep showing the total from the page-1 fetch
+    // instead of losing it (e.g. falling back to 0 → "Page 1 of 1").
+    mockEventTypesThenEntries(undefined, {
+      entries: mockEntries,
+      total: 120,
+      page: 1,
+      limit: 50,
+    });
+
+    render(<AuditLogTable />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+
+    const nextButton = screen.getByRole("button", { name: "Next" });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        entries: mockEntries,
+        // No `total` field — the page > 1 contract.
+        page: 2,
+        limit: 50,
+      }),
+    } as Response);
+
+    const user = userEvent.setup();
+    await user.click(nextButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("page=2"));
+    });
+    // Still "of 3" — the total from page 1 was retained, not reset.
+    expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+  });
+
   it("should have an event type filter with combobox role", async () => {
     renderWithEntriesLoaded();
 

--- a/packages/web/src/__tests__/lib/audit-append.test.ts
+++ b/packages/web/src/__tests__/lib/audit-append.test.ts
@@ -57,6 +57,7 @@ import {
   computeRowHmacV2,
   computeRowHmacV3,
   resetAuditPseudonymCache,
+  resetLockWaitWarnWindow,
   type AuditLogEntry,
 } from "@/lib/audit";
 import { auditLog } from "@/db/schema";
@@ -75,6 +76,7 @@ describe("appendAuditLog", () => {
     mockPrevRow.mockResolvedValue([]); // genesis: no previous row
     mockPseudonymRow.mockResolvedValue([]); // no matching user by default
     resetAuditPseudonymCache();
+    resetLockWaitWarnWindow();
   });
 
   it("should insert a row into the audit_log table", async () => {
@@ -631,6 +633,93 @@ describe("appendAuditLog", () => {
       } finally {
         delete process.env.AUDIT_PSEUDONYM_CACHE_MAX;
       }
+    });
+  });
+
+  // ── Lock-wait warning ────────────────────────────────────────────────────
+  //
+  // appendAuditLog holds pg_advisory_xact_lock across the whole transaction,
+  // so every state-changing route and every tool call queues behind whoever
+  // holds it. A slow acquisition (checkpoint, autovacuum, a stuck writer) was
+  // previously invisible — nothing pointed at the lock as the cause. A
+  // one-shot, rate-limited console.warn makes that stall diagnosable without
+  // spamming the log if many concurrent appends are all slow at once.
+  //
+  // appendAuditLog calls Date.now() exactly twice per invocation — once
+  // before tx.execute(pg_advisory_xact_lock) and once right after — so a
+  // spy queues two return values per append below. `new Date()` (used for
+  // the row's own timestamp) does not go through the Date.now() spy.
+  describe("lock-wait warning", () => {
+    it("warns once when acquiring the lock takes at least 1s", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(1_000).mockReturnValueOnce(2_500); // 1500ms
+
+      await appendAuditLog({
+        actorType: "system",
+        actorId: "system",
+        eventType: "config.changed",
+        detail: {},
+        outcome: "success",
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("1500ms");
+
+      warnSpy.mockRestore();
+      nowSpy.mockRestore();
+    });
+
+    it("does not warn when acquiring the lock is fast", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(1_000).mockReturnValueOnce(1_500); // 500ms
+
+      await appendAuditLog({
+        actorType: "system",
+        actorId: "system",
+        eventType: "config.changed",
+        detail: {},
+        outcome: "success",
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+      nowSpy.mockRestore();
+    });
+
+    it("suppresses repeated warnings within the window and reports the suppressed count on the next one", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const nowSpy = vi.spyOn(Date, "now");
+      const append = () =>
+        appendAuditLog({
+          actorType: "system",
+          actorId: "system",
+          eventType: "config.changed",
+          detail: {},
+          outcome: "success",
+        });
+
+      // Call 1: 2000ms wait, at t=0..2000 — opens the window and warns.
+      nowSpy.mockReturnValueOnce(0).mockReturnValueOnce(2_000);
+      await append();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).not.toContain("suppressed");
+
+      // Call 2: 2000ms wait, at t=3000..5000 — still inside the 60s window
+      // opened by call 1 → suppressed, no warn.
+      nowSpy.mockReturnValueOnce(3_000).mockReturnValueOnce(5_000);
+      await append();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // Call 3: 2000ms wait, at t=100000..102000 — well past the window →
+      // warns again, and reports the one suppressed in between.
+      nowSpy.mockReturnValueOnce(100_000).mockReturnValueOnce(102_000);
+      await append();
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy.mock.calls[1][0]).toContain("1 similar warning");
+
+      warnSpy.mockRestore();
+      nowSpy.mockRestore();
     });
   });
 });

--- a/packages/web/src/__tests__/lib/encryption.test.ts
+++ b/packages/web/src/__tests__/lib/encryption.test.ts
@@ -5,6 +5,9 @@ vi.mock("fs", async (importOriginal) => {
   const existsSyncMock = vi.fn(() => false);
   const readFileSyncMock = vi.fn();
   const writeFileSyncMock = vi.fn();
+  // The file-secret cache invalidates on mtime — default to a fixed value so
+  // every existing test (one getOrCreateSecret call each) is unaffected.
+  const statSyncMock = vi.fn(() => ({ mtimeMs: 1 }));
   return {
     ...actual,
     default: {
@@ -12,18 +15,21 @@ vi.mock("fs", async (importOriginal) => {
       existsSync: existsSyncMock,
       readFileSync: readFileSyncMock,
       writeFileSync: writeFileSyncMock,
+      statSync: statSyncMock,
     },
     existsSync: existsSyncMock,
     readFileSync: readFileSyncMock,
     writeFileSync: writeFileSyncMock,
+    statSync: statSyncMock,
   };
 });
 
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, statSync } from "fs";
 
 const mockedExistsSync = vi.mocked(existsSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedWriteFileSync = vi.mocked(writeFileSync);
+const mockedStatSync = vi.mocked(statSync);
 
 describe("encryption", () => {
   const TEST_KEY = "a".repeat(64); // 32 bytes in hex
@@ -34,6 +40,8 @@ describe("encryption", () => {
     mockedExistsSync.mockReturnValue(false);
     mockedReadFileSync.mockReset();
     mockedWriteFileSync.mockReset();
+    mockedStatSync.mockReset();
+    mockedStatSync.mockReturnValue({ mtimeMs: 1 } as ReturnType<typeof statSync>);
   });
 
   afterEach(() => {
@@ -177,6 +185,68 @@ describe("encryption", () => {
       const mod = await import("@/lib/encryption");
       mod.getOrCreateSecret(SECRET_NAME);
       expect(mockedReadFileSync).toHaveBeenCalledWith(`/app/secrets/${FILE_NAME}`, "utf-8");
+    });
+
+    // ── File-secret cache (mtime-invalidated) ─────────────────────────────
+    //
+    // appendAuditLog calls getOrCreateSecret("audit_hmac_secret") on every
+    // audit row, which previously meant a synchronous readFileSync on every
+    // append. Caching the parsed Buffer keyed on the file's mtime removes
+    // that read from the hot path while still picking up a rotated secret
+    // without a restart.
+
+    describe("file-secret cache", () => {
+      it("caches the parsed secret across calls and does not re-read the file", async () => {
+        const validHex = "f".repeat(64);
+        mockedExistsSync.mockImplementation((path) => String(path).endsWith(FILE_NAME));
+        mockedReadFileSync.mockReturnValue(validHex);
+        mockedStatSync.mockReturnValue({ mtimeMs: 1000 } as ReturnType<typeof statSync>);
+
+        const mod = await import("@/lib/encryption");
+        const first = mod.getOrCreateSecret(SECRET_NAME);
+        const second = mod.getOrCreateSecret(SECRET_NAME);
+
+        expect(first).toEqual(Buffer.from(validHex, "hex"));
+        expect(second).toEqual(Buffer.from(validHex, "hex"));
+        expect(mockedReadFileSync).toHaveBeenCalledTimes(1);
+        // statSync is the cheap check that runs every time — the whole point
+        // is trading a read for a stat.
+        expect(mockedStatSync).toHaveBeenCalledTimes(2);
+      });
+
+      it("re-reads the file when its mtime changes (rotation without a restart)", async () => {
+        mockedExistsSync.mockImplementation((path) => String(path).endsWith(FILE_NAME));
+        mockedReadFileSync.mockReturnValueOnce("1".repeat(64));
+        mockedStatSync.mockReturnValueOnce({ mtimeMs: 1000 } as ReturnType<typeof statSync>);
+
+        const mod = await import("@/lib/encryption");
+        const before = mod.getOrCreateSecret(SECRET_NAME);
+        expect(before).toEqual(Buffer.from("1".repeat(64), "hex"));
+
+        // Secret rotated on disk: new content, new mtime.
+        mockedReadFileSync.mockReturnValueOnce("2".repeat(64));
+        mockedStatSync.mockReturnValueOnce({ mtimeMs: 2000 } as ReturnType<typeof statSync>);
+
+        const after = mod.getOrCreateSecret(SECRET_NAME);
+        expect(after).toEqual(Buffer.from("2".repeat(64), "hex"));
+        expect(mockedReadFileSync).toHaveBeenCalledTimes(2);
+      });
+
+      it("keeps separate cache entries for different secret names (different files)", async () => {
+        mockedExistsSync.mockReturnValue(true);
+        mockedReadFileSync.mockImplementation((path) =>
+          String(path).includes("audit_hmac_secret") ? "a".repeat(64) : "b".repeat(64)
+        );
+        mockedStatSync.mockReturnValue({ mtimeMs: 1 } as ReturnType<typeof statSync>);
+
+        const mod = await import("@/lib/encryption");
+        const audit = mod.getOrCreateSecret("audit_hmac_secret");
+        const encryption = mod.getOrCreateSecret("encryption_key");
+
+        expect(audit).toEqual(Buffer.from("a".repeat(64), "hex"));
+        expect(encryption).toEqual(Buffer.from("b".repeat(64), "hex"));
+        expect(mockedReadFileSync).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/packages/web/src/__tests__/lib/encryption.test.ts
+++ b/packages/web/src/__tests__/lib/encryption.test.ts
@@ -5,9 +5,23 @@ vi.mock("fs", async (importOriginal) => {
   const existsSyncMock = vi.fn(() => false);
   const readFileSyncMock = vi.fn();
   const writeFileSyncMock = vi.fn();
+  // The implementation stats and reads the secret file through one file
+  // descriptor (TOCTOU fix, CodeQL js/file-system-race), so the mock hands
+  // out fake fds and remembers which path each one names — `__fdToPath` lets
+  // a test dispatch a readFileSync(fd) back onto the path it opened.
+  const fdPaths = new Map<number, string>();
+  let nextFd = 100;
+  const openSyncMock = vi.fn((path: unknown) => {
+    const fd = nextFd++;
+    fdPaths.set(fd, String(path));
+    return fd;
+  });
+  const closeSyncMock = vi.fn((fd: number) => {
+    fdPaths.delete(fd);
+  });
   // The file-secret cache invalidates on mtime — default to a fixed value so
   // every existing test (one getOrCreateSecret call each) is unaffected.
-  const statSyncMock = vi.fn(() => ({ mtimeMs: 1 }));
+  const fstatSyncMock = vi.fn(() => ({ mtimeMs: 1 }));
   return {
     ...actual,
     default: {
@@ -15,21 +29,31 @@ vi.mock("fs", async (importOriginal) => {
       existsSync: existsSyncMock,
       readFileSync: readFileSyncMock,
       writeFileSync: writeFileSyncMock,
-      statSync: statSyncMock,
+      openSync: openSyncMock,
+      fstatSync: fstatSyncMock,
+      closeSync: closeSyncMock,
     },
     existsSync: existsSyncMock,
     readFileSync: readFileSyncMock,
     writeFileSync: writeFileSyncMock,
-    statSync: statSyncMock,
+    openSync: openSyncMock,
+    fstatSync: fstatSyncMock,
+    closeSync: closeSyncMock,
+    __fdToPath: (fd: number) => fdPaths.get(fd),
   };
 });
 
-import { existsSync, readFileSync, writeFileSync, statSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, openSync, fstatSync } from "fs";
+
+const { __fdToPath } = (await import("fs")) as unknown as {
+  __fdToPath: (fd: number) => string | undefined;
+};
 
 const mockedExistsSync = vi.mocked(existsSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedWriteFileSync = vi.mocked(writeFileSync);
-const mockedStatSync = vi.mocked(statSync);
+const mockedOpenSync = vi.mocked(openSync);
+const mockedFstatSync = vi.mocked(fstatSync);
 
 describe("encryption", () => {
   const TEST_KEY = "a".repeat(64); // 32 bytes in hex
@@ -40,8 +64,8 @@ describe("encryption", () => {
     mockedExistsSync.mockReturnValue(false);
     mockedReadFileSync.mockReset();
     mockedWriteFileSync.mockReset();
-    mockedStatSync.mockReset();
-    mockedStatSync.mockReturnValue({ mtimeMs: 1 } as ReturnType<typeof statSync>);
+    mockedFstatSync.mockReset();
+    mockedFstatSync.mockReturnValue({ mtimeMs: 1 } as ReturnType<typeof fstatSync>);
   });
 
   afterEach(() => {
@@ -125,7 +149,7 @@ describe("encryption", () => {
       const mod = await import("@/lib/encryption");
       const secret = mod.getOrCreateSecret(SECRET_NAME);
       expect(secret).toEqual(Buffer.from(validHex, "hex"));
-      expect(mockedReadFileSync).toHaveBeenCalledWith(expect.stringContaining(FILE_NAME), "utf-8");
+      expect(mockedOpenSync).toHaveBeenCalledWith(expect.stringContaining(FILE_NAME), "r");
     });
 
     it("should auto-generate and persist when neither env nor file exists", async () => {
@@ -173,7 +197,7 @@ describe("encryption", () => {
 
       const mod = await import("@/lib/encryption");
       mod.getOrCreateSecret(SECRET_NAME);
-      expect(mockedReadFileSync).toHaveBeenCalledWith(`/custom/dir/${FILE_NAME}`, "utf-8");
+      expect(mockedOpenSync).toHaveBeenCalledWith(`/custom/dir/${FILE_NAME}`, "r");
     });
 
     it("should default to /app/secrets when ENCRYPTION_KEY_DIR is not set", async () => {
@@ -184,7 +208,7 @@ describe("encryption", () => {
 
       const mod = await import("@/lib/encryption");
       mod.getOrCreateSecret(SECRET_NAME);
-      expect(mockedReadFileSync).toHaveBeenCalledWith(`/app/secrets/${FILE_NAME}`, "utf-8");
+      expect(mockedOpenSync).toHaveBeenCalledWith(`/app/secrets/${FILE_NAME}`, "r");
     });
 
     // ── File-secret cache (mtime-invalidated) ─────────────────────────────
@@ -200,7 +224,7 @@ describe("encryption", () => {
         const validHex = "f".repeat(64);
         mockedExistsSync.mockImplementation((path) => String(path).endsWith(FILE_NAME));
         mockedReadFileSync.mockReturnValue(validHex);
-        mockedStatSync.mockReturnValue({ mtimeMs: 1000 } as ReturnType<typeof statSync>);
+        mockedFstatSync.mockReturnValue({ mtimeMs: 1000 } as ReturnType<typeof fstatSync>);
 
         const mod = await import("@/lib/encryption");
         const first = mod.getOrCreateSecret(SECRET_NAME);
@@ -211,13 +235,13 @@ describe("encryption", () => {
         expect(mockedReadFileSync).toHaveBeenCalledTimes(1);
         // statSync is the cheap check that runs every time — the whole point
         // is trading a read for a stat.
-        expect(mockedStatSync).toHaveBeenCalledTimes(2);
+        expect(mockedFstatSync).toHaveBeenCalledTimes(2);
       });
 
       it("re-reads the file when its mtime changes (rotation without a restart)", async () => {
         mockedExistsSync.mockImplementation((path) => String(path).endsWith(FILE_NAME));
         mockedReadFileSync.mockReturnValueOnce("1".repeat(64));
-        mockedStatSync.mockReturnValueOnce({ mtimeMs: 1000 } as ReturnType<typeof statSync>);
+        mockedFstatSync.mockReturnValueOnce({ mtimeMs: 1000 } as ReturnType<typeof fstatSync>);
 
         const mod = await import("@/lib/encryption");
         const before = mod.getOrCreateSecret(SECRET_NAME);
@@ -225,7 +249,7 @@ describe("encryption", () => {
 
         // Secret rotated on disk: new content, new mtime.
         mockedReadFileSync.mockReturnValueOnce("2".repeat(64));
-        mockedStatSync.mockReturnValueOnce({ mtimeMs: 2000 } as ReturnType<typeof statSync>);
+        mockedFstatSync.mockReturnValueOnce({ mtimeMs: 2000 } as ReturnType<typeof fstatSync>);
 
         const after = mod.getOrCreateSecret(SECRET_NAME);
         expect(after).toEqual(Buffer.from("2".repeat(64), "hex"));
@@ -234,10 +258,12 @@ describe("encryption", () => {
 
       it("keeps separate cache entries for different secret names (different files)", async () => {
         mockedExistsSync.mockReturnValue(true);
-        mockedReadFileSync.mockImplementation((path) =>
-          String(path).includes("audit_hmac_secret") ? "a".repeat(64) : "b".repeat(64)
+        mockedReadFileSync.mockImplementation((fd) =>
+          String(__fdToPath(Number(fd))).includes("audit_hmac_secret")
+            ? "a".repeat(64)
+            : "b".repeat(64)
         );
-        mockedStatSync.mockReturnValue({ mtimeMs: 1 } as ReturnType<typeof statSync>);
+        mockedFstatSync.mockReturnValue({ mtimeMs: 1 } as ReturnType<typeof fstatSync>);
 
         const mod = await import("@/lib/encryption");
         const audit = mod.getOrCreateSecret("audit_hmac_secret");

--- a/packages/web/src/app/api/audit/route.ts
+++ b/packages/web/src/app/api/audit/route.ts
@@ -2,9 +2,47 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { auditLog } from "@/db/schema";
-import { desc, and, count } from "drizzle-orm";
+import { desc, and, count, sql, type SQL } from "drizzle-orm";
 import { apiKeyActorName } from "@/lib/api-key-identity";
 import { buildAuditFilters, auditSelectWithJoins } from "@/lib/audit-query";
+
+/**
+ * Total is only ever (re)computed on page 1 — deep-page navigation (Previous
+ * / Next) would otherwise pay for a count/estimate query on every click even
+ * though the number can't have changed since the page-1 fetch that started
+ * the session. The client (`audit-log-table.tsx`) keeps the page-1 total in
+ * state and doesn't overwrite it when a later response omits the field.
+ *
+ * Returns the RAW total/estimate, without the entries.length floor applied
+ * below — that keeps this query independent of the entries query so both can
+ * still run concurrently via Promise.all.
+ */
+async function rawTotalForPage1(where: SQL | undefined): Promise<number> {
+  if (where) {
+    // Filtered: an exact count is the honest answer, and filters typically
+    // narrow the row set enough that the scan is cheap.
+    const result = await db.select({ count: count() }).from(auditLog).where(where);
+    return result[0]?.count ?? 0;
+  }
+
+  // Unfiltered: audit_log is append-only and can grow unbounded, so an exact
+  // count(*) here means a full-table scan on every page-1 view. Read
+  // Postgres's own planner statistic instead — a single index lookup
+  // regardless of table size.
+  //
+  // This is an ESTIMATE, not an exact count: pg_class.reltuples is only
+  // refreshed by ANALYZE/VACUUM, so a table that has never been analyzed yet
+  // (a brand-new install, before autovacuum's first pass) reports 0, and a
+  // recent burst of inserts can leave the number stale for up to one
+  // autovacuum cycle. The caller floors this against the page's own entry
+  // count, so the total can never read as less than what the admin is
+  // already looking at.
+  const estimateRows = await db.execute<{ estimate: string | number | null }>(
+    sql`SELECT reltuples::bigint AS estimate FROM pg_class WHERE oid = 'audit_log'::regclass`
+  );
+  const raw = estimateRows[0]?.estimate;
+  return raw === null || raw === undefined ? 0 : Number(raw);
+}
 
 export async function GET(request: NextRequest) {
   const sessionOrError = await requireAdmin();
@@ -24,14 +62,20 @@ export async function GET(request: NextRequest) {
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-  const [entries, totalResult] = await Promise.all([
+  const [entries, rawTotal] = await Promise.all([
     auditSelectWithJoins()
       .where(where)
       .orderBy(desc(auditLog.timestamp))
       .limit(limit)
       .offset((page - 1) * limit),
-    db.select({ count: count() }).from(auditLog).where(where),
+    // Only computed on page 1 — see rawTotalForPage1's own comment.
+    page === 1 ? rawTotalForPage1(where) : Promise.resolve(undefined),
   ]);
+
+  // Floored against entries.length here (rather than inside rawTotalForPage1)
+  // so the count/estimate query above can still run concurrently with the
+  // entries query instead of waiting on it.
+  const responseTotal = rawTotal === undefined ? undefined : Math.max(rawTotal, entries.length);
 
   const processedEntries = entries.map((e) => ({
     id: e.id,
@@ -54,7 +98,10 @@ export async function GET(request: NextRequest) {
   return NextResponse.json(
     {
       entries: processedEntries,
-      total: totalResult[0]?.count ?? 0,
+      // Omitted (not null/0) on page > 1 — see rawTotalForPage1's comment.
+      // JSON.stringify drops an `undefined` property entirely, so the client
+      // sees no `total` key at all rather than a misleading value.
+      ...(responseTotal === undefined ? {} : { total: responseTotal }),
       page,
       limit,
     },

--- a/packages/web/src/components/audit-log-table.tsx
+++ b/packages/web/src/components/audit-log-table.tsx
@@ -77,7 +77,10 @@ function StatusCell({ outcome }: { outcome: "success" | "failure" | null }) {
 
 interface AuditResponse {
   entries: AuditEntry[];
-  total: number;
+  // Only present on page 1 — the server never recomputes it for a later page
+  // (see app/api/audit/route.ts), so a page > 1 response omits the field and
+  // the total already in state (from the page-1 fetch) is kept as-is.
+  total?: number;
   page: number;
   limit: number;
 }
@@ -238,7 +241,12 @@ export function AuditLogTable() {
           const data: AuditResponse = await res.json();
           if (!cancelled) {
             setEntries(data.entries);
-            setTotal(data.total);
+            // Deep pages (page > 1) omit `total` entirely (see AuditResponse)
+            // — keep whatever the page-1 fetch already put in state instead
+            // of clobbering it with undefined.
+            if (data.total !== undefined) {
+              setTotal(data.total);
+            }
           }
         }
       } finally {

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -12,6 +12,35 @@ import type { ProbeFailureCode } from "@/lib/integrations/imap-probe";
 // predecessor). Arbitrary fixed constant, unique to the audit chain.
 const AUDIT_CHAIN_LOCK_KEY = 738291002;
 
+// A slow lock acquisition (checkpoint, autovacuum, a stuck writer) previously
+// stalled every appendAuditLog caller with nothing pointing at the lock as
+// the cause. Warn once a wait crosses this threshold — high enough that a
+// normal acquisition never trips it, low enough to catch a stall while it's
+// happening rather than after routes have already started timing out.
+const LOCK_WAIT_WARN_THRESHOLD_MS = 1000;
+// Rate-limited like claimScopeDenialSlot (api-auth.ts) and the host-blocked
+// throttle: if the lock is chronically slow, many concurrent appends could
+// all cross the threshold at once, and one warning per append would spam the
+// log exactly when it's least useful. One warning per window; the window
+// reports how many were suppressed since the last one.
+const LOCK_WAIT_WARN_WINDOW_MS = 60_000;
+let lockWaitWarnWindow: { openedAt: number; suppressed: number } | null = null;
+
+/** Test seam — the window is process-global. */
+export function resetLockWaitWarnWindow(): void {
+  lockWaitWarnWindow = null;
+}
+
+function claimLockWaitWarnSlot(now: number): { write: boolean; suppressed: number } {
+  if (lockWaitWarnWindow && now - lockWaitWarnWindow.openedAt < LOCK_WAIT_WARN_WINDOW_MS) {
+    lockWaitWarnWindow.suppressed++;
+    return { write: false, suppressed: lockWaitWarnWindow.suppressed };
+  }
+  const suppressed = lockWaitWarnWindow?.suppressed ?? 0;
+  lockWaitWarnWindow = { openedAt: now, suppressed: 0 };
+  return { write: true, suppressed };
+}
+
 // ── Audit Detail Base Types ─────────────────────────────────────────────
 
 export type EntityRef = { id: string; name: string };
@@ -957,7 +986,21 @@ export async function appendAuditLog(
   // predecessor and fork the chain, which verifyIntegrity would (correctly) then
   // flag as tampering.
   return db.transaction(async (tx) => {
+    const lockAcquireStart = Date.now();
     await tx.execute(sql`SELECT pg_advisory_xact_lock(${AUDIT_CHAIN_LOCK_KEY})`);
+    const lockAcquiredAt = Date.now();
+    const lockWaitMs = lockAcquiredAt - lockAcquireStart;
+    if (lockWaitMs >= LOCK_WAIT_WARN_THRESHOLD_MS) {
+      const slot = claimLockWaitWarnSlot(lockAcquiredAt);
+      if (slot.write) {
+        console.warn(
+          `[audit] appendAuditLog waited ${lockWaitMs}ms to acquire the audit chain lock` +
+            (slot.suppressed > 0
+              ? ` (${slot.suppressed} similar warning${slot.suppressed === 1 ? "" : "s"} suppressed since the last one)`
+              : "")
+        );
+      }
+    }
 
     const [prev] = await tx
       .select({ rowHmac: auditLog.rowHmac })

--- a/packages/web/src/lib/encryption.ts
+++ b/packages/web/src/lib/encryption.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
-import { readFileSync, writeFileSync, existsSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, statSync } from "fs";
 import { join } from "path";
 
 const ALGORITHM = "aes-256-gcm";
@@ -12,6 +12,17 @@ function secretPaths(name: string) {
   const keyFileDir = process.env.ENCRYPTION_KEY_DIR || "/app/secrets";
   return { keyFileDir, keyFilePath: join(keyFileDir, `.${name}`) };
 }
+
+/**
+ * getOrCreateSecret is called on every audit append (audit_hmac_secret) and
+ * every encrypt/decrypt (encryption_key) — a synchronous file read on every
+ * one of those, holding up an advisory-locked transaction in the audit case.
+ * Cache the parsed Buffer per key-file path, invalidated by the file's mtime
+ * rather than never: a rotated secret (new content, new mtime) is picked up
+ * on the next call with no restart, while an unchanged file costs only a
+ * cheap statSync instead of a read + hex-validate on every call.
+ */
+const fileSecretCache = new Map<string, { mtimeMs: number; secret: Buffer }>();
 
 /**
  * Resolve the provenance of a secret WITHOUT creating it. Mirrors the
@@ -38,11 +49,19 @@ export function getOrCreateSecret(name: string): Buffer {
       return Buffer.from(process.env[envVarName]!, "hex");
 
     case "file": {
+      const mtimeMs = statSync(keyFilePath).mtimeMs;
+      const cached = fileSecretCache.get(keyFilePath);
+      if (cached && cached.mtimeMs === mtimeMs) {
+        return cached.secret;
+      }
+
       const fileKey = readFileSync(keyFilePath, "utf-8").trim();
       if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
         throw new Error(`Invalid secret in ${keyFilePath}: expected 64 hex characters`);
       }
-      return Buffer.from(fileKey, "hex");
+      const secret = Buffer.from(fileKey, "hex");
+      fileSecretCache.set(keyFilePath, { mtimeMs, secret });
+      return secret;
     }
 
     case "unset": {

--- a/packages/web/src/lib/encryption.ts
+++ b/packages/web/src/lib/encryption.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
-import { readFileSync, writeFileSync, existsSync, statSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, openSync, fstatSync, closeSync } from "fs";
 import { join } from "path";
 
 const ALGORITHM = "aes-256-gcm";
@@ -49,19 +49,29 @@ export function getOrCreateSecret(name: string): Buffer {
       return Buffer.from(process.env[envVarName]!, "hex");
 
     case "file": {
-      const mtimeMs = statSync(keyFilePath).mtimeMs;
-      const cached = fileSecretCache.get(keyFilePath);
-      if (cached && cached.mtimeMs === mtimeMs) {
-        return cached.secret;
-      }
+      // stat and read through the SAME descriptor: a path-based stat followed
+      // by a path-based read is a TOCTOU race (CodeQL js/file-system-race) —
+      // the file could be replaced between the two calls, and the cache would
+      // then pair the old file's mtime with the new file's bytes and never
+      // notice the rotation.
+      const fd = openSync(keyFilePath, "r");
+      try {
+        const mtimeMs = fstatSync(fd).mtimeMs;
+        const cached = fileSecretCache.get(keyFilePath);
+        if (cached && cached.mtimeMs === mtimeMs) {
+          return cached.secret;
+        }
 
-      const fileKey = readFileSync(keyFilePath, "utf-8").trim();
-      if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
-        throw new Error(`Invalid secret in ${keyFilePath}: expected 64 hex characters`);
+        const fileKey = readFileSync(fd, "utf-8").trim();
+        if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
+          throw new Error(`Invalid secret in ${keyFilePath}: expected 64 hex characters`);
+        }
+        const secret = Buffer.from(fileKey, "hex");
+        fileSecretCache.set(keyFilePath, { mtimeMs, secret });
+        return secret;
+      } finally {
+        closeSync(fd);
       }
-      const secret = Buffer.from(fileKey, "hex");
-      fileSecretCache.set(keyFilePath, { mtimeMs, secret });
-      return secret;
     }
 
     case "unset": {


### PR DESCRIPTION
## Summary

Part of #1076 (repo-review DB/performance findings around `audit_log`). Implements parts 1 and 3 only — parts 2 (composite indexes) and 4 (non-`CONCURRENTLY` DDL upgrade window) are left as open decisions, not implemented here.

**Part 1 — count(*) on every audit-UI page view (`GET /api/audit`)**
- `total` is now only (re)computed on **page 1**. A `page > 1` response omits the field entirely (not `null`/`0` — the key is absent from the JSON). The client (`audit-log-table.tsx`) keeps the page-1 total in state across Previous/Next instead of re-fetching it.
- An **unfiltered** page-1 request reads `pg_class.reltuples` (a Postgres planner statistic) instead of running `count(*)` over the whole table. This is an estimate, floored against the page's own entry count so a never-analyzed or recently-stale table can never report fewer rows than the response is already returning.
- A **filtered** page-1 request (`eventType`/`actorId`/`from`/`to`/`status`) still gets an exact `count(*)` — filters typically narrow the scan enough that it's cheap, and an estimate wouldn't be meaningful per-filter anyway.
- Docs updated in `docs/src/content/docs/reference/api.mdx` to describe the new `total` contract.

**Part 3 — advisory-lock hold time in `appendAuditLog`**
- `resolveActorId` (and thus `getOrCreateSecret`) already ran before the transaction in the current code, so the lock only ever wrapped the prev-hash SELECT + INSERT + COMMIT. What was left:
  - `getOrCreateSecret`'s file-backed secret read is now cached, invalidated by the key file's `mtime` — a rotated secret is picked up on the next call with no restart, and an unchanged file costs a `statSync` instead of a `readFileSync` + hex-validate on every audit append.
  - A lock wait ≥ 1s now logs a rate-limited `console.warn` (one per 60s window, reporting how many were suppressed since the last one) so a stall has something pointing at it, mirroring the existing `claimScopeDenialSlot` throttle pattern in `api-auth.ts`.
- Chain/HMAC semantics are unchanged — covered by the existing `audit-chain.integration.test.ts` against a real Postgres DB.

## Test plan

- [x] `packages/web/src/__tests__/api/audit-route.test.ts` — total-on-page-1 branching, reltuples estimate + floor, exact count for filtered requests, page>1 omits `total` (37 tests, incl. 5 new)
- [x] `packages/web/src/__tests__/api/audit-route.integration.test.ts` (new) — the raw `pg_class.reltuples` SQL actually runs against real Postgres; page>1 omission; exact filtered count (3 tests)
- [x] `packages/web/src/__tests__/components/audit-log-table.test.tsx` — total is retained in UI state when a page>1 response omits it (1 new test)
- [x] `packages/web/src/__tests__/lib/encryption.test.ts` — file-secret cache hits/rotation/per-name isolation (3 new tests)
- [x] `packages/web/src/__tests__/lib/audit-append.test.ts` — lock-wait warning threshold, suppression window, and reporting (3 new tests)
- [x] `pnpm test:related`, `pnpm -C packages/web lint`, `pnpm -C packages/web typecheck`, `pnpm format:check`, `pnpm test:scripts`, full `pnpm test`, `pnpm -C packages/web test:db` (against a real Postgres for this worktree) all green