### PR TITLE
docs: fill the Diataxis gaps, and guard the two lists that kept drifting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,31 +85,52 @@ That is the whole thing: no build step, pre-built images on GHCR. Pair it with a
 
 ## Status
 
-> Pinchy is in early development. The core is working — setup, auth, multi-user, agent chat, permissions, knowledge base agents, and audit trail. We're building the enterprise features (granular RBAC, plugin marketplace, cross-channel workflows) next.
+> Pinchy is in early development. The core is working — setup, auth, multi-user, agent chat, scoped permissions, knowledge base agents, the audit trail, and integrations for email, Telegram, Odoo and web search. Granular RBAC and a plugin marketplace are what we're building next.
 
 ### What works today
 
+**Platform**
+
 - **Setup wizard** — Create your admin account on first run
 - **Authentication** — Credentials-based login with database sessions
-- **Multi-user** — Invite users, admin and user roles, personal and shared agents
+- **Multi-user** — Invite users, admin and member roles, personal and shared agents
+- **Groups** _(Enterprise)_ — Bundle users into groups and scope a shared agent's visibility to them
+- **Context management** — Per-user personal context and organization-wide context, editable in Settings
+- **Provider management** — Configure Anthropic, OpenAI, Google, Ollama (local or cloud), and any number of OpenAI-compatible endpoints
+
+**Agents**
+
 - **Agent chat** — Real-time WebSocket chat with OpenClaw agents, conversation history
 - **Agent permissions** — Allow-list model for agent tools (safe and powerful categories)
-- **Agent settings** — Configure name, model, system prompt, and tool permissions per agent
+- **Agent settings** — Configure name, model, personality, instructions, and tool permissions per agent
 - **Knowledge Base agents** — Create agents with scoped read-only access to specific directories
-- **Context management** — Per-user personal context and organization-wide context, editable in Settings
-- **Email integration** — Connect Gmail or Microsoft 365 mailboxes via OAuth; agents can read, search, draft, and send email with per-agent permissions
 - **Smithers onboarding** — New users get an onboarding interview where Smithers learns about them through conversation
-- **Provider management** — Configure API keys for Anthropic, OpenAI, and Google
-- **Docker Compose deployment** — Single command to run the full stack
+
+**Integrations**
+
+- **Email integration** — Connect Gmail, Microsoft 365, or any IMAP/SMTP mailbox; agents can read, search, draft, and send email with per-agent permissions
+- **Email automations** — Standing workflows that let an agent act on incoming mail on its own, each one created disabled until a person switches it on
+- **Telegram channels** — Chat with your agents from Telegram, one bot per agent, with the same permissions and audit trail
+- **Odoo integration** — Scoped, permission-aware access to your Odoo ERP with 20+ pre-built templates
+- **Web search** — Live web access via the Brave Search API, with per-agent domain allow/deny lists
+
+**Operations**
+
 - **Audit trail** — Cryptographic audit logging with HMAC-signed entries, integrity verification, and CSV export
+- **Usage & costs dashboard** — Token usage, estimated costs, and cache savings per agent (per-user breakdown and CSV export are Enterprise)
+- **Domain lock** — Pin the instance to one hostname and serve it over HTTPS, so a stray IP request is refused and audited
+- **Docker Compose deployment** — Single command to run the full stack
 - **CI pipeline** — Automated linting, testing, and security auditing
 
 ### What's coming
 
-- Full RBAC with team-scoped permissions
+- Granular RBAC with custom roles beyond admin/member ([#527](https://github.com/heypinchy/pinchy/issues/527))
 - Plugin marketplace for agent tools
-- Cross-channel workflows (email, Slack)
-- Admin dashboard with usage analytics
+- Additional chat channels for reaching agents
+
+<!-- Both lists are checked against the code by scripts/lib/readme-status.test.mjs:
+     a shipped feature missing from "What works today", or a promise here that
+     the tree already contains, fails `pnpm test:scripts`. -->
 
 Follow our progress on [the blog](https://heypinchy.com/blog/building-pinchy-in-public) and [LinkedIn](https://linkedin.com/in/clemenshelm).
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -149,6 +149,10 @@ export default defineConfig({
           items: [
             { label: "Introduction", slug: "" },
             { label: "Quick Start", slug: "getting-started" },
+            {
+              label: "Your First Governed Agent",
+              slug: "tutorials/first-governed-agent",
+            },
             { label: "Installation", slug: "installation" },
             { label: "Releases", slug: "releases" },
           ],
@@ -211,6 +215,10 @@ export default defineConfig({
                   slug: "guides/connect-email-imap",
                 },
               ],
+            },
+            {
+              label: "Set Up Email Automations",
+              slug: "guides/email-automations",
             },
             { label: "Connect Odoo", slug: "guides/connect-odoo" },
             { label: "Upload Files in Chat", slug: "guides/file-uploads" },
@@ -303,6 +311,10 @@ export default defineConfig({
           label: "Reference",
           items: [
             { label: "API Reference", slug: "reference/api" },
+            {
+              label: "Environment Variables",
+              slug: "reference/environment-variables",
+            },
             {
               label: "Agent Provisioning API",
               slug: "reference/agent-provisioning-api",

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -173,6 +173,8 @@ The tab lists every workflow on the agent with its trigger (in plain words, not 
 
 Use **Enable** / **Disable** to turn a workflow on or off, and **Delete** to remove one for good. Enabling is the human-gated step that turns a proposal into a live automation; disabling pauses it without deleting it.
 
+For a walkthrough from a connected mailbox to a running workflow — including how to scope a trigger and what to check afterwards — see [Set Up Email Automations](/guides/email-automations/).
+
 ## Creating agents
 
 Agents are created from the **Create New Agent** page. Pinchy ships with pre-configured templates for common use cases — Knowledge Base agents, vision-powered document analyzers, Odoo ERP assistants, email agents, and more. Each template auto-configures tools, personality, and system instructions; you choose a name and any template-specific options.

--- a/docs/src/content/docs/guides/customizing-deployment.mdx
+++ b/docs/src/content/docs/guides/customizing-deployment.mdx
@@ -110,7 +110,7 @@ Your `docker-compose.override.yml` survives upgrades unchanged. However, if a ne
 
 ## Resource limits and health checks
 
-Pinchy's `docker-compose.yml` caps memory and CPU for all three containers, and gives `pinchy` and `db` HTTP/TCP health checks so Docker can tell a wedged container from a healthy one. All six limits are overridable via `.env` — you never need to touch `docker-compose.yml` itself.
+Pinchy's `docker-compose.yml` caps memory and CPU for all three containers, and gives `pinchy` and `db` HTTP/TCP health checks so Docker can tell a wedged container from a healthy one. All six limits are overridable via `.env` — you never need to touch `docker-compose.yml` itself. For every other variable `.env` accepts, see the [Environment Variables reference](/reference/environment-variables/).
 
 | Variable             | Default | Caps                                                              |
 | -------------------- | ------- | ----------------------------------------------------------------- |

--- a/docs/src/content/docs/guides/email-automations.mdx
+++ b/docs/src/content/docs/guides/email-automations.mdx
@@ -1,0 +1,99 @@
+---
+title: Set Up Email Automations
+description: Let an agent act on incoming mail on its own — a trigger that decides which mail fires, an instruction that says what to do, and a human-gated switch that turns it on.
+---
+
+An automation is a standing rule: when mail matching a **trigger** arrives, the agent carries out an **instruction** on it, without anyone opening a chat. Pinchy checks the connected mailboxes every 15 minutes and runs the instruction once per new matching message.
+
+This is the point where an agent stops being something you talk to and becomes something that acts while you sleep — so the whole design is built around one rule: **an automation is proposed, never self-activated.** Every new workflow is created switched off. Nothing runs until a person reads it and enables it.
+
+## Before you start
+
+You need three things, in this order:
+
+1. **A connected mailbox.** Gmail, Microsoft 365, or plain IMAP — see [Connect Email](/guides/connect-email/).
+2. **A shared agent** to own the workflow. Create one from the **Email** template, or any agent you want to do the work.
+3. **Email permissions on that agent.** At minimum **Read messages**, in **Agent Settings → Permissions**. Add **Create drafts** or **Send messages** only if the instruction needs them — an automation runs with exactly the agent's permissions and cannot exceed them.
+
+The mailbox picker only offers mailboxes this agent is allowed to read, so a workflow can never point at a mailbox the agent cannot open. If the picker is empty, the agent is missing the email connection or the read permission.
+
+## Create the automation
+
+Open the agent, go to **Agent Settings → Automations**, and click **New automation**.
+
+### Name
+
+A short label for the list — "Supplier invoices to Odoo", not a description of the logic.
+
+### Instruction
+
+What the agent should do with each matching mail, in plain words:
+
+> Draft a supplier bill in Odoo from the attached invoice, then reply to the sender confirming we received it.
+
+Write it as if you were handing the mail to a colleague. The agent runs it with its own tools and permissions, so an instruction that asks for something the agent may not do simply fails — it does not escalate.
+
+### Trigger
+
+Filters that narrow which mail fires the workflow. Every field is optional:
+
+| Field                | Matches                                |
+| -------------------- | -------------------------------------- |
+| Sender addresses     | Mail from any of these addresses       |
+| Recipient domain     | Mail addressed to this domain          |
+| Words in the subject | Subjects containing these words        |
+| Has attachment       | Whether the mail carries an attachment |
+| Attachment type      | Attachments of this type, e.g. PDF     |
+| Folder               | Mail in this folder                    |
+
+Filled-in fields are combined with **AND**: mail must match every one of them. Leave them all blank and the workflow watches the entire mailbox — which is occasionally what you want and usually not.
+
+:::caution[Start narrow]
+A trigger that is too broad is the expensive mistake here, because every match spends a model call. Begin with the tightest filter that still catches your cases — a sender address and an attachment type — and widen it after you have seen what it actually matches.
+:::
+
+### Mailboxes
+
+Which connected mailboxes to watch. One workflow can watch several.
+
+### Look back (days)
+
+How far back each pass re-checks for mail it may have missed, so a mailbox outage or a restart does not silently drop messages. The default is **14** days; the maximum is 365.
+
+Pinchy tracks exactly which messages it has already handled, so a longer window re-examines mail without re-processing it. It deliberately never relies on the read/unread state you see in your own inbox — your reading habits are not a workflow's state.
+
+## Review it, then switch it on
+
+The new workflow appears in the list as **Pending**: proposed, never yet run. Read it once more — the trigger in plain words, the instruction, the mailboxes — and click **Enable**.
+
+That click is the whole governance model of this feature. Pinchy proposes; a person grants standing autonomous authority. This holds even when the workflow was drafted conversationally: ask Smithers to set up an automation and it still lands switched off, waiting for you.
+
+Each workflow shows one of three states:
+
+- **Pending** — proposed but never yet run
+- **Active** — enabled and running on its schedule
+- **Error** — the last run hit a problem
+
+**Disable** pauses a workflow without losing it; **Delete** removes it for good.
+
+## Watch what it did
+
+An automation acts on its own, which is exactly why its actions need to be readable afterwards. Every tool call an automation makes lands in the [audit trail](/concepts/audit-trail/) like any other — same events, same signatures — attributed to the agent that ran it.
+
+Open **Audit Trail** in the sidebar after the first matching mail arrives and confirm the run did what you meant. If a workflow shows **Error**, that is where the reason is.
+
+## Who can manage automations
+
+The same rule as the underlying API:
+
+- **Members** can manage automations on a personal agent they own.
+- **Admins** can manage them on any agent.
+
+In practice automations live on shared agents, because that is where mailboxes can be connected — a personal Smithers has no integrations of its own. See [Integrations](/concepts/integrations/#integrations-are-admin-managed-and-attach-to-shared-agents).
+
+## Related
+
+- [Connect Email](/guides/connect-email/) — connect the mailbox first
+- [Agent Settings](/concepts/agent-settings/#automations-tab) — the tab's full reference
+- [Agent Permissions](/concepts/agent-permissions/) — what the instruction is allowed to do
+- [Audit Trail](/concepts/audit-trail/) — reading back what ran

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -50,6 +50,8 @@ Only port **7777** is exposed to the host. OpenClaw and PostgreSQL are only reac
 
 Almost no configuration is needed to get started: session key, encryption key, HMAC signing key, and the database password are auto-generated on first start and persisted in Docker volumes so they survive restarts. The one value you set yourself is `PINCHY_VERSION` — the Compose file refuses to start without a pinned version. See the [Getting Started](/getting-started/) guide.
 
+For the complete list — every variable, its default, and what happens when you leave it unset — see the [Environment Variables reference](/reference/environment-variables/).
+
 #### Optional: production hardening
 
 For production deployments, extend the `.env` file to pin your own secrets instead of relying on auto-generated ones:
@@ -64,9 +66,6 @@ BETTER_AUTH_SECRET=your-random-secret
 # Encryption key for API keys — 64 hex characters (auto-generated if omitted)
 ENCRYPTION_KEY=
 
-# HMAC secret for audit trail signing (auto-generated if omitted)
-AUDIT_HMAC_SECRET=
-
 # Enterprise license key (optional — enables Groups, agent access control, basic RBAC)
 PINCHY_ENTERPRISE_KEY=
 ```
@@ -77,7 +76,7 @@ PINCHY_ENTERPRISE_KEY=
 
 **`ENCRYPTION_KEY`** — Used to encrypt provider API keys at rest (AES-256-GCM). Auto-generated and persisted in the `pinchy-secrets` volume if omitted. For production, set explicitly with `openssl rand -hex 32`.
 
-**`AUDIT_HMAC_SECRET`** — Used to sign audit trail entries with HMAC-SHA256. Auto-generated and persisted in the `pinchy-secrets` volume if omitted. Set explicitly if you need consistent signatures across deployments.
+**`AUDIT_HMAC_SECRET`** — Used to sign audit trail entries with HMAC-SHA256. Auto-generated and persisted in the `pinchy-secrets` volume. Note that the Compose file above does **not** forward this one, so setting it in `.env` has no effect without an override file — see [Environment Variables](/reference/environment-variables/#secrets).
 
 **`PINCHY_ENTERPRISE_KEY`** — License key for enterprise features (Groups, agent access control, basic RBAC — granular RBAC with custom roles is planned, [#527](https://github.com/heypinchy/pinchy/issues/527)). Optional — can also be entered via **Settings → License** in the UI. See [Enterprise Setup](/guides/enterprise-setup/) for details.
 
@@ -94,6 +93,7 @@ Docker volumes ensure data survives container restarts:
 | `pinchy-secrets`      | `/app/secrets` (Pinchy)                                                         | Auto-generated encryption and HMAC keys                                                          |
 | `openclaw-secrets`    | `/openclaw-secrets` (both)                                                      | **tmpfs** — runtime-only SecretRef bundle. Cleared on container restart and rebuilt from the DB. |
 | `pinchy-pdf-cache`    | `/var/cache/pinchy-files` (Pinchy)                                              | Cached PDF-text extractions so repeated reads of the same upload skip re-parsing                 |
+| `pinchy-kb-artifacts` | `/var/cache/pinchy-kb-artifacts` (Pinchy)                                       | Converted Office-document PDFs. Safe to delete — every artifact is re-derived from its source.   |
 | `openclaw-extensions` | `/openclaw-extensions` (Pinchy), `/root/.openclaw/extensions` (OpenClaw)        | Pinchy plugins for OpenClaw                                                                      |
 
 ### Port configuration

--- a/docs/src/content/docs/reference/environment-variables.mdx
+++ b/docs/src/content/docs/reference/environment-variables.mdx
@@ -1,0 +1,129 @@
+---
+title: Environment Variables
+description: Every variable Pinchy's docker-compose.yml reads — version pin, port binding, secrets, licence key, and resource limits — with its default and what happens if you leave it unset.
+---
+
+Everything Pinchy needs to run lives in one file next to your `docker-compose.yml`: a plain `.env`. This page lists every variable that file can contain, what it does, and what happens when you leave it out.
+
+Only one is mandatory. Pinchy generates its own secrets on first start and persists them in Docker volumes, so a working install is two lines long:
+
+```bash
+# .env
+PINCHY_VERSION=%%PINCHY_VERSION%%
+```
+
+:::note
+This page is checked against the shipped `docker-compose.yml` on every pull request — a variable it expands that isn't listed here, a variable listed here that it doesn't expand, and a default stated wrongly all fail CI. If something below disagrees with your Compose file, the Compose file is right and we have a bug.
+:::
+
+## Required
+
+| Variable         | Default | What it does                                                                                                                                                   |
+| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PINCHY_VERSION` | none    | The image tag for all Pinchy containers, e.g. `%%PINCHY_VERSION%%`. Compose **refuses to start** without it, so the stack you run today is the one you pinned. |
+
+Pinning is deliberate: an unpinned stack silently changes under you on the next `docker compose pull`. See [Upgrading](/guides/upgrading/) for moving between versions.
+
+## Network
+
+| Variable      | Default          | What it does                                                                                |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------------- |
+| `PINCHY_PORT` | `127.0.0.1:7777` | Where the web UI binds **on the host**. Pinchy always listens on 7777 inside the container. |
+
+Accepted forms are `HOST_PORT` (`3000`) or `HOST_IP:HOST_PORT` (`0.0.0.0:80`). Do not append the container port — Compose does that.
+
+The default binds to localhost only, which means a fresh install is not reachable from the internet even if the host has a public IP. Change it only when something else terminates TLS in front of Pinchy:
+
+```bash
+# Reachable only from this machine (the default)
+PINCHY_PORT=127.0.0.1:7777
+
+# All interfaces — only behind a reverse proxy
+PINCHY_PORT=0.0.0.0:80
+```
+
+For a public deployment, read [VPS Deployment](/guides/vps-deployment/) and [HTTPS & Domain Lock](/guides/domain-lock/) before widening this.
+
+## Secrets
+
+Pinchy generates each of these on first start and persists it in the `pinchy-secrets` volume, so you can ignore all of them and still have a secure install. Set them explicitly when you want to own the credential — for backup, rotation, or restoring an install onto a new host.
+
+| Variable             | Default        | What it does                                                                                                |
+| -------------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
+| `DB_PASSWORD`        | `pinchy_dev`   | Password for the PostgreSQL `pinchy` user. See the note below — the development default never stays active. |
+| `BETTER_AUTH_SECRET` | auto-generated | Signs login sessions. Generate with `openssl rand -hex 32`.                                                 |
+| `ENCRYPTION_KEY`     | auto-generated | Encrypts provider API keys at rest with AES-256-GCM. 64 hex characters.                                     |
+| `AUDIT_HMAC_SECRET`  | auto-generated | Signs audit-trail entries with HMAC-SHA256. **Not forwarded by the shipped Compose file** — see below.      |
+
+**`DB_PASSWORD`** is the one whose default deserves a second look. `docker-compose.yml` falls back to the literal `pinchy_dev`, which is fine for a laptop and unacceptable in production — so Pinchy does not leave it there. On the first production start the entrypoint generates a real password, applies it to PostgreSQL, and persists it in the `pinchy-secrets` volume. Set the variable yourself and your value wins, applied on the next restart even if the database still runs on an older one.
+
+**`AUDIT_HMAC_SECRET`** is read by the application, but the `docker-compose.yml` we ship does **not** pass it into the container. Putting it in `.env` therefore has no effect on a standard install: Pinchy keeps using the key it generated into the `pinchy-secrets` volume. Forwarding it needs an override file:
+
+```yaml
+# docker-compose.override.yml
+services:
+  pinchy:
+    environment:
+      - AUDIT_HMAC_SECRET=${AUDIT_HMAC_SECRET:-}
+```
+
+Do this only on a **fresh** install. Existing audit rows are signed with the generated key, and swapping the key mid-life breaks the hash chain that [audit trail verification](/concepts/audit-trail-verification/) checks.
+
+:::caution
+Losing `ENCRYPTION_KEY` means losing every stored provider API key — they cannot be recovered, only re-entered. If you back up anything, back up the `pinchy-secrets` volume.
+:::
+
+## Licence
+
+| Variable                | Default | What it does                                                                                                              |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `PINCHY_ENTERPRISE_KEY` | none    | Activates Enterprise features: groups, agent access control, and the usage dashboard's per-user breakdown and CSV export. |
+
+You can enter the same key in **Settings → License** instead — the environment variable exists so an unattended deployment doesn't need a human in the UI. See [Enterprise Setup](/guides/enterprise-setup/).
+
+## Resource limits
+
+Every container carries a memory and CPU cap so one runaway agent cannot take the host down with it. The defaults suit a 4 GB VPS.
+
+| Variable             | Default | What it does                                                      |
+| -------------------- | ------- | ----------------------------------------------------------------- |
+| `PINCHY_MEM_LIMIT`   | `1g`    | Memory for the `pinchy` container (web UI, API, WebSocket bridge) |
+| `PINCHY_CPUS`        | `1.5`   | CPU cores for `pinchy`                                            |
+| `OPENCLAW_MEM_LIMIT` | `2g`    | Memory for the `openclaw` container (agent runtime, model calls)  |
+| `OPENCLAW_CPUS`      | `2`     | CPU cores for `openclaw`                                          |
+| `DB_MEM_LIMIT`       | `1g`    | Memory for the `db` container (PostgreSQL 17 + pgvector)          |
+| `DB_CPUS`            | `1`     | CPU cores for `db`                                                |
+
+Lowering `OPENCLAW_MEM_LIMIT` too far gets the gateway OOM-killed mid-conversation, which looks like a dropped chat rather than an out-of-memory error. [Customizing Your Deployment](/guides/customizing-deployment/) has sizing tables, including what the knowledge base needs while it indexes Office documents.
+
+## Anything else
+
+The list above is everything `docker-compose.yml` reads. Variables the containers use internally — `DATABASE_URL`, `OPENCLAW_WS_URL` — are assembled by Compose and are not meant to be set in `.env`; to change one anyway, use an override file rather than editing the Compose file you downloaded, so an upgrade doesn't discard your change:
+
+```yaml
+# docker-compose.override.yml
+services:
+  pinchy:
+    environment:
+      - SOME_VARIABLE=value
+```
+
+Compose merges `docker-compose.override.yml` automatically. [Customizing Your Deployment](/guides/customizing-deployment/) covers the recipes we support and the ones we don't.
+
+## Where the data lives
+
+Variables configure the stack; volumes hold its state. These survive `docker compose down` and are what a backup must cover.
+
+| Volume                | Purpose                                                                                  |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `pgdata`              | PostgreSQL data — users, agents, conversations, the audit log                            |
+| `pinchy-secrets`      | Auto-generated secrets. **Back this up**, or you lose access to encrypted provider keys. |
+| `openclaw-config`     | Shared OpenClaw configuration                                                            |
+| `pinchy-workspaces`   | Agent workspaces (`SOUL.md`, `AGENTS.md`, uploads, workbench)                            |
+| `pinchy-data`         | The knowledge-base corpus, mounted read-only into the web tier                           |
+| `openclaw-extensions` | Pinchy's plugins for OpenClaw                                                            |
+| `pinchy-pdf-cache`    | Cached PDF text extractions — safe to delete, re-derived on demand                       |
+| `pinchy-kb-artifacts` | Converted Office-document PDFs — safe to delete, re-derived on demand                    |
+| `openclaw-secrets`    | **tmpfs**, runtime only. Cleared on restart and rebuilt from the database.               |
+
+[Installation](/installation/) shows the exact mount paths per container.

--- a/docs/src/content/docs/tutorials/first-governed-agent.mdx
+++ b/docs/src/content/docs/tutorials/first-governed-agent.mdx
@@ -51,19 +51,19 @@ Open the agent's chat, click the gear icon to open **Agent Settings**, and selec
 
 You are looking at an allow-list. Nothing here is on unless you switch it on, and Pinchy deliberately exposes no shell tool and no "read any file" tool at all — those stay unreachable no matter what you check.
 
-For this tutorial, grant exactly one thing beyond the default:
+For this tutorial, change nothing — the point is to see how little is on:
 
 <Steps>
 
-1. Leave **Read workspace** as it is — it is always on. Any text file, PDF, or image a user attaches in chat is readable by the agent.
+1. Confirm **Write files** is enabled. This lets the agent save results into its own `workbench/` and hand you generated files in chat.
 
-2. Confirm **Write files** is enabled. This lets the agent save results into its own `workbench/` and hand you generated files in chat.
+2. Leave everything else **off**. In particular leave the web tools off — we will come back to why.
 
-3. Leave everything else **off**. In particular leave the web tools off — we will come back to why.
-
-4. Click **Save & Restart**. Permission changes need the runtime to restart; the dialog lists what is pending and warns that active chats disconnect briefly.
+3. Click **Save & Restart**. Permission changes need the runtime to restart; the dialog lists what is pending and warns that active chats disconnect briefly.
 
 </Steps>
+
+You will not find a toggle for reading the workspace, and that is deliberate: listing and reading files inside the agent's own workspace is implicit, so any text file, PDF, or image a user attaches in chat is readable without granting anything. [Agent Permissions](/concepts/agent-permissions/) lists it as **Read workspace**, always on.
 
 <Aside type="caution" title="Why the web tools stay off">
   Pinchy warns you if you ever enable **Fetch web pages** on an agent that can

--- a/docs/src/content/docs/tutorials/first-governed-agent.mdx
+++ b/docs/src/content/docs/tutorials/first-governed-agent.mdx
@@ -1,0 +1,160 @@
+---
+title: Your First Governed Agent
+description: Build a team agent end to end — create it, scope what it may do, invite a colleague to use it, and read back in the audit trail exactly what happened.
+---
+
+import { Aside, Badge, Steps } from "@astrojs/starlight/components";
+
+[Quick Start](/getting-started/) got Pinchy running and you talking to Smithers. This tutorial is the next step, and it is the one that shows what Pinchy is actually for: an agent your **team** uses, that can do exactly what you allowed and nothing else, with a record of everything it did.
+
+By the end you will have:
+
+- a shared agent your whole team can reach,
+- a deliberate allow-list of what it may do,
+- a colleague using it under their own account,
+- and an audit trail showing who asked for what, and which tools ran.
+
+It takes about 20 minutes. Everything here works on a plain install — no licence key, no external API beyond the LLM provider you already configured.
+
+## Before you start
+
+- Pinchy running and your admin account created ([Quick Start](/getting-started/))
+- An LLM provider configured
+- A second browser profile or a private window — you will claim an invite as somebody else
+
+<Aside type="note">
+  Use a real second person if you have one. Watching a colleague use the agent
+  teaches you more about your permission choices than reading them back does.
+</Aside>
+
+## 1. Create a shared agent
+
+Every agent you create is a **shared** agent — the only personal one is the Smithers each user gets automatically. Shared is what we want: personal agents have no Permissions tab, because there is nobody to govern them for.
+
+<Steps>
+
+1. Open **Create New Agent** from the agent sidebar.
+
+2. Choose the **Custom Agent** template. It starts with only **Write files** enabled, which is the honest starting point: an agent with almost nothing, that you grant capabilities to on purpose.
+
+3. Name it `Team Assistant`, add a tagline if you like, and click **Create**.
+
+</Steps>
+
+Pinchy restarts the agent runtime to activate the new agent. When it comes back, the agent is in the sidebar with its own generated avatar.
+
+You now have an agent that can read files you attach in chat and write into its own workbench, and cannot do anything else — no web, no email, no directories on the server. That is not a hardened configuration you had to build; it is where every Pinchy agent starts.
+
+## 2. Scope what it may do
+
+Open the agent's chat, click the gear icon to open **Agent Settings**, and select the **Permissions** tab.
+
+You are looking at an allow-list. Nothing here is on unless you switch it on, and Pinchy deliberately exposes no shell tool and no "read any file" tool at all — those stay unreachable no matter what you check.
+
+For this tutorial, grant exactly one thing beyond the default:
+
+<Steps>
+
+1. Leave **Read workspace** as it is — it is always on. Any text file, PDF, or image a user attaches in chat is readable by the agent.
+
+2. Confirm **Write files** is enabled. This lets the agent save results into its own `workbench/` and hand you generated files in chat.
+
+3. Leave everything else **off**. In particular leave the web tools off — we will come back to why.
+
+4. Click **Save & Restart**. Permission changes need the runtime to restart; the dialog lists what is pending and warns that active chats disconnect briefly.
+
+</Steps>
+
+<Aside type="caution" title="Why the web tools stay off">
+  Pinchy warns you if you ever enable **Fetch web pages** on an agent that can
+  also reach sensitive data. A hostile web page can carry instructions that
+  trick an agent into encoding private data into a URL it fetches. When you do
+  need it, scope it with Include domain restrictions — see [Set Up Web
+  Search](/guides/web-search-setup/).
+</Aside>
+
+Take a moment on what you just did. You did not write a policy document about what the agent should avoid; you removed the capability. The agent cannot be talked out of a tool it does not have.
+
+## 3. Invite a colleague
+
+<Steps>
+
+1. Go to **Settings → Users** and click **Invite User**.
+
+2. Leave the email blank (anyone with the link can claim it) or enter your colleague's address to pre-fill it.
+
+3. Choose the **Member** role. Members can use agents; they cannot change permissions or read the audit trail — which is exactly the separation we are demonstrating.
+
+4. Click **Create Invite** and copy the link. It is valid for 7 days and works once.
+
+</Steps>
+
+Open that link in your second browser profile. The invited user sets a name and password, signs in, and is greeted by their **own** personal Smithers, which runs a short onboarding interview.
+
+They will also see `Team Assistant` in their sidebar. On an install without an Enterprise licence, every member can reach every shared agent; agent-level access control — restricting an agent to specific groups — is what the **Access** tab <Badge text="Enterprise" variant="note" /> adds. See [Groups](/concepts/groups/) if you want to narrow that later.
+
+## 4. Use it as they would
+
+Still signed in as the invited user, open `Team Assistant` and give it something real to do:
+
+<Steps>
+
+1. Attach a document to the chat — a PDF, a spreadsheet, a Markdown file. Anything text-bearing works, and PDFs are extracted for you.
+
+2. Ask for something concrete: _"Summarise this into five bullet points and save it as a file I can download."_
+
+3. Watch it read the attachment, then produce the file.
+
+</Steps>
+
+Then try the boundary. Ask it to look something up online:
+
+> _"Search the web for the latest version of this standard."_
+
+It cannot, and it will say so. Nothing was blocked at runtime by a filter — the tool was never in its allow-list to begin with.
+
+## 5. Read the audit trail
+
+Switch back to your admin account and open **Audit Trail** in the sidebar. This entry only exists for admins; your colleague never saw it.
+
+You are looking at every significant action on the platform, each row signed with HMAC-SHA256 and stored append-only — database triggers reject modification and deletion outright.
+
+Find the work you just watched:
+
+- **`tool.pinchy_read`** — the agent reading the attachment
+- **`tool.pinchy_write`** or **`tool.pinchy_generate_file`** — the file it produced
+- **`user.invited`** — you, creating the invite in step 3
+
+Open a tool row. It records which agent ran the tool, on whose behalf, when, the parameters, and the result — with an `outcome` of success or failure. Filter by the **Status** dropdown to isolate failures.
+
+Two things are deliberately not there, and both are worth knowing now rather than discovering during an audit:
+
+- **Chat messages are not logged.** The audit trail records actions, not conversation content. What was said lives in the conversation history.
+- **Email addresses are not stored in plaintext.** Invite events keep a keyed hash and a short masked preview; deactivation events omit the address entirely.
+
+<Aside type="tip">
+  The trail is verifiable, not just readable — a background job re-checks the
+  hash chain and records the result as `audit.integrity_check`. See [Verifying
+  the audit trail](/concepts/audit-trail-verification/).
+</Aside>
+
+## What you built
+
+A governed agent, in the sense Pinchy means it:
+
+| You did                | Which gave you                                                           |
+| ---------------------- | ------------------------------------------------------------------------ |
+| Created a shared agent | One agent the team reaches, instead of one tool per person               |
+| Scoped its permissions | Capabilities it cannot be argued out of, because they were never granted |
+| Invited a member       | A separate identity, without admin rights, doing real work               |
+| Read the audit trail   | Evidence of what ran — attributable, signed, and append-only             |
+
+None of it required the agent to be trusted. That is the whole idea: the guardrails are structural, so the interesting question stops being "will it behave?" and becomes "what should it be allowed to do?"
+
+## Where to go next
+
+- **[Create a Knowledge Base Agent](/guides/create-knowledge-base-agent/)** — point an agent at real document directories with scoped, read-only access
+- **[Agent Permissions](/concepts/agent-permissions/)** — the full tool catalogue, including integration tools
+- **[Set Up Email Automations](/guides/email-automations/)** — let an agent act on incoming mail on its own
+- **[Groups](/concepts/groups/)** <Badge text="Enterprise" variant="note" /> — restrict an agent to specific teams
+- **[Audit Trail](/concepts/audit-trail/)** — every event type, and how to export

--- a/scripts/lib/env-var-reference.mjs
+++ b/scripts/lib/env-var-reference.mjs
@@ -81,6 +81,44 @@ export function extractComposeVariables(composeSource) {
 }
 
 /**
+ * Every name that appears as a key in any `environment:` block, in either
+ * spelling Compose accepts:
+ *
+ *   - `- NAME=${NAME:-}` — the explicit form, also caught by `COMPOSE_VAR`
+ *   - `- NAME`           — pass-through, which forwards the host value and
+ *                          contains no `${…}` at all
+ *
+ * The second form is why this exists. `assertReadNotForwardedAreAbsent` claims
+ * a caveat cannot outlive the gap it describes, and reading only `${VAR}`
+ * expansions would break that claim on the likelier of the two ways somebody
+ * wires `AUDIT_HMAC_SECRET` up — the exception would stay green while the page
+ * kept telling readers the variable does nothing.
+ *
+ * @param {string} composeSource contents of docker-compose.yml
+ * @returns {Set<string>}
+ */
+export function extractForwardedEnvNames(composeSource) {
+  const names = new Set();
+  let inEnvironment = false;
+  let blockIndent = 0;
+  for (const line of composeSource.split("\n")) {
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    const indent = line.length - line.trimStart().length;
+    if (inEnvironment && indent <= blockIndent) inEnvironment = false;
+    const header = /^(\s*)environment:\s*$/.exec(line);
+    if (header) {
+      inEnvironment = true;
+      blockIndent = header[1].length;
+      continue;
+    }
+    if (!inEnvironment) continue;
+    const entry = /^\s*-\s*([A-Z_][A-Z0-9_]*)\s*(=|$)/.exec(line);
+    if (entry) names.add(entry[1]);
+  }
+  return names;
+}
+
+/**
  * Variables the reference page documents, with the default it states.
  *
  * Reads the markdown table rows: `| \`NAME\` | \`default\` | description |`.
@@ -189,19 +227,22 @@ export function findWrongDefaults(compose, documented) {
  * should describe it as an ordinary knob and the exception should go.
  *
  * @param {Map<string, unknown>} compose
+ * @param {Set<string>} forwarded names from every `environment:` block
  * @param {Record<string, string>} [readNotForwarded]
  * @returns {string[]} problems (empty = ok)
  */
 export function assertReadNotForwardedAreAbsent(
   compose,
+  forwarded,
   readNotForwarded = READ_NOT_FORWARDED,
 ) {
   const problems = [];
   for (const [name, reason] of Object.entries(readNotForwarded)) {
-    if (compose.has(name)) {
+    if (compose.has(name) || forwarded.has(name)) {
       problems.push(
-        `READ_NOT_FORWARDED lists ${name}, but docker-compose.yml now expands ` +
-          `it. Drop the exception and document it as a normal variable.`,
+        `READ_NOT_FORWARDED lists ${name}, but docker-compose.yml now passes ` +
+          `it through. Drop the exception and document it as a normal variable ` +
+          `— the page still tells readers that setting it does nothing.`,
       );
     }
     if (reason.trim().length < 30) {

--- a/scripts/lib/env-var-reference.mjs
+++ b/scripts/lib/env-var-reference.mjs
@@ -1,0 +1,212 @@
+/**
+ * The environment-variable reference, read against docker-compose.yml (#1082).
+ *
+ * Before this page existed, the variables a self-hoster sets were spread across
+ * `installation.mdx` (secrets, ports), `customizing-deployment.mdx` (resource
+ * limits) and `enterprise-setup.mdx` (the licence key), with no page listing
+ * them all. Nobody could answer "what can I put in `.env`?" without reading
+ * three guides and the Compose file.
+ *
+ * A consolidated list is only worth having if it stays true, so it is derived
+ * rather than trusted: `findUndocumentedVariables` reads every `${VAR}` out of
+ * the shipped `docker-compose.yml` and fails when the page omits one, and
+ * `findGhostVariables` fails on the opposite — a documented variable that
+ * Compose never expands.
+ *
+ * The second direction is the one that costs a reader real time, and it is not
+ * hypothetical here. `AUDIT_HMAC_SECRET` is documented in `installation.mdx` as
+ * something to set in `.env`; the app does read it, but the production Compose
+ * file has never forwarded it, so setting it does exactly nothing. That is the
+ * `findGhostEndpoints` lesson from AGENTS.md in a different file: an
+ * undocumented variable costs a grep, a documented one that isn't wired costs
+ * an afternoon.
+ *
+ * Defaults are checked too. A default is the single most copied fact on a
+ * reference page — it is what a reader assumes when they *don't* set the
+ * variable — and `${PINCHY_MEM_LIMIT:-1g}` states it precisely enough that no
+ * one should ever have to trust prose for it.
+ */
+
+/**
+ * Variables the app reads but the shipped `docker-compose.yml` does not pass
+ * through, so they are documented with that caveat rather than as ordinary
+ * knobs. Each entry must say what is true, because the page repeats it.
+ *
+ * This is not a way to silence the ghost check — an entry here is a claim that
+ * the gap is known and deliberate, and `assertReadNotForwardedAreAbsent` fails
+ * the moment Compose starts forwarding one, so the caveat cannot outlive the
+ * bug it describes.
+ */
+export const READ_NOT_FORWARDED = {
+  AUDIT_HMAC_SECRET:
+    "read by packages/web/src/lib/encryption.ts, but absent from the pinchy " +
+    "service's environment block in docker-compose.yml — setting it in .env " +
+    "has no effect without an override file",
+};
+
+/** `${VAR}`, `${VAR:-default}`, `${VAR:?message}`. */
+const COMPOSE_VAR = /\$\{([A-Z_][A-Z0-9_]*)(?::([-?])([^}]*))?\}/g;
+
+/**
+ * Every variable the Compose file expands, with the default it falls back to.
+ *
+ * @param {string} composeSource contents of docker-compose.yml
+ * @returns {Map<string, {default: string|null, required: boolean}>}
+ */
+export function extractComposeVariables(composeSource) {
+  const found = new Map();
+  for (const [, name, kind, rest] of composeSource.matchAll(COMPOSE_VAR)) {
+    const required = kind === "?";
+    const fallback = kind === "-" ? rest : null;
+    const prev = found.get(name);
+    // A variable used twice keeps the more specific reading: a stated default
+    // beats none, and "required" beats a default (PINCHY_VERSION is `:?` in
+    // both image tags, DB_PASSWORD is `:-pinchy_dev` in two places).
+    if (!prev) {
+      found.set(name, { default: fallback, required });
+    } else {
+      found.set(name, {
+        default: prev.default ?? fallback,
+        required: prev.required || required,
+      });
+    }
+  }
+  if (found.size === 0) {
+    throw new Error(
+      "docker-compose.yml: no ${VAR} expansions found. Either the file moved " +
+        "or the pattern stopped matching — both make this guard vacuous.",
+    );
+  }
+  return found;
+}
+
+/**
+ * Variables the reference page documents, with the default it states.
+ *
+ * Reads the markdown table rows: `| \`NAME\` | \`default\` | description |`.
+ * A row whose default cell is `—` or `_auto_` documents "no default"; anything
+ * in backticks is read as the literal default.
+ *
+ * @param {string} pageSource contents of the reference page
+ * @returns {Map<string, {default: string|null}>}
+ */
+export function extractDocumentedVariables(pageSource) {
+  const found = new Map();
+  const row = /^\|\s*`([A-Z_][A-Z0-9_]*)`\s*\|\s*([^|]*?)\s*\|/gm;
+  for (const [, name, defaultCell] of pageSource.matchAll(row)) {
+    const literal = /`([^`]*)`/.exec(defaultCell);
+    found.set(name, { default: literal ? literal[1] : null });
+  }
+  if (found.size === 0) {
+    throw new Error(
+      "environment-variables.mdx: no `| `VAR` | … |` table rows found. If the " +
+        "table's shape changed, change this reader with it.",
+    );
+  }
+  return found;
+}
+
+/**
+ * Compose expands it, the page never mentions it.
+ *
+ * @param {Map<string, unknown>} compose
+ * @param {Map<string, unknown>} documented
+ * @returns {string[]} problems (empty = ok)
+ */
+export function findUndocumentedVariables(compose, documented) {
+  return [...compose.keys()]
+    .filter((name) => !documented.has(name))
+    .map(
+      (name) =>
+        `docker-compose.yml expands \${${name}} but the environment-variable ` +
+        `reference never documents it. Add a row for it.`,
+    );
+}
+
+/**
+ * The page documents it, Compose never expands it.
+ *
+ * @param {Map<string, unknown>} compose
+ * @param {Map<string, unknown>} documented
+ * @param {Record<string, string>} [readNotForwarded]
+ * @returns {string[]} problems (empty = ok)
+ */
+export function findGhostVariables(
+  compose,
+  documented,
+  readNotForwarded = READ_NOT_FORWARDED,
+) {
+  return [...documented.keys()]
+    .filter((name) => !compose.has(name) && !(name in readNotForwarded))
+    .map(
+      (name) =>
+        `the environment-variable reference documents ${name}, which ` +
+        `docker-compose.yml never expands — setting it would do nothing. ` +
+        `Remove the row, or add it to READ_NOT_FORWARDED with what is true.`,
+    );
+}
+
+/**
+ * Rows whose stated default is not the one Compose falls back to.
+ *
+ * @param {Map<string, {default: string|null, required: boolean}>} compose
+ * @param {Map<string, {default: string|null}>} documented
+ * @returns {string[]} problems (empty = ok)
+ */
+export function findWrongDefaults(compose, documented) {
+  const problems = [];
+  for (const [name, doc] of documented) {
+    const actual = compose.get(name);
+    if (!actual) continue;
+    if (actual.required) {
+      if (doc.default !== null) {
+        problems.push(
+          `${name}: the reference states a default of \`${doc.default}\`, but ` +
+            `docker-compose.yml makes it required (\${${name}:?…}).`,
+        );
+      }
+      continue;
+    }
+    // An empty Compose fallback (`${X:-}`) is "unset", which the page states as
+    // prose rather than a backticked literal — both readings are "no value".
+    const composeDefault = actual.default === "" ? null : actual.default;
+    if (composeDefault !== doc.default) {
+      problems.push(
+        `${name}: the reference states a default of ` +
+          `${doc.default === null ? "none" : `\`${doc.default}\``}, but ` +
+          `docker-compose.yml falls back to ` +
+          `${composeDefault === null ? "none" : `\`${composeDefault}\``}.`,
+      );
+    }
+  }
+  return problems;
+}
+
+/**
+ * A `READ_NOT_FORWARDED` entry that Compose now forwards after all.
+ *
+ * The caveat must not outlive the gap: once the variable is wired, the page
+ * should describe it as an ordinary knob and the exception should go.
+ *
+ * @param {Map<string, unknown>} compose
+ * @param {Record<string, string>} [readNotForwarded]
+ * @returns {string[]} problems (empty = ok)
+ */
+export function assertReadNotForwardedAreAbsent(
+  compose,
+  readNotForwarded = READ_NOT_FORWARDED,
+) {
+  const problems = [];
+  for (const [name, reason] of Object.entries(readNotForwarded)) {
+    if (compose.has(name)) {
+      problems.push(
+        `READ_NOT_FORWARDED lists ${name}, but docker-compose.yml now expands ` +
+          `it. Drop the exception and document it as a normal variable.`,
+      );
+    }
+    if (reason.trim().length < 30) {
+      problems.push(`READ_NOT_FORWARDED["${name}"] needs a real reason`);
+    }
+  }
+  return problems;
+}

--- a/scripts/lib/env-var-reference.test.mjs
+++ b/scripts/lib/env-var-reference.test.mjs
@@ -8,6 +8,7 @@ import {
   assertReadNotForwardedAreAbsent,
   extractComposeVariables,
   extractDocumentedVariables,
+  extractForwardedEnvNames,
   findGhostVariables,
   findUndocumentedVariables,
   findWrongDefaults,
@@ -168,19 +169,60 @@ test("findWrongDefaults rejects a stated default for a required variable", () =>
 test("assertReadNotForwardedAreAbsent flags a caveat that outlived the gap", () => {
   const problems = assertReadNotForwardedAreAbsent(
     new Map([["AUDIT_HMAC_SECRET", {}]]),
+    new Set(),
     {
       AUDIT_HMAC_SECRET:
         "read by the app, absent from the compose environment block",
     },
   );
   assert.equal(problems.length, 1);
-  assert.match(problems[0], /now expands/);
+  assert.match(problems[0], /now passes it through/);
+});
+
+test("assertReadNotForwardedAreAbsent sees the bare pass-through form too", () => {
+  // `- AUDIT_HMAC_SECRET` forwards the host value and contains no `${…}`, so a
+  // check reading only expansions would keep the caveat alive after the fix.
+  const problems = assertReadNotForwardedAreAbsent(
+    new Map(),
+    new Set(["AUDIT_HMAC_SECRET"]),
+    {
+      AUDIT_HMAC_SECRET:
+        "read by the app, absent from the compose environment block",
+    },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /now passes it through/);
 });
 
 test("assertReadNotForwardedAreAbsent wants a real reason", () => {
-  const problems = assertReadNotForwardedAreAbsent(new Map(), { X: "because" });
+  const problems = assertReadNotForwardedAreAbsent(new Map(), new Set(), {
+    X: "because",
+  });
   assert.equal(problems.length, 1);
   assert.match(problems[0], /real reason/);
+});
+
+test("extractForwardedEnvNames reads both spellings, and only environment blocks", () => {
+  const names = extractForwardedEnvNames(
+    [
+      "services:",
+      "  pinchy:",
+      "    image: pinchy:${PINCHY_VERSION}",
+      "    environment:",
+      "      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}",
+      "      - AUDIT_HMAC_SECRET",
+      "    volumes:",
+      "      - NOT_AN_ENV_VAR:/data",
+      "  db:",
+      "    environment:",
+      "      - POSTGRES_DB=pinchy",
+    ].join("\n"),
+  );
+  assert.deepEqual([...names].sort(), [
+    "AUDIT_HMAC_SECRET",
+    "ENCRYPTION_KEY",
+    "POSTGRES_DB",
+  ]);
 });
 
 // ── the repo itself ───────────────────────────────────────────────────────
@@ -206,8 +248,13 @@ test("every default the reference states is the one compose falls back to", () =
 });
 
 test("every READ_NOT_FORWARDED entry is still un-forwarded, with a reason", () => {
+  const forwarded = extractForwardedEnvNames(readFileSync(COMPOSE, "utf8"));
+  assert.ok(
+    forwarded.has("ENCRYPTION_KEY"),
+    "environment blocks did not parse — this check would pass vacuously",
+  );
   assert.deepEqual(
-    assertReadNotForwardedAreAbsent(compose(), READ_NOT_FORWARDED),
+    assertReadNotForwardedAreAbsent(compose(), forwarded, READ_NOT_FORWARDED),
     [],
   );
 });

--- a/scripts/lib/env-var-reference.test.mjs
+++ b/scripts/lib/env-var-reference.test.mjs
@@ -1,0 +1,226 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  READ_NOT_FORWARDED,
+  assertReadNotForwardedAreAbsent,
+  extractComposeVariables,
+  extractDocumentedVariables,
+  findGhostVariables,
+  findUndocumentedVariables,
+  findWrongDefaults,
+} from "./env-var-reference.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const COMPOSE = join(REPO_ROOT, "docker-compose.yml");
+const PAGE = join(
+  REPO_ROOT,
+  "docs/src/content/docs/reference/environment-variables.mdx",
+);
+
+// ── pure logic ────────────────────────────────────────────────────────────
+
+test("extractComposeVariables reads defaults, required markers and bare uses", () => {
+  const vars = extractComposeVariables(
+    [
+      "image: pinchy:${PINCHY_VERSION:?set it}",
+      'ports: ["${PINCHY_PORT:-127.0.0.1:7777}:7777"]',
+      "mem_limit: ${PINCHY_MEM_LIMIT:-1g}",
+      "environment: [FOO=${BARE_ONE}]",
+    ].join("\n"),
+  );
+  assert.deepEqual(vars.get("PINCHY_VERSION"), {
+    default: null,
+    required: true,
+  });
+  assert.deepEqual(vars.get("PINCHY_PORT"), {
+    default: "127.0.0.1:7777",
+    required: false,
+  });
+  assert.deepEqual(vars.get("PINCHY_MEM_LIMIT"), {
+    default: "1g",
+    required: false,
+  });
+  assert.deepEqual(vars.get("BARE_ONE"), { default: null, required: false });
+});
+
+test("extractComposeVariables keeps the most specific reading of a repeated var", () => {
+  // PINCHY_VERSION appears in both image tags; DB_PASSWORD twice with a default.
+  const vars = extractComposeVariables(
+    "a: ${DB_PASSWORD:-pinchy_dev}\nb: ${DB_PASSWORD:-pinchy_dev}\nc: ${V:?x}\nd: ${V:?x}",
+  );
+  assert.deepEqual(vars.get("DB_PASSWORD"), {
+    default: "pinchy_dev",
+    required: false,
+  });
+  assert.equal(vars.get("V").required, true);
+});
+
+test("extractComposeVariables throws rather than reporting an empty compose file", () => {
+  assert.throws(
+    () => extractComposeVariables("services:\n  pinchy:\n"),
+    /no \$\{VAR\}/,
+  );
+});
+
+test("extractDocumentedVariables reads the table rows", () => {
+  const page = [
+    "| Variable | Default | What it does |",
+    "| -------- | ------- | ------------ |",
+    "| `PINCHY_PORT` | `127.0.0.1:7777` | host binding |",
+    "| `ENCRYPTION_KEY` | auto-generated | encrypts keys |",
+  ].join("\n");
+  const documented = extractDocumentedVariables(page);
+  assert.deepEqual(documented.get("PINCHY_PORT"), {
+    default: "127.0.0.1:7777",
+  });
+  // "auto-generated" is prose, not a literal default.
+  assert.deepEqual(documented.get("ENCRYPTION_KEY"), { default: null });
+});
+
+test("extractDocumentedVariables throws when the table shape changes", () => {
+  assert.throws(
+    () => extractDocumentedVariables("# Environment variables\n\nProse only."),
+    /table rows/,
+  );
+});
+
+test("findUndocumentedVariables flags a compose variable the page omits", () => {
+  const problems = findUndocumentedVariables(
+    new Map([
+      ["PINCHY_PORT", {}],
+      ["DB_CPUS", {}],
+    ]),
+    new Map([["PINCHY_PORT", {}]]),
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /DB_CPUS/);
+});
+
+test("findGhostVariables flags a documented variable compose never expands", () => {
+  const problems = findGhostVariables(
+    new Map([["PINCHY_PORT", {}]]),
+    new Map([
+      ["PINCHY_PORT", {}],
+      ["MADE_UP", {}],
+    ]),
+    {},
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /MADE_UP/);
+});
+
+test("findGhostVariables lets a known read-not-forwarded variable through", () => {
+  assert.deepEqual(
+    findGhostVariables(
+      new Map([["PINCHY_PORT", {}]]),
+      new Map([["AUDIT_HMAC_SECRET", {}]]),
+      {
+        AUDIT_HMAC_SECRET:
+          "read by the app, absent from the compose environment block",
+      },
+    ),
+    [],
+  );
+});
+
+test("findWrongDefaults catches a default the page states wrongly", () => {
+  const compose = new Map([
+    ["PINCHY_MEM_LIMIT", { default: "1g", required: false }],
+  ]);
+  assert.deepEqual(
+    findWrongDefaults(
+      compose,
+      new Map([["PINCHY_MEM_LIMIT", { default: "1g" }]]),
+    ),
+    [],
+  );
+  const problems = findWrongDefaults(
+    compose,
+    new Map([["PINCHY_MEM_LIMIT", { default: "2g" }]]),
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /PINCHY_MEM_LIMIT/);
+});
+
+test("findWrongDefaults treats an empty compose fallback as no default", () => {
+  // `${ENCRYPTION_KEY:-}` and a page that says "auto-generated" agree.
+  assert.deepEqual(
+    findWrongDefaults(
+      new Map([["ENCRYPTION_KEY", { default: "", required: false }]]),
+      new Map([["ENCRYPTION_KEY", { default: null }]]),
+    ),
+    [],
+  );
+});
+
+test("findWrongDefaults rejects a stated default for a required variable", () => {
+  const problems = findWrongDefaults(
+    new Map([["PINCHY_VERSION", { default: null, required: true }]]),
+    new Map([["PINCHY_VERSION", { default: "v0.9.1" }]]),
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /required/);
+});
+
+test("assertReadNotForwardedAreAbsent flags a caveat that outlived the gap", () => {
+  const problems = assertReadNotForwardedAreAbsent(
+    new Map([["AUDIT_HMAC_SECRET", {}]]),
+    {
+      AUDIT_HMAC_SECRET:
+        "read by the app, absent from the compose environment block",
+    },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /now expands/);
+});
+
+test("assertReadNotForwardedAreAbsent wants a real reason", () => {
+  const problems = assertReadNotForwardedAreAbsent(new Map(), { X: "because" });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /real reason/);
+});
+
+// ── the repo itself ───────────────────────────────────────────────────────
+
+const compose = () => extractComposeVariables(readFileSync(COMPOSE, "utf8"));
+const documented = () => extractDocumentedVariables(readFileSync(PAGE, "utf8"));
+
+test("the reference documents every variable docker-compose.yml expands", () => {
+  const vars = compose();
+  assert.ok(
+    vars.size > 8,
+    `expected the full variable set, found ${vars.size}`,
+  );
+  assert.deepEqual(findUndocumentedVariables(vars, documented()), []);
+});
+
+test("the reference documents no variable docker-compose.yml ignores", () => {
+  assert.deepEqual(findGhostVariables(compose(), documented()), []);
+});
+
+test("every default the reference states is the one compose falls back to", () => {
+  assert.deepEqual(findWrongDefaults(compose(), documented()), []);
+});
+
+test("every READ_NOT_FORWARDED entry is still un-forwarded, with a reason", () => {
+  assert.deepEqual(
+    assertReadNotForwardedAreAbsent(compose(), READ_NOT_FORWARDED),
+    [],
+  );
+});
+
+test("the page really covers the READ_NOT_FORWARDED variables it claims to", () => {
+  // The exception exists so the page can carry the caveat. If the page stops
+  // mentioning the variable, the exception is silencing the ghost check for
+  // nothing.
+  const doc = documented();
+  for (const name of Object.keys(READ_NOT_FORWARDED)) {
+    assert.ok(
+      doc.has(name),
+      `READ_NOT_FORWARDED lists ${name}, but the reference page has no row for it`,
+    );
+  }
+});

--- a/scripts/lib/readme-status.mjs
+++ b/scripts/lib/readme-status.mjs
@@ -1,0 +1,262 @@
+/**
+ * The README's status section, read against the code (#1082).
+ *
+ * `docs-consistency` and `docs-coverage` both stop at `docs/`. The README is
+ * the page most people read first — it is the repository's landing page and
+ * what GitHub renders on the project card — and nothing had ever checked it.
+ * The 2026-08-04 audit found it stale in *both* directions at once:
+ *
+ *   - "What works today" omitted Telegram, Odoo, web search, email
+ *     automations, the usage dashboard, groups and the domain lock — seven
+ *     shipped features, three of them headline ones.
+ *   - "What's coming" still promised email automations and usage analytics,
+ *     both of which had shipped. A reader comparing the two lists would
+ *     conclude the opposite of the truth about the same feature.
+ *
+ * That second direction is the one worth naming: a stale promise is not a
+ * missing sentence, it is a *false* one, and it reads as authoritative because
+ * it sits under a heading that claims to describe the future.
+ *
+ * The check is deliberately evidence-based rather than a hand-kept list of
+ * feature names. Each entry pairs the words the README would use with a path
+ * whose existence proves the feature shipped, and `findFeaturesWithoutEvidence`
+ * fails when that path goes away — so a verdict here cannot outlive the code it
+ * describes, the same contract `KNOWN_PRE_GUARD_DRIFT` and the triage ledger
+ * carry elsewhere in this repo.
+ *
+ * What it deliberately does NOT do is judge the roadmap. "Plugin marketplace"
+ * names nothing in the tree, so it stays a promise and this check has no
+ * opinion on it. It only ever says: this shipped, so stop calling it future
+ * work — and: this shipped, so say so.
+ *
+ * One sharp edge, met while writing this: `findShippedPromises` reads a name,
+ * not a sentence, so "More channels beyond web and Telegram" is flagged even
+ * though it promises the opposite of shipping Telegram. That is a false
+ * positive, and the fix is the prose, not an exception for "beyond" — a
+ * roadmap line that argues from the name of a shipped feature is exactly the
+ * ambiguity this section had. Say what is coming without naming what is here.
+ */
+
+/**
+ * Features whose presence in the tree is a fact, paired with the words the
+ * README uses for them.
+ *
+ * `terms` are matched word-wise and unordered: every word of a term must appear
+ * in the text, so "usage dashboard" matches "Admin dashboard with usage
+ * analytics" (the exact stale promise this check was written for) while
+ * "agent permissions" does NOT match "Full RBAC with team-scoped permissions".
+ * A term therefore needs at least two words, or one word specific enough to
+ * mean only this feature — `assertTermsAreSpecific` holds that line.
+ *
+ * `evidence` is a repo-relative path. Prefer the route or plugin directory that
+ * *is* the feature over a file that merely mentions it.
+ */
+export const SHIPPED_FEATURES = [
+  {
+    name: "Telegram channels",
+    terms: ["telegram"],
+    evidence: "packages/web/src/app/api/settings/telegram",
+  },
+  {
+    name: "Odoo integration",
+    terms: ["odoo"],
+    evidence: "packages/plugins/pinchy-odoo",
+  },
+  {
+    name: "Web search",
+    terms: ["web search"],
+    evidence: "packages/plugins/pinchy-web",
+  },
+  {
+    name: "Email integration",
+    terms: ["email integration", "connect email", "read email", "send email"],
+    evidence: "packages/plugins/pinchy-email",
+  },
+  {
+    name: "Email automations",
+    terms: ["email automations", "email workflows", "inbox automations"],
+    evidence: "packages/web/src/app/api/automations",
+  },
+  {
+    name: "Usage & costs dashboard",
+    terms: ["usage dashboard", "usage analytics", "usage costs", "token usage"],
+    evidence: "packages/web/src/app/api/usage",
+  },
+  {
+    name: "Groups",
+    terms: ["groups"],
+    evidence: "packages/web/src/app/api/groups",
+  },
+  {
+    name: "Domain lock",
+    terms: ["domain lock"],
+    evidence: "packages/web/src/app/api/settings/domain",
+  },
+  {
+    name: "Knowledge base agents",
+    terms: ["knowledge base"],
+    evidence: "packages/plugins/pinchy-knowledge",
+  },
+];
+
+/** Words a one-word term must not be, because they mean too many things. */
+const TOO_GENERIC = new Set([
+  "agent",
+  "agents",
+  "api",
+  "chat",
+  "dashboard",
+  "email",
+  "permissions",
+  "search",
+  "settings",
+  "usage",
+  "users",
+  "workflows",
+]);
+
+const words = (text) => text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+
+/**
+ * Does `text` mention `term`? Every word of the term must appear in the text,
+ * in any order.
+ *
+ * Word-wise rather than `includes` for the reason AGENTS.md gives about the
+ * docs-coverage guard: a substring match makes "usage" match "usages" and
+ * "groups" match "subgroups", and a check that accepts a coincidence is a check
+ * that passes when it should not.
+ *
+ * @param {string} text
+ * @param {string} term
+ */
+export function mentions(text, term) {
+  const have = new Set(words(text));
+  const want = words(term);
+  return want.length > 0 && want.every((w) => have.has(w));
+}
+
+/**
+ * The bullet items under a `### <heading>` in the README.
+ *
+ * Throws rather than returning `[]` when the heading is missing or carries no
+ * bullets. An empty list would make every check below vacuously pass, which is
+ * exactly how a coverage gate becomes decoration — the same failure the
+ * docs-coverage extractors throw to avoid.
+ *
+ * @param {string} readme
+ * @param {string} heading e.g. "What works today"
+ * @returns {string[]} one entry per bullet, markdown intact
+ */
+export function extractStatusItems(readme, heading) {
+  const lines = readme.split("\n");
+  const start = lines.findIndex(
+    (l) => l.trim().toLowerCase() === `### ${heading}`.toLowerCase(),
+  );
+  if (start === -1) {
+    throw new Error(
+      `README.md: no "### ${heading}" heading. The status section is what ` +
+        `readme-status.mjs checks; if it moved, move this check with it.`,
+    );
+  }
+  const items = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^#{1,3} /.test(line)) break;
+    const bullet = /^\s*[-*]\s+(.*)$/.exec(line);
+    if (bullet) items.push(bullet[1].trim());
+  }
+  if (items.length === 0) {
+    throw new Error(`README.md: "### ${heading}" has no bullet items`);
+  }
+  return items;
+}
+
+/**
+ * Shipped features the "What works today" list never mentions.
+ *
+ * @param {string[]} items
+ * @param {typeof SHIPPED_FEATURES} features
+ * @returns {string[]} problems (empty = ok)
+ */
+export function findUnmentionedShippedFeatures(items, features) {
+  const text = items.join("\n");
+  return features
+    .filter((f) => !f.terms.some((t) => mentions(text, t)))
+    .map(
+      (f) =>
+        `README.md "What works today" never mentions ${f.name}, which shipped ` +
+        `(${f.evidence} is in the tree). Add it, or drop the SHIPPED_FEATURES entry.`,
+    );
+}
+
+/**
+ * "What's coming" entries that name something already shipped.
+ *
+ * This is the direction that produces a false sentence rather than a missing
+ * one, so the message quotes the bullet back — the point is not that a name
+ * appears somewhere, it is that *this line* promises a thing that exists.
+ *
+ * @param {string[]} items
+ * @param {typeof SHIPPED_FEATURES} features
+ * @returns {string[]} problems (empty = ok)
+ */
+export function findShippedPromises(items, features) {
+  const problems = [];
+  for (const item of items) {
+    for (const f of features) {
+      if (f.terms.some((t) => mentions(item, t))) {
+        problems.push(
+          `README.md "What's coming" promises ${f.name}, which already shipped ` +
+            `(${f.evidence}):\n    > ${item}`,
+        );
+      }
+    }
+  }
+  return problems;
+}
+
+/**
+ * Entries whose evidence path is gone — the verdict outliving its evidence.
+ *
+ * @param {typeof SHIPPED_FEATURES} features
+ * @param {(path: string) => boolean} exists
+ * @returns {string[]} problems (empty = ok)
+ */
+export function findFeaturesWithoutEvidence(features, exists) {
+  return features
+    .filter((f) => !exists(f.evidence))
+    .map(
+      (f) =>
+        `SHIPPED_FEATURES entry "${f.name}" points at ${f.evidence}, which no ` +
+        `longer exists. Repoint it at what proves the feature ships today, or ` +
+        `remove the entry (and say so in the README).`,
+    );
+}
+
+/**
+ * Terms too generic to mean one feature.
+ *
+ * A single word like "dashboard" would match half the roadmap and turn this
+ * check into noise; the fix is a more specific term, never a longer ignore
+ * list.
+ *
+ * @param {typeof SHIPPED_FEATURES} features
+ * @returns {string[]} problems (empty = ok)
+ */
+export function assertTermsAreSpecific(features) {
+  const problems = [];
+  for (const f of features) {
+    if (f.terms.length === 0) {
+      problems.push(`SHIPPED_FEATURES entry "${f.name}" has no terms`);
+    }
+    for (const term of f.terms) {
+      const w = words(term);
+      if (w.length === 1 && TOO_GENERIC.has(w[0])) {
+        problems.push(
+          `SHIPPED_FEATURES entry "${f.name}" uses the one-word term "${term}", ` +
+            `which is too generic to mean this feature alone. Use two words.`,
+        );
+      }
+    }
+  }
+  return problems;
+}

--- a/scripts/lib/readme-status.mjs
+++ b/scripts/lib/readme-status.mjs
@@ -160,7 +160,10 @@ export function extractStatusItems(readme, heading) {
   }
   const items = [];
   for (const line of lines.slice(start + 1)) {
-    if (/^#{1,3} /.test(line)) break;
+    // Any heading ends the section, including a deeper one: `#### Something`
+    // introduces its own bullets, and counting those as this section's would
+    // let a subsection satisfy a check about the section above it.
+    if (/^#{1,6} /.test(line)) break;
     const bullet = /^\s*[-*]\s+(.*)$/.exec(line);
     if (bullet) items.push(bullet[1].trim());
   }
@@ -178,9 +181,12 @@ export function extractStatusItems(readme, heading) {
  * @returns {string[]} problems (empty = ok)
  */
 export function findUnmentionedShippedFeatures(items, features) {
-  const text = items.join("\n");
+  // Per bullet, never across the joined list. A term's words scattered over two
+  // unrelated bullets — "web" in one, "search" in another — would satisfy a
+  // joined match while nothing in the list describes the feature, which is the
+  // same accept-a-coincidence failure `mentions` refuses at the word level.
   return features
-    .filter((f) => !f.terms.some((t) => mentions(text, t)))
+    .filter((f) => !f.terms.some((t) => items.some((i) => mentions(i, t))))
     .map(
       (f) =>
         `README.md "What works today" never mentions ${f.name}, which shipped ` +

--- a/scripts/lib/readme-status.test.mjs
+++ b/scripts/lib/readme-status.test.mjs
@@ -1,0 +1,179 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  SHIPPED_FEATURES,
+  assertTermsAreSpecific,
+  extractStatusItems,
+  findFeaturesWithoutEvidence,
+  findShippedPromises,
+  findUnmentionedShippedFeatures,
+  mentions,
+} from "./readme-status.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const README = join(REPO_ROOT, "README.md");
+
+// ── pure logic ────────────────────────────────────────────────────────────
+
+test("mentions matches every word of a term, in any order", () => {
+  assert.ok(
+    mentions("Admin dashboard with usage analytics", "usage dashboard"),
+  );
+  assert.ok(mentions("Usage & Costs Dashboard", "usage dashboard"));
+  assert.ok(!mentions("Admin dashboard", "usage dashboard"));
+});
+
+test("mentions does not fire on a substring", () => {
+  // The bug a naive `includes` would ship: "groups" inside "subgroups".
+  assert.ok(!mentions("Manage subgroups of a team", "groups"));
+  assert.ok(mentions("Manage groups of a team", "groups"));
+});
+
+test("mentions keeps RBAC's 'permissions' away from agent permissions", () => {
+  // The real "What's coming" line. It must stay a legal promise: granular RBAC
+  // has not shipped, and a check that flagged it would be flagged off.
+  assert.ok(
+    !mentions("Full RBAC with team-scoped permissions", "agent permissions"),
+  );
+});
+
+test("extractStatusItems reads the bullets under a heading and stops at the next one", () => {
+  const readme = [
+    "### What works today",
+    "",
+    "- **Setup wizard** — first run",
+    "- **Telegram** — chat from your phone",
+    "",
+    "### What's coming",
+    "",
+    "- Plugin marketplace",
+  ].join("\n");
+  assert.deepEqual(extractStatusItems(readme, "What works today"), [
+    "**Setup wizard** — first run",
+    "**Telegram** — chat from your phone",
+  ]);
+  assert.deepEqual(extractStatusItems(readme, "What's coming"), [
+    "Plugin marketplace",
+  ]);
+});
+
+test("extractStatusItems throws instead of returning an empty list", () => {
+  // An empty list makes every check below pass vacuously — the exact way a
+  // coverage gate turns into decoration.
+  assert.throws(
+    () => extractStatusItems("# Pinchy\n\nNo status here.", "What works today"),
+    /What works today/,
+  );
+  assert.throws(
+    () =>
+      extractStatusItems(
+        "### What works today\n\nProse, no bullets.",
+        "What works today",
+      ),
+    /no bullet items/,
+  );
+});
+
+test("findUnmentionedShippedFeatures flags a shipped feature the list omits", () => {
+  const features = [
+    {
+      name: "Odoo integration",
+      terms: ["odoo"],
+      evidence: "packages/plugins/pinchy-odoo",
+    },
+  ];
+  const problems = findUnmentionedShippedFeatures(
+    ["- **Setup wizard**"],
+    features,
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /Odoo integration/);
+  assert.deepEqual(
+    findUnmentionedShippedFeatures(["**Odoo** — scoped ERP access"], features),
+    [],
+  );
+});
+
+test("findShippedPromises flags a promise of something that already shipped", () => {
+  const features = [
+    {
+      name: "Usage & costs dashboard",
+      terms: ["usage dashboard", "usage analytics"],
+      evidence: "packages/web/src/app/api/usage",
+    },
+  ];
+  const problems = findShippedPromises(
+    [
+      "Admin dashboard with usage analytics",
+      "Plugin marketplace for agent tools",
+    ],
+    features,
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /already shipped/);
+  // The roadmap item that names nothing in the tree is left alone.
+  assert.match(problems[0], /usage analytics/);
+});
+
+test("findFeaturesWithoutEvidence flags a verdict that outlived its evidence", () => {
+  const features = [
+    { name: "Gone", terms: ["gone"], evidence: "packages/plugins/pinchy-gone" },
+  ];
+  assert.equal(findFeaturesWithoutEvidence(features, () => false).length, 1);
+  assert.deepEqual(
+    findFeaturesWithoutEvidence(features, () => true),
+    [],
+  );
+});
+
+test("assertTermsAreSpecific rejects a one-word term that means too much", () => {
+  assert.equal(
+    assertTermsAreSpecific([{ name: "X", terms: ["dashboard"], evidence: "p" }])
+      .length,
+    1,
+  );
+  assert.deepEqual(
+    assertTermsAreSpecific([
+      { name: "X", terms: ["usage dashboard"], evidence: "p" },
+    ]),
+    [],
+  );
+});
+
+// ── the repo itself ───────────────────────────────────────────────────────
+
+test("every SHIPPED_FEATURES entry still points at code that exists", () => {
+  assert.ok(
+    SHIPPED_FEATURES.length > 5,
+    `expected the full feature set, found ${SHIPPED_FEATURES.length}`,
+  );
+  assert.deepEqual(
+    findFeaturesWithoutEvidence(SHIPPED_FEATURES, (p) =>
+      existsSync(join(REPO_ROOT, p)),
+    ),
+    [],
+  );
+});
+
+test("every SHIPPED_FEATURES term is specific enough to mean one feature", () => {
+  assert.deepEqual(assertTermsAreSpecific(SHIPPED_FEATURES), []);
+});
+
+test("the README's 'What works today' names every shipped feature", () => {
+  const items = extractStatusItems(
+    readFileSync(README, "utf8"),
+    "What works today",
+  );
+  assert.deepEqual(findUnmentionedShippedFeatures(items, SHIPPED_FEATURES), []);
+});
+
+test("the README's 'What's coming' promises nothing that already shipped", () => {
+  const items = extractStatusItems(
+    readFileSync(README, "utf8"),
+    "What's coming",
+  );
+  assert.deepEqual(findShippedPromises(items, SHIPPED_FEATURES), []);
+});

--- a/scripts/lib/readme-status.test.mjs
+++ b/scripts/lib/readme-status.test.mjs
@@ -60,6 +60,21 @@ test("extractStatusItems reads the bullets under a heading and stops at the next
   ]);
 });
 
+test("extractStatusItems stops at a deeper heading too", () => {
+  const readme = [
+    "### What works today",
+    "",
+    "- **Setup wizard** — first run",
+    "",
+    "#### Coming later this year",
+    "",
+    "- Plugin marketplace",
+  ].join("\n");
+  assert.deepEqual(extractStatusItems(readme, "What works today"), [
+    "**Setup wizard** — first run",
+  ]);
+});
+
 test("extractStatusItems throws instead of returning an empty list", () => {
   // An empty list makes every check below pass vacuously — the exact way a
   // coverage gate turns into decoration.
@@ -93,6 +108,29 @@ test("findUnmentionedShippedFeatures flags a shipped feature the list omits", ()
   assert.match(problems[0], /Odoo integration/);
   assert.deepEqual(
     findUnmentionedShippedFeatures(["**Odoo** — scoped ERP access"], features),
+    [],
+  );
+});
+
+test("findUnmentionedShippedFeatures does not accept a term split across bullets", () => {
+  // The looseness a joined match would ship: "web" in one bullet and "search"
+  // in another satisfy "web search" while no bullet describes the feature.
+  const features = [
+    {
+      name: "Web search",
+      terms: ["web search"],
+      evidence: "packages/plugins/pinchy-web",
+    },
+  ];
+  assert.equal(
+    findUnmentionedShippedFeatures(
+      ["**Web UI** — chat in the browser", "**Search** — find a conversation"],
+      features,
+    ).length,
+    1,
+  );
+  assert.deepEqual(
+    findUnmentionedShippedFeatures(["**Web search** — via Brave"], features),
     [],
   );
 });


### PR DESCRIPTION
## What does this PR do?

Closes #1082

Fills the four Diataxis gaps the 2026-08-04 docs audit found, and wires a guard behind each list that can drift.

**1. A tutorial for the differentiator.** The tutorial quadrant was Quick Start plus two "Create a … Agent" guides — none of which covers what Pinchy is actually for: an agent a *team* uses, scoped on purpose, with a record of what it did. `tutorials/first-governed-agent` walks that end to end — create a shared agent, scope its allow-list, invite a member, watch them hit the boundary, then read the run back out of the audit trail. It deliberately needs no licence key and no integration beyond the LLM provider, so it works on a plain install.

**2. A consolidated environment-variable reference.** `PINCHY_PORT` lived in `installation.mdx`, the `*_MEM_LIMIT` knobs in `customizing-deployment.mdx`, `PINCHY_ENTERPRISE_KEY` in `enterprise-setup.mdx`, and no page answered "what can I put in `.env`?". `reference/environment-variables` collects all twelve plus the volumes, and `scripts/lib/env-var-reference.mjs` keeps it honest in both directions: a `${VAR}` the page omits, a variable the page invents, and a default stated wrongly each fail CI.

**3. A guide for automations.** Email automations were a headline feature documented only as a tab subsection of `concepts/agent-settings`. `guides/email-automations` is the task-shaped version: prerequisites, scoping a trigger, and the human-gated switch that turns a proposal into standing authority.

**4. The README status section, stale in both directions.** "What works today" omitted Telegram, Odoo, web search, email automations, the usage dashboard, groups and the domain lock. "What's coming" still promised email automations and usage analytics, both shipped — so the two lists said opposite things about the same feature. That second direction is the one worth naming: a stale promise is not a missing sentence, it is a false one, and it reads as authoritative because it sits under a heading that claims to describe the future.

## A real bug the env-var guard surfaced

`AUDIT_HMAC_SECRET` was documented in `installation.mdx` as something to set in `.env`. The app does read it (`getSecretSource` checks env before the file fallback), but the shipped `docker-compose.yml` has **never** forwarded it — so setting it does exactly nothing on a standard install.

This PR does not fix the wiring, on purpose. env takes precedence over the file secret, so adding the passthrough would swap the signing key on every install that followed the old instruction and break the existing HMAC chain. That needs a migration and an upgrade note, not a one-line compose edit. What this PR does instead: records it as `READ_NOT_FORWARDED` with what is actually true, states the caveat on both pages, and asserts the exception dies the moment compose does forward it — so the caveat cannot outlive the gap.

## Why guards, not just prose

Per AGENTS.md § "A Hand-Maintained List That Mirrors Code Will Be Wrong": the one list with a guard is the one list that stayed correct. Both new guards are evidence-based rather than second hand-kept lists, and both fail when their evidence disappears:

- `readme-status.mjs` pairs each feature with a path whose existence proves it shipped; `findFeaturesWithoutEvidence` fails when that path goes away. It has no opinion on the roadmap — "plugin marketplace" names nothing in the tree, so it stays a promise.
- `env-var-reference.mjs` derives the variable list from `docker-compose.yml` and checks names *and* defaults in both directions.

Both were verified by canary rather than by reading, which is what AGENTS.md asks for:

- dropping the Odoo bullet turns the README guard red on that exact line; restoring it turns it green.
- adding `${CANARY_RESTART}` to compose turns the env-var guard red naming that variable; removing it turns it green.

## Type of change

- [x] 📝 Documentation
- [x] 🧪 Tests

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

## Verification

| Gate | Result |
| ---- | ------ |
| `pnpm test` | 10917 passed, 18 skipped (tracked) |
| `pnpm test:scripts` | 944 passed (31 new) |
| `pnpm -C docs build` + `check:anchors` + `check:rendered` | 73 pages, no broken internal links, every table rendered |
| `pnpm format:check` | clean |

## Notes for the reviewer

- `installation.mdx` and `customizing-deployment.mdx` keep their context and now link to the reference rather than duplicating it. `installation.mdx`'s volume table was also missing `pinchy-kb-artifacts`.
- Left alone deliberately: `.env.example` advertises `PINCHY_ADMIN_EMAIL`/`PINCHY_ADMIN_PASSWORD`, which nothing in the tree reads, and its `PINCHY_VERSION` lags the README — the latter is already tracked as #1079.
- The README's "What's coming" no longer names a shipped feature even to exclude it ("beyond Telegram"), because the guard reads a name rather than a sentence. That is a deliberate false positive: a roadmap line arguing from the name of a shipped feature is the exact ambiguity this section had.
