### PR TITLE
fix(inbox): give an undeliverable workflow a trace, not a silent drop

### DIFF
--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -169,9 +169,14 @@ The tab lists every workflow on the agent with its trigger (in plain words, not 
 
 - **Pending** — proposed but never yet run.
 - **Active** — enabled and running on its schedule.
-- **Error** — the workflow is switched on, but Pinchy can't run it. Either a mailbox it watches won't open (expired credentials, a wrong host), or there's nobody left to notify — on a shared agent, results go to whoever created the workflow, and that person's account has since been deleted. Pinchy names the workflow and the reason in the server log the moment this happens.
+- **Error** — the workflow is switched on, but Pinchy can't run it. There are three causes:
+  - A mailbox it watches won't open — expired credentials, a wrong host.
+  - It watches no mailboxes at all, because the integration was disconnected under **Settings → Integrations**. Removing a connection takes it out of every workflow that pointed at it.
+  - There's nobody left to notify: on a shared agent, results go to whoever created the workflow, and that person's account has since been deleted.
 
-An errored workflow stays switched on and keeps being retried, so there's nothing to re-enable: fix the cause and the next pass moves it back to **Active** by itself. To hand an orphaned workflow to someone else, delete it and create it again as the new owner.
+Pinchy names the workflow and the reason in the server log the first time a workflow lands in this state. After that the badge is the record, so if you missed the line, the three causes above are what to check.
+
+An errored workflow stays switched on and keeps being retried, so there's nothing to re-enable. Repair the connection's credentials and the next pass moves the workflow back to **Active** by itself. The other two causes can't be edited on an existing workflow: a workflow's mailboxes and its recipient are fixed when you create it, so delete it and create it again — pointed at the reconnected mailbox, and by the person who should receive the results.
 
 Use **Enable** / **Disable** to turn a workflow on or off, and **Delete** to remove one for good. Enabling is the human-gated step that turns a proposal into a live automation; disabling pauses it without deleting it.
 

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -169,7 +169,9 @@ The tab lists every workflow on the agent with its trigger (in plain words, not 
 
 - **Pending** — proposed but never yet run.
 - **Active** — enabled and running on its schedule.
-- **Error** — the last run hit a problem.
+- **Error** — the workflow is switched on, but Pinchy can't run it. Either a mailbox it watches won't open (expired credentials, a wrong host), or there's nobody left to notify — on a shared agent, results go to whoever created the workflow, and that person's account has since been deleted. Pinchy names the workflow and the reason in the server log the moment this happens.
+
+An errored workflow stays switched on and keeps being retried, so there's nothing to re-enable: fix the cause and the next pass moves it back to **Active** by itself. To hand an orphaned workflow to someone else, delete it and create it again as the new owner.
 
 Use **Enable** / **Disable** to turn a workflow on or off, and **Delete** to remove one for good. Enabling is the human-gated step that turns a proposal into a live automation; disabling pauses it without deleting it.
 

--- a/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
@@ -585,7 +585,7 @@ async function workflowStatus(workflowId: string) {
  * shared agent's workflow leaves the row behind, still `enabled`, with a null
  * creator. Before that FK change the DELETE would have failed loudly instead.
  */
-async function seedUndeliverableWorkflow() {
+async function seedUnrunnableWorkflow() {
   const [agent] = await db
     .insert(agents)
     .values({
@@ -687,6 +687,31 @@ describe("reconciliation sweep — workflow health status", () => {
     expect((await ledgerRow(workflow.id, "msg-1")).status).toBe("done");
   });
 
+  it("names the workflow, not just its id, when a mailbox will not open", async () => {
+    // Both `error` causes have to read the same way in the log, because the
+    // docs promise one thing for both: Pinchy names the workflow and the
+    // reason. An id alone sends the reader back to the database to find out
+    // which automation is broken — and to nothing at all if it has since been
+    // deleted. Same snapshot rule as an audit row (AGENTS.md).
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const createPort = async (id: string): Promise<EmailPort> => {
+      if (id === connection.id) throw new Error("connection credentials missing");
+      return emptyMailbox(id);
+    };
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    let logged: string[] = [];
+    try {
+      await runReconciliationSweep({ createPort, runAgent: doneRun });
+      logged = error.mock.calls.map((call) => String(call[0]));
+    } finally {
+      error.mockRestore();
+    }
+
+    const mine = logged.filter((msg) => msg.includes(workflow.id));
+    expect(mine).toHaveLength(1);
+    expect(mine[0]).toContain("File invoices");
+  });
+
   it("marks a workflow error when nobody can be notified of its runs", async () => {
     // The other error path is a mailbox that throws. This one never throws at
     // all: the loader resolves no recipient, drops the workflow before it
@@ -695,7 +720,7 @@ describe("reconciliation sweep — workflow health status", () => {
     // without this the workflow has silently stopped running with nothing
     // anywhere saying so — the exact state `created_by ON DELETE SET NULL`
     // (#1097) made reachable.
-    const { workflow, connection } = await seedUndeliverableWorkflow();
+    const { workflow, connection } = await seedUnrunnableWorkflow();
     const opened: string[] = [];
     const createPort = async (id: string): Promise<EmailPort> => {
       opened.push(id);
@@ -709,11 +734,32 @@ describe("reconciliation sweep — workflow health status", () => {
     expect(opened).not.toContain(connection.id);
   });
 
-  it("recovers an undeliverable workflow once it has a recipient again", async () => {
+  it("marks a workflow error when its last mailbox has been disconnected", async () => {
+    // Reproduced the way it actually happens: `DELETE /api/integrations/:id`
+    // hard-deletes the connection, and the FK cascades the workflow's link row
+    // away. The workflow is left enabled with nothing to watch.
+    //
+    // This one used to be invisible even to the status write — the loader's
+    // fan-out join yields no row for a workflow with no connections, so it was
+    // in neither the units nor the report, and the sweep never reached it. It
+    // kept displaying `active` while doing nothing, which is a worse silence
+    // than the missing-recipient case it sits next to.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
+    expect(await workflowStatus(workflow.id)).toBe("active");
+
+    await db.delete(integrationConnections).where(eq(integrationConnections.id, connection.id));
+
+    await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
+
+    expect(await workflowStatus(workflow.id)).toBe("error");
+  });
+
+  it("recovers an unrunnable workflow once it has a recipient again", async () => {
     // Same contract as the unreachable-mailbox recovery above: `error` is a
     // health signal, not a latch. Re-assigning the workflow to a live user is
     // the fix, and the next pass has to show it worked.
-    const { workflow } = await seedUndeliverableWorkflow();
+    const { workflow } = await seedUnrunnableWorkflow();
 
     await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
     expect(await workflowStatus(workflow.id)).toBe("error");
@@ -729,30 +775,36 @@ describe("reconciliation sweep — workflow health status", () => {
     expect(await workflowStatus(workflow.id)).toBe("active");
   });
 
-  it("names an undeliverable workflow in the log once, not on every pass", async () => {
+  it("names an unrunnable workflow in the log once, not on every pass", async () => {
     // The sweep runs every minute and this condition cannot resolve itself, so
     // a line per pass is ~1400 identical lines a day per broken workflow — the
     // kind of volume that gets a whole logger filtered out. The durable trace is
     // the `status` column; the log line only timestamps the moment it changed,
     // so it is emitted on the transition into `error` and not again.
-    const { workflow } = await seedUndeliverableWorkflow();
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    let warned: string[] = [];
+    //
+    // At `error`, not `warn`: the sibling failure — a mailbox that won't open —
+    // logs at error on EVERY pass, and this one logs once in the workflow's
+    // lifetime. Giving the quieter signal the lower severity is backwards, and
+    // an operator filtering on error would see the loud fault and miss the
+    // silent one.
+    const { workflow } = await seedUnrunnableWorkflow();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    let logged: string[] = [];
     try {
       await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
       await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
       // Read the calls BEFORE restoring: mockRestore() also clears mock.calls.
-      warned = warn.mock.calls.map((call) => String(call[0]));
+      logged = error.mock.calls.map((call) => String(call[0]));
     } finally {
-      warn.mockRestore();
+      error.mockRestore();
     }
 
     // Scoped to this test's own workflow: the sweep is global, and other suites
-    // seed undeliverable workflows of their own against the same database.
-    const mine = warned.filter((msg) => msg.includes(workflow.id));
+    // seed unrunnable workflows of their own against the same database.
+    const mine = logged.filter((msg) => msg.includes(workflow.id));
     expect(
       mine,
-      `expected exactly one warning for the workflow; warnings seen: ${JSON.stringify(warned)}`
+      `expected exactly one log line for the workflow; lines seen: ${JSON.stringify(logged)}`
     ).toHaveLength(1);
     // It has to say what to fix, and read sensibly for a workflow the reader
     // cannot look up — hence the snapshotted name beside the id.

--- a/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
@@ -576,6 +576,47 @@ async function workflowStatus(workflowId: string) {
   return row.status;
 }
 
+/**
+ * An enabled workflow on a shared agent with no recorded creator: nobody can be
+ * notified of its runs, so the loader emits no unit of work for it at all.
+ *
+ * `email_workflows.created_by` is `ON DELETE SET NULL` (#1097), which is what
+ * makes this state reachable on a live instance — erasing the user who created a
+ * shared agent's workflow leaves the row behind, still `enabled`, with a null
+ * creator. Before that FK change the DELETE would have failed loudly instead.
+ */
+async function seedUndeliverableWorkflow() {
+  const [agent] = await db
+    .insert(agents)
+    .values({
+      name: "Penny",
+      model: "ollama-cloud/gemini-3-flash",
+      greetingMessage: "Hi",
+      isPersonal: false,
+      ownerId: null,
+    })
+    .returning();
+  const [workflow] = await db
+    .insert(emailWorkflows)
+    .values({
+      agentId: agent.id,
+      name: "File invoices",
+      filter: { hasAttachment: true, attachmentType: "application/pdf" },
+      action: "Draft a supplier bill in Odoo from the attached invoice.",
+      enabled: true,
+      createdBy: null,
+    })
+    .returning();
+  const connection = await seedConnection();
+  await db
+    .insert(emailWorkflowConnections)
+    .values({ workflowId: workflow.id, connectionId: connection.id, sinceTs: new Date(0) });
+  return { agent, workflow, connection };
+}
+
+/** A port that hands back an empty mailbox for every connection. */
+const emptyMailbox = portFor("no-connection-owns-this-id", []).createPort;
+
 describe("reconciliation sweep — workflow health status", () => {
   it("marks a workflow active once a pass completes", async () => {
     // `status` is the health signal the loader deliberately does NOT gate on —
@@ -644,6 +685,79 @@ describe("reconciliation sweep — workflow health status", () => {
     expect(await workflowStatus(workflow.id)).toBe("error");
     // The healthy mailbox still delivered — degraded, not dead.
     expect((await ledgerRow(workflow.id, "msg-1")).status).toBe("done");
+  });
+
+  it("marks a workflow error when nobody can be notified of its runs", async () => {
+    // The other error path is a mailbox that throws. This one never throws at
+    // all: the loader resolves no recipient, drops the workflow before it
+    // becomes a unit of work, and the sweep completes cleanly. The row stays
+    // `enabled: true` and the Automations UI keeps showing it that way, so
+    // without this the workflow has silently stopped running with nothing
+    // anywhere saying so — the exact state `created_by ON DELETE SET NULL`
+    // (#1097) made reachable.
+    const { workflow, connection } = await seedUndeliverableWorkflow();
+    const opened: string[] = [];
+    const createPort = async (id: string): Promise<EmailPort> => {
+      opened.push(id);
+      return emptyMailbox(id);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(await workflowStatus(workflow.id)).toBe("error");
+    // And it really is not running: its mailbox is never even opened.
+    expect(opened).not.toContain(connection.id);
+  });
+
+  it("recovers an undeliverable workflow once it has a recipient again", async () => {
+    // Same contract as the unreachable-mailbox recovery above: `error` is a
+    // health signal, not a latch. Re-assigning the workflow to a live user is
+    // the fix, and the next pass has to show it worked.
+    const { workflow } = await seedUndeliverableWorkflow();
+
+    await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
+    expect(await workflowStatus(workflow.id)).toBe("error");
+
+    const rescuer = await seedUser();
+    await db
+      .update(emailWorkflows)
+      .set({ createdBy: rescuer.id })
+      .where(eq(emailWorkflows.id, workflow.id));
+
+    await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
+
+    expect(await workflowStatus(workflow.id)).toBe("active");
+  });
+
+  it("names an undeliverable workflow in the log once, not on every pass", async () => {
+    // The sweep runs every minute and this condition cannot resolve itself, so
+    // a line per pass is ~1400 identical lines a day per broken workflow — the
+    // kind of volume that gets a whole logger filtered out. The durable trace is
+    // the `status` column; the log line only timestamps the moment it changed,
+    // so it is emitted on the transition into `error` and not again.
+    const { workflow } = await seedUndeliverableWorkflow();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let warned: string[] = [];
+    try {
+      await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
+      await runReconciliationSweep({ createPort: emptyMailbox, runAgent: doneRun });
+      // Read the calls BEFORE restoring: mockRestore() also clears mock.calls.
+      warned = warn.mock.calls.map((call) => String(call[0]));
+    } finally {
+      warn.mockRestore();
+    }
+
+    // Scoped to this test's own workflow: the sweep is global, and other suites
+    // seed undeliverable workflows of their own against the same database.
+    const mine = warned.filter((msg) => msg.includes(workflow.id));
+    expect(
+      mine,
+      `expected exactly one warning for the workflow; warnings seen: ${JSON.stringify(warned)}`
+    ).toHaveLength(1);
+    // It has to say what to fix, and read sensibly for a workflow the reader
+    // cannot look up — hence the snapshotted name beside the id.
+    expect(mine[0]).toContain("shared-agent-has-no-creator");
+    expect(mine[0]).toContain("File invoices");
   });
 
   it("isolates a broken workflow — the rest of the sweep still runs", async () => {

--- a/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
@@ -81,8 +81,14 @@ async function linkConnection(workflowId: string, connectionId: string, sinceTs:
   await db.insert(emailWorkflowConnections).values({ workflowId, connectionId, sinceTs });
 }
 
-const onlyWorkflow = (rows: Awaited<ReturnType<typeof loadDispatchableWorkflows>>, id: string) =>
-  rows.filter((r) => r.workflow.id === id);
+type LoaderResult = Awaited<ReturnType<typeof loadDispatchableWorkflows>>;
+
+const onlyWorkflow = (result: LoaderResult, id: string) =>
+  result.units.filter((r) => r.workflow.id === id);
+
+/** The undeliverable report, scoped to one test's own workflow. */
+const onlyUndeliverable = (result: LoaderResult, id: string) =>
+  result.undeliverable.filter((r) => r.workflowId === id);
 
 describe("email workflow loader — loadDispatchableWorkflows", () => {
   it("loads an enabled personal-agent workflow with the owner as the recipient", async () => {
@@ -197,6 +203,78 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     expect(mine).toHaveLength(0);
   });
 
+  it("reports the shared-agent drop as undeliverable rather than swallowing it", async () => {
+    // Dropping is correct; dropping *silently* is not. The workflow stays
+    // `enabled: true` and the UI keeps showing it as such, so the loader has to
+    // hand the reason to its caller — the sweep turns this into the workflow's
+    // `error` status, which is the only thing an operator ever sees.
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: null });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const mine = onlyUndeliverable(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toEqual([
+      {
+        workflowId: wf.id,
+        agentId: agent.id,
+        // The name is snapshotted beside the id (AGENTS.md): the log line this
+        // feeds must still read sensibly for a workflow nobody can look up.
+        name: "File invoices",
+        reason: "shared-agent-has-no-creator",
+      },
+    ]);
+  });
+
+  it("distinguishes the personal-agent drop by its own reason", async () => {
+    // Two different misconfigurations reach the same dead end, and they need
+    // different fixes: re-assign the workflow vs. give the agent an owner. A
+    // single "no recipient" verdict would leave the operator guessing.
+    const agent = await seedAgent({ isPersonal: true, ownerId: null });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: null });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const mine = onlyUndeliverable(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine.map((r) => r.reason)).toEqual(["personal-agent-has-no-owner"]);
+  });
+
+  it("reports an undeliverable workflow once, however many mailboxes it watches", async () => {
+    // The loader fans out per (workflow × connection), but a missing recipient
+    // is a property of the workflow alone — every one of its rows drops. The
+    // report is per workflow, matching the per-workflow `status` column the
+    // sweep writes from it; without the dedup a two-mailbox workflow would log
+    // itself twice every pass.
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: null });
+    const connA = await seedConnection();
+    const connB = await seedConnection();
+    await linkConnection(wf.id, connA.id, new Date());
+    await linkConnection(wf.id, connB.id, new Date());
+
+    const result = await loadDispatchableWorkflows();
+
+    expect(onlyWorkflow(result, wf.id)).toHaveLength(0);
+    expect(onlyUndeliverable(result, wf.id)).toHaveLength(1);
+  });
+
+  it("reports nothing undeliverable for a workflow that is merely disabled", async () => {
+    // A disabled workflow is not dispatched by choice, so it is not a fault —
+    // and it never reaches the recipient resolution at all. Reporting it would
+    // flip every paused workflow in the instance to `error`.
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: false, createdBy: null });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const result = await loadDispatchableWorkflows();
+
+    expect(onlyWorkflow(result, wf.id)).toHaveLength(0);
+    expect(onlyUndeliverable(result, wf.id)).toHaveLength(0);
+  });
+
   it("keeps a shared-agent workflow when its creator is deleted, and stops dispatching it (#1097)", async () => {
     // `email_workflows.created_by` is ON DELETE SET NULL, and this is the test
     // that pins all three drift directions at once — the same contract as the
@@ -227,7 +305,15 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     // nobody to notify.
     expect(survivor.enabled).toBe(true);
 
-    expect(onlyWorkflow(await loadDispatchableWorkflows(), wf.id)).toHaveLength(0);
+    const after = await loadDispatchableWorkflows();
+    expect(onlyWorkflow(after, wf.id)).toHaveLength(0);
+    // ...and the drop is reported, not swallowed. Before the FK change this
+    // state was unreachable (the DELETE would have failed), so the change traded
+    // a hard failure for a silent one unless the loader says what it dropped —
+    // the sweep turns this into the workflow's `error` status.
+    expect(onlyUndeliverable(after, wf.id).map((r) => r.reason)).toEqual([
+      "shared-agent-has-no-creator",
+    ]);
   });
 
   it("dispatches an enabled workflow even when its status is 'error' — status is a health signal, not a dispatch gate", async () => {

--- a/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
@@ -86,9 +86,9 @@ type LoaderResult = Awaited<ReturnType<typeof loadDispatchableWorkflows>>;
 const onlyWorkflow = (result: LoaderResult, id: string) =>
   result.units.filter((r) => r.workflow.id === id);
 
-/** The undeliverable report, scoped to one test's own workflow. */
-const onlyUndeliverable = (result: LoaderResult, id: string) =>
-  result.undeliverable.filter((r) => r.workflowId === id);
+/** The unrunnable report, scoped to one test's own workflow. */
+const onlyUnrunnable = (result: LoaderResult, id: string) =>
+  result.unrunnable.filter((r) => r.workflowId === id);
 
 describe("email workflow loader — loadDispatchableWorkflows", () => {
   it("loads an enabled personal-agent workflow with the owner as the recipient", async () => {
@@ -174,7 +174,7 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     );
   });
 
-  it("drops a workflow with no resolvable recipient — it would be undeliverable", async () => {
+  it("drops a workflow with no resolvable recipient — its notifications would go nowhere", async () => {
     // Shared agent, no creator recorded: dispatchEmails would reject an empty
     // recipient set, so the loader must not emit it at all.
     const agent = await seedAgent({ isPersonal: false, ownerId: null });
@@ -203,7 +203,7 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     expect(mine).toHaveLength(0);
   });
 
-  it("reports the shared-agent drop as undeliverable rather than swallowing it", async () => {
+  it("reports the shared-agent drop as unrunnable rather than swallowing it", async () => {
     // Dropping is correct; dropping *silently* is not. The workflow stays
     // `enabled: true` and the UI keeps showing it as such, so the loader has to
     // hand the reason to its caller — the sweep turns this into the workflow's
@@ -213,7 +213,7 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     const conn = await seedConnection();
     await linkConnection(wf.id, conn.id, new Date());
 
-    const mine = onlyUndeliverable(await loadDispatchableWorkflows(), wf.id);
+    const mine = onlyUnrunnable(await loadDispatchableWorkflows(), wf.id);
 
     expect(mine).toEqual([
       {
@@ -236,12 +236,12 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     const conn = await seedConnection();
     await linkConnection(wf.id, conn.id, new Date());
 
-    const mine = onlyUndeliverable(await loadDispatchableWorkflows(), wf.id);
+    const mine = onlyUnrunnable(await loadDispatchableWorkflows(), wf.id);
 
     expect(mine.map((r) => r.reason)).toEqual(["personal-agent-has-no-owner"]);
   });
 
-  it("reports an undeliverable workflow once, however many mailboxes it watches", async () => {
+  it("reports an unrunnable workflow once, however many mailboxes it watches", async () => {
     // The loader fans out per (workflow × connection), but a missing recipient
     // is a property of the workflow alone — every one of its rows drops. The
     // report is per workflow, matching the per-workflow `status` column the
@@ -257,10 +257,10 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     const result = await loadDispatchableWorkflows();
 
     expect(onlyWorkflow(result, wf.id)).toHaveLength(0);
-    expect(onlyUndeliverable(result, wf.id)).toHaveLength(1);
+    expect(onlyUnrunnable(result, wf.id)).toHaveLength(1);
   });
 
-  it("reports nothing undeliverable for a workflow that is merely disabled", async () => {
+  it("reports nothing unrunnable for a workflow that is merely disabled", async () => {
     // A disabled workflow is not dispatched by choice, so it is not a fault —
     // and it never reaches the recipient resolution at all. Reporting it would
     // flip every paused workflow in the instance to `error`.
@@ -272,7 +272,28 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     const result = await loadDispatchableWorkflows();
 
     expect(onlyWorkflow(result, wf.id)).toHaveLength(0);
-    expect(onlyUndeliverable(result, wf.id)).toHaveLength(0);
+    expect(onlyUnrunnable(result, wf.id)).toHaveLength(0);
+  });
+
+  it("reports an enabled workflow that watches no mailboxes at all", async () => {
+    // The second door into the same dead end, and the one an admin walks
+    // through by accident: `DELETE /api/integrations/:id` hard-deletes the
+    // connection and cascades `email_workflow_connections` away, leaving an
+    // enabled workflow with nothing to watch.
+    //
+    // The fan-out join means such a workflow yields no row at all, so before
+    // this it was invisible even to the sweep's status write — it kept whatever
+    // status it last had (`active`) and the UI showed it as healthy while it
+    // did nothing. Worse than the missing-recipient case, which at least ends
+    // up on `error`.
+    const owner = await seedUser();
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: owner.id });
+
+    const result = await loadDispatchableWorkflows();
+
+    expect(onlyWorkflow(result, wf.id)).toHaveLength(0);
+    expect(onlyUnrunnable(result, wf.id).map((r) => r.reason)).toEqual(["watches-no-mailbox"]);
   });
 
   it("keeps a shared-agent workflow when its creator is deleted, and stops dispatching it (#1097)", async () => {
@@ -311,7 +332,7 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     // state was unreachable (the DELETE would have failed), so the change traded
     // a hard failure for a silent one unless the loader says what it dropped —
     // the sweep turns this into the workflow's `error` status.
-    expect(onlyUndeliverable(after, wf.id).map((r) => r.reason)).toEqual([
+    expect(onlyUnrunnable(after, wf.id).map((r) => r.reason)).toEqual([
       "shared-agent-has-no-creator",
     ]);
   });

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -617,10 +617,10 @@ export const emailWorkflows = pgTable(
     // not take the workflow (and its mailbox connections) down with them —
     // `loadDispatchableWorkflows` treats a null `createdBy` as "no creator
     // recipient" and drops the workflow from the shared-agent fan-out rather
-    // than crashing on it. It also *reports* the drop, and the sweep turns that
-    // into the workflow's `error` status: the row survives still `enabled`, so
-    // without that this FK would have traded a hard failure (the old rejected
-    // DELETE) for a silent one.
+    // than crashing on it. It also *reports* the drop as `unrunnable`, and the
+    // sweep turns that into the workflow's `error` status: the row survives
+    // still `enabled`, so without that this FK would have traded a hard failure
+    // (the old rejected DELETE) for a silent one.
     createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
@@ -662,6 +662,12 @@ export const emailWorkflowConnections = pgTable(
     // Disconnecting an integration hard-deletes the connection row
     // (`DELETE /api/integrations/:connectionId`), cascading here. The PK leads
     // with workflowId, so that cascade had no usable index.
+    //
+    // That cascade can take away a workflow's LAST connection, leaving it
+    // enabled with nothing to watch. `loadDispatchableWorkflows` LEFT-joins this
+    // table so such a workflow still surfaces (reported `watches-no-mailbox`)
+    // instead of vanishing from the query — an inner join dropped it before the
+    // sweep could mark it, and it went on displaying `active` while idle.
     index("email_workflow_connections_connection_idx").on(table.connectionId),
   ]
 );

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -615,9 +615,12 @@ export const emailWorkflows = pgTable(
     openclawJobId: text("openclaw_job_id"),
     // `set null` (not cascade): deleting the user who created a workflow must
     // not take the workflow (and its mailbox connections) down with them —
-    // `loadDispatchableWorkflows` already treats a null `createdBy` as "no
-    // creator recipient" and drops the workflow from the shared-agent fan-out
-    // rather than crashing on it.
+    // `loadDispatchableWorkflows` treats a null `createdBy` as "no creator
+    // recipient" and drops the workflow from the shared-agent fan-out rather
+    // than crashing on it. It also *reports* the drop, and the sweep turns that
+    // into the workflow's `error` status: the row survives still `enabled`, so
+    // without that this FK would have traded a hard failure (the old rejected
+    // DELETE) for a silent one.
     createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/packages/web/src/lib/email-workflows/loader.ts
+++ b/packages/web/src/lib/email-workflows/loader.ts
@@ -18,6 +18,42 @@ export interface DispatchableWorkflow {
 }
 
 /**
+ * Why an enabled workflow could not be turned into a unit of work. The two
+ * misconfigurations reach the same dead end but need different fixes — hand the
+ * workflow to someone else, or give the agent an owner — so they are reported
+ * apart rather than as one "no recipient".
+ */
+export type UndeliverableReason = "shared-agent-has-no-creator" | "personal-agent-has-no-owner";
+
+/**
+ * An enabled workflow the loader refused to emit because nobody could be
+ * notified of its runs. One entry per *workflow*, not per (workflow ×
+ * connection): the recipient is resolved from workflow and agent columns alone,
+ * so every one of a workflow's rows drops together.
+ */
+export interface UndeliverableWorkflow {
+  workflowId: string;
+  agentId: string;
+  /**
+   * Snapshotted beside the id (AGENTS.md), because this feeds an operator-facing
+   * log line that has to read sensibly for a workflow nobody is going to look up.
+   */
+  name: string;
+  reason: UndeliverableReason;
+}
+
+/**
+ * What one load produced: the dispatchable units, and the enabled workflows that
+ * yielded none. The second half exists because dropping an undeliverable
+ * workflow is correct but dropping it *silently* is not — see
+ * {@link loadDispatchableWorkflows}.
+ */
+export interface DispatchableWorkflows {
+  units: DispatchableWorkflow[];
+  undeliverable: UndeliverableWorkflow[];
+}
+
+/**
  * Load every *enabled* email workflow, fanned out to one unit of work per
  * attached connection with its notification recipients resolved. This is the
  * missing link between the DB and the already-complete `dispatchEmails`: it
@@ -38,8 +74,17 @@ export interface DispatchableWorkflow {
  * recorded creator, or a personal agent with no owner) is dropped rather than
  * emitted — `dispatchEmails` rejects an empty recipient set, so an
  * undeliverable unit of work must never reach it.
+ *
+ * It is **reported** as well as dropped, in `undeliverable`. The row stays
+ * `enabled: true` and the Automations UI keeps showing it that way, so a bare
+ * `continue` here is a workflow that has quietly stopped running with nothing
+ * anywhere saying so. `email_workflows.created_by` is `ON DELETE SET NULL`
+ * (#1097), which makes exactly that state reachable by erasing a user — before
+ * that FK change the DELETE would have failed loudly instead. The sweep turns
+ * this report into the workflow's `error` status, which is what an operator
+ * actually sees.
  */
-export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflow[]> {
+export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflows> {
   const rows = await db
     .select({
       workflowId: emailWorkflows.id,
@@ -59,11 +104,23 @@ export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflow[
     .innerJoin(emailWorkflowConnections, eq(emailWorkflowConnections.workflowId, emailWorkflows.id))
     .where(eq(emailWorkflows.enabled, true));
 
-  const result: DispatchableWorkflow[] = [];
+  const units: DispatchableWorkflow[] = [];
+  // Keyed by workflow id: a workflow drops on every one of its connection rows
+  // (the recipient does not depend on the connection), and the sweep writes one
+  // `status` per workflow — so report it once rather than once per mailbox.
+  const undeliverable = new Map<string, UndeliverableWorkflow>();
   for (const row of rows) {
     const recipientUserIds = resolveRecipients(row);
-    if (recipientUserIds.length === 0) continue;
-    result.push({
+    if (recipientUserIds.length === 0) {
+      undeliverable.set(row.workflowId, {
+        workflowId: row.workflowId,
+        agentId: row.agentId,
+        name: row.name,
+        reason: row.isPersonal ? "personal-agent-has-no-owner" : "shared-agent-has-no-creator",
+      });
+      continue;
+    }
+    units.push({
       workflow: {
         id: row.workflowId,
         agentId: row.agentId,
@@ -77,13 +134,13 @@ export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflow[
       sweepWindowDays: row.sweepWindowDays,
     });
   }
-  return result;
+  return { units, undeliverable: [...undeliverable.values()] };
 }
 
 /**
  * Scope model (design §7): a personal agent's workflow notifies its owner; a
  * shared agent's workflow notifies its creator. Returns `[]` when no recipient
- * can be resolved, which the caller drops.
+ * can be resolved, which the caller drops and reports as undeliverable.
  */
 function resolveRecipients(row: {
   isPersonal: boolean;

--- a/packages/web/src/lib/email-workflows/loader.ts
+++ b/packages/web/src/lib/email-workflows/loader.ts
@@ -18,20 +18,20 @@ export interface DispatchableWorkflow {
 }
 
 /**
- * Why an enabled workflow could not be turned into a unit of work. The two
- * misconfigurations reach the same dead end but need different fixes — hand the
- * workflow to someone else, or give the agent an owner — so they are reported
- * apart rather than as one "no recipient".
+ * Why an enabled workflow could not be turned into a unit of work. Three
+ * misconfigurations reach the same dead end and each needs a different fix —
+ * hand the workflow to someone else, give the agent an owner, or point it at a
+ * mailbox again — so they are reported apart rather than as one "cannot run".
  */
-export type UndeliverableReason = "shared-agent-has-no-creator" | "personal-agent-has-no-owner";
+export type UnrunnableReason =
+  "shared-agent-has-no-creator" | "personal-agent-has-no-owner" | "watches-no-mailbox";
 
 /**
- * An enabled workflow the loader refused to emit because nobody could be
- * notified of its runs. One entry per *workflow*, not per (workflow ×
- * connection): the recipient is resolved from workflow and agent columns alone,
- * so every one of a workflow's rows drops together.
+ * An enabled workflow the loader emitted no unit of work for. One entry per
+ * *workflow*, not per (workflow × connection): every reason here is a property
+ * of the workflow alone, so all of its rows drop together.
  */
-export interface UndeliverableWorkflow {
+export interface UnrunnableWorkflow {
   workflowId: string;
   agentId: string;
   /**
@@ -39,18 +39,18 @@ export interface UndeliverableWorkflow {
    * log line that has to read sensibly for a workflow nobody is going to look up.
    */
   name: string;
-  reason: UndeliverableReason;
+  reason: UnrunnableReason;
 }
 
 /**
  * What one load produced: the dispatchable units, and the enabled workflows that
- * yielded none. The second half exists because dropping an undeliverable
- * workflow is correct but dropping it *silently* is not — see
+ * yielded none. The second half exists because dropping a workflow that cannot
+ * run is correct but dropping it *silently* is not — see
  * {@link loadDispatchableWorkflows}.
  */
-export interface DispatchableWorkflows {
+export interface WorkflowLoadResult {
   units: DispatchableWorkflow[];
-  undeliverable: UndeliverableWorkflow[];
+  unrunnable: UnrunnableWorkflow[];
 }
 
 /**
@@ -75,16 +75,28 @@ export interface DispatchableWorkflows {
  * emitted — `dispatchEmails` rejects an empty recipient set, so an
  * undeliverable unit of work must never reach it.
  *
- * It is **reported** as well as dropped, in `undeliverable`. The row stays
- * `enabled: true` and the Automations UI keeps showing it that way, so a bare
- * `continue` here is a workflow that has quietly stopped running with nothing
- * anywhere saying so. `email_workflows.created_by` is `ON DELETE SET NULL`
- * (#1097), which makes exactly that state reachable by erasing a user — before
- * that FK change the DELETE would have failed loudly instead. The sweep turns
- * this report into the workflow's `error` status, which is what an operator
- * actually sees.
+ * Every such workflow is **reported** as well as dropped, in `unrunnable`. The
+ * row stays `enabled: true` and the Automations UI keeps showing it that way, so
+ * a bare `continue` here is a workflow that has quietly stopped running with
+ * nothing anywhere saying so. The sweep turns this report into the workflow's
+ * `error` status, which is what an operator actually sees.
+ *
+ * Two of the three reasons are reachable through an ordinary admin action, and
+ * neither used to leave a trace (the third, a personal agent without an owner,
+ * is a shape the app never produces):
+ * - `email_workflows.created_by` is `ON DELETE SET NULL` (#1097), so erasing a
+ *   user orphans the workflows they created on shared agents. Before that FK
+ *   change the DELETE would have failed loudly instead.
+ * - `DELETE /api/integrations/:connectionId` hard-deletes a connection and
+ *   cascades `email_workflow_connections`, so disconnecting a mailbox can leave
+ *   an enabled workflow watching nothing.
+ *
+ * The second is why the connection join is a LEFT join. An inner join drops a
+ * workflow with no connections before this function can see it at all — not in
+ * `units`, not in `unrunnable`, and therefore not in the set of ids the sweep
+ * writes `status` for, so it went on displaying `active` while doing nothing.
  */
-export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflows> {
+export async function loadDispatchableWorkflows(): Promise<WorkflowLoadResult> {
   const rows = await db
     .select({
       workflowId: emailWorkflows.id,
@@ -101,23 +113,35 @@ export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflows
     })
     .from(emailWorkflows)
     .innerJoin(agents, eq(agents.id, emailWorkflows.agentId))
-    .innerJoin(emailWorkflowConnections, eq(emailWorkflowConnections.workflowId, emailWorkflows.id))
+    .leftJoin(emailWorkflowConnections, eq(emailWorkflowConnections.workflowId, emailWorkflows.id))
     .where(eq(emailWorkflows.enabled, true));
 
   const units: DispatchableWorkflow[] = [];
-  // Keyed by workflow id: a workflow drops on every one of its connection rows
-  // (the recipient does not depend on the connection), and the sweep writes one
-  // `status` per workflow — so report it once rather than once per mailbox.
-  const undeliverable = new Map<string, UndeliverableWorkflow>();
+  // Keyed by workflow id: every reason is a property of the workflow, so it
+  // holds on all of its connection rows, and the sweep writes one `status` per
+  // workflow — report it once rather than once per mailbox.
+  const unrunnable = new Map<string, UnrunnableWorkflow>();
+  const report = (row: (typeof rows)[number], reason: UnrunnableReason) => {
+    unrunnable.set(row.workflowId, {
+      workflowId: row.workflowId,
+      agentId: row.agentId,
+      name: row.name,
+      reason,
+    });
+  };
   for (const row of rows) {
+    // The LEFT join's unmatched row: an enabled workflow with no connections at
+    // all. Checked first because it is the row-shape question — the recipient
+    // is moot for a workflow with nothing to read. A workflow that has lost both
+    // its mailboxes and its recipient reports only this one; the operator hits
+    // the other on the next pass, once this is fixed.
+    if (row.connectionId === null || row.sinceTs === null) {
+      report(row, "watches-no-mailbox");
+      continue;
+    }
     const recipientUserIds = resolveRecipients(row);
     if (recipientUserIds.length === 0) {
-      undeliverable.set(row.workflowId, {
-        workflowId: row.workflowId,
-        agentId: row.agentId,
-        name: row.name,
-        reason: row.isPersonal ? "personal-agent-has-no-owner" : "shared-agent-has-no-creator",
-      });
+      report(row, row.isPersonal ? "personal-agent-has-no-owner" : "shared-agent-has-no-creator");
       continue;
     }
     units.push({
@@ -134,13 +158,13 @@ export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflows
       sweepWindowDays: row.sweepWindowDays,
     });
   }
-  return { units, undeliverable: [...undeliverable.values()] };
+  return { units, unrunnable: [...unrunnable.values()] };
 }
 
 /**
  * Scope model (design §7): a personal agent's workflow notifies its owner; a
  * shared agent's workflow notifies its creator. Returns `[]` when no recipient
- * can be resolved, which the caller drops and reports as undeliverable.
+ * can be resolved, which the caller drops and reports as unrunnable.
  */
 function resolveRecipients(row: {
   isPersonal: boolean;

--- a/packages/web/src/lib/email-workflows/sweep.ts
+++ b/packages/web/src/lib/email-workflows/sweep.ts
@@ -67,7 +67,7 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
   const reset = await resetStuckProcessingEmails(deps.graceMs ?? DEFAULT_STUCK_GRACE_MS);
   await auditClaimResets(reset, crypto.randomUUID());
 
-  const { units, undeliverable } = await loadDispatchableWorkflows();
+  const { units, unrunnable } = await loadDispatchableWorkflows();
 
   // `status` is per workflow, but a unit of work is per (workflow × connection)
   // (D9). Collect each unit's health first and write the column once, so a
@@ -76,18 +76,18 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
   const failedWorkflowIds = new Set<string>();
   const seenWorkflowIds = new Set<string>();
 
-  // A workflow the loader could resolve no recipient for never becomes a unit of
-  // work at all: nothing runs, nothing throws, and the pass completes cleanly —
+  // A workflow the loader could emit no unit of work for never runs at all:
+  // nothing is dispatched, nothing throws, and the pass completes cleanly —
   // while the row stays `enabled: true` and the Automations UI keeps showing it
   // that way. That is a fault, and this is the only place that can say so:
   // `enabled` is the user's intent, `status` is what actually happens to it.
   //
-  // Disjoint from `units` by construction — the recipient is resolved from
-  // workflow and agent columns alone, so a workflow drops on all of its
+  // Disjoint from `units` by construction — every reason the loader reports is a
+  // property of the workflow alone, so a workflow drops on all of its
   // connections or on none — which is why adding to both sets here cannot
   // contradict a healthy unit below.
-  const undeliverableById = new Map(undeliverable.map((dropped) => [dropped.workflowId, dropped]));
-  for (const workflowId of undeliverableById.keys()) {
+  const unrunnableById = new Map(unrunnable.map((dropped) => [dropped.workflowId, dropped]));
+  for (const workflowId of unrunnableById.keys()) {
     seenWorkflowIds.add(workflowId);
     failedWorkflowIds.add(workflowId);
   }
@@ -119,8 +119,11 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
       // surfaces as the workflow's health status. One bad mailbox must never
       // stall the rest of the sweep.
       failedWorkflowIds.add(unit.workflow.id);
+      // The name is snapshotted beside the id, same rule as an audit row
+      // (AGENTS.md): an id alone sends the reader to the database to find out
+      // which automation broke, and to nothing at all once it is deleted.
       console.error(
-        `reconciliation sweep: workflow ${unit.workflow.id} failed on connection ${unit.workflow.connectionId}`,
+        `reconciliation sweep: workflow ${unit.workflow.id} ("${unit.workflow.name}") failed on connection ${unit.workflow.connectionId}`,
         err
       );
     }
@@ -134,22 +137,28 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
       workflowId,
       failedWorkflowIds.has(workflowId) ? "error" : "active"
     );
-    const dropped = undeliverableById.get(workflowId);
-    // Only on the transition. This sweep runs every minute and an undeliverable
-    // workflow cannot fix itself, so a line per pass is ~1400 identical lines a
-    // day per broken workflow — volume that gets a logger filtered out rather
-    // than read. The durable trace is the `status` column (and the badge the UI
-    // renders from it); this line only timestamps the moment it changed.
+    const dropped = unrunnableById.get(workflowId);
+    // Only on the transition. This sweep runs every minute and a workflow that
+    // cannot run will not fix itself, so a line per pass is ~1400 identical
+    // lines a day per broken workflow — volume that gets a logger filtered out
+    // rather than read. The durable trace is the `status` column (and the badge
+    // the UI renders from it); this line only timestamps the moment it changed.
     //
     // The cost of keying on the transition: a workflow already sitting at
     // `error` for a broken mailbox, which then loses its recipient, changes
     // cause without changing status and so is not re-logged. It still reads
     // `error`, which is the claim that matters.
+    //
+    // `error`, not `warn`, and deliberately: the broken-mailbox failure above
+    // logs at error on every single pass, while this one logs once in the
+    // workflow's lifetime. The quieter signal must not also be the lower
+    // severity, or an operator filtering on error sees the loud fault and never
+    // the silent one.
     if (changed && dropped) {
-      console.warn(
+      console.error(
         `reconciliation sweep: workflow ${dropped.workflowId} ("${dropped.name}") on agent ` +
-          `${dropped.agentId} is enabled but has nobody to notify (${dropped.reason}) — it is ` +
-          `marked error and dispatches nothing until it has a recipient again`
+          `${dropped.agentId} is enabled but cannot run (${dropped.reason}) — it is marked ` +
+          `error and dispatches nothing until that is fixed`
       );
     }
   }

--- a/packages/web/src/lib/email-workflows/sweep.ts
+++ b/packages/web/src/lib/email-workflows/sweep.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, ne } from "drizzle-orm";
 
 import { db } from "@/db";
 import { emailWorkflows } from "@/db/schema";
@@ -67,7 +67,7 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
   const reset = await resetStuckProcessingEmails(deps.graceMs ?? DEFAULT_STUCK_GRACE_MS);
   await auditClaimResets(reset, crypto.randomUUID());
 
-  const units = await loadDispatchableWorkflows();
+  const { units, undeliverable } = await loadDispatchableWorkflows();
 
   // `status` is per workflow, but a unit of work is per (workflow × connection)
   // (D9). Collect each unit's health first and write the column once, so a
@@ -75,6 +75,22 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
   // whichever connection the loader happened to return last.
   const failedWorkflowIds = new Set<string>();
   const seenWorkflowIds = new Set<string>();
+
+  // A workflow the loader could resolve no recipient for never becomes a unit of
+  // work at all: nothing runs, nothing throws, and the pass completes cleanly —
+  // while the row stays `enabled: true` and the Automations UI keeps showing it
+  // that way. That is a fault, and this is the only place that can say so:
+  // `enabled` is the user's intent, `status` is what actually happens to it.
+  //
+  // Disjoint from `units` by construction — the recipient is resolved from
+  // workflow and agent columns alone, so a workflow drops on all of its
+  // connections or on none — which is why adding to both sets here cannot
+  // contradict a healthy unit below.
+  const undeliverableById = new Map(undeliverable.map((dropped) => [dropped.workflowId, dropped]));
+  for (const workflowId of undeliverableById.keys()) {
+    seenWorkflowIds.add(workflowId);
+    failedWorkflowIds.add(workflowId);
+  }
 
   for (const unit of units) {
     seenWorkflowIds.add(unit.workflow.id);
@@ -114,7 +130,28 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
     // Not a latch: a clean pass clears a previous `error`, otherwise any blip
     // would need manual intervention — and the loader deliberately does not gate
     // on `status`, so the workflow would keep running while displaying `error`.
-    await setWorkflowStatus(workflowId, failedWorkflowIds.has(workflowId) ? "error" : "active");
+    const changed = await setWorkflowStatus(
+      workflowId,
+      failedWorkflowIds.has(workflowId) ? "error" : "active"
+    );
+    const dropped = undeliverableById.get(workflowId);
+    // Only on the transition. This sweep runs every minute and an undeliverable
+    // workflow cannot fix itself, so a line per pass is ~1400 identical lines a
+    // day per broken workflow — volume that gets a logger filtered out rather
+    // than read. The durable trace is the `status` column (and the badge the UI
+    // renders from it); this line only timestamps the moment it changed.
+    //
+    // The cost of keying on the transition: a workflow already sitting at
+    // `error` for a broken mailbox, which then loses its recipient, changes
+    // cause without changing status and so is not re-logged. It still reads
+    // `error`, which is the claim that matters.
+    if (changed && dropped) {
+      console.warn(
+        `reconciliation sweep: workflow ${dropped.workflowId} ("${dropped.name}") on agent ` +
+          `${dropped.agentId} is enabled but has nobody to notify (${dropped.reason}) — it is ` +
+          `marked error and dispatches nothing until it has a recipient again`
+      );
+    }
   }
 }
 
@@ -175,8 +212,26 @@ async function sweepUnit(
   await dispatchEmails({ workflow: unit.workflow, emails: fresh, runAgent: deps.runAgent });
 }
 
-async function setWorkflowStatus(workflowId: string, status: EmailWorkflowStatus): Promise<void> {
-  await db.update(emailWorkflows).set({ status }).where(eq(emailWorkflows.id, workflowId));
+/**
+ * Write the health status, and report whether it actually changed.
+ *
+ * The write is conditional on the value differing, which buys two things. An
+ * unchanged state is not an event — the automations PATCH route already treats
+ * a no-op toggle that way — and this sweep runs every minute, so an
+ * unconditional write would rewrite every workflow row ~1400 times a day to
+ * store the value it already held. The returned flag is what lets a permanent
+ * fault be logged once instead of once per pass.
+ */
+async function setWorkflowStatus(
+  workflowId: string,
+  status: EmailWorkflowStatus
+): Promise<boolean> {
+  const changed = await db
+    .update(emailWorkflows)
+    .set({ status })
+    .where(and(eq(emailWorkflows.id, workflowId), ne(emailWorkflows.status, status)))
+    .returning({ id: emailWorkflows.id });
+  return changed.length > 0;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1097.

`email_workflows.created_by` is now `ON DELETE SET NULL`, so erasing the user who created a shared agent's workflow leaves the row behind, still `enabled: true`. `loadDispatchableWorkflows` resolves no recipient for it and drops it — correctly, since `dispatchEmails` rejects an empty recipient set — but it dropped it **in silence**: no log line, no audit row, no change to `status`, and the Automations UI still showing it as enabled.

Before the FK change that state was unreachable: the `DELETE` would have failed on the FK. So #1097 traded a hard failure for a silent one, which is the failure shape AGENTS.md objects to ("a rejected request must leave a trace").

Reviewing that fix turned up a second door into the same dead end, so this PR closes both.

## What changed

**The loader reports what it drops.** `loadDispatchableWorkflows` now returns `{ units, unrunnable }`. One entry per *workflow*, not per connection — every reason is a property of the workflow alone, so it drops on all of its mailboxes or on none. Each entry carries the agent id, the snapshotted name, and which of three misconfigurations it is; they need different fixes, so they are reported apart:

| reason | how it happens |
| --- | --- |
| `shared-agent-has-no-creator` | the creator's account was erased (#1097's `SET NULL`) |
| `watches-no-mailbox` | `DELETE /api/integrations/:connectionId` cascaded the workflow's last connection away |
| `personal-agent-has-no-owner` | a shape the app never produces; reported for completeness |

**The connection join is a LEFT join.** That is the second door, and it was the worse one. With an inner join an enabled workflow with no connection rows produced no row at all — absent from `units`, absent from the report, and therefore absent from the set of ids the sweep writes `status` for. It went on displaying **Active** while dispatching nothing, where the missing-recipient case at least reaches `error`. Disconnecting a mailbox is a routine admin action, and `DELETE /api/integrations/:connectionId` does not touch workflows.

**The sweep turns the report into health.** It is already the `status` writer, so an unrunnable workflow joins `failedWorkflowIds` and lands on `status: "error"` — the badge the Automations tab renders. `enabled` stays the user's intent; `status` says what actually happens to it. Recovery is automatic on the next pass: `error` is a signal here, not a latch.

**The log line fires on the transition only.** `setWorkflowStatus` now writes conditionally and reports whether the value really changed. At the one-minute cadence a per-pass line would be ~1400 identical lines a day per broken workflow — the volume that gets a logger filtered out rather than read. The durable trace is the column; the line timestamps the moment it changed. Falling out of the same change: every workflow row stops being rewritten every minute to store the value it already held.

It logs at `error`, not `warn`. Its sibling — a mailbox that will not open — logs at error on *every* pass, while this one logs once in a workflow's lifetime; the quieter signal must not also carry the lower severity. That sibling line now also snapshots the workflow name beside its id, so both causes read the same way in the log.

No audit row: this condition is re-observed every cadence, and `appendAuditLog` serializes on one advisory lock, so an unbounded stream of rows would queue every other audit write behind itself.

## Docs

`concepts/agent-settings.mdx` described `Error` as "the last run hit a problem". That was already wrong — a failed run is finalized as an outcome and never reaches this path — so the entry now names all three causes and is precise about recovery: repairing a connection's credentials moves the workflow back to **Active** by itself, while the other two need it recreated, because a workflow's mailboxes and recipient are fixed at creation (`PATCH /api/automations/[id]` accepts `enabled` and nothing else).

## Tests

- Loader (5 new): reports the shared-agent drop with its reason; distinguishes the personal-agent reason; reports a workflow that watches no mailboxes; reports once however many mailboxes the workflow watches; reports nothing for a merely *disabled* workflow.
- #1097's own test now also asserts the drop is reported, tying the trace to the FK change that made the state reachable.
- Sweep (5 new): marks the workflow `error` for a missing recipient and proves its mailbox is never opened; marks it `error` after its last connection is deleted — reproduced through the real integration-delete cascade, not by seeding the end state; recovers to `active` once a recipient exists again; logs once across two passes, naming the reason and the snapshotted name; names the workflow, not just its id, when a mailbox will not open.

## Verification

- `pnpm -C packages/web test:db` — 472 passed (64 files)
- `pnpm test` — 11170 passed, 18 skipped (785 files)
- `pnpm test:scripts` — 966 passed
- `pnpm -C docs test`, `pnpm -C docs build`, `check:anchors` (70 pages), `check:rendered` (70 pages) — clean
- `pnpm -C packages/web typecheck`, `pnpm -C packages/web lint` (0 errors), `pnpm format:check` — clean
