### PR TITLE
fix(eval): guard the candidate set a sweep actually dispatches, not just the default

### DIFF
--- a/packages/web/eval/README.md
+++ b/packages/web/eval/README.md
@@ -585,6 +585,13 @@ sweeps and was broken by the 2026-07-15 retirement wave before anything checked
 it (a dispatched-but-retired id 404s into `run-infra-error` rows the exporter
 drops from `n`, so the scorecard quietly holds fewer models than intended).
 
+A vitest guard can only see those two lists, and most sweeps do not run them
+unmodified — `EVAL_CANDIDATE_MODELS` replaces them wholesale, and every probe
+is supposed to (iron rule 2). So `candidateModelsFromEnv` puts the same check
+on whatever it is about to return: prefixed, served, distinct, non-empty, or it
+throws before the stack boots and the key is spent. A model the catalog does
+not know is a reason to run `pnpm models:discover`, not to pass a flag.
+
 The set started as three models — `kimi-k2.6`, `gemma4:31b` and `glm-4.7` — the
 ones named in the model-selection methodology's R1 evidence (the 2026-07-07
 staging incident: `gemma4:31b` corrupted a Graph message id across turns while
@@ -606,8 +613,9 @@ sentences × k`.
 
 Running Eval-v1 against this set is the action item the methodology names under
 `kimi-k2.6`: _"Eval-v1 (the Hetzner scenario) quantifies its residual
-false-success rate before any deeper intervention."_ A scorecard produced here is the evidence tier-1 input the
-methodology expects for any future rule change — see
+false-success rate before any deeper intervention."_ A scorecard produced here
+is the evidence tier-1 input the methodology expects for any future rule
+change — see
 `packages/web/eval/model-selection-methodology.md` for the full evidence
 hierarchy and how a scorecard is meant to feed back into the resolver
 tier-map (always human-ratified, per rule R6).

--- a/packages/web/eval/README.md
+++ b/packages/web/eval/README.md
@@ -592,6 +592,14 @@ on whatever it is about to return: prefixed, served, distinct, non-empty, or it
 throws before the stack boots and the key is spent. A model the catalog does
 not know is a reason to run `pnpm models:discover`, not to pass a flag.
 
+The KB sweep's NLI judge has the same hand-typed override
+(`KB_EVAL_JUDGE_MODEL`) and gets the same treatment through
+`judgeModelFromEnv`, against the candidate set it is about to grade. Its two
+properties — served, and not itself under test — belong to the resolved pair
+rather than to the pinned literal, and it is the more expensive of the two ids
+to get wrong: a bad candidate costs that model's column, a bad judge fails
+every verdict, so no KB run is gradeable at all.
+
 The set started as three models — `kimi-k2.6`, `gemma4:31b` and `glm-4.7` — the
 ones named in the model-selection methodology's R1 evidence (the 2026-07-07
 staging incident: `gemma4:31b` corrupted a Graph message id across turns while

--- a/packages/web/eval/candidates.ts
+++ b/packages/web/eval/candidates.ts
@@ -14,11 +14,18 @@
  * `data/CHANGELOG.md`'s legacy policy, and the reason this file is not the
  * place to "clean up" a model's history.
  *
- * Both are overridable per run with `EVAL_CANDIDATE_MODELS`.
+ * Both are overridable per run with `EVAL_CANDIDATE_MODELS`, which is why
+ * `assertCandidatesDispatchable` below exists: the vitest guard can only see
+ * the two lists in this file, and the override is the path an operator types
+ * by hand.
  */
+
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS } from "../src/lib/ollama-cloud-models";
 
 /** Provider prefix every candidate id carries, stripped to index the catalog. */
 export const OLLAMA_CLOUD_PREFIX = "ollama-cloud/";
+
+const SERVED_IDS: ReadonlySet<string> = new Set(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS);
 
 /**
  * The curated candidate set for the public open-weight agent-reliability
@@ -70,3 +77,71 @@ export const DEFAULT_KB_CANDIDATES = [
   "ollama-cloud/qwen3.5:397b",
   "ollama-cloud/gpt-oss:120b",
 ];
+
+/**
+ * The candidate ids the curated catalog does not serve, as written (not bare),
+ * so an error message can echo back exactly what was typed. A missing provider
+ * prefix counts as unserved too — `kimi-k2.6` without it is not an id any
+ * dispatch path resolves.
+ */
+export function unservedCandidates(candidates: readonly string[]): string[] {
+  return candidates.filter(
+    (id) =>
+      !id.startsWith(OLLAMA_CLOUD_PREFIX) || !SERVED_IDS.has(id.slice(OLLAMA_CLOUD_PREFIX.length))
+  );
+}
+
+/**
+ * Refuses a candidate set no sweep should dispatch — BEFORE the stack boots
+ * and a real key is spent.
+ *
+ * `sweep-candidates.test.ts` checks the two lists above at `pnpm test` time,
+ * but a sweep rarely runs them unmodified: `EVAL_CANDIDATE_MODELS` overrides
+ * them wholesale, and the `run-model-eval` skill's iron rule 2 tells the
+ * operator to probe with exactly that env var before every full sweep. A typo
+ * or a just-retired id there hits the same silent failure the guard was
+ * written for — every run 404s, the rows land as `run-infra-error`, the
+ * exporter drops them from `n`, and the scorecard quietly holds fewer models
+ * than the operator believes they measured.
+ *
+ * So the override gets the same three guarantees the defaults have (prefixed,
+ * served, distinct), plus a non-empty check: `EVAL_CANDIDATE_MODELS=","`
+ * currently produces an empty set and a sweep that "succeeds" measuring
+ * nothing.
+ *
+ * There is deliberately no escape hatch for a model missing from the catalog.
+ * The catalog is generated from what the provider serves (`pnpm
+ * models:discover`, iron rule 1), so refreshing it is both the fix and the
+ * step that should have happened first.
+ */
+export function assertCandidatesDispatchable(candidates: readonly string[], source: string): void {
+  if (candidates.length === 0) {
+    throw new Error(
+      `${source} resolves to an empty candidate set. The sweep would boot the ` +
+        `stack, dispatch nothing and export an empty scorecard — which reads as ` +
+        `a clean run. Name at least one model.`
+    );
+  }
+
+  const unserved = unservedCandidates(candidates);
+  if (unserved.length > 0) {
+    throw new Error(
+      `${source} names models the curated catalog does not serve: ` +
+        `${unserved.join(", ")}. Every run against these 404s and lands as a ` +
+        `run-infra-error row the exporter drops from n, so the scorecard would ` +
+        `quietly measure fewer models than intended. Ids need the ` +
+        `"${OLLAMA_CLOUD_PREFIX}" prefix and must exist in ` +
+        `src/lib/ollama-cloud-models.ts — run \`pnpm models:discover\` to ` +
+        `refresh it before blaming the id.`
+    );
+  }
+
+  const duplicates = [...new Set(candidates.filter((id, i) => candidates.indexOf(id) !== i))];
+  if (duplicates.length > 0) {
+    throw new Error(
+      `${source} names the same model twice: ${duplicates.join(", ")}. Both ` +
+        `copies write rows under one model key, so that cell's n comes out a ` +
+        `multiple of every other cell's and the sweep costs more than it reports.`
+    );
+  }
+}

--- a/packages/web/eval/candidates.ts
+++ b/packages/web/eval/candidates.ts
@@ -113,6 +113,13 @@ export function unservedCandidates(candidates: readonly string[]): string[] {
  * The catalog is generated from what the provider serves (`pnpm
  * models:discover`, iron rule 1), so refreshing it is both the fix and the
  * step that should have happened first.
+ *
+ * A missing prefix is refused SEPARATELY from a retirement, even though
+ * `unservedCandidates` folds the two together for the checked-in lists. The
+ * remedies are opposites: `kimi-k2.6` is in the catalog and needs a prefix,
+ * and reporting it as unserved both states something false and sends the
+ * operator to `models:discover`, which refreshes a catalog that already has
+ * the model. The point of failing early is to hand back the next step.
  */
 export function assertCandidatesDispatchable(candidates: readonly string[], source: string): void {
   if (candidates.length === 0) {
@@ -123,14 +130,23 @@ export function assertCandidatesDispatchable(candidates: readonly string[], sour
     );
   }
 
+  const unprefixed = candidates.filter((id) => !id.startsWith(OLLAMA_CLOUD_PREFIX));
+  if (unprefixed.length > 0) {
+    throw new Error(
+      `${source} names ids without the "${OLLAMA_CLOUD_PREFIX}" prefix: ` +
+        `${unprefixed.join(", ")}. A bare id is not what any dispatch path ` +
+        `resolves, so every run against it 404s. Write them as ` +
+        `"${OLLAMA_CLOUD_PREFIX}<id>".`
+    );
+  }
+
   const unserved = unservedCandidates(candidates);
   if (unserved.length > 0) {
     throw new Error(
       `${source} names models the curated catalog does not serve: ` +
         `${unserved.join(", ")}. Every run against these 404s and lands as a ` +
         `run-infra-error row the exporter drops from n, so the scorecard would ` +
-        `quietly measure fewer models than intended. Ids need the ` +
-        `"${OLLAMA_CLOUD_PREFIX}" prefix and must exist in ` +
+        `quietly measure fewer models than intended. They must exist in ` +
         `src/lib/ollama-cloud-models.ts — run \`pnpm models:discover\` to ` +
         `refresh it before blaming the id.`
     );
@@ -144,4 +160,95 @@ export function assertCandidatesDispatchable(candidates: readonly string[], sour
         `multiple of every other cell's and the sweep costs more than it reports.`
     );
   }
+}
+
+/**
+ * The candidate set a sweep will actually dispatch — the caller's default, or
+ * `EVAL_CANDIDATE_MODELS` when set — validated before it is returned.
+ *
+ * This lives beside the lists rather than in `run-eval.ts` for the reason this
+ * whole module exists: a spec is unreachable from vitest, and the guard that
+ * pins this behavior has to run in `pnpm test`. Resolving the candidate set is
+ * not orchestration, and routing the guard through the orchestrator would make
+ * it die on the first value import `run-eval.ts` grows that vitest cannot
+ * load. `run-eval.ts` re-exports it, so both specs and `kb/run-kb-eval.ts`
+ * still resolve candidates through one function.
+ */
+export function candidateModelsFromEnv(defaultModels: string[]): string[] {
+  const raw = process.env.EVAL_CANDIDATE_MODELS;
+  const candidates = raw
+    ? raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : defaultModels;
+
+  assertCandidatesDispatchable(
+    candidates,
+    raw ? "EVAL_CANDIDATE_MODELS" : "The sweep default in eval/candidates.ts"
+  );
+
+  return candidates;
+}
+
+/**
+ * Refuses an NLI judge a KB sweep should not dispatch — same two properties
+ * `sweep-candidates.test.ts` pins for the checked-in pin, applied to whatever
+ * the sweep resolved.
+ *
+ * The judge is the second model a KB sweep dispatches and it has its own
+ * hand-typed override (`KB_EVAL_JUDGE_MODEL`), so it inherits the argument
+ * this module was written for. It is the more expensive of the two to get
+ * wrong: a bad candidate costs that model's column, a bad judge fails every
+ * verdict and no KB run is gradeable at all — after the stack is up, the
+ * corpus is seeded and a real key has been spent.
+ *
+ * Independence from the models under test is the whole justification for
+ * pinning a judge, and it is a property of the RESOLVED pair, not of the two
+ * literals: either override can put the judge in the candidate set. The
+ * overlap leaves no trace in the scorecard — one model's groundedness column
+ * is quietly self-graded while every other column is not.
+ */
+export function assertJudgeDispatchable(
+  judge: string,
+  candidates: readonly string[],
+  source: string
+): void {
+  if (unservedCandidates([judge]).length > 0) {
+    throw new Error(
+      `${source} names \`${judge}\`, which is not a model the curated catalog ` +
+        `serves. Every NLI verdict fails against a judge that 404s, so no KB ` +
+        `run is gradeable at all — and it surfaces only after the stack is up ` +
+        `and the key is spent. Ids need the "${OLLAMA_CLOUD_PREFIX}" prefix and ` +
+        `must exist in src/lib/ollama-cloud-models.ts (\`pnpm models:discover\`).`
+    );
+  }
+
+  if (candidates.includes(judge)) {
+    throw new Error(
+      `${source} names \`${judge}\`, which is also a candidate under test. The ` +
+        `pin buys independence only while the judge is not one of the models ` +
+        `being graded — that model's groundedness column would be self-graded ` +
+        `and every other column would not, with nothing in the scorecard to ` +
+        `show for it. Judge with a model outside the candidate set.`
+    );
+  }
+}
+
+/**
+ * The NLI judge a KB sweep will actually dispatch — the caller's pin, or
+ * `KB_EVAL_JUDGE_MODEL` when set — validated against the candidate set it will
+ * grade. The `candidateModelsFromEnv` shape, for the same reason.
+ */
+export function judgeModelFromEnv(defaultJudge: string, candidates: readonly string[]): string {
+  const raw = process.env.KB_EVAL_JUDGE_MODEL?.trim();
+  const judge = raw || defaultJudge;
+
+  assertJudgeDispatchable(
+    judge,
+    candidates,
+    raw ? "KB_EVAL_JUDGE_MODEL" : "DEFAULT_KB_JUDGE_MODEL in src/lib/eval/kb/llm-nli.ts"
+  );
+
+  return judge;
 }

--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -64,6 +64,7 @@ import { dispatchAndScrape } from "../run-eval";
 import {
   requireOllamaCloudApiKey,
   candidateModelsFromEnv,
+  judgeModelFromEnv,
   runsPerModelFromEnv,
   pinAgentModel,
   appendRunResult,
@@ -283,19 +284,26 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
     }
 
     const candidates = candidateModelsFromEnv(DEFAULT_KB_CANDIDATES);
-    const n = runsPerModelFromEnv(1);
-    const goldIds = GOLD_QA.map((g) => g.id);
-
-    const { agentId } = await setupKbSweepAgent(cookie);
 
     // The LLM-as-NLI judge + relevance judge (llm-nli.ts) — a pinned,
     // separate model from the candidates under test, same reasoning as
     // groundedness-grader.ts's DEFAULT_TAU comment: keep the JUDGE fixed so
     // score drift over a long sweep reflects the candidate's behavior, not
-    // the judge's. The default lives in llm-nli.ts (one literal, checked
-    // against the catalog by sweep-candidates.test.ts); override per run with
+    // the judge's. The default lives in llm-nli.ts; override per run with
     // KB_EVAL_JUDGE_MODEL.
-    const judgeModel = process.env.KB_EVAL_JUDGE_MODEL || DEFAULT_KB_JUDGE_MODEL;
+    //
+    // Resolved HERE, next to the candidates, rather than after the agent
+    // setup below: `judgeModelFromEnv` checks the pair (served, and not one of
+    // the candidates it is about to grade), and a judge that 404s fails every
+    // verdict — so no KB run is gradeable at all. That refusal is worth
+    // nothing once the corpus is seeded and the key is being spent.
+    const judgeModel = judgeModelFromEnv(DEFAULT_KB_JUDGE_MODEL, candidates);
+
+    const n = runsPerModelFromEnv(1);
+    const goldIds = GOLD_QA.map((g) => g.id);
+
+    const { agentId } = await setupKbSweepAgent(cookie);
+
     const chat = createOllamaCloudChatFn({ apiKey: ollamaKey, model: judgeModel });
     const nli = new LlmNliClient(chat);
     const relevance = new LlmRelevanceJudge(chat);

--- a/packages/web/eval/kb/run-kb-eval.ts
+++ b/packages/web/eval/kb/run-kb-eval.ts
@@ -26,6 +26,7 @@ import type { RetrievedSource } from "../../src/lib/eval/kb/attribution-graders"
 export {
   requireOllamaCloudApiKey,
   candidateModelsFromEnv,
+  judgeModelFromEnv,
   runsPerModelFromEnv,
   pinAgentModel,
   pinchyGet,

--- a/packages/web/eval/run-eval.ts
+++ b/packages/web/eval/run-eval.ts
@@ -24,6 +24,7 @@ import { mkdir, writeFile, appendFile, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { EVAL_CANARY_JSONL_LINE, parseEvalJsonl } from "./canary";
+import { assertCandidatesDispatchable } from "./candidates";
 import type { RunFingerprint } from "./fingerprint";
 import type { TokenCollector } from "./token-usage";
 import { buildTrajectory, type NormalizeAuditEntry } from "../src/lib/eval/normalize";
@@ -849,13 +850,32 @@ export function requireOllamaCloudApiKey(): string {
   return key;
 }
 
+/**
+ * The candidate set a sweep will actually dispatch — the caller's default, or
+ * `EVAL_CANDIDATE_MODELS` when set — validated before it is returned.
+ *
+ * The validation is here rather than at each call site because this is the one
+ * place both sweeps and `kb/run-kb-eval.ts` funnel through, and because the
+ * env path is the unchecked one: `sweep-candidates.test.ts` guards the two
+ * lists in `candidates.ts` at `pnpm test` time, but it cannot see a string
+ * typed into a shell. See `assertCandidatesDispatchable` for what a bad id
+ * costs.
+ */
 export function candidateModelsFromEnv(defaultModels: string[]): string[] {
   const raw = process.env.EVAL_CANDIDATE_MODELS;
-  if (!raw) return defaultModels;
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const candidates = raw
+    ? raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : defaultModels;
+
+  assertCandidatesDispatchable(
+    candidates,
+    raw ? "EVAL_CANDIDATE_MODELS" : "The sweep default in eval/candidates.ts"
+  );
+
+  return candidates;
 }
 
 /**

--- a/packages/web/eval/run-eval.ts
+++ b/packages/web/eval/run-eval.ts
@@ -24,7 +24,6 @@ import { mkdir, writeFile, appendFile, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { EVAL_CANARY_JSONL_LINE, parseEvalJsonl } from "./canary";
-import { assertCandidatesDispatchable } from "./candidates";
 import type { RunFingerprint } from "./fingerprint";
 import type { TokenCollector } from "./token-usage";
 import { buildTrajectory, type NormalizeAuditEntry } from "../src/lib/eval/normalize";
@@ -851,32 +850,13 @@ export function requireOllamaCloudApiKey(): string {
 }
 
 /**
- * The candidate set a sweep will actually dispatch — the caller's default, or
- * `EVAL_CANDIDATE_MODELS` when set — validated before it is returned.
- *
- * The validation is here rather than at each call site because this is the one
- * place both sweeps and `kb/run-kb-eval.ts` funnel through, and because the
- * env path is the unchecked one: `sweep-candidates.test.ts` guards the two
- * lists in `candidates.ts` at `pnpm test` time, but it cannot see a string
- * typed into a shell. See `assertCandidatesDispatchable` for what a bad id
- * costs.
+ * Candidate/judge resolution lives in `candidates.ts` — a Playwright-free
+ * module a vitest guard can import — and is re-exported here so both specs and
+ * `kb/run-kb-eval.ts` keep resolving through the one place they always have.
+ * See `assertCandidatesDispatchable` for what a bad id costs, and why the
+ * checks sit on the resolved value rather than on the checked-in lists.
  */
-export function candidateModelsFromEnv(defaultModels: string[]): string[] {
-  const raw = process.env.EVAL_CANDIDATE_MODELS;
-  const candidates = raw
-    ? raw
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : defaultModels;
-
-  assertCandidatesDispatchable(
-    candidates,
-    raw ? "EVAL_CANDIDATE_MODELS" : "The sweep default in eval/candidates.ts"
-  );
-
-  return candidates;
-}
+export { candidateModelsFromEnv, judgeModelFromEnv } from "./candidates";
 
 /**
  * A positive-integer run count from a raw env value, falling back to

--- a/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
+++ b/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
@@ -21,23 +21,40 @@
  * runs in `pnpm test`, so a catalog refresh that removes a model can no longer
  * leave a sweep default pointing at it.
  *
+ * What this file cannot see is the set an operator types by hand
+ * (`EVAL_CANDIDATE_MODELS`), which is the set most sweeps actually dispatch —
+ * iron rule 2 makes every probe use it. That path is guarded at runtime by
+ * `assertCandidatesDispatchable`, whose behavior is pinned at the bottom of
+ * this file, so both halves of the same rule live in one place.
+ *
  * Retired models keep their published numbers — every superseded version stays
  * published and citable, per `eval/data/CHANGELOG.md`. This guard only governs
  * what a FUTURE sweep would dispatch.
  */
 
-import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 
-import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS } from "@/lib/ollama-cloud-models";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { DEFAULT_KB_JUDGE_MODEL } from "@/lib/eval/kb/llm-nli";
 
 import {
   DEFAULT_INVOICE_CANDIDATES,
   DEFAULT_KB_CANDIDATES,
   OLLAMA_CLOUD_PREFIX,
+  assertCandidatesDispatchable,
+  unservedCandidates,
 } from "../../../../eval/candidates";
+import { candidateModelsFromEnv } from "../../../../eval/run-eval";
 
-const SERVED_IDS = new Set<string>(TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m) => m.id));
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const EVAL_DIR = path.join(__dirname, "..", "..", "..", "..", "eval");
+
+const README = await readFile(path.join(EVAL_DIR, "README.md"), "utf8");
 
 const SWEEPS: Array<{ name: string; candidates: readonly string[] }> = [
   { name: "invoice (eval-models.spec.ts)", candidates: DEFAULT_INVOICE_CANDIDATES },
@@ -56,9 +73,9 @@ describe.each(SWEEPS)("the $name sweep's default candidates", ({ candidates }) =
   });
 
   it("names only models the curated catalog still serves", () => {
-    const retired = candidates
-      .map((id) => id.slice(OLLAMA_CLOUD_PREFIX.length))
-      .filter((bare) => !SERVED_IDS.has(bare));
+    // Through the same oracle the runtime guard uses, so the checked-in lists
+    // and a hand-typed override can never disagree about what "served" means.
+    const retired = unservedCandidates(candidates);
 
     expect(
       retired,
@@ -92,14 +109,137 @@ describe("the KB sweep's pinned NLI judge", () => {
   });
 
   it("names a model the curated catalog still serves", () => {
-    const bare = DEFAULT_KB_JUDGE_MODEL.slice(OLLAMA_CLOUD_PREFIX.length);
+    const [unserved] = unservedCandidates([DEFAULT_KB_JUDGE_MODEL]);
 
     expect(
-      SERVED_IDS.has(bare),
-      `The pinned judge \`${bare}\` is not in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS. ` +
-        `Every NLI verdict would fail against a retired judge, so no KB run ` +
-        `can be graded at all — after the stack is up and the key is spent. ` +
-        `Repin DEFAULT_KB_JUDGE_MODEL in src/lib/eval/kb/llm-nli.ts.`
-    ).toBe(true);
+      unserved,
+      `The pinned judge \`${DEFAULT_KB_JUDGE_MODEL}\` is not in ` +
+        `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS. Every NLI verdict would fail against ` +
+        `a retired judge, so no KB run can be graded at all — after the stack is ` +
+        `up and the key is spent. Repin DEFAULT_KB_JUDGE_MODEL in ` +
+        `src/lib/eval/kb/llm-nli.ts.`
+    ).toBeUndefined();
+  });
+
+  it("stays out of the candidate sets, so it never grades its own runs", () => {
+    // The pin only buys independence while the judge is not also under test.
+    // Nothing structural prevents the overlap: `gpt-oss:20b` — the judge — is
+    // already a live id in DEFAULT_INVOICE_CANDIDATES, one copy-paste from the
+    // KB list. A judge grading its own output would move every groundedness
+    // score for that one model without leaving a trace in the scorecard.
+    expect(DEFAULT_KB_CANDIDATES).not.toContain(DEFAULT_KB_JUDGE_MODEL);
+  });
+});
+
+/**
+ * The runtime half: the same rule applied to whatever a sweep is about to
+ * dispatch, whether it came from `candidates.ts` or from a shell.
+ */
+describe("assertCandidatesDispatchable", () => {
+  it("accepts the checked-in defaults", () => {
+    expect(() => assertCandidatesDispatchable(DEFAULT_INVOICE_CANDIDATES, "test")).not.toThrow();
+    expect(() => assertCandidatesDispatchable(DEFAULT_KB_CANDIDATES, "test")).not.toThrow();
+  });
+
+  it("refuses a model the catalog no longer serves, naming it", () => {
+    expect(() =>
+      assertCandidatesDispatchable(["ollama-cloud/kimi-k2.6", "ollama-cloud/glm-4.7"], "test")
+    ).toThrow(/glm-4\.7/);
+  });
+
+  it("refuses an id missing the provider prefix", () => {
+    // Reaches the dispatch path as an unresolvable model rather than a typo.
+    expect(() => assertCandidatesDispatchable(["kimi-k2.6"], "test")).toThrow(/kimi-k2\.6/);
+  });
+
+  it("refuses an empty set rather than exporting an empty scorecard", () => {
+    expect(() => assertCandidatesDispatchable([], "test")).toThrow(/empty/i);
+  });
+
+  it("refuses the same model twice, which would double one cell's n", () => {
+    expect(() =>
+      assertCandidatesDispatchable(["ollama-cloud/kimi-k2.6", "ollama-cloud/kimi-k2.6"], "test")
+    ).toThrow(/twice/i);
+  });
+
+  it("names its source, so the operator knows which set to fix", () => {
+    expect(() => assertCandidatesDispatchable(["nope"], "EVAL_CANDIDATE_MODELS")).toThrow(
+      /EVAL_CANDIDATE_MODELS/
+    );
+  });
+});
+
+/**
+ * And the wiring, because an assertion nothing calls guards nothing: this is
+ * the single function both sweeps and `kb/run-kb-eval.ts` resolve their
+ * candidates through.
+ */
+describe("candidateModelsFromEnv", () => {
+  it("returns the caller's default when the env var is unset", () => {
+    vi.stubEnv("EVAL_CANDIDATE_MODELS", undefined);
+
+    expect(candidateModelsFromEnv([...DEFAULT_KB_CANDIDATES])).toEqual(DEFAULT_KB_CANDIDATES);
+  });
+
+  it("parses a comma-separated override, trimming whitespace", () => {
+    vi.stubEnv("EVAL_CANDIDATE_MODELS", "ollama-cloud/kimi-k2.6, ollama-cloud/gpt-oss:120b");
+
+    expect(candidateModelsFromEnv([...DEFAULT_KB_CANDIDATES])).toEqual([
+      "ollama-cloud/kimi-k2.6",
+      "ollama-cloud/gpt-oss:120b",
+    ]);
+  });
+
+  it("throws on an override naming a retired model, before anything is dispatched", () => {
+    vi.stubEnv("EVAL_CANDIDATE_MODELS", "ollama-cloud/kimi-k2.6,ollama-cloud/glm-4.7");
+
+    expect(() => candidateModelsFromEnv([...DEFAULT_KB_CANDIDATES])).toThrow(/glm-4\.7/);
+    expect(() => candidateModelsFromEnv([...DEFAULT_KB_CANDIDATES])).toThrow(
+      /EVAL_CANDIDATE_MODELS/
+    );
+  });
+
+  it("throws on an override that parses to nothing", () => {
+    vi.stubEnv("EVAL_CANDIDATE_MODELS", " , ");
+
+    expect(() => candidateModelsFromEnv([...DEFAULT_KB_CANDIDATES])).toThrow(/empty/i);
+  });
+});
+
+/**
+ * `eval/README.md` states both set sizes as prose. That is the same shape of
+ * claim this whole file exists because of — a rule stated in a comment for two
+ * sweeps and broken without anything going red. The counts are worth keeping
+ * (a reader wants to know the sweep is 12 models, not 3), so they get parsed
+ * out of the sentence rather than restated here: rewrite the sentence and this
+ * guard tells you; change a list and it tells you that too.
+ *
+ * Same technique as `eval/__tests__/comparisons-published-guard.test.ts`.
+ */
+describe("eval/README.md's candidate-set claims", () => {
+  /** Pulls one number out of a README sentence, failing loudly if it moved. */
+  function claim(pattern: RegExp, what: string): number {
+    const match = README.match(pattern);
+    if (!match) {
+      throw new Error(
+        `eval/README.md no longer states ${what} in a form this guard can read ` +
+          `(${pattern}). The claim and its guard must move together — update the ` +
+          `regex if you rewrote the sentence, and re-check the number while you ` +
+          `are there.`
+      );
+    }
+    return Number(match[1]);
+  }
+
+  it("states the invoice sweep's size", () => {
+    expect(
+      claim(/leaving the \*\*(\d+)\*\* a sweep dispatches today/, "the invoice set size")
+    ).toBe(DEFAULT_INVOICE_CANDIDATES.length);
+  });
+
+  it("states the KB sweep's size", () => {
+    expect(claim(/deliberately smaller set of (\d+)/, "the KB set size")).toBe(
+      DEFAULT_KB_CANDIDATES.length
+    );
   });
 });

--- a/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
+++ b/packages/web/src/__tests__/lib/eval/sweep-candidates.test.ts
@@ -44,13 +44,29 @@ import {
   DEFAULT_KB_CANDIDATES,
   OLLAMA_CLOUD_PREFIX,
   assertCandidatesDispatchable,
+  assertJudgeDispatchable,
+  candidateModelsFromEnv,
+  judgeModelFromEnv,
   unservedCandidates,
 } from "../../../../eval/candidates";
-import { candidateModelsFromEnv } from "../../../../eval/run-eval";
 
 afterEach(() => {
   vi.unstubAllEnvs();
 });
+
+/**
+ * The message a refusal carried, so a case can assert WHICH check fired rather
+ * than only that something did. Two of these refusals differ by their advice,
+ * and a test matching the model id alone passes for either one.
+ */
+function refusalMessage(call: () => unknown): string {
+  try {
+    call();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error("Expected the call to refuse, but it returned normally.");
+}
 
 const EVAL_DIR = path.join(__dirname, "..", "..", "..", "..", "eval");
 
@@ -152,6 +168,19 @@ describe("assertCandidatesDispatchable", () => {
     expect(() => assertCandidatesDispatchable(["kimi-k2.6"], "test")).toThrow(/kimi-k2\.6/);
   });
 
+  it("tells a missing prefix apart from a retirement, so the advice fits", () => {
+    // `kimi-k2.6` IS in the catalog — only the prefix is missing. Reporting it
+    // as unserved states something false and sends the operator to `pnpm
+    // models:discover`, which refreshes a catalog that already has the model
+    // and leaves them exactly where they started. This guard exists to save
+    // that hour, so its two refusals must not read alike.
+    const message = refusalMessage(() => assertCandidatesDispatchable(["kimi-k2.6"], "test"));
+
+    expect(message).toContain(`"${OLLAMA_CLOUD_PREFIX}"`);
+    expect(message).not.toMatch(/does not serve/);
+    expect(message).not.toMatch(/models:discover/);
+  });
+
   it("refuses an empty set rather than exporting an empty scorecard", () => {
     expect(() => assertCandidatesDispatchable([], "test")).toThrow(/empty/i);
   });
@@ -203,6 +232,84 @@ describe("candidateModelsFromEnv", () => {
     vi.stubEnv("EVAL_CANDIDATE_MODELS", " , ");
 
     expect(() => candidateModelsFromEnv([...DEFAULT_KB_CANDIDATES])).toThrow(/empty/i);
+  });
+});
+
+/**
+ * The judge is the OTHER model a KB sweep dispatches, and it has the same
+ * hand-typed override — `KB_EVAL_JUDGE_MODEL`. Both properties the two
+ * describes above pin for the checked-in default (served, and not itself under
+ * test) are properties of whatever the sweep ends up using, so they belong on
+ * the resolved value rather than on the literal.
+ *
+ * A judge id is the more expensive of the two to get wrong: a bad candidate
+ * costs that model's column, a bad judge fails every verdict, so NO KB run is
+ * gradeable at all — discovered after the stack is up, the corpus is seeded and
+ * a real key has been spent.
+ */
+describe("assertJudgeDispatchable", () => {
+  it("accepts the pinned default against the checked-in KB set", () => {
+    expect(() =>
+      assertJudgeDispatchable(DEFAULT_KB_JUDGE_MODEL, DEFAULT_KB_CANDIDATES, "test")
+    ).not.toThrow();
+  });
+
+  it("refuses a judge the catalog no longer serves", () => {
+    expect(() =>
+      assertJudgeDispatchable("ollama-cloud/glm-4.7", DEFAULT_KB_CANDIDATES, "test")
+    ).toThrow(/glm-4\.7/);
+  });
+
+  it("refuses a judge that is also under test", () => {
+    // The pin buys independence only while the judge is not a candidate. The
+    // overlap leaves no trace in the scorecard: one model's groundedness column
+    // is simply self-graded, and every other column is not.
+    expect(() =>
+      assertJudgeDispatchable("ollama-cloud/kimi-k2.6", DEFAULT_KB_CANDIDATES, "test")
+    ).toThrow(/kimi-k2\.6/);
+  });
+});
+
+describe("judgeModelFromEnv", () => {
+  it("returns the pinned default when the env var is unset", () => {
+    vi.stubEnv("KB_EVAL_JUDGE_MODEL", undefined);
+
+    expect(judgeModelFromEnv(DEFAULT_KB_JUDGE_MODEL, DEFAULT_KB_CANDIDATES)).toBe(
+      DEFAULT_KB_JUDGE_MODEL
+    );
+  });
+
+  it("takes the override, trimming whitespace", () => {
+    vi.stubEnv("KB_EVAL_JUDGE_MODEL", "  ollama-cloud/gpt-oss:120b  ");
+
+    expect(judgeModelFromEnv(DEFAULT_KB_JUDGE_MODEL, [])).toBe("ollama-cloud/gpt-oss:120b");
+  });
+
+  it("throws on an override naming a retired judge, before anything is graded", () => {
+    vi.stubEnv("KB_EVAL_JUDGE_MODEL", "ollama-cloud/glm-4.7");
+
+    const message = refusalMessage(() =>
+      judgeModelFromEnv(DEFAULT_KB_JUDGE_MODEL, DEFAULT_KB_CANDIDATES)
+    );
+
+    expect(message).toMatch(/glm-4\.7/);
+    expect(message).toMatch(/KB_EVAL_JUDGE_MODEL/);
+  });
+
+  it("throws on an override that puts the judge in the candidate set", () => {
+    vi.stubEnv("KB_EVAL_JUDGE_MODEL", "ollama-cloud/qwen3.5:397b");
+
+    expect(() => judgeModelFromEnv(DEFAULT_KB_JUDGE_MODEL, DEFAULT_KB_CANDIDATES)).toThrow(
+      /qwen3\.5:397b/
+    );
+  });
+
+  it("names the pin, not the env var, when the default is the bad one", () => {
+    vi.stubEnv("KB_EVAL_JUDGE_MODEL", undefined);
+
+    expect(() => judgeModelFromEnv("ollama-cloud/glm-4.7", DEFAULT_KB_CANDIDATES)).toThrow(
+      /DEFAULT_KB_JUDGE_MODEL/
+    );
   });
 });
 


### PR DESCRIPTION
Follow-up to #1011.

## What this fixes

#1011 moved both sweeps' defaults into `eval/candidates.ts` and put a vitest guard on them — closing a rule that had been prose since the first sweep and was broken twice over by the 2026-07-15 retirement wave.

That guard sees the two checked-in lists. Almost no sweep runs those unmodified: `EVAL_CANDIDATE_MODELS` replaces them wholesale, and the `run-model-eval` skill's **iron rule 2** tells the operator to probe with exactly that env var before every full sweep.

So the path most likely to carry a typo — a string typed into a shell, reviewed by nobody — was the one path nothing checked.

## Why it matters

The failure is verbatim the one #1011 describes. A retired or mistyped id 404s on every run, the rows land as `run-infra-error`, the exporter drops them from `n`, and the scorecard quietly holds fewer models than the operator believes they measured. Worse here than in the default case: this happens *during the probe whose entire job is to catch that* before a 12-hour sweep.

`EVAL_CANDIDATE_MODELS=","` had its own version — an empty candidate set, a sweep that boots the stack, dispatches nothing, exports an empty scorecard, and exits clean.

## The change

- **`assertCandidatesDispatchable`** (`eval/candidates.ts`) — any candidate set gets the same four guarantees the defaults have: prefixed, served, distinct, non-empty. Throws before the stack boots and the key is spent. Deliberately no escape hatch for an unknown model: the catalog is generated from what the provider serves, so `pnpm models:discover` is both the fix and the step that should have run first.
- **`candidateModelsFromEnv`** calls it — the single funnel both sweeps and `kb/run-kb-eval.ts` resolve candidates through.
- **The pinned NLI judge may no longer appear in a candidate list.** Its whole justification is independence from the models under test, and `gpt-oss:20b` is already a live id in the invoice set — one copy-paste from grading its own runs, with nothing in the scorecard to show for it.
- **`unservedCandidates` is now the single oracle.** The guard stopped re-deriving ids the catalog already exports as `TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS`, so the checked-in lists and a hand-typed override cannot drift apart on what "served" means.
- **`eval/README.md`** stated both set sizes as unchecked prose two paragraphs after explaining that unchecked prose is what broke. Parsed out of the sentence now — same technique as `comparisons-published-guard.test.ts`. Plus the one 100-char line #1011 left behind.

Published numbers are untouched; this governs only what a future sweep dispatches.

## Verification

- Each new guard confirmed **red first**: judge added to the KB set, README counts edited, the `candidateModelsFromEnv` call removed — 3, then 2 failures respectively, all naming the right thing.
- `pnpm test` — 780 files / 11 156 tests passed
- `pnpm -C packages/web typecheck`, `pnpm format:check` — green