### PR TITLE
refactor: collapse the duplicated blocks #1087 found, guard the one that stays

### DIFF
--- a/packages/web/src/__tests__/api/automations-connections.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-connections.integration.test.ts
@@ -147,6 +147,8 @@ describe("GET /api/automations/connections", () => {
     const agent = await seedAgent({ isPersonal: false, ownerId: null });
     const res = await GET(req(agent.id), routeContext());
     expect(res.status).toBe(403);
+    // Read-side default wording from the shared gate (#1087).
+    expect(await res.json()).toEqual({ error: "You do not have access to this agent" });
   });
 
   it("forbids a member from listing another user's personal agent's connections", async () => {

--- a/packages/web/src/__tests__/api/automations-create.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-create.integration.test.ts
@@ -185,6 +185,13 @@ describe("POST /api/automations — create email workflow", () => {
 
     const res = await POST(postBody(validBody(agent.id, "conn-shared")), routeContext());
     expect(res.status).toBe(403);
+    // The wording, not just the status: create shares its scope gate with the
+    // two GET routes but keeps its own refusal ("permission to create a
+    // workflow", not "access to this agent"). Since #1087 that is a defaulted
+    // parameter, so an omitted argument would silently swap the sentence.
+    expect(await res.json()).toEqual({
+      error: "You do not have permission to create a workflow on this agent",
+    });
     expect(await loadWorkflows(agent.id)).toHaveLength(0);
     expect(deferAuditLogMock).not.toHaveBeenCalled();
   });

--- a/packages/web/src/__tests__/api/automations-manage.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-manage.integration.test.ts
@@ -148,6 +148,9 @@ describe("Automations management API", () => {
         routeContext()
       );
       expect(res.status).toBe(403);
+      // The read-side wording, which the shared gate supplies as its default
+      // (#1087) — the create route deliberately overrides it.
+      expect(await res.json()).toEqual({ error: "You do not have access to this agent" });
     });
 
     it("requires an agentId query parameter", async () => {

--- a/packages/web/src/__tests__/lib/api-client.test.ts
+++ b/packages/web/src/__tests__/lib/api-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { apiPost, apiDelete, apiGet, ApiError } from "@/lib/api-client";
+import { apiPost, apiDelete, apiGet, ApiError, extractFieldErrors } from "@/lib/api-client";
 
 /**
  * Helper to build a Response-shaped mock that matches what `send()` reads.
@@ -114,5 +114,54 @@ describe("apiPost", () => {
       expect((e as ApiError).status).toBe(403);
       expect((e as ApiError).message).toBe("Forbidden");
     }
+  });
+});
+
+/**
+ * The inline-vs-toast split from AGENTS.md § "Error And Notification UI" hangs
+ * off this helper's null: a field the user can correct gets an inline message,
+ * anything else gets a toast. It lived as an untested copy inside two settings
+ * components until #1087 pulled it here, so its contract is pinned now.
+ */
+describe("extractFieldErrors", () => {
+  it("flattens Zod's fieldErrors to the first message per field", () => {
+    const err = new ApiError(400, "Validation failed", {
+      fieldErrors: { name: ["Name is required", "Name is too short"], scopes: ["Pick one"] },
+    });
+    expect(extractFieldErrors(err)).toEqual({
+      name: "Name is required",
+      scopes: "Pick one",
+    });
+  });
+
+  it("returns null for an error that is not an ApiError", () => {
+    expect(extractFieldErrors(new Error("network down"))).toBeNull();
+    expect(extractFieldErrors("nope")).toBeNull();
+    expect(extractFieldErrors(undefined)).toBeNull();
+  });
+
+  it("returns null for an ApiError carrying no details", () => {
+    expect(extractFieldErrors(new ApiError(500, "Server error"))).toBeNull();
+  });
+
+  it("returns null when details carry no fieldErrors", () => {
+    expect(extractFieldErrors(new ApiError(400, "Bad", { formErrors: ["nope"] }))).toBeNull();
+  });
+
+  it("returns null when every field's message list is empty", () => {
+    // Not `{}` — the caller branches on null to fall back to a toast, so an
+    // empty map would render an inline error area with nothing in it.
+    const err = new ApiError(400, "Validation failed", { fieldErrors: { name: [] } });
+    expect(extractFieldErrors(err)).toBeNull();
+  });
+
+  it("skips a field whose messages are not an array but keeps the rest", () => {
+    const err = new ApiError(400, "Validation failed", {
+      fieldErrors: { name: "not-an-array", scopes: ["Pick one"] } as unknown as Record<
+        string,
+        string[]
+      >,
+    });
+    expect(extractFieldErrors(err)).toEqual({ scopes: "Pick one" });
   });
 });

--- a/packages/web/src/__tests__/lib/butler-personality-drift.test.ts
+++ b/packages/web/src/__tests__/lib/butler-personality-drift.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Drift-guard: the butler personality prose is duplicated across
+ * `lib/smithers-soul.ts` (SMITHERS_SOUL_MD's `## Personality` section) and
+ * `lib/personality-presets.ts` (`the-butler`.soulMd).
+ *
+ * They are the same voice by design, not by accident: `createSmithersAgent`
+ * stamps `personalityPresetId: "the-butler"` onto Smithers itself, so an
+ * instance whose preset says one thing and whose SOUL.md says another is
+ * describing one agent two ways.
+ *
+ * The duplication is kept rather than single-sourced, and the reason is the
+ * hash contract next door. `CURRENT_SOUL_HASH` is derived from the evaluated
+ * SMITHERS_SOUL_MD, and `SHIPPED_SOUL_HASHES` is append-only: sharing one
+ * constant would make an ordinary preset-copy tweak silently change Smithers'
+ * soul hash, forcing a new history entry and re-running the boot migration
+ * across every existing install. A cosmetic edit must not carry that blast
+ * radius — so the two texts stay separate and this test is what keeps them
+ * honest (#1087).
+ *
+ * Deliberately diverging the two is allowed; it just has to be a decision.
+ * Change the expectation here and say why, the same way a released upgrade
+ * note or a test deletion has to be authorized rather than merely done.
+ *
+ * Note what this does NOT relax: `smithers-soul-history.test.ts` still forbids
+ * a preset from hashing into SHIPPED_SOUL_HASHES. That guard is about the
+ * WHOLE soul colliding; this one is about the shared paragraph drifting. Both
+ * hold at once — the butler preset carries only this prose, while Smithers
+ * wraps it in a `# Smithers` header and a `## Platform Knowledge` section, so
+ * the two full strings can never be equal.
+ */
+import { describe, it, expect } from "vitest";
+
+import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
+import { PERSONALITY_PRESETS } from "@/lib/personality-presets";
+
+/**
+ * Slice out the text between two markers. Throws rather than returning "" when
+ * a marker is missing: an extractor that quietly returns nothing would compare
+ * empty against empty and pass, which is the failure mode this guard exists to
+ * prevent.
+ */
+function sliceBetween(source: string, start: string, end: string | null, label: string): string {
+  const from = source.indexOf(start);
+  if (from === -1) {
+    throw new Error(`${label}: start marker ${JSON.stringify(start)} not found`);
+  }
+  const bodyStart = from + start.length;
+  if (end === null) return source.slice(bodyStart).trim();
+
+  const to = source.indexOf(end, bodyStart);
+  if (to === -1) {
+    throw new Error(`${label}: end marker ${JSON.stringify(end)} not found`);
+  }
+  return source.slice(bodyStart, to).trim();
+}
+
+describe("butler personality prose drift guard", () => {
+  it("Smithers' SOUL and the-butler preset carry identical personality prose", () => {
+    const fromSoul = sliceBetween(
+      SMITHERS_SOUL_MD,
+      "## Personality\n",
+      "\n## Platform Knowledge",
+      "SMITHERS_SOUL_MD"
+    );
+    const fromPreset = sliceBetween(
+      PERSONALITY_PRESETS["the-butler"].soulMd,
+      "# Personality\n",
+      null,
+      "the-butler.soulMd"
+    );
+
+    expect(fromPreset).toBe(fromSoul);
+  });
+
+  it("extracts a substantial block from both, not an empty string", () => {
+    // A corpus floor, for the same reason the docs-coverage checks carry one:
+    // a comparison of two empty strings passes while proving nothing.
+    const fromSoul = sliceBetween(
+      SMITHERS_SOUL_MD,
+      "## Personality\n",
+      "\n## Platform Knowledge",
+      "SMITHERS_SOUL_MD"
+    );
+    expect(fromSoul.length).toBeGreaterThan(500);
+    expect(fromSoul).toContain("unfailingly polite");
+  });
+
+  it("the two full souls still differ, so the migration cannot overwrite a preset", () => {
+    // The complement of the collision guard in smithers-soul-history.test.ts,
+    // asserted here too because it is what makes "share the prose, not the
+    // soul" safe.
+    expect(PERSONALITY_PRESETS["the-butler"].soulMd).not.toBe(SMITHERS_SOUL_MD);
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/resolve-agent.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/resolve-agent.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the shared Automations agent-scope gate.
+ *
+ * `canManageAgentWorkflows` (authz.test.ts) is the rule; this is the HTTP
+ * preamble wrapped around it — load, 404, gate, 403 — which three routes used
+ * to carry as their own copy (#1087).
+ *
+ * The 403 wording gets its own cases on purpose. Collapsing the copies turned
+ * user-visible copy into a defaulted parameter, so the drift this refactor
+ * newly makes possible is a caller that omits the third argument and silently
+ * downgrades "you may not create a workflow" to "you have no access". The
+ * route-level counterpart lives in automations-create.integration.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/db", () => ({ db: { select: vi.fn() } }));
+
+import { db } from "@/db";
+import {
+  resolveWorkflowAgent,
+  resolveWorkflowAgentFromQuery,
+} from "@/lib/email-workflows/resolve-agent";
+
+const OWNER = "user-owner";
+const OTHER = "user-other";
+
+const personalAgent = {
+  id: "agent-1",
+  name: "Owner's assistant",
+  isPersonal: true,
+  ownerId: OWNER,
+};
+const sharedAgent = { id: "agent-2", name: "Team bot", isPersonal: false, ownerId: null };
+
+/** Stub the `select().from().where()` chain with the row the lookup finds. */
+function mockLookup(row: unknown | undefined) {
+  const where = vi.fn().mockResolvedValue(row === undefined ? [] : [row]);
+  const from = vi.fn().mockReturnValue({ where });
+  vi.mocked(db.select).mockReturnValue({ from } as never);
+  return { from, where };
+}
+
+async function bodyOf(response: Response) {
+  return (await response.json()) as { error?: string };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveWorkflowAgent", () => {
+  it("returns the agent when the actor owns it", async () => {
+    mockLookup(personalAgent);
+    const result = await resolveWorkflowAgent("agent-1", { id: OWNER, role: "user" });
+    expect(result).toEqual({ agent: personalAgent });
+  });
+
+  it("returns the agent for an admin on a shared agent", async () => {
+    mockLookup(sharedAgent);
+    const result = await resolveWorkflowAgent("agent-2", { id: OTHER, role: "admin" });
+    expect(result).toEqual({ agent: sharedAgent });
+  });
+
+  it("answers 404 when no agent matches", async () => {
+    mockLookup(undefined);
+    const result = await resolveWorkflowAgent("ghost", { id: OWNER, role: "user" });
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(result.error.status).toBe(404);
+    expect(await bodyOf(result.error)).toEqual({ error: "Agent not found" });
+  });
+
+  it("answers 403 with the read-side default wording", async () => {
+    mockLookup(sharedAgent);
+    const result = await resolveWorkflowAgent("agent-2", { id: OWNER, role: "user" });
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(result.error.status).toBe(403);
+    expect(await bodyOf(result.error)).toEqual({
+      error: "You do not have access to this agent",
+    });
+  });
+
+  it("answers 403 with the caller's wording when one is given", async () => {
+    mockLookup(sharedAgent);
+    const result = await resolveWorkflowAgent(
+      "agent-2",
+      { id: OWNER, role: "user" },
+      "You do not have permission to create a workflow on this agent"
+    );
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(await bodyOf(result.error)).toEqual({
+      error: "You do not have permission to create a workflow on this agent",
+    });
+  });
+
+  it("refuses someone else's personal agent", async () => {
+    mockLookup(personalAgent);
+    const result = await resolveWorkflowAgent("agent-1", { id: OTHER, role: "user" });
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(result.error.status).toBe(403);
+  });
+});
+
+describe("resolveWorkflowAgentFromQuery", () => {
+  it("answers 400 before touching the database when agentId is missing", async () => {
+    mockLookup(personalAgent);
+    const result = await resolveWorkflowAgentFromQuery(
+      new Request("http://localhost/api/automations"),
+      { id: OWNER, role: "user" }
+    );
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(result.error.status).toBe(400);
+    expect(await bodyOf(result.error)).toEqual({ error: "agentId is required" });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("resolves the agentId out of the query string", async () => {
+    mockLookup(personalAgent);
+    const result = await resolveWorkflowAgentFromQuery(
+      new Request("http://localhost/api/automations?agentId=agent-1"),
+      { id: OWNER, role: "user" }
+    );
+    expect(result).toEqual({ agent: personalAgent });
+  });
+
+  it("forwards a caller's 403 wording", async () => {
+    mockLookup(sharedAgent);
+    const result = await resolveWorkflowAgentFromQuery(
+      new Request("http://localhost/api/automations?agentId=agent-2"),
+      { id: OWNER, role: "user" },
+      "Custom refusal"
+    );
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(await bodyOf(result.error)).toEqual({ error: "Custom refusal" });
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-params.test.ts
+++ b/packages/web/src/__tests__/lib/usage-params.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { NextResponse } from "next/server";
-import { parseDays } from "@/lib/usage-params";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+import { parseDays, parseUsageFilter } from "@/lib/usage-params";
 
 describe("parseDays", () => {
   it("should default to 30 when param is null", () => {
@@ -41,5 +43,83 @@ describe("parseDays", () => {
 
   it("should default to 30 for empty string (falsy)", () => {
     expect(parseDays("")).toBe(30);
+  });
+});
+
+/**
+ * The four usage read routes (summary, by-user, export, timeseries) share this
+ * one filter since #1087. It is tested here rather than only through the routes
+ * because the thing worth pinning is not a status code but *which rows an admin
+ * sees* — and the route tests each assert their own response shape, so a filter
+ * that quietly stopped applying `agentId` would still look right in all four.
+ *
+ * The assertions read the rendered SQL rather than the SQL object's internals:
+ * what matters is the predicate Postgres receives.
+ */
+describe("parseUsageFilter", () => {
+  const dialect = new PgDialect();
+
+  /** Render a drizzle condition the way the driver would. */
+  function rendered(where: SQL | undefined) {
+    if (!where) throw new Error("expected a WHERE clause");
+    return dialect.sqlToQuery(where);
+  }
+
+  function filterFor(query: string) {
+    const result = parseUsageFilter(new URL(`http://localhost/api/usage/summary${query}`));
+    if (result instanceof NextResponse) throw new Error("expected a filter, got a response");
+    return result;
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("passes a bad `days` straight back as the 400 response", () => {
+    const result = parseUsageFilter(new URL("http://localhost/api/usage/summary?days=abc"));
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(400);
+  });
+
+  it("applies no WHERE at all for days=0 without an agentId", () => {
+    const filter = filterFor("?days=0");
+    expect(filter.days).toBe(0);
+    expect(filter.agentId).toBeNull();
+    // undefined, not an empty and(): drizzle reads that as "select everything".
+    expect(filter.where).toBeUndefined();
+  });
+
+  it("bounds the timestamp at exactly `days` before now", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T12:00:00.000Z"));
+
+    const { sql, params } = rendered(filterFor("?days=7").where);
+    expect(sql).toContain('"timestamp" >=');
+    // Drizzle's timestamp mapper hands the driver an ISO string, not the Date.
+    expect(params).toEqual(["2026-07-29T12:00:00.000Z"]);
+  });
+
+  it("filters by agent alone when days=0", () => {
+    const filter = filterFor("?days=0&agentId=agent-1");
+    const { sql, params } = rendered(filter.where);
+    expect(sql).toContain('"agent_id" =');
+    expect(sql).not.toContain('"timestamp"');
+    expect(params).toEqual(["agent-1"]);
+  });
+
+  it("ands both conditions together when both apply", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T12:00:00.000Z"));
+
+    const { sql, params } = rendered(filterFor("?days=30&agentId=agent-1").where);
+    expect(sql).toContain('"timestamp" >=');
+    expect(sql).toContain('"agent_id" =');
+    expect(params).toEqual(["2026-07-06T12:00:00.000Z", "agent-1"]);
+  });
+
+  it("defaults to the last 30 days when no params are given", () => {
+    const filter = filterFor("");
+    expect(filter.days).toBe(30);
+    expect(rendered(filter.where).sql).toContain('"timestamp" >=');
   });
 });

--- a/packages/web/src/app/(app)/chat/[agentId]/[chatId]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/[chatId]/page.tsx
@@ -1,14 +1,6 @@
 import type { Metadata } from "next";
-import { db } from "@/db";
-import { activeAgents } from "@/db/schema";
-import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
 import { Chat } from "@/components/chat";
-import { requireAuth } from "@/lib/require-auth";
-import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
-import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
-import { getLicenseState } from "@/lib/enterprise";
-import { getAgentAvatarSvg } from "@/lib/avatar";
+import { loadChatAgentName, loadChatPageAgent } from "@/lib/chats/load-chat-agent";
 
 export async function generateMetadata({
   params,
@@ -16,13 +8,7 @@ export async function generateMetadata({
   params: Promise<{ agentId: string; chatId: string }>;
 }): Promise<Metadata> {
   const { agentId } = await params;
-  const agent = await db
-    .select({ name: activeAgents.name })
-    .from(activeAgents)
-    .where(eq(activeAgents.id, agentId))
-    .then((rows) => rows[0]);
-
-  return { title: agent?.name ?? "Chat" };
+  return { title: (await loadChatAgentName(agentId)) ?? "Chat" };
 }
 
 export default async function ChatPage({
@@ -31,36 +17,7 @@ export default async function ChatPage({
   params: Promise<{ agentId: string; chatId: string }>;
 }) {
   const { agentId, chatId } = await params;
-  const session = await requireAuth();
-  const userId = session.user.id!;
-  const userRole = session.user.role;
-
-  const agent = await db
-    .select()
-    .from(activeAgents)
-    .where(eq(activeAgents.id, agentId))
-    .then((rows) => rows[0]);
-
-  if (!agent) notFound();
-
-  const licenseState = await getLicenseState();
-  const effVis = effectiveVisibility(agent.visibility, licenseState);
-  const needsGroups = userRole !== "admin" && effVis === "restricted";
-
-  const [userGroupIds, agentGroupIds] = await Promise.all([
-    needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
-    needsGroups ? getAgentGroupIds(agentId) : Promise.resolve([]),
-  ]);
-
-  try {
-    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
-  } catch {
-    notFound();
-  }
-
-  const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
-  const isAdmin = userRole === "admin";
-  const canEdit = isAdmin || (agent.isPersonal && agent.ownerId === userId);
+  const { agent, avatarUrl, canEdit } = await loadChatPageAgent(agentId);
 
   return (
     <Chat

--- a/packages/web/src/app/(app)/chat/[agentId]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/page.tsx
@@ -1,14 +1,7 @@
 import type { Metadata } from "next";
-import { db } from "@/db";
-import { activeAgents } from "@/db/schema";
-import { eq } from "drizzle-orm";
-import { notFound, redirect } from "next/navigation";
+import { redirect } from "next/navigation";
 import { Chat } from "@/components/chat";
-import { requireAuth } from "@/lib/require-auth";
-import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
-import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
-import { getLicenseState } from "@/lib/enterprise";
-import { getAgentAvatarSvg } from "@/lib/avatar";
+import { loadChatAgentName, loadChatPageAgent } from "@/lib/chats/load-chat-agent";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
 import { selectMostRecentWebChatId } from "@/lib/chats/select-most-recent-chat";
@@ -19,13 +12,7 @@ export async function generateMetadata({
   params: Promise<{ agentId: string }>;
 }): Promise<Metadata> {
   const { agentId } = await params;
-  const agent = await db
-    .select({ name: activeAgents.name })
-    .from(activeAgents)
-    .where(eq(activeAgents.id, agentId))
-    .then((rows) => rows[0]);
-
-  return { title: agent?.name ?? "Chat" };
+  return { title: (await loadChatAgentName(agentId)) ?? "Chat" };
 }
 
 export default async function ChatPage({
@@ -36,32 +23,7 @@ export default async function ChatPage({
   searchParams?: Promise<{ keep?: string }>;
 }) {
   const { agentId } = await params;
-  const session = await requireAuth();
-  const userId = session.user.id!;
-  const userRole = session.user.role;
-
-  const agent = await db
-    .select()
-    .from(activeAgents)
-    .where(eq(activeAgents.id, agentId))
-    .then((rows) => rows[0]);
-
-  if (!agent) notFound();
-
-  const licenseState = await getLicenseState();
-  const effVis = effectiveVisibility(agent.visibility, licenseState);
-  const needsGroups = userRole !== "admin" && effVis === "restricted";
-
-  const [userGroupIds, agentGroupIds] = await Promise.all([
-    needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
-    needsGroups ? getAgentGroupIds(agentId) : Promise.resolve([]),
-  ]);
-
-  try {
-    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
-  } catch {
-    notFound();
-  }
+  const { agent, userId, avatarUrl, canEdit } = await loadChatPageAgent(agentId);
 
   // Where should a bare /chat/<agentId> land? (#508) The user's most-recently-
   // interacted chat — the sidebar links here when this device has no recorded
@@ -87,10 +49,6 @@ export default async function ChatPage({
   }
   // redirect() throws NEXT_REDIRECT, so it must run OUTSIDE the try/catch above.
   if (mostRecentChatId) redirect(`/chat/${agentId}/${mostRecentChatId}`);
-
-  const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
-  const isAdmin = userRole === "admin";
-  const canEdit = isAdmin || (agent.isPersonal && agent.ownerId === userId);
 
   return (
     <Chat

--- a/packages/web/src/app/(app)/chat/[agentId]/telegram/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/telegram/page.tsx
@@ -1,14 +1,6 @@
 import type { Metadata } from "next";
-import { db } from "@/db";
-import { activeAgents } from "@/db/schema";
-import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
 import { TelegramChatView } from "@/components/telegram-chat-view";
-import { requireAuth } from "@/lib/require-auth";
-import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
-import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
-import { getLicenseState } from "@/lib/enterprise";
-import { getAgentAvatarSvg } from "@/lib/avatar";
+import { loadChatAgentName, loadChatPageAgent } from "@/lib/chats/load-chat-agent";
 
 export async function generateMetadata({
   params,
@@ -16,13 +8,8 @@ export async function generateMetadata({
   params: Promise<{ agentId: string }>;
 }): Promise<Metadata> {
   const { agentId } = await params;
-  const agent = await db
-    .select({ name: activeAgents.name })
-    .from(activeAgents)
-    .where(eq(activeAgents.id, agentId))
-    .then((rows) => rows[0]);
-
-  return { title: agent ? `${agent.name} on Telegram` : "Telegram chat" };
+  const name = await loadChatAgentName(agentId);
+  return { title: name ? `${name} on Telegram` : "Telegram chat" };
 }
 
 /**
@@ -30,7 +17,7 @@ export async function generateMetadata({
  *
  * The static `telegram` segment wins over the dynamic `[chatId]` segment in
  * Next.js routing (same as `settings`), so `/chat/<id>/<chatId>` is unaffected.
- * Auth gating mirrors the base `chat/[agentId]/page.tsx`.
+ * Auth gating is literally the base chat page's, via loadChatPageAgent.
  */
 export default async function TelegramChatPage({
   params,
@@ -38,36 +25,7 @@ export default async function TelegramChatPage({
   params: Promise<{ agentId: string }>;
 }) {
   const { agentId } = await params;
-  const session = await requireAuth();
-  const userId = session.user.id!;
-  const userRole = session.user.role;
-
-  const agent = await db
-    .select()
-    .from(activeAgents)
-    .where(eq(activeAgents.id, agentId))
-    .then((rows) => rows[0]);
-
-  if (!agent) notFound();
-
-  const licenseState = await getLicenseState();
-  const effVis = effectiveVisibility(agent.visibility, licenseState);
-  const needsGroups = userRole !== "admin" && effVis === "restricted";
-
-  const [userGroupIds, agentGroupIds] = await Promise.all([
-    needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
-    needsGroups ? getAgentGroupIds(agentId) : Promise.resolve([]),
-  ]);
-
-  try {
-    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
-  } catch {
-    notFound();
-  }
-
-  const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
-  const isAdmin = userRole === "admin";
-  const canEdit = isAdmin || (agent.isPersonal && agent.ownerId === userId);
+  const { agent, avatarUrl, canEdit } = await loadChatPageAgent(agentId);
 
   return (
     <TelegramChatView

--- a/packages/web/src/app/api/automations/connections/route.ts
+++ b/packages/web/src/app/api/automations/connections/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 import { and, eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
-import { agents, agentConnectionPermissions, integrationConnections } from "@/db/schema";
+import { agentConnectionPermissions, integrationConnections } from "@/db/schema";
 import { withAuth } from "@/lib/api-auth";
 import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
-import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+import { resolveWorkflowAgentFromQuery } from "@/lib/email-workflows/resolve-agent";
 
 /**
  * GET /api/automations/connections?agentId=<id> — the mailbox choices the
@@ -25,21 +25,12 @@ import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
  * audit-exempt: read-only; returns nothing state-changing and writes nothing.
  */
 export const GET = withAuth(async (request, _ctx, session) => {
-  const agentId = new URL(request.url).searchParams.get("agentId");
-  if (!agentId) {
-    return NextResponse.json({ error: "agentId is required" }, { status: 400 });
-  }
-
-  const [agent] = await db
-    .select({ isPersonal: agents.isPersonal, ownerId: agents.ownerId })
-    .from(agents)
-    .where(eq(agents.id, agentId));
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
-  if (!canManageAgentWorkflows(agent, { id: session.user.id!, role: session.user.role })) {
-    return NextResponse.json({ error: "You do not have access to this agent" }, { status: 403 });
-  }
+  const resolved = await resolveWorkflowAgentFromQuery(request, {
+    id: session.user.id!,
+    role: session.user.role,
+  });
+  if ("error" in resolved) return resolved.error;
+  const agentId = resolved.agent.id;
 
   // selectDistinct: an agent can hold several read-operation rows (read, and the
   // legacy "search"/"list" aliases) for one connection — collapse them to one id.

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -2,19 +2,17 @@ import { NextResponse } from "next/server";
 import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { db } from "@/db";
-import {
-  agents,
-  emailWorkflows,
-  emailWorkflowConnections,
-  agentConnectionPermissions,
-} from "@/db/schema";
+import { emailWorkflows, emailWorkflowConnections, agentConnectionPermissions } from "@/db/schema";
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
 import { createAutomationSchema } from "@/lib/schemas/automations";
 import { scrubEmails } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { EMAIL_READ_OPERATIONS } from "@/lib/tool-registry";
-import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
+import {
+  resolveWorkflowAgent,
+  resolveWorkflowAgentFromQuery,
+} from "@/lib/email-workflows/resolve-agent";
 
 /**
  * GET /api/automations?agentId=<id> — list an agent's email workflows for the
@@ -24,21 +22,12 @@ import { canManageAgentWorkflows } from "@/lib/email-workflows/authz";
  * structured translation before enabling it.
  */
 export const GET = withAuth(async (request, _ctx, session) => {
-  const agentId = new URL(request.url).searchParams.get("agentId");
-  if (!agentId) {
-    return NextResponse.json({ error: "agentId is required" }, { status: 400 });
-  }
-
-  const [agent] = await db
-    .select({ isPersonal: agents.isPersonal, ownerId: agents.ownerId })
-    .from(agents)
-    .where(eq(agents.id, agentId));
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
-  if (!canManageAgentWorkflows(agent, { id: session.user.id!, role: session.user.role })) {
-    return NextResponse.json({ error: "You do not have access to this agent" }, { status: 403 });
-  }
+  const resolved = await resolveWorkflowAgentFromQuery(request, {
+    id: session.user.id!,
+    role: session.user.role,
+  });
+  if ("error" in resolved) return resolved.error;
+  const agentId = resolved.agent.id;
 
   const workflows = await db
     .select({
@@ -103,25 +92,13 @@ export const POST = withAuth(async (request, _ctx, session) => {
 
   const userId = session.user.id!;
 
-  const [agent] = await db
-    .select({
-      id: agents.id,
-      name: agents.name,
-      isPersonal: agents.isPersonal,
-      ownerId: agents.ownerId,
-    })
-    .from(agents)
-    .where(eq(agents.id, agentId));
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
-
-  if (!canManageAgentWorkflows(agent, { id: userId, role: session.user.role })) {
-    return NextResponse.json(
-      { error: "You do not have permission to create a workflow on this agent" },
-      { status: 403 }
-    );
-  }
+  const resolved = await resolveWorkflowAgent(
+    agentId,
+    { id: userId, role: session.user.role },
+    "You do not have permission to create a workflow on this agent"
+  );
+  if ("error" in resolved) return resolved.error;
+  const { agent } = resolved;
 
   // Every requested mailbox must be one the agent is allowed to READ — a
   // workflow's trigger lists and reads mail, so a draft/send-only grant is not

--- a/packages/web/src/app/api/usage/by-user/route.ts
+++ b/packages/web/src/app/api/usage/by-user/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
-import { parseDays } from "@/lib/usage-params";
+import { parseUsageFilter } from "@/lib/usage-params";
 import { db } from "@/db";
 import { usageRecords, users } from "@/db/schema";
-import { sum, gte, eq, and } from "drizzle-orm";
+import { sum, eq } from "drizzle-orm";
 
 export async function GET(request: NextRequest) {
   const sessionOrError = await requireAdmin();
@@ -15,22 +15,9 @@ export async function GET(request: NextRequest) {
   }
 
   const url = new URL(request.url);
-  const daysOrError = parseDays(url.searchParams.get("days"));
-  if (daysOrError instanceof NextResponse) return daysOrError;
-  const days = daysOrError;
-  const agentId = url.searchParams.get("agentId");
-
-  const conditions = [];
-  if (days > 0) {
-    const since = new Date();
-    since.setDate(since.getDate() - days);
-    conditions.push(gte(usageRecords.timestamp, since));
-  }
-  if (agentId) {
-    conditions.push(eq(usageRecords.agentId, agentId));
-  }
-
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const filter = parseUsageFilter(url);
+  if (filter instanceof NextResponse) return filter;
+  const { where } = filter;
 
   const result = await db
     .select({

--- a/packages/web/src/app/api/usage/export/route.ts
+++ b/packages/web/src/app/api/usage/export/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
-import { parseDays } from "@/lib/usage-params";
+import { parseUsageFilter } from "@/lib/usage-params";
 import { db } from "@/db";
 import { usageRecords } from "@/db/schema";
-import { desc, gte, eq, and } from "drizzle-orm";
+import { desc } from "drizzle-orm";
 import { csvEscape } from "@/lib/csv";
 
 const MAX_EXPORT_ROWS = 100_000;
@@ -19,22 +19,9 @@ export async function GET(request: NextRequest) {
 
   const url = new URL(request.url);
   const format = url.searchParams.get("format") || "json";
-  const daysOrError = parseDays(url.searchParams.get("days"));
-  if (daysOrError instanceof NextResponse) return daysOrError;
-  const days = daysOrError;
-  const agentId = url.searchParams.get("agentId");
-
-  const conditions = [];
-  if (days > 0) {
-    const since = new Date();
-    since.setDate(since.getDate() - days);
-    conditions.push(gte(usageRecords.timestamp, since));
-  }
-  if (agentId) {
-    conditions.push(eq(usageRecords.agentId, agentId));
-  }
-
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const filter = parseUsageFilter(url);
+  if (filter instanceof NextResponse) return filter;
+  const { where } = filter;
 
   const records = await db
     .select()

--- a/packages/web/src/app/api/usage/summary/route.ts
+++ b/packages/web/src/app/api/usage/summary/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { parseDays } from "@/lib/usage-params";
+import { parseUsageFilter } from "@/lib/usage-params";
 import { db } from "@/db";
 import { usageRecords, agents } from "@/db/schema";
-import { max, sum, gte, eq, and, sql } from "drizzle-orm";
+import { max, sum, eq, sql } from "drizzle-orm";
 import type { UsageSource } from "@/lib/usage-source";
 
 type SourceBucket = {
@@ -27,22 +27,9 @@ export async function GET(request: NextRequest) {
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
   const url = new URL(request.url);
-  const daysOrError = parseDays(url.searchParams.get("days"));
-  if (daysOrError instanceof NextResponse) return daysOrError;
-  const days = daysOrError;
-  const agentId = url.searchParams.get("agentId");
-
-  const conditions = [];
-  if (days > 0) {
-    const since = new Date();
-    since.setDate(since.getDate() - days);
-    conditions.push(gte(usageRecords.timestamp, since));
-  }
-  if (agentId) {
-    conditions.push(eq(usageRecords.agentId, agentId));
-  }
-
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const filter = parseUsageFilter(url);
+  if (filter instanceof NextResponse) return filter;
+  const { where } = filter;
 
   // max(agentName) returns the lexicographically greatest name.
   // If an agent is renamed, this may show either old or new name

--- a/packages/web/src/app/api/usage/timeseries/route.ts
+++ b/packages/web/src/app/api/usage/timeseries/route.ts
@@ -1,21 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { parseDays } from "@/lib/usage-params";
+import { parseUsageFilter } from "@/lib/usage-params";
 import { db } from "@/db";
 import { usageRecords } from "@/db/schema";
-import { sql, sum, gte, eq, and } from "drizzle-orm";
+import { sql, sum } from "drizzle-orm";
 
 export async function GET(request: NextRequest) {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
   const url = new URL(request.url);
-  const daysOrError = parseDays(url.searchParams.get("days"));
-  if (daysOrError instanceof NextResponse) return daysOrError;
-  const days = daysOrError;
-  const agentId = url.searchParams.get("agentId");
-  const tz = url.searchParams.get("tz");
+  const filter = parseUsageFilter(url);
+  if (filter instanceof NextResponse) return filter;
+  const { where } = filter;
 
+  const tz = url.searchParams.get("tz");
   if (tz) {
     try {
       Intl.DateTimeFormat(undefined, { timeZone: tz });
@@ -23,18 +22,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Invalid timezone" }, { status: 400 });
     }
   }
-
-  const conditions = [];
-  if (days > 0) {
-    const since = new Date();
-    since.setDate(since.getDate() - days);
-    conditions.push(gte(usageRecords.timestamp, since));
-  }
-  if (agentId) {
-    conditions.push(eq(usageRecords.agentId, agentId));
-  }
-
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
 
   // Use sql.raw for the timezone identifier — it's already validated above via
   // Intl.DateTimeFormat and only contains [A-Za-z/_+-] characters. A parameterised

--- a/packages/web/src/components/edit-credentials-dialog.tsx
+++ b/packages/web/src/components/edit-credentials-dialog.tsx
@@ -67,6 +67,84 @@ type ImapFormValues = {
   senderName: string;
 };
 
+/**
+ * The submit lifecycle every credential form in this dialog shares: clear the
+ * previous error, show the spinner, PATCH, toast-and-close on success, surface
+ * the server's own message on failure.
+ *
+ * Written once because it was written three times (#1087). The catch block is
+ * the part that matters: a copy that loses the `ApiError` branch degrades a
+ * precise server message ("Authentication failed for user X") into the generic
+ * fallback, and nothing about the form would look broken.
+ */
+function useCredentialUpdate(
+  connectionId: string,
+  onSuccess: () => void,
+  onOpenChange: (open: boolean) => void
+) {
+  const [serverError, setServerError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function save(credentials: Record<string, unknown>) {
+    setSaving(true);
+    setServerError("");
+    try {
+      await apiPatch(`/api/integrations/${connectionId}`, { credentials });
+      toast.success("Credentials updated");
+      onSuccess();
+      onOpenChange(false);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setServerError(err.message);
+      } else {
+        setServerError("Something went wrong. Please try again.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return { serverError, setServerError, saving, save };
+}
+
+/**
+ * The "your saved credentials stopped working" banner. Renders nothing unless
+ * the connection is actually in `auth_failed`, so each form can place it
+ * unconditionally at the top of its fields.
+ */
+function AuthFailedAlert({ status }: { status: IntegrationConnection["status"] }) {
+  if (status !== "auth_failed") return null;
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="h-4 w-4" />
+      <AlertDescription>
+        Current credentials failed authentication — please enter new credentials below.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/** Cancel + Save, with Save carrying the in-flight spinner. */
+function CredentialFormFooter({ saving, onCancel }: { saving: boolean; onCancel: () => void }) {
+  return (
+    <div className="flex justify-end gap-2">
+      <Button type="button" variant="outline" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button type="submit" disabled={saving}>
+        {saving ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Saving...
+          </>
+        ) : (
+          "Save"
+        )}
+      </Button>
+    </div>
+  );
+}
+
 function OdooForm({
   connection,
   onSuccess,
@@ -76,8 +154,7 @@ function OdooForm({
   onSuccess: () => void;
   onOpenChange: (open: boolean) => void;
 }) {
-  const [serverError, setServerError] = useState("");
-  const [saving, setSaving] = useState(false);
+  const { serverError, saving, save } = useCredentialUpdate(connection.id, onSuccess, onOpenChange);
 
   const maskedCreds =
     connection.credentials && typeof connection.credentials === "object"
@@ -95,41 +172,18 @@ function OdooForm({
   });
 
   async function onSubmit(values: OdooFormValues) {
-    setSaving(true);
-    setServerError("");
     const credentials: Record<string, string> = {};
     if (values.url) credentials.url = values.url;
     if (values.db) credentials.db = values.db;
     if (values.login) credentials.login = values.login;
     if (values.apiKey) credentials.apiKey = values.apiKey;
-
-    try {
-      await apiPatch(`/api/integrations/${connection.id}`, { credentials });
-      toast.success("Credentials updated");
-      onSuccess();
-      onOpenChange(false);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setServerError(err.message);
-      } else {
-        setServerError("Something went wrong. Please try again.");
-      }
-    } finally {
-      setSaving(false);
-    }
+    await save(credentials);
   }
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} method="post" className="space-y-4">
-        {connection.status === "auth_failed" && (
-          <Alert variant="destructive">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription>
-              Current credentials failed authentication — please enter new credentials below.
-            </AlertDescription>
-          </Alert>
-        )}
+        <AuthFailedAlert status={connection.status} />
 
         <FormField
           control={form.control}
@@ -186,21 +240,7 @@ function OdooForm({
 
         {serverError && <p className="text-sm text-destructive">{serverError}</p>}
 
-        <div className="flex justify-end gap-2">
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button type="submit" disabled={saving}>
-            {saving ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              "Save"
-            )}
-          </Button>
-        </div>
+        <CredentialFormFooter saving={saving} onCancel={() => onOpenChange(false)} />
       </form>
     </Form>
   );
@@ -215,8 +255,7 @@ function WebSearchForm({
   onSuccess: () => void;
   onOpenChange: (open: boolean) => void;
 }) {
-  const [serverError, setServerError] = useState("");
-  const [saving, setSaving] = useState(false);
+  const { serverError, saving, save } = useCredentialUpdate(connection.id, onSuccess, onOpenChange);
 
   const form = useForm<WebSearchFormValues>({
     resolver: zodResolver(webSearchEditSchema),
@@ -224,38 +263,15 @@ function WebSearchForm({
   });
 
   async function onSubmit(values: WebSearchFormValues) {
-    setSaving(true);
-    setServerError("");
     const credentials: Record<string, string> = {};
     if (values.apiKey) credentials.apiKey = values.apiKey;
-
-    try {
-      await apiPatch(`/api/integrations/${connection.id}`, { credentials });
-      toast.success("Credentials updated");
-      onSuccess();
-      onOpenChange(false);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setServerError(err.message);
-      } else {
-        setServerError("Something went wrong. Please try again.");
-      }
-    } finally {
-      setSaving(false);
-    }
+    await save(credentials);
   }
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} method="post" className="space-y-4">
-        {connection.status === "auth_failed" && (
-          <Alert variant="destructive">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription>
-              Current credentials failed authentication — please enter new credentials below.
-            </AlertDescription>
-          </Alert>
-        )}
+        <AuthFailedAlert status={connection.status} />
 
         <FormField
           control={form.control}
@@ -273,21 +289,7 @@ function WebSearchForm({
 
         {serverError && <p className="text-sm text-destructive">{serverError}</p>}
 
-        <div className="flex justify-end gap-2">
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button type="submit" disabled={saving}>
-            {saving ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              "Save"
-            )}
-          </Button>
-        </div>
+        <CredentialFormFooter saving={saving} onCancel={() => onOpenChange(false)} />
       </form>
     </Form>
   );
@@ -302,8 +304,11 @@ function ImapForm({
   onSuccess: () => void;
   onOpenChange: (open: boolean) => void;
 }) {
-  const [serverError, setServerError] = useState("");
-  const [saving, setSaving] = useState(false);
+  const { serverError, setServerError, saving, save } = useCredentialUpdate(
+    connection.id,
+    onSuccess,
+    onOpenChange
+  );
   const [showPassword, setShowPassword] = useState(false);
 
   // Masked credentials (server strips the password). Ports arrive as strings.
@@ -339,9 +344,6 @@ function ImapForm({
   });
 
   async function onSubmit(values: ImapFormValues) {
-    setSaving(true);
-    setServerError("");
-
     // Build only the non-empty/edited fields, then coerce ports to numbers and
     // validate the subset with imapEditSchema before sending. senderName
     // follows the same "leave empty to keep current" convention as every
@@ -361,40 +363,22 @@ function ImapForm({
       edited.senderName = values.senderName;
     }
 
+    // Client-side validation runs BEFORE the shared save, so a rejected form
+    // never shows the spinner at all — the previous inline copy set `saving`
+    // first and cleared it again, which is the same end state one frame later.
     const parsed = imapEditSchema.safeParse(edited);
     if (!parsed.success) {
       setServerError(parsed.error.issues[0]?.message ?? "Please check your input.");
-      setSaving(false);
       return;
     }
 
-    try {
-      await apiPatch(`/api/integrations/${connection.id}`, { credentials: parsed.data });
-      toast.success("Credentials updated");
-      onSuccess();
-      onOpenChange(false);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setServerError(err.message);
-      } else {
-        setServerError("Something went wrong. Please try again.");
-      }
-    } finally {
-      setSaving(false);
-    }
+    await save(parsed.data);
   }
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} method="post" className="space-y-4">
-        {connection.status === "auth_failed" && (
-          <Alert variant="destructive">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription>
-              Current credentials failed authentication — please enter new credentials below.
-            </AlertDescription>
-          </Alert>
-        )}
+        <AuthFailedAlert status={connection.status} />
 
         <FormField
           control={form.control}
@@ -531,21 +515,7 @@ function ImapForm({
 
         {serverError && <p className="text-sm text-destructive">{serverError}</p>}
 
-        <div className="flex justify-end gap-2">
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button type="submit" disabled={saving}>
-            {saving ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              "Save"
-            )}
-          </Button>
-        </div>
+        <CredentialFormFooter saving={saving} onCancel={() => onOpenChange(false)} />
       </form>
     </Form>
   );

--- a/packages/web/src/components/enterprise-banner.tsx
+++ b/packages/web/src/components/enterprise-banner.tsx
@@ -12,6 +12,7 @@ import {
   CALENDLY_URL,
   conversionLink,
 } from "@/lib/conversion-links";
+import { formatLicenseDate } from "@/lib/format-date";
 
 const REFETCH_INTERVAL_MS = 15 * 60 * 1000;
 const RENEWAL_WINDOW_MS = 14 * 86400000;
@@ -41,14 +42,6 @@ interface Banner {
   links: BannerLink[];
 }
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
 /**
  * License-lifecycle banner per the pricing concept's § 6 state table.
  * Factual copy, no countdowns, no guilt — and never red: an expired
@@ -76,7 +69,7 @@ function licenseBanner(license: LicenseInfo, now: Date): Banner | null {
       return {
         key: "license:trial-expired",
         tone: "warn",
-        message: `Your trial ended${expiresAt ? ` on ${formatDate(expiresAt)}` : ""}. Your configuration is preserved.`,
+        message: `Your trial ended${expiresAt ? ` on ${formatLicenseDate(expiresAt)}` : ""}. Your configuration is preserved.`,
         links: [
           { label: "See pricing", href: conversionLink(PRICING_URL, "expired-banner", "pro-10") },
         ],
@@ -91,7 +84,7 @@ function licenseBanner(license: LicenseInfo, now: Date): Banner | null {
       return {
         key: "license:renewal",
         tone: "info",
-        message: `Your license period ends on ${formatDate(periodEnd)}. Your renewal key arrives by email after payment.`,
+        message: `Your license period ends on ${formatLicenseDate(periodEnd)}. Your renewal key arrives by email after payment.`,
         links: [{ label: "Renew", href: conversionLink(PORTAL_URL, "expired-banner", "pro-10") }],
       };
     }
@@ -99,14 +92,14 @@ function licenseBanner(license: LicenseInfo, now: Date): Banner | null {
       return {
         key: "license:grace",
         tone: "warn",
-        message: `License period ended${periodEnd ? ` ${formatDate(periodEnd)}` : ""}.${expiresAt ? ` Grace until ${formatDate(expiresAt)}.` : ""}`,
+        message: `License period ended${periodEnd ? ` ${formatLicenseDate(periodEnd)}` : ""}.${expiresAt ? ` Grace until ${formatLicenseDate(expiresAt)}.` : ""}`,
         links: [{ label: "Renew", href: conversionLink(PORTAL_URL, "expired-banner", "pro-10") }],
       };
     case "expired":
       return {
         key: "license:expired",
         tone: "warn",
-        message: `Your license period ended${periodEnd ? ` on ${formatDate(periodEnd)}` : ""}. Existing access restrictions remain enforced; management features are locked.`,
+        message: `Your license period ended${periodEnd ? ` on ${formatLicenseDate(periodEnd)}` : ""}. Existing access restrictions remain enforced; management features are locked.`,
         links: [{ label: "Renew", href: conversionLink(PORTAL_URL, "expired-banner", "pro-10") }],
       };
     case "community":

--- a/packages/web/src/components/license-cliff-dialog.tsx
+++ b/packages/web/src/components/license-cliff-dialog.tsx
@@ -17,6 +17,7 @@ import {
   conversionLink,
   type UtmCampaign,
 } from "@/lib/conversion-links";
+import { formatLicenseDate } from "@/lib/format-date";
 
 interface LicenseCliffDialogProps {
   open: boolean;
@@ -29,14 +30,6 @@ interface LicenseCliffDialogProps {
   licenseState: LicenseState;
   /** ISO date the license period ended (paidUntil, or exp as fallback). */
   periodEnd: string | null;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
 }
 
 /**
@@ -53,7 +46,7 @@ export function LicenseCliffDialog({
   licenseState,
   periodEnd,
 }: LicenseCliffDialogProps) {
-  const ended = periodEnd ? ` on ${formatDate(periodEnd)}` : "";
+  const ended = periodEnd ? ` on ${formatLicenseDate(periodEnd)}` : "";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/packages/web/src/components/settings-api-keys.tsx
+++ b/packages/web/src/components/settings-api-keys.tsx
@@ -33,7 +33,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
-import { apiGet, apiPost, apiDelete, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, apiDelete, ApiError, extractFieldErrors } from "@/lib/api-client";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { API_KEY_SCOPES, type ApiKeyScope } from "@/lib/api-key-scopes";
 import type { CreateApiKeyInput } from "@/lib/schemas/api-keys";
@@ -149,24 +149,6 @@ export function SettingsApiKeys() {
       cancelled = true;
     };
   }, [fetchKeys]);
-
-  /**
-   * Pulls Zod's flattened fieldErrors out of an ApiError (if present) and
-   * returns a flat `{ fieldName: message }` map. Returns null when the error
-   * is not a structured field-level validation failure — caller should fall
-   * back to a toast in that case. (Same helper as settings-groups.tsx.)
-   */
-  function extractFieldErrors(e: unknown): Record<string, string> | null {
-    if (!(e instanceof ApiError) || !e.details) return null;
-    const details = e.details as { fieldErrors?: Record<string, string[]> };
-    const fe = details.fieldErrors;
-    if (!fe || typeof fe !== "object") return null;
-    const flat: Record<string, string> = {};
-    for (const [field, messages] of Object.entries(fe)) {
-      if (Array.isArray(messages) && messages.length > 0) flat[field] = messages[0];
-    }
-    return Object.keys(flat).length > 0 ? flat : null;
-  }
 
   function openCreateDialog() {
     setFormName("");

--- a/packages/web/src/components/settings-groups.tsx
+++ b/packages/web/src/components/settings-groups.tsx
@@ -34,7 +34,14 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
-import { apiPost, apiPatch, apiPut, apiDelete, ApiError } from "@/lib/api-client";
+import {
+  apiPost,
+  apiPatch,
+  apiPut,
+  apiDelete,
+  ApiError,
+  extractFieldErrors,
+} from "@/lib/api-client";
 import type { CreateGroupInput } from "@/lib/schemas/groups";
 import type { LicenseState } from "@/lib/license-state";
 
@@ -131,24 +138,6 @@ export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsPro
     setFormMemberIds([]);
     setFieldErrors({});
     setCreateOpen(true);
-  }
-
-  /**
-   * Pulls Zod's flattened fieldErrors out of an ApiError (if present) and
-   * returns a flat `{ fieldName: message }` map. Returns null when the error
-   * is not a structured field-level validation failure — caller should fall
-   * back to a toast in that case.
-   */
-  function extractFieldErrors(e: unknown): Record<string, string> | null {
-    if (!(e instanceof ApiError) || !e.details) return null;
-    const details = e.details as { fieldErrors?: Record<string, string[]> };
-    const fe = details.fieldErrors;
-    if (!fe || typeof fe !== "object") return null;
-    const flat: Record<string, string> = {};
-    for (const [field, messages] of Object.entries(fe)) {
-      if (Array.isArray(messages) && messages.length > 0) flat[field] = messages[0];
-    }
-    return Object.keys(flat).length > 0 ? flat : null;
   }
 
   async function openEditDialog(group: Group) {

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -20,14 +20,7 @@ import { toast } from "sonner";
 import { apiDelete, ApiError } from "@/lib/api-client";
 import type { LicenseInfo } from "@/lib/enterprise";
 import { PRICING_URL, PORTAL_URL, conversionLink } from "@/lib/conversion-links";
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
+import { formatLicenseDate } from "@/lib/format-date";
 
 interface SettingsLicenseProps {
   onEnterpriseActivated?: () => void;
@@ -141,12 +134,14 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
               // exp is paidUntil plus the 30-day grace window.
               <p className="text-sm">
                 License period {license.state === "grace" ? "ended" : "ends"}{" "}
-                {formatDate(license.paidUntil)}. Grace until {formatDate(license.expiresAt)}.
+                {formatLicenseDate(license.paidUntil)}. Grace until{" "}
+                {formatLicenseDate(license.expiresAt)}.
               </p>
             ) : (
               license.expiresAt && (
                 <p className="text-sm">
-                  Expires: {formatDate(license.expiresAt)} ({license.daysRemaining} days remaining)
+                  Expires: {formatLicenseDate(license.expiresAt)} ({license.daysRemaining} days
+                  remaining)
                 </p>
               )
             )}
@@ -185,14 +180,14 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
               <p className="text-sm">
                 Your license period ended
                 {(license.paidUntil ?? license.expiresAt) &&
-                  ` on ${formatDate(license.paidUntil ?? license.expiresAt!)}`}
+                  ` on ${formatLicenseDate(license.paidUntil ?? license.expiresAt!)}`}
                 . Existing access restrictions remain enforced; management features are locked.
               </p>
             )}
             {license?.state === "trial-expired" && (
               <p className="text-sm">
-                Your trial ended{license.expiresAt && ` on ${formatDate(license.expiresAt)}`}. Your
-                configuration is preserved.
+                Your trial ended{license.expiresAt && ` on ${formatLicenseDate(license.expiresAt)}`}
+                . Your configuration is preserved.
               </p>
             )}
             <p className="text-sm text-muted-foreground">

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -174,11 +174,16 @@ export class OfficeDocumentAttachmentAdapter {
 
   async add(state: { file: File }) {
     const { file } = state;
-    if (file.size > CLIENT_MAX_ATTACHMENT_SIZE_BYTES) {
-      const limitMb = Math.round(CLIENT_MAX_ATTACHMENT_SIZE_BYTES / 1024 / 1024);
-      throw new Error(
-        `File "${file.name}" is too large (${Math.round(file.size / 1024 / 1024)} MB). The limit is ${limitMb} MB.`
-      );
+    // Same helper, and therefore the same sentence, the composer's own picker
+    // rejects with (#1087) — this used to re-implement the check with its own
+    // wording, so one user hit two different messages for one rule.
+    //
+    // The helper exempts images; that branch is unreachable here because this
+    // adapter only ever accepts .docx (see `accept` above), and a file that did
+    // arrive claiming image/* would fail in mammoth a moment later regardless.
+    const sizeError = oversizeAttachmentError(file);
+    if (sizeError) {
+      throw new Error(sizeError);
     }
     return {
       id: uuid(),

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -54,3 +54,28 @@ export const apiPut = <R = unknown, B = unknown>(url: string, body: B): Promise<
 export const apiDelete = <R = void, B = unknown>(url: string, body?: B): Promise<R> =>
   send<R>(url, "DELETE", body);
 export const apiGet = <R = unknown>(url: string): Promise<R> => send<R>(url, "GET");
+
+/**
+ * Unwrap a `parseRequestBody` validation failure into a flat
+ * `{ fieldName: firstMessage }` map for inline form errors.
+ *
+ * Returns null when the error is not a structured field-level validation
+ * failure — the caller should fall back to a toast in that case, which is the
+ * split AGENTS.md "Error And Notification UI" describes: a field the user can
+ * correct gets an inline message, anything else gets a toast.
+ *
+ * Lives beside ApiError because it reads `ApiError.details`, whose shape is
+ * this module's contract with the route layer. It was copied verbatim into two
+ * settings components before (#1087).
+ */
+export function extractFieldErrors(e: unknown): Record<string, string> | null {
+  if (!(e instanceof ApiError) || !e.details) return null;
+  const details = e.details as { fieldErrors?: Record<string, string[]> };
+  const fe = details.fieldErrors;
+  if (!fe || typeof fe !== "object") return null;
+  const flat: Record<string, string> = {};
+  for (const [field, messages] of Object.entries(fe)) {
+    if (Array.isArray(messages) && messages.length > 0) flat[field] = messages[0];
+  }
+  return Object.keys(flat).length > 0 ? flat : null;
+}

--- a/packages/web/src/lib/chats/load-chat-agent.ts
+++ b/packages/web/src/lib/chats/load-chat-agent.ts
@@ -1,0 +1,81 @@
+import { eq } from "drizzle-orm";
+import { notFound } from "next/navigation";
+
+import { db } from "@/db";
+import { activeAgents } from "@/db/schema";
+import { requireAuth } from "@/lib/require-auth";
+import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
+import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
+import { getLicenseState } from "@/lib/enterprise";
+import { getAgentAvatarSvg } from "@/lib/avatar";
+
+/**
+ * The agent name a chat route's `generateMetadata` puts in the tab title.
+ *
+ * Deliberately unauthenticated: `generateMetadata` runs before (and
+ * independently of) the page body, and Next.js gives it no way to answer 404 —
+ * so the gate lives in the page, and the callers already fall back to a generic
+ * title when this returns undefined. An agent's display name is not the secret
+ * here; its contents are, and those never load without `loadChatPageAgent`.
+ */
+export async function loadChatAgentName(agentId: string): Promise<string | undefined> {
+  const agent = await db
+    .select({ name: activeAgents.name })
+    .from(activeAgents)
+    .where(eq(activeAgents.id, agentId))
+    .then((rows) => rows[0]);
+  return agent?.name;
+}
+
+/**
+ * Load an agent for a chat page, or answer 404 — the auth → load → visibility
+ * preamble that every chat route opens with (`/chat/[agentId]`, its
+ * `[chatId]` child, and the read-only `telegram` mirror).
+ *
+ * Single-sourced because all three carried it byte-identically (#1087). Like
+ * the Automations gate, the risk is not a cosmetic difference: this block
+ * decides who may read an agent's conversations, and the realistic drift is a
+ * new condition (a license state, a group rule) landing in two of three copies.
+ *
+ * `notFound()` throws, so it escapes to Next.js from here exactly as it did
+ * inline — including for a denied `assertAgentAccess`, which stays a 404 rather
+ * than a 403 on purpose: a member who cannot see an agent should not learn that
+ * it exists.
+ *
+ * Group ids are fetched only when they can change the answer (a non-admin
+ * hitting a restricted agent), which is what keeps the common case at one
+ * query.
+ */
+export async function loadChatPageAgent(agentId: string) {
+  const session = await requireAuth();
+  const userId = session.user.id!;
+  const userRole = session.user.role;
+
+  const agent = await db
+    .select()
+    .from(activeAgents)
+    .where(eq(activeAgents.id, agentId))
+    .then((rows) => rows[0]);
+
+  if (!agent) notFound();
+
+  const licenseState = await getLicenseState();
+  const effVis = effectiveVisibility(agent.visibility, licenseState);
+  const needsGroups = userRole !== "admin" && effVis === "restricted";
+
+  const [userGroupIds, agentGroupIds] = await Promise.all([
+    needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
+    needsGroups ? getAgentGroupIds(agentId) : Promise.resolve([]),
+  ]);
+
+  try {
+    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
+  } catch {
+    notFound();
+  }
+
+  const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
+  const canEdit = userRole === "admin" || (agent.isPersonal && agent.ownerId === userId);
+
+  return { agent, userId, userRole, avatarUrl, canEdit };
+}

--- a/packages/web/src/lib/email-workflows/resolve-agent.ts
+++ b/packages/web/src/lib/email-workflows/resolve-agent.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { agents } from "@/db/schema";
+import { canManageAgentWorkflows } from "./authz";
+
+/**
+ * The agent fields every agent-scoped Automations route needs: the two the
+ * scope gate reads, plus the `{ id, name }` pair the audit snapshot writes.
+ */
+export interface WorkflowAgent {
+  id: string;
+  name: string;
+  isPersonal: boolean;
+  ownerId: string | null;
+}
+
+export type WorkflowAgentResult = { agent: WorkflowAgent } | { error: NextResponse };
+
+/**
+ * Resolve an agentId to an agent the actor may manage workflows on — the
+ * load → 404 → scope-gate → 403 preamble that every agent-scoped Automations
+ * route opens with (list, create, connection picker).
+ *
+ * Single-sourced deliberately: `canManageAgentWorkflows` was already shared,
+ * but the lookup and the two HTTP answers around it were copied per route
+ * (#1087). That copy is an authorization block, where a drifted duplicate is a
+ * latent security bug rather than a style problem — the interesting drift is
+ * not a differing message but a route that adds a branch (a deleted agent, a
+ * second actor shape) to two of three copies.
+ *
+ * The 403 wording is a parameter because it is user-visible copy that legitimately
+ * differs per route ("access to this agent" when reading, "permission to create a
+ * workflow" when writing). Sharing the gate must not silently rewrite either.
+ */
+export async function resolveWorkflowAgent(
+  agentId: string,
+  actor: { id: string; role: string | null | undefined },
+  forbiddenMessage = "You do not have access to this agent"
+): Promise<WorkflowAgentResult> {
+  const [agent] = await db
+    .select({
+      id: agents.id,
+      name: agents.name,
+      isPersonal: agents.isPersonal,
+      ownerId: agents.ownerId,
+    })
+    .from(agents)
+    .where(eq(agents.id, agentId));
+
+  if (!agent) {
+    return { error: NextResponse.json({ error: "Agent not found" }, { status: 404 }) };
+  }
+  if (!canManageAgentWorkflows(agent, actor)) {
+    return { error: NextResponse.json({ error: forbiddenMessage }, { status: 403 }) };
+  }
+  return { agent };
+}
+
+/**
+ * The same gate for the two GET routes that take their agentId from the query
+ * string, including the `agentId is required` 400 they both open with.
+ */
+export async function resolveWorkflowAgentFromQuery(
+  request: Request,
+  actor: { id: string; role: string | null | undefined },
+  forbiddenMessage?: string
+): Promise<WorkflowAgentResult> {
+  const agentId = new URL(request.url).searchParams.get("agentId");
+  if (!agentId) {
+    return { error: NextResponse.json({ error: "agentId is required" }, { status: 400 }) };
+  }
+  return resolveWorkflowAgent(agentId, actor, forbiddenMessage);
+}

--- a/packages/web/src/lib/format-date.ts
+++ b/packages/web/src/lib/format-date.ts
@@ -1,0 +1,21 @@
+/**
+ * Render an ISO date the way every license-lifecycle surface renders it
+ * ("Aug 4, 2026") — the settings panel, the banner, and the cliff dialog.
+ *
+ * The locale is pinned to "en-US" rather than the visitor's, deliberately and
+ * as it always was here: these three surfaces quote a contractual date back to
+ * an admin, and the machine's locale deciding between 4/8 and 8/4 is a real
+ * ambiguity on a renewal deadline. Pinchy's UI copy is English throughout
+ * (PERSONALITY.md), so a month name is unambiguous for the reader it has.
+ *
+ * Single-sourced from three byte-identical copies (#1087): a date format that
+ * drifts between the banner and the panel below it reads as two different
+ * dates for one license.
+ */
+export function formatLicenseDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/packages/web/src/lib/knowledge/types.ts
+++ b/packages/web/src/lib/knowledge/types.ts
@@ -47,22 +47,3 @@ export interface IngestResult {
 export function zeroIngestResult(): IngestResult {
   return { indexed: 0, skipped: 0, removed: 0, unsearchable: 0, failed: 0, archived: 0 };
 }
-
-/**
- * Sums ingest results. Written out field by field on purpose: a counter added
- * to IngestResult fails to compile here until it is summed, so a new counter
- * cannot silently drop out of the numbers an admin sees.
- */
-export function totalCounts(results: readonly IngestResult[]): IngestResult {
-  return results.reduce<IngestResult>(
-    (total, result) => ({
-      indexed: total.indexed + result.indexed,
-      skipped: total.skipped + result.skipped,
-      removed: total.removed + result.removed,
-      unsearchable: total.unsearchable + result.unsearchable,
-      failed: total.failed + result.failed,
-      archived: total.archived + result.archived,
-    }),
-    zeroIngestResult()
-  );
-}

--- a/packages/web/src/lib/schemas/imap.ts
+++ b/packages/web/src/lib/schemas/imap.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { LegResult, SmtpPortProbe } from "@/lib/integrations/imap-probe";
+import { senderNameSchema } from "@/lib/schemas/sender-name";
 
 export const imapTestSchema = z.object({
   imapHost: z.string().min(1),
@@ -17,18 +18,9 @@ export const imapCreateSchema = imapTestSchema.extend({
   // Optional label for the integrations list; the create route defaults it to
   // the mailbox address when omitted (rename is available in the list).
   name: z.string().min(1).optional(),
-  // Optional display name for the From header of agent-sent mail
-  // ("Clemens Helm <clemens@example.com>"). NOT the integration label. CR/LF
-  // is rejected at the schema edge as the first header-injection barrier; the
-  // plugin adapter guards again at send/draft time (defense in depth).
-  senderName: z
-    .string()
-    .min(1)
-    .max(200)
-    .refine((v) => !/[\r\n]/.test(v), {
-      message: "Sender name must not contain line breaks",
-    })
-    .optional(),
+  // Optional display name for the From header of agent-sent mail. Shared with
+  // the edit schema — see schemas/sender-name.ts for the header-injection rule.
+  senderName: senderNameSchema.optional(),
 });
 
 export type ImapCreateInput = z.infer<typeof imapCreateSchema>;

--- a/packages/web/src/lib/schemas/integration-edit.ts
+++ b/packages/web/src/lib/schemas/integration-edit.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { senderNameSchema } from "@/lib/schemas/sender-name";
+
 // All fields optional — empty string means "leave current value unchanged".
 // The submit handler filters out empty strings before sending the PATCH body.
 export const odooEditSchema = z.object({
@@ -29,15 +31,8 @@ export const imapEditSchema = z
     username: z.string().min(1).optional(),
     password: z.string().min(1).optional(),
     security: z.enum(["tls", "starttls", "none"]).optional(),
-    // From-header display name. Same CR/LF header-injection guard as
-    // imapCreateSchema (packages/web/src/lib/schemas/imap.ts).
-    senderName: z
-      .string()
-      .min(1)
-      .max(200)
-      .refine((v) => !/[\r\n]/.test(v), {
-        message: "Sender name must not contain line breaks",
-      })
-      .optional(),
+    // From-header display name. Literally the same rule object as
+    // imapCreateSchema uses — see schemas/sender-name.ts.
+    senderName: senderNameSchema.optional(),
   })
   .strict();

--- a/packages/web/src/lib/schemas/sender-name.ts
+++ b/packages/web/src/lib/schemas/sender-name.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+/**
+ * Display name for the From header of agent-sent mail ("Clemens Helm
+ * <clemens@example.com>"). NOT the integration label.
+ *
+ * CR/LF is rejected here as the first header-injection barrier; the plugin
+ * adapter guards again at send/draft time (defense in depth).
+ *
+ * Shared by the create schema (`schemas/imap.ts`) and the edit schema
+ * (`schemas/integration-edit.ts`) rather than written twice (#1087). A security
+ * guard kept in two copies is one refactor away from being kept in one, and the
+ * half that loses the `.refine` accepts a header injection while still looking
+ * validated — the drift nobody notices until it is a CVE.
+ *
+ * Callers add `.optional()` themselves: both current users treat the field as
+ * "leave empty to keep current", but that is their contract, not this rule's.
+ */
+export const senderNameSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .refine((v) => !/[\r\n]/.test(v), {
+    message: "Sender name must not contain line breaks",
+  });

--- a/packages/web/src/lib/usage-params.ts
+++ b/packages/web/src/lib/usage-params.ts
@@ -1,4 +1,7 @@
 import { NextResponse } from "next/server";
+import { and, eq, gte, type SQL } from "drizzle-orm";
+
+import { usageRecords } from "@/db/schema";
 
 /**
  * Parse and validate the `days` query parameter from a usage API request.
@@ -12,4 +15,42 @@ export function parseDays(daysParam: string | null): number | NextResponse {
     return NextResponse.json({ error: "Invalid days parameter" }, { status: 400 });
   }
   return days;
+}
+
+export interface UsageFilter {
+  /** Days to look back; 0 means all time (no lower bound on `timestamp`). */
+  days: number;
+  agentId: string | null;
+  /** `undefined` when neither filter applies — drizzle reads that as "no WHERE". */
+  where: SQL | undefined;
+}
+
+/**
+ * The `days` + `agentId` filter every usage route applies to `usage_records`.
+ *
+ * Single-sourced because all four read routes (`summary`, `by-user`, `export`,
+ * `timeseries`) carried a byte-identical copy of it (#1087), and a filter that
+ * drifts between them silently answers the same question two different ways —
+ * an export that disagrees with the summary above it is a data-integrity bug,
+ * not a cosmetic one.
+ *
+ * Returns the caller's 400 response unchanged when `days` is unparseable.
+ */
+export function parseUsageFilter(url: URL): UsageFilter | NextResponse {
+  const days = parseDays(url.searchParams.get("days"));
+  if (days instanceof NextResponse) return days;
+
+  const agentId = url.searchParams.get("agentId");
+
+  const conditions: SQL[] = [];
+  if (days > 0) {
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+    conditions.push(gte(usageRecords.timestamp, since));
+  }
+  if (agentId) {
+    conditions.push(eq(usageRecords.agentId, agentId));
+  }
+
+  return { days, agentId, where: conditions.length > 0 ? and(...conditions) : undefined };
 }


### PR DESCRIPTION
## What does this PR do?

Works through the component-layer duplication sweep in #1087 — six of its seven findings, plus two corrections to the issue itself.

Refs #1087 (deliberately not `Closes`: one sub-item is left open, see below)

**The two that carried real risk were not the biggest ones.**

- **Automations agent-scope gate, copied 3×** (`api/automations/route.ts` GET + POST, `automations/connections/route.ts`). Load → 404 → `canManageAgentWorkflows` → 403. A drifted copy of an authorization block is a latent security bug rather than a style problem — the realistic drift is a new condition landing in two of three copies. Now `resolveWorkflowAgent` / `resolveWorkflowAgentFromQuery`. The 403 wording stays a **parameter**: it is user-visible copy that legitimately differs between reading ("access to this agent") and writing ("permission to create a workflow"), and sharing the gate must not silently rewrite either.
- **`days`/`agentId` filter over `usage_records` — byte-identical in FOUR routes**, not the three the issue counted (`timeseries` was missed). An export that filters differently from the summary above it is a data-integrity bug. Now `parseUsageFilter`.

**The rest**

| # | Finding | Resolution |
|---|---|---|
| 1 | `edit-credentials-dialog.tsx`: submit ×3, catch ×4, alert ×3, footer ×3 | `useCredentialUpdate` + `AuthFailedAlert` + `CredentialFormFooter` |
| 4 | Chat page shells ×3 | `loadChatPageAgent` / `loadChatAgentName` |
| 6 | senderName CR/LF guard ×2; `extractFieldErrors` ×2; license `formatDate` ×3; attachment size check | one shared source each |
| 7 | `totalCounts()` | deleted — `ingestPaths` accumulates through one queue + `snapshot()`, nothing has called it since that rewrite |

### Finding 5 solved the other way the issue allows

The issue offers "add a drift test **or** single-source it". This takes the drift test, and the reason is the hash contract next door: `CURRENT_SOUL_HASH` derives from `SMITHERS_SOUL_MD` and `SHIPPED_SOUL_HASHES` is append-only. One shared constant would let a **cosmetic preset tweak** change Smithers' soul hash — forcing a history entry and re-running the boot migration on every existing install. That blast radius does not belong on a copy edit.

`butler-personality-drift.test.ts` holds the two texts together instead, following the `normalize-docx-table-html-drift.test.ts` precedent. **Canary-verified**: changing one word in the preset prose turns it red; the file was restored byte-clean afterwards.

### Two corrections to the issue

- **Finding 3 undercounts** — four copies, not three.
- **Finding 7 contains a false positive.** `xlsx-extract`'s `extractXlsx` reads as dead but is not: it is fully tested (500+ lines) and simply **not yet wired into the ingest** — `lib/eval/kb/attribution-graders.ts:169` says so out loud. Deleting it would have thrown away finished work. Left in place.

### Not done, deliberately

The **"~20 exports only used in-file"** sub-item. It cites a list living in review notes that are not in the issue. A scan here surfaced 56 candidates, but a mechanical sweep is unsafe: drizzle relations (`usersRelations` and friends) **must** stay exported to be discovered, and most test-only exports are documented seams (`assertAgentWriteAccess` is used in-file and unit-tested through that export). Worth doing with the original list in hand.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [x] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (the drift guard; everything else is behaviour-preserving and covered by existing tests)
- [x] I've updated the documentation (n/a — `Docs-not-needed:` trailer, see below)
- [x] All existing tests pass

## Reviewer notes

**Gates run locally, all green:** `format:check` · `lint` (0 errors) · `test:scripts` (913) · `pnpm test` (**10943 passed**, 18 pre-existing skips) · `typecheck` · **`pnpm build`** (the one check that sees the client/server bundling boundary — relevant here because `sender-name.ts` is reached from a client component and `load-chat-agent.ts` pulls `@/db`).

**One user-visible string change, intended.** The office-attachment adapter re-implemented the size check it already imported, so one user could meet two different sentences for one rejection (`The limit is` vs `The maximum is`). It now uses the helper. The text appears in no docs page — the docs describe the image/frame cap only — hence the `Docs-not-needed:` trailer rather than a docs edit.

**Behaviour-preserving claims worth spot-checking:**
- `timeseries`: the `tz` validation still runs after `days` parsing, so error precedence for `?days=abc&tz=bad` is unchanged.
- `ImapForm`: client-side validation now runs before the shared save, so a rejected form no longer flashes the spinner for one frame. Same end state.
- `/chat/[agentId]`: `avatarUrl`/`canEdit` are computed before the most-recent-chat redirect rather than after. Wasted only in the redirect case, and the redirect discards the render anyway.
