### PR TITLE
fix(enterprise): validate a license key before storing it, so a typo can't cost the working one

### DIFF
--- a/docs/src/content/docs/guides/enterprise-setup.mdx
+++ b/docs/src/content/docs/guides/enterprise-setup.mdx
@@ -26,6 +26,8 @@ There are two ways to enter your license key. Use whichever fits your workflow.
 
 The key is validated immediately. If valid, enterprise features activate instantly — no restart needed.
 
+If Pinchy refuses the key, nothing is saved: you get an inline error and the license you were already running stays active. Pasting the wrong key by mistake cannot cost you the one that works.
+
 ### Option 2: Environment variable
 
 Set `PINCHY_ENTERPRISE_KEY` in your Docker Compose configuration:

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1501,13 +1501,26 @@ Save or update the enterprise license key. **Admin only.** Not available when th
 | ----- | ------ | -------- | --------------------- |
 | `key` | string | Yes      | The JWT license token |
 
-**Response:** `{ "success": true }` — the new license status takes effect immediately without a restart.
+The key is verified **before** it is stored. A key Pinchy refuses is never written, so a rejected attempt — a typo, an expired token, a key from another install — leaves the license you already had in place and active. There is nothing to restore and no window in which the instance drops to community.
+
+**Response:** the status of the key that was just accepted, which takes effect immediately without a restart. These five fields carry the same meaning as in `GET /api/enterprise/status`, which returns the fuller picture (`state`, `seatsUsed`, `managedByEnv`, …):
+
+```json
+{
+  "enterprise": true,
+  "type": "paid",
+  "org": "acme-gmbh",
+  "expiresAt": "2027-01-01T00:00:00.000Z",
+  "daysRemaining": 300
+}
+```
 
 **Errors:**
 
-- `400` — key is missing or the JWT signature is invalid
+- `400` — key is missing, or its signature is invalid or expired (nothing is stored; the previous key stays active)
 - `401` — not authenticated
-- `403` — not an admin, or key is managed by env var
+- `403` — not an admin
+- `409` — the key is managed by the `PINCHY_ENTERPRISE_KEY` environment variable and cannot be changed here
 
 ### `DELETE /api/enterprise/gated-config`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1510,14 +1510,16 @@ The key is verified **before** it is stored. A key Pinchy refuses is never writt
   "enterprise": true,
   "type": "paid",
   "org": "acme-gmbh",
-  "expiresAt": "2027-01-01T00:00:00.000Z",
+  "expiresAt": "2027-06-01T00:00:00.000Z",
   "daysRemaining": 300
 }
 ```
 
+`daysRemaining` counts from the moment of the request, so it moves while `expiresAt` stays put.
+
 **Errors:**
 
-- `400` — key is missing, or its signature is invalid or expired (nothing is stored; the previous key stays active)
+- `400` — the key is missing, or Pinchy does not accept it: a bad signature, an issuer that is not ours, an expired token, or a valid token that does not carry the `enterprise` feature (nothing is stored; the previous key stays active)
 - `401` — not authenticated
 - `403` — not an admin
 - `409` — the key is managed by the `PINCHY_ENTERPRISE_KEY` environment variable and cannot be changed here

--- a/packages/web/src/__tests__/api/enterprise-key.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-key.test.ts
@@ -166,8 +166,15 @@ describe("PUT /api/enterprise/key", () => {
     const res = await putKey("expired-or-typo-token");
     expect(res.status).toBe(400);
 
+    // The load-bearing claims: the route touched neither setting, so the value
+    // it was holding is the value it is still holding.
     expect(settingsStore.get("enterprise_key")).toBe(VALID_TOKEN);
     expect(deleteSetting).not.toHaveBeenCalled();
+    expect(setSetting).not.toHaveBeenCalled();
+
+    // And the consequence, spelled out. This re-derives from the same store —
+    // it proves nothing the two lines above don't — but it is the sentence a
+    // reader of this file cares about, so state it rather than leave it implied.
     await expect(getLicenseStatus()).resolves.toMatchObject({ active: true, type: "paid" });
   });
 

--- a/packages/web/src/__tests__/api/enterprise-key.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-key.test.ts
@@ -3,6 +3,31 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
+// The settings mock is a real in-memory store rather than a set of bare
+// spies. The bug this file guards against (#1083 review) is about the value
+// that survives a rejected PUT, and "setSetting was not called" is an
+// assertion about the route's calls — not about what the install is left
+// holding. A store lets the test read the end state.
+const { settingsStore, VALID_TOKEN, ACTIVE_STATUS, statusFor } = vi.hoisted(() => {
+  const settingsStore = new Map<string, string>();
+  const VALID_TOKEN = "eyJ.valid.token";
+  const ACTIVE_STATUS = {
+    active: true,
+    type: "paid" as const,
+    org: "test-org",
+    features: ["enterprise"],
+    expiresAt: new Date("2027-01-01"),
+    daysRemaining: 300,
+    ver: 1,
+    maxUsers: 10,
+  };
+  const statusFor = (token: string | undefined) =>
+    token === VALID_TOKEN
+      ? ACTIVE_STATUS
+      : { active: false, features: [] as string[], ver: 1, maxUsers: 0 };
+  return { settingsStore, VALID_TOKEN, ACTIVE_STATUS, statusFor };
+});
+
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
 }));
@@ -20,13 +45,21 @@ vi.mock("@/lib/auth", () => {
 });
 
 vi.mock("@/lib/settings", () => ({
-  setSetting: vi.fn().mockResolvedValue(undefined),
-  deleteSetting: vi.fn().mockResolvedValue(undefined),
+  getSetting: vi.fn(async (key: string) => settingsStore.get(key) ?? null),
+  setSetting: vi.fn(async (key: string, value: string) => {
+    settingsStore.set(key, value);
+  }),
+  deleteSetting: vi.fn(async (key: string) => {
+    settingsStore.delete(key);
+  }),
 }));
 
 vi.mock("@/lib/enterprise", () => ({
   clearLicenseCache: vi.fn(),
-  getLicenseStatus: vi.fn(),
+  // Reads the store, so it answers what the install would answer *after*
+  // whatever the route did to it.
+  getLicenseStatus: vi.fn(async () => statusFor(settingsStore.get("enterprise_key"))),
+  validateLicenseToken: vi.fn(async (token: string) => statusFor(token)),
   isKeyFromEnv: vi.fn().mockReturnValue(false),
 }));
 
@@ -36,83 +69,63 @@ vi.mock("@/lib/audit", () => ({
 
 import { getSession } from "@/lib/auth";
 import { setSetting, deleteSetting } from "@/lib/settings";
-import { clearLicenseCache, getLicenseStatus } from "@/lib/enterprise";
+import { clearLicenseCache, getLicenseStatus, validateLicenseToken } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
 import { makeNextRequest } from "@/test-helpers/route";
 
+function adminSession() {
+  vi.mocked(getSession).mockResolvedValueOnce({
+    user: { id: "u1", role: "admin", name: "Admin" },
+  } as never);
+}
+
+async function putKey(key: unknown) {
+  const { PUT } = await import("@/app/api/enterprise/key/route");
+  return PUT(
+    makeNextRequest("http://localhost/api/enterprise/key", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(key === undefined ? {} : { key }),
+    })
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  settingsStore.clear();
 });
 
 describe("PUT /api/enterprise/key", () => {
   it("returns 401 for unauthenticated requests", async () => {
     vi.mocked(getSession).mockResolvedValueOnce(null);
-    const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = makeNextRequest("http://localhost/api/enterprise/key", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key: "test" }),
-    });
-    const res = await PUT(req);
+    const res = await putKey("test");
     expect(res.status).toBe(401);
   });
 
   it("returns 403 for non-admin users", async () => {
     vi.mocked(getSession).mockResolvedValueOnce({
       user: { id: "u1", role: "member", name: "User" },
-    } as any);
-    const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = makeNextRequest("http://localhost/api/enterprise/key", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key: "test" }),
-    });
-    const res = await PUT(req);
+    } as never);
+    const res = await putKey("test");
     expect(res.status).toBe(403);
   });
 
   it("returns 400 for missing key", async () => {
-    vi.mocked(getSession).mockResolvedValueOnce({
-      user: { id: "u1", role: "admin", name: "Admin" },
-    } as any);
-    const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = makeNextRequest("http://localhost/api/enterprise/key", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    });
-    const res = await PUT(req);
+    adminSession();
+    const res = await putKey(undefined);
     expect(res.status).toBe(400);
   });
 
   it("saves valid key, clears cache, logs audit, returns status", async () => {
-    vi.mocked(getSession).mockResolvedValueOnce({
-      user: { id: "u1", role: "admin", name: "Admin" },
-    } as any);
-    vi.mocked(getLicenseStatus).mockResolvedValueOnce({
-      active: true,
-      type: "paid",
-      org: "test-org",
-      features: ["enterprise"],
-      expiresAt: new Date("2027-01-01"),
-      daysRemaining: 300,
-      ver: 1,
-      maxUsers: 10,
-    });
+    adminSession();
 
-    const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = makeNextRequest("http://localhost/api/enterprise/key", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key: "eyJ.valid.token" }),
-    });
-    const res = await PUT(req);
+    const res = await putKey(VALID_TOKEN);
     expect(res.status).toBe(200);
 
     // Verify save flow
-    expect(setSetting).toHaveBeenCalledWith("enterprise_key", "eyJ.valid.token", true);
+    expect(setSetting).toHaveBeenCalledWith("enterprise_key", VALID_TOKEN, true);
     expect(clearLicenseCache).toHaveBeenCalled();
-    expect(getLicenseStatus).toHaveBeenCalled();
+    expect(validateLicenseToken).toHaveBeenCalledWith(VALID_TOKEN);
     expect(appendAuditLog).toHaveBeenCalled();
 
     // Verify response contains status
@@ -121,28 +134,12 @@ describe("PUT /api/enterprise/key", () => {
     expect(body.type).toBe("paid");
   });
 
-  it("deletes key and returns 400 when key is invalid", async () => {
-    vi.mocked(getSession).mockResolvedValueOnce({
-      user: { id: "u1", role: "admin", name: "Admin" },
-    } as any);
-    vi.mocked(getLicenseStatus).mockResolvedValueOnce({
-      active: false,
-      features: [],
-    } as any);
+  it("returns 400 and audits the failure when the key is invalid", async () => {
+    adminSession();
 
-    const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = makeNextRequest("http://localhost/api/enterprise/key", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key: "invalid-token" }),
-    });
-    const res = await PUT(req);
+    const res = await putKey("invalid-token");
     expect(res.status).toBe(400);
 
-    // Should have tried to save, then deleted when invalid
-    expect(setSetting).toHaveBeenCalled();
-    expect(clearLicenseCache).toHaveBeenCalled();
-    expect(deleteSetting).toHaveBeenCalledWith("enterprise_key");
     // A rejected license-activation attempt is a governance-relevant security
     // action and must leave a failure trail — silence is the bug.
     expect(appendAuditLog).toHaveBeenCalledWith(
@@ -155,21 +152,67 @@ describe("PUT /api/enterprise/key", () => {
     );
   });
 
-  it("does not write the license key value into the failure audit detail", async () => {
-    vi.mocked(getSession).mockResolvedValueOnce({
-      user: { id: "u1", role: "admin", name: "Admin" },
-    } as any);
-    vi.mocked(getLicenseStatus).mockResolvedValueOnce({ active: false, features: [] } as any);
+  // ── Regression: a rejected key must not cost the admin their working one ──
+  //
+  // The route used to write the submitted key before validating it and then
+  // "roll back" with deleteSetting — which deletes rather than restores. An
+  // admin on a valid paid license who pasted a typo lost it, dropped to the
+  // community state, and could only recover by re-entering the original key.
 
-    const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = makeNextRequest("http://localhost/api/enterprise/key", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key: "super-secret-invalid-token" }),
-    });
-    await PUT(req);
+  it("leaves a previously stored valid key in place when the submitted key is rejected", async () => {
+    settingsStore.set("enterprise_key", VALID_TOKEN);
+    adminSession();
+
+    const res = await putKey("expired-or-typo-token");
+    expect(res.status).toBe(400);
+
+    expect(settingsStore.get("enterprise_key")).toBe(VALID_TOKEN);
+    expect(deleteSetting).not.toHaveBeenCalled();
+    await expect(getLicenseStatus()).resolves.toMatchObject({ active: true, type: "paid" });
+  });
+
+  it("stores nothing when a rejected key arrives on an install with no license", async () => {
+    adminSession();
+
+    const res = await putKey("garbage");
+    expect(res.status).toBe(400);
+
+    expect(settingsStore.has("enterprise_key")).toBe(false);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it("does not clear the license cache when the submitted key is rejected", async () => {
+    settingsStore.set("enterprise_key", VALID_TOKEN);
+    adminSession();
+
+    await putKey("expired-or-typo-token");
+
+    // Nothing changed, so the cached verdict is still correct. Clearing it
+    // would force every gate to re-derive the same answer.
+    expect(clearLicenseCache).not.toHaveBeenCalled();
+  });
+
+  it("does not write the license key value into the failure audit detail", async () => {
+    adminSession();
+
+    await putKey("super-secret-invalid-token");
 
     const serialized = JSON.stringify(vi.mocked(appendAuditLog).mock.calls);
     expect(serialized).not.toContain("super-secret-invalid-token");
+  });
+
+  it("reports the validated status of the submitted key", async () => {
+    adminSession();
+
+    const res = await putKey(VALID_TOKEN);
+    const body = await res.json();
+
+    expect(body).toMatchObject({
+      enterprise: true,
+      type: ACTIVE_STATUS.type,
+      org: ACTIVE_STATUS.org,
+      expiresAt: ACTIVE_STATUS.expiresAt.toISOString(),
+      daysRemaining: ACTIVE_STATUS.daysRemaining,
+    });
   });
 });

--- a/packages/web/src/__tests__/lib/enterprise.test.ts
+++ b/packages/web/src/__tests__/lib/enterprise.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import * as jose from "jose";
+
+const ENTERPRISE_SOURCE = resolve(__dirname, "../../lib/enterprise.ts");
 
 let testPublicKeyPem: string;
 let testPrivateKey: CryptoKey;
@@ -113,6 +117,90 @@ describe("getLicenseStatus", () => {
     const status2 = await mod.getLicenseStatus(testPublicKeyPem);
     expect(status1).not.toBe(status2);
     expect(status2.active).toBe(true);
+  });
+});
+
+describe("validateLicenseToken", () => {
+  it("validates a token without reading or writing settings", async () => {
+    const token = await createTestToken({ type: "paid" }, "365d");
+
+    const mod = await import("@/lib/enterprise");
+    const status = await mod.validateLicenseToken(token, testPublicKeyPem);
+
+    expect(status.active).toBe(true);
+    expect(status.type).toBe("paid");
+    expect(getSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns inactive for a token this build does not trust", async () => {
+    const { privateKey } = await jose.generateKeyPair("ES256", { extractable: true });
+    const foreign = await new jose.SignJWT({ type: "paid", features: ["enterprise"] })
+      .setProtectedHeader({ alg: "ES256" })
+      .setIssuer("heypinchy.com")
+      .setSubject("other-org")
+      .setIssuedAt()
+      .setExpirationTime("365d")
+      .sign(privateKey);
+
+    const mod = await import("@/lib/enterprise");
+    expect((await mod.validateLicenseToken(foreign, testPublicKeyPem)).active).toBe(false);
+  });
+
+  it("leaves the cached status untouched", async () => {
+    const stored = await createTestToken({ type: "trial" });
+    process.env.PINCHY_ENTERPRISE_KEY = stored;
+
+    const mod = await import("@/lib/enterprise");
+    const before = await mod.getLicenseStatus(testPublicKeyPem);
+    await mod.validateLicenseToken("not-a-token", testPublicKeyPem);
+    const after = await mod.getLicenseStatus(testPublicKeyPem);
+
+    // Same object reference — validating a candidate is not a config change,
+    // so it must not evict the verdict every gate is reading.
+    expect(after).toBe(before);
+    expect(after.active).toBe(true);
+  });
+
+  // Structural drift pin, and it has to be structural.
+  //
+  // `PUT /api/enterprise/key` decides with validateLicenseToken what the app
+  // then reads through getLicenseStatus. Split those two and the route accepts
+  // a key the app treats as community, or refuses one it would honour — and
+  // the behavioural test below cannot see it, because it can only feed tokens
+  // signed by the one key it generates. A verdict that differs per *key* (a
+  // second trusted key, a refused subject — exactly what #1083 adds) is
+  // invisible to any fixture written before that key exists.
+  //
+  // So assert the shape instead: there is one validation path and
+  // getLicenseStatus takes it. Verified by canary — point getLicenseStatus at
+  // validateLicense directly and this goes red.
+  it("has getLicenseStatus validate through validateLicenseToken", () => {
+    const source = readFileSync(ENTERPRISE_SOURCE, "utf8");
+    const body = source.slice(source.indexOf("export async function getLicenseStatus"));
+    const fn = body.slice(0, body.indexOf("\n}"));
+
+    expect(fn).toContain("validateLicenseToken(");
+    expect(fn).not.toContain("validateLicense(");
+  });
+
+  // Drift pin: getLicenseStatus and validateLicenseToken must agree, because
+  // the license route decides with the second what the app then reads through
+  // the first.
+  it("agrees with getLicenseStatus on the stored token", async () => {
+    for (const token of [
+      await createTestToken({ type: "paid" }, "365d"),
+      "not-a-token",
+      "",
+    ] as const) {
+      vi.resetModules();
+      vi.mocked(getSetting).mockResolvedValue(token);
+
+      const mod = await import("@/lib/enterprise");
+      const viaStatus = await mod.getLicenseStatus(testPublicKeyPem);
+      const viaValidate = await mod.validateLicenseToken(token, testPublicKeyPem);
+
+      expect(viaValidate).toEqual(viaStatus);
+    }
   });
 });
 

--- a/packages/web/src/__tests__/lib/enterprise.test.ts
+++ b/packages/web/src/__tests__/lib/enterprise.test.ts
@@ -38,7 +38,12 @@ vi.mock("@/lib/settings", () => ({
 import { getSetting } from "@/lib/settings";
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // reset, not clear: `clearAllMocks` keeps implementations, so a test that
+  // sets a lasting `mockResolvedValue` (the agreement loop below does) would
+  // hand its last token to every test after it. Nothing breaks today, which is
+  // exactly what makes it worth removing — `getSetting` is declared as a bare
+  // `vi.fn()`, so resetting restores the state each test already assumes.
+  vi.resetAllMocks();
   delete process.env.PINCHY_ENTERPRISE_KEY;
   vi.resetModules();
 });
@@ -176,9 +181,21 @@ describe("validateLicenseToken", () => {
   // validateLicense directly and this goes red.
   it("has getLicenseStatus validate through validateLicenseToken", () => {
     const source = readFileSync(ENTERPRISE_SOURCE, "utf8");
-    const body = source.slice(source.indexOf("export async function getLicenseStatus"));
-    const fn = body.slice(0, body.indexOf("\n}"));
 
+    // Fail on input this cannot read, rather than on the empty slice it would
+    // otherwise produce. `indexOf` answering -1 walks straight through both
+    // slices to "", and the report becomes `expected '' to contain
+    // 'validateLicenseToken('` — the symptom, with the cause (the function was
+    // renamed, or its brace no longer closes at column 0) nowhere in it.
+    const start = source.indexOf("export async function getLicenseStatus");
+    expect(
+      start,
+      "no `export async function getLicenseStatus` in lib/enterprise.ts"
+    ).toBeGreaterThan(-1);
+    const end = source.indexOf("\n}", start);
+    expect(end, "getLicenseStatus has no closing brace at column 0").toBeGreaterThan(start);
+
+    const fn = source.slice(start, end);
     expect(fn).toContain("validateLicenseToken(");
     expect(fn).not.toContain("validateLicense(");
   });

--- a/packages/web/src/app/api/enterprise/key/route.ts
+++ b/packages/web/src/app/api/enterprise/key/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
-import { setSetting, deleteSetting } from "@/lib/settings";
-import { clearLicenseCache, getLicenseStatus, isKeyFromEnv } from "@/lib/enterprise";
+import { setSetting } from "@/lib/settings";
+import { clearLicenseCache, validateLicenseToken, isKeyFromEnv } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
 import { parseRequestBody } from "@/lib/api-validation";
 
@@ -26,15 +26,14 @@ export async function PUT(req: NextRequest) {
   if ("error" in parsed) return parsed.error;
   const { key } = parsed.data;
 
-  // Save the key encrypted, clear cache, then validate via production key path
-  await setSetting("enterprise_key", key, true);
-  clearLicenseCache();
-
-  const status = await getLicenseStatus();
+  // Validate BEFORE writing anything. Storing first and rolling back on a bad
+  // verdict looks equivalent and is not: the rollback deleted the setting
+  // rather than restoring it, so an admin who pasted a typo lost the working
+  // license that had been there and dropped to the community state. Nothing
+  // here reads the stored key, so a rejected attempt leaves the install
+  // exactly as it found it — no write, no cache eviction.
+  const status = await validateLicenseToken(key);
   if (!status.active) {
-    // Invalid key — roll back
-    await deleteSetting("enterprise_key");
-    clearLicenseCache();
     // A rejected license-activation attempt is a governance-relevant security
     // action; audit the failure (never log the key value itself).
     await appendAuditLog({
@@ -47,6 +46,11 @@ export async function PUT(req: NextRequest) {
     });
     return NextResponse.json({ error: "Invalid or expired license key" }, { status: 400 });
   }
+
+  // Accepted — store it encrypted and evict the cached verdict so every gate
+  // re-derives against the new key.
+  await setSetting("enterprise_key", key, true);
+  clearLicenseCache();
 
   // Audit log (don't log the key value itself)
   await appendAuditLog({

--- a/packages/web/src/lib/enterprise.ts
+++ b/packages/web/src/lib/enterprise.ts
@@ -51,6 +51,28 @@ export function isKeyFromEnv(): boolean {
 }
 
 /**
+ * Validate a candidate token without storing it or touching the cache.
+ *
+ * This is the entry point for "would this key work?", which is a different
+ * question from "what is this install licensed for?" and must be answerable
+ * without changing the answer to the second one. `PUT /api/enterprise/key`
+ * used to conflate them: it wrote the submitted key, asked `getLicenseStatus`,
+ * and deleted the setting when the verdict came back inactive — so a typo cost
+ * an admin the working license that had been there.
+ *
+ * It is deliberately the same code path `getLicenseStatus` takes, not a second
+ * copy of it. The route decides with this function what the app then reads
+ * through that one; a change to how a token is verified must reach both or the
+ * route would accept a key the app treats as community.
+ */
+export async function validateLicenseToken(
+  token: string,
+  publicKeyPem: string = PRODUCTION_PUBLIC_KEY
+): Promise<LicenseStatus> {
+  return validateLicense(token, publicKeyPem);
+}
+
+/**
  * Get the full license status. Cached for 1 hour.
  * Pass publicKeyPem only in tests — production uses the hardcoded key.
  */
@@ -63,7 +85,7 @@ export async function getLicenseStatus(
   }
 
   const token = await loadToken();
-  cachedStatus = await validateLicense(token, publicKeyPem);
+  cachedStatus = await validateLicenseToken(token, publicKeyPem);
   cacheTimestamp = now;
   return cachedStatus;
 }


### PR DESCRIPTION
Pre-existing data-loss bug found while reviewing #1107 (issue #1083) and deliberately left out of scope there.

## The bug

`PUT /api/enterprise/key` wrote the submitted key **before** validating it, and its rollback path deleted rather than restored:

```ts
await setSetting("enterprise_key", key, true);   // overwrites unconditionally
clearLicenseCache();
const status = await getLicenseStatus();
if (!status.active) {
  await deleteSetting("enterprise_key");         // deletes — does NOT restore
```

So an admin on a **valid paid license** who submitted a wrong, expired or mistyped key lost the working one. The install dropped to the community/expired state and could only be recovered by re-entering the original token — which they may not have to hand.

#1107 makes it slightly easier to hit: the development license token that used to be accepted on any install is now refused, so an admin who pastes it (it is in this repo's history and in older docs and issue threads) triggers exactly this rollback.

## The fix

Storing first was never necessary — `validateLicense` is pure. `enterprise.ts` now exposes `validateLicenseToken`: the same validation path `getLicenseStatus` takes, callable without touching settings or the cache. The route asks it first and writes only on `active`.

A rejected attempt now leaves the install exactly as it found it — no write, no delete, no cache eviction. The audit trail is unchanged: `config.changed`, outcome `failure`, reason `invalid_or_expired`, never carrying the key value.

## Why the drift pin is structural

The two functions must stay one path — the route decides with `validateLicenseToken` what the app then reads through `getLicenseStatus`. A behavioural test cannot pin that: it can only feed tokens signed by the one key it generates, and a verdict that differs *per key* — which is precisely what #1107 introduces with a second trusted key and a refused subject — is invisible to a fixture written before that key exists.

So the guard reads the source and asserts `getLicenseStatus` validates through `validateLicenseToken`. Verified by canary (point it back at `validateLicense`, the guard goes red, revert).

**Note for whoever rebases #1107:** it changes that same line to `validateAgainstKeyRing`, so expect a conflict there. That is intentional — resolve it by moving the key ring *into* `validateLicenseToken`, so the route and the app keep asking the same question. The structural guard fails if only one of them gets it.

## Tests

`packages/web/src/__tests__/api/enterprise-key.test.ts` — the settings mock is now a real in-memory store rather than bare spies, because the claim under test is about the value that survives a rejected PUT, not about which calls the route made:

- a rejected key leaves a previously stored valid key intact **and the license still active**
- a rejected key on an install with no license stores nothing
- a rejected key does not clear the license cache
- the existing failure-audit and no-PII tests carry over unchanged

`packages/web/src/__tests__/lib/enterprise.test.ts` — `validateLicenseToken` validates without reading settings, without evicting the cache, and agrees with `getLicenseStatus`; plus the structural pin above.

Net test count is up; nothing was removed.

## Docs

Touching this route surfaced two claims in the API reference that were already wrong:

- the documented response was `{ "success": true }`, which this route has never returned (it returns the license status)
- `403` was documented for the env-managed case; the route answers `409`

Both corrected, alongside the new no-clobber guarantee in the reference and in the Enterprise Setup guide.

## Verification

- `pnpm test` — 11133 passed, 18 skipped
- `pnpm test:scripts` — 965 passed
- `pnpm -C packages/web typecheck`, `pnpm -C packages/web lint` (0 errors), `pnpm format:check`
- `pnpm -C docs build && check:anchors && check:rendered && test` — 70 pages, all green