### PR TITLE
fix: root-owned TOOLS.md blocked every agent save and disabled pinchy-email

### DIFF
--- a/config/fix-config-permissions.sh
+++ b/config/fix-config-permissions.sh
@@ -83,6 +83,43 @@ fix_config_permissions() {
     find "$OPENCLAW_STATE_DIR/agents" -name "auth-profiles.json" -type f -not -perm 0600 \
         -exec chmod 0600 {} \; 2>/dev/null || true
 
+    # The same trap, one directory over: workspaces/<id>/ holds the bootstrap
+    # files (AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md)
+    # that BOTH sides write. Pinchy writes them as uid 999 from
+    # regenerateOpenClawConfig(); OpenClaw creates any that are missing from its
+    # own bundled template, as root, when it boots the agent.
+    #
+    # Pinchy opens the race itself. writeToolsFile() DELETES TOOLS.md for an
+    # agent with no mailbox (rmSync — so a revoked permission cannot leave a
+    # stale mailbox identity behind), and the next agent start finds the file
+    # missing and re-creates it root-owned. Grant that agent an email connection
+    # afterwards and Pinchy's writeFileSync gets EACCES forever.
+    #
+    # This reached production (#1095): `pinchy.heypinchy.com` carried two
+    # root-owned TOOLS.md files on 2026-08-04 and had rejected every agent save
+    # since 2026-08-02 08:25, the last successful `agent.updated` audit row. The
+    # two symptoms looked unrelated and were one bug — the EACCES aborts
+    # regenerateOpenClawConfig() before the push, so the model the user saved
+    # never reached the runtime AND pinchy-email never entered the plugin list,
+    # leaving the agent to truthfully answer that it has no mailbox access while
+    # the UI showed the connection saved.
+    #
+    # Ownership again, not mode: the file lands 0644 root-owned, which already
+    # grants uid 999 read — it is the WRITE that is denied, and root ignores any
+    # chmod we make. The directory needs it too, or a deleted TOOLS.md can never
+    # be recreated.
+    #
+    # Scoped to the bootstrap filenames rather than a recursive sweep: this runs
+    # on a 50 ms tick, and workspaces also hold uploads/ and memory/ with
+    # unbounded file counts. Same `! -uid` ctime gate as above.
+    find "$OPENCLAW_STATE_DIR/workspaces" -maxdepth 1 -type d ! -uid "$PINCHY_UID" \
+        -exec chown "$PINCHY_UID:$PINCHY_GID" {} \; 2>/dev/null || true
+    find "$OPENCLAW_STATE_DIR/workspaces" -mindepth 2 -maxdepth 2 -type f \
+        \( -name "AGENTS.md" -o -name "SOUL.md" -o -name "TOOLS.md" \
+        -o -name "IDENTITY.md" -o -name "USER.md" -o -name "HEARTBEAT.md" \) \
+        ! -uid "$PINCHY_UID" \
+        -exec chown "$PINCHY_UID:$PINCHY_GID" {} \; 2>/dev/null || true
+
     # Cross-uid read access for Pinchy's self-service diagnostics export.
     # OpenClaw writes per-agent sessions.json and *.trajectory.jsonl as root
     # under agents/<agentId>/sessions/ — with default umask these emerge

--- a/config/fix-config-permissions.sh
+++ b/config/fix-config-permissions.sh
@@ -112,6 +112,12 @@ fix_config_permissions() {
     # Scoped to the bootstrap filenames rather than a recursive sweep: this runs
     # on a 50 ms tick, and workspaces also hold uploads/ and memory/ with
     # unbounded file counts. Same `! -uid` ctime gate as above.
+    #
+    # The directory pass has no `-mindepth`, so it covers workspaces/ ITSELF as
+    # well as workspaces/<id> — deliberately. ensureWorkspace() mkdirs a new
+    # agent's directory as uid 999 and needs write permission on the parent to
+    # do it, so a root-owned workspaces/ breaks every agent that does not exist
+    # yet, not just the saves of the ones that do.
     find "$OPENCLAW_STATE_DIR/workspaces" -maxdepth 1 -type d ! -uid "$PINCHY_UID" \
         -exec chown "$PINCHY_UID:$PINCHY_GID" {} \; 2>/dev/null || true
     find "$OPENCLAW_STATE_DIR/workspaces" -mindepth 2 -maxdepth 2 -type f \

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -221,7 +221,9 @@ The same shared-volume mix-up as above reached the agent's workspace, where the 
 
 Two symptoms, one cause, and they didn't look related. Saving an agent's settings failed with "Failed to save some settings" and nothing more. And an agent with a connected mailbox insisted it had no email access at all — truthfully, because its email tools never reached the runtime either, while the **Permissions** tab showed the connection saved.
 
-The runtime now hands those files back on start and on every tick, so an affected install repairs itself on upgrade — no manual step. Saving also tells you what actually happened now: if a change is stored but can't reach the runtime, it says so and names the reason, instead of reporting a flat failure.
+An affected install repairs itself on upgrade, with no manual step and nothing to configure. Pinchy now takes such a file back the moment it writes it — so the first save after upgrading is already the fix — and the runtime hands them over on start and on every tick as well, which also covers files Pinchy isn't currently writing.
+
+Saving also tells you what actually happened now: if a change is stored but can't reach the runtime, it says so and names the reason, instead of reporting a flat failure.
 
 #### Ollama Cloud catalog: one model removed, two gain vision
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -215,6 +215,14 @@ Pinchy and the agent runtime share one config volume under two different users, 
 
 The runtime now hands that directory back on start and on every tick, so the case should not arise. If it ever does, saving a provider key tells you plainly that it saved but couldn't be applied, and the affected agent says it has no API key instead of going quiet. Nothing to configure.
 
+#### An agent that couldn't save, or couldn't see its mailbox, can again
+
+The same shared-volume mix-up as above reached the agent's workspace, where the files that brief an agent live. If the runtime created one of them first, it came out owned by the wrong user, and from then on Pinchy couldn't write it — which stopped the whole config from reaching the runtime.
+
+Two symptoms, one cause, and they didn't look related. Saving an agent's settings failed with "Failed to save some settings" and nothing more. And an agent with a connected mailbox insisted it had no email access at all — truthfully, because its email tools never reached the runtime either, while the **Permissions** tab showed the connection saved.
+
+The runtime now hands those files back on start and on every tick, so an affected install repairs itself on upgrade — no manual step. Saving also tells you what actually happened now: if a change is stored but can't reach the runtime, it says so and names the reason, instead of reporting a flat failure.
+
 #### Ollama Cloud catalog: one model removed, two gain vision
 
 Re-verified against the live API. `nemotron-3-nano:30b` is **no longer offered**: it now skips the tool call outright in most attempts, which for an agent looks like deciding not to act rather than failing. Any agent pinned to it needs a new model — the fast tier's general pick (`deepseek-v4-flash`) is the closest equivalent.

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -223,7 +223,7 @@ Two symptoms, one cause, and they didn't look related. Saving an agent's setting
 
 An affected install repairs itself on upgrade, with no manual step and nothing to configure. Pinchy now takes such a file back the moment it writes it — so the first save after upgrading is already the fix — and the runtime hands them over on start and on every tick as well, which also covers files Pinchy isn't currently writing.
 
-Saving also tells you what actually happened now: if a change is stored but can't reach the runtime, it says so and names the reason, instead of reporting a flat failure.
+Saving also tells you what actually happened now, instead of reporting a flat failure. A change that was stored but hasn't reached the agent yet says exactly that — and so does one that never got stored, which is the case where trying again is the right move. Both name the reason.
 
 #### Ollama Cloud catalog: one model removed, two gain vision
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -242,12 +242,19 @@ Update an agent's settings. Any combination of fields can be included.
 - `401` — not authenticated
 - `403` — only admins can change `allowedTools` or `pluginConfig`
 - `404` — agent not found
-- `500` — the update was **saved**, but could not be applied to the agent runtime
+- `500` — the update failed, either before or after it was stored
 
-The `500` is worth handling deliberately, because it does not mean the request
-was rejected. Pinchy writes the agent row first and then regenerates the runtime
-configuration; if that second step fails, the change is already persisted and a
-later save (or a restart) applies it. The response body names the reason:
+The `500` is worth handling deliberately, because it covers two outcomes that
+call for different responses. Pinchy stores the agent row first and then
+regenerates the runtime configuration, and the message tells you which step
+gave out:
+
+```json
+{ "error": "Could not update the agent: <cause>" }
+```
+
+Nothing was stored. The agent is unchanged and the request can simply be
+repeated.
 
 ```json
 {
@@ -255,8 +262,11 @@ later save (or a restart) applies it. The response body names the reason:
 }
 ```
 
-Retrying is safe — the update is idempotent — but treating the change as
-discarded is not.
+The change **is** stored; only the runtime has not caught up. A later save or a
+restart applies it. Retrying is safe — the update is idempotent — but treating
+the change as discarded is not. Pinchy records this case in the audit trail as
+an `agent.updated` entry with outcome `failure`, so a change that reached the
+database but not the runtime still leaves a trace.
 
 ### `DELETE /api/agents/:id`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -242,6 +242,21 @@ Update an agent's settings. Any combination of fields can be included.
 - `401` — not authenticated
 - `403` — only admins can change `allowedTools` or `pluginConfig`
 - `404` — agent not found
+- `500` — the update was **saved**, but could not be applied to the agent runtime
+
+The `500` is worth handling deliberately, because it does not mean the request
+was rejected. Pinchy writes the agent row first and then regenerates the runtime
+configuration; if that second step fails, the change is already persisted and a
+later save (or a restart) applies it. The response body names the reason:
+
+```json
+{
+  "error": "Settings were saved, but the agent runtime was not updated: <cause>"
+}
+```
+
+Retrying is safe — the update is idempotent — but treating the change as
+discarded is not.
 
 ### `DELETE /api/agents/:id`
 

--- a/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// When regenerateOpenClawConfig() throws, updateAgent() has ALREADY written the
+// agents row — the DB update runs first and there is no transaction around the
+// pair. The route had no try/catch, so the throw escaped into Next.js, which
+// answers 500 with a framework body carrying no `error` field. The client then
+// showed a flat "Failed to save some settings".
+//
+// That message is wrong in both directions, and the production incident (#1095)
+// is what it costs. The real state was: model saved to the DB, runtime never
+// told, no audit row, and the cause (EACCES on a root-owned TOOLS.md) visible
+// only in `docker compose logs`. The user retried four times in three minutes.
+//
+// So the route must answer the two questions the flat message destroyed:
+// WHAT persisted, and WHY the rest did not.
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("@/lib/audit", () => ({ appendAuditLog: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: vi.fn().mockResolvedValue([]),
+  getAgentGroupIds: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/auth", () => {
+  const mockGetSession = vi.fn();
+  return { getSession: mockGetSession, auth: { api: { getSession: mockGetSession } } };
+});
+vi.mock("@/lib/agents", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/agents")>();
+  return { ...actual, updateAgent: vi.fn() };
+});
+vi.mock("@/lib/openclaw-config", () => ({
+  regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/workspace", () => ({
+  ensureWorkspace: vi.fn(),
+  writeWorkspaceFile: vi.fn(),
+  writeWorkspaceFileInternal: vi.fn(),
+  writeIdentityFile: vi.fn(),
+}));
+vi.mock("@/lib/telegram-allow-store", () => ({
+  recalculateTelegramAllowStores: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
+}));
+vi.mock("@/lib/provider-models", () => ({
+  fetchProviderModels: vi.fn().mockResolvedValue([
+    {
+      id: "ollama-cloud",
+      name: "Ollama Cloud",
+      models: [{ id: "ollama-cloud/deepseek-v4-pro", name: "deepseek-v4-pro" }],
+    },
+  ]),
+}));
+vi.mock("@/db", () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+    delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
+    })),
+  },
+}));
+vi.mock("@/db/schema", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/db/schema")>();
+  return { ...actual };
+});
+
+import { auth } from "@/lib/auth";
+import { updateAgent } from "@/lib/agents";
+import { db } from "@/db";
+
+function mockAgent(agent: Record<string, unknown>) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([agent]) }),
+  } as never);
+}
+
+function adminSession() {
+  vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+    user: { id: "user-1", role: "admin" },
+    expires: "",
+  } as never);
+}
+
+function patchModel() {
+  return new NextRequest("http://localhost/api/agents/agent-1", {
+    method: "PATCH",
+    body: JSON.stringify({ model: "ollama-cloud/deepseek-v4-pro" }),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** The exact shape production failed with: EACCES on a root-owned TOOLS.md. */
+function eaccesOnToolsFile(): Error {
+  const err: NodeJS.ErrnoException = new Error(
+    "EACCES: permission denied, open '/openclaw-config/workspaces/agent-1/TOOLS.md'"
+  );
+  err.code = "EACCES";
+  err.errno = -13;
+  return err;
+}
+
+describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", () => {
+  let PATCH: typeof import("@/app/api/agents/[agentId]/route").PATCH;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/agents/[agentId]/route");
+    PATCH = mod.PATCH;
+  });
+
+  it("answers with a JSON error instead of letting the throw escape to Next.js", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(eaccesOnToolsFile());
+
+    const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(typeof body.error).toBe("string");
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  it("names the underlying cause, so the operator does not need container logs", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(eaccesOnToolsFile());
+
+    const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    // The whole point: "Failed to save some settings" sent the user to us. The
+    // response has to carry what `docker compose logs` carried.
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining("EACCES") as unknown as string,
+    });
+  });
+
+  it("says the settings were saved but the runtime was not updated", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(eaccesOnToolsFile());
+
+    const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    // updateAgent writes the row and THEN regenerates; a failure past that point
+    // leaves the change persisted. Reporting a flat failure is a lie the user
+    // acts on — they retry, and each retry looks like it changed nothing.
+    const { error } = (await res.json()) as { error: string };
+    expect(error.toLowerCase()).toContain("saved");
+    expect(error.toLowerCase()).toMatch(/runtime|restart|not applied/);
+  });
+});

--- a/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
@@ -15,6 +15,29 @@ import { NextRequest } from "next/server";
 // So the route must answer the two questions the flat message destroyed:
 // WHAT persisted, and WHY the rest did not.
 
+// `after()` defers the audit write past the response. Run it inline so the
+// assertions can see it, matching the convention in the other route tests.
+const pendingAfter: Promise<unknown>[] = [];
+async function flushAfter(): Promise<void> {
+  while (pendingAfter.length > 0) {
+    await Promise.allSettled(pendingAfter.splice(0));
+  }
+}
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  return {
+    ...actual,
+    after: vi.fn((fn: () => void | Promise<void>) => {
+      try {
+        const result = fn();
+        if (result instanceof Promise) pendingAfter.push(result.catch(() => {}));
+      } catch {
+        // Swallowed — matches Next's after() error handling.
+      }
+    }),
+  };
+});
+
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
 vi.mock("@/lib/audit", () => ({ appendAuditLog: vi.fn().mockResolvedValue(undefined) }));
@@ -70,7 +93,8 @@ vi.mock("@/db/schema", async (importOriginal) => {
 });
 
 import { auth } from "@/lib/auth";
-import { updateAgent } from "@/lib/agents";
+import { updateAgent, AgentRuntimeUpdateError } from "@/lib/agents";
+import { appendAuditLog } from "@/lib/audit";
 import { db } from "@/db";
 
 function mockAgent(agent: Record<string, unknown>) {
@@ -104,6 +128,21 @@ function eaccesOnToolsFile(): Error {
   return err;
 }
 
+const PERSISTED_ROW = {
+  id: "agent-1",
+  name: "Penny",
+  model: "ollama-cloud/deepseek-v4-pro",
+} as never;
+
+/**
+ * The row was written, the runtime push then failed — the production case.
+ * updateAgent marks this with its own error type precisely so the route does
+ * not have to guess which half broke.
+ */
+function runtimeFailure(): AgentRuntimeUpdateError {
+  return new AgentRuntimeUpdateError(PERSISTED_ROW, eaccesOnToolsFile());
+}
+
 describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", () => {
   let PATCH: typeof import("@/app/api/agents/[agentId]/route").PATCH;
 
@@ -116,7 +155,7 @@ describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", 
   it("answers with a JSON error instead of letting the throw escape to Next.js", async () => {
     adminSession();
     mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
-    vi.mocked(updateAgent).mockRejectedValueOnce(eaccesOnToolsFile());
+    vi.mocked(updateAgent).mockRejectedValueOnce(runtimeFailure());
 
     const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
 
@@ -129,7 +168,7 @@ describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", 
   it("names the underlying cause, so the operator does not need container logs", async () => {
     adminSession();
     mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
-    vi.mocked(updateAgent).mockRejectedValueOnce(eaccesOnToolsFile());
+    vi.mocked(updateAgent).mockRejectedValueOnce(runtimeFailure());
 
     const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
 
@@ -143,7 +182,7 @@ describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", 
   it("says the settings were saved but the runtime was not updated", async () => {
     adminSession();
     mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
-    vi.mocked(updateAgent).mockRejectedValueOnce(eaccesOnToolsFile());
+    vi.mocked(updateAgent).mockRejectedValueOnce(runtimeFailure());
 
     const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
 
@@ -153,5 +192,60 @@ describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", 
     const { error } = (await res.json()) as { error: string };
     expect(error.toLowerCase()).toContain("saved");
     expect(error.toLowerCase()).toMatch(/runtime|restart|not applied/);
+  });
+
+  it("does NOT claim the settings were saved when the write itself failed", async () => {
+    // The other half of the same honesty problem. updateAgent throws from two
+    // places — the row write and the runtime push — and "Settings were saved"
+    // is only true for the second. Told it for a failed DB write, a user stops
+    // retrying a change that never landed, which is the flat message's mistake
+    // pointing the other way.
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(new Error("connection terminated unexpectedly"));
+
+    const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    expect(res.status).toBe(500);
+    const { error } = (await res.json()) as { error: string };
+    expect(error.toLowerCase()).not.toContain("saved");
+    expect(error).toContain("connection terminated unexpectedly");
+  });
+
+  it("writes an agent.updated audit row with outcome failure — the row DID change", async () => {
+    // A regeneration failure is a state change: the model column already holds
+    // the new value. AGENTS.md is explicit that every state-changing route
+    // writes an audit entry, and `outcome: "failure"` exists for exactly this.
+    // Returning 500 without one leaves the change with no trace at all.
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(runtimeFailure());
+
+    await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+    await flushAfter();
+
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "agent.updated",
+        resource: "agent:agent-1",
+        outcome: "failure",
+        detail: expect.objectContaining({
+          changes: { model: { from: "old", to: "ollama-cloud/deepseek-v4-pro" } },
+        }) as unknown,
+      })
+    );
+  });
+
+  it("does not write an audit row when nothing was persisted", async () => {
+    // The mirror of the test above: a failed row write changed nothing, so an
+    // `agent.updated` row would assert a change that never happened.
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(new Error("connection terminated unexpectedly"));
+
+    await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+    await flushAfter();
+
+    expect(appendAuditLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-config-failure.test.ts
@@ -40,7 +40,13 @@ vi.mock("next/server", async (importOriginal) => {
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
-vi.mock("@/lib/audit", () => ({ appendAuditLog: vi.fn().mockResolvedValue(undefined) }));
+// Only appendAuditLog is faked. safeProviderError stays real — the assertions
+// below are about the sanitising the route actually applies, and a stubbed
+// version would let an unsanitised detail pass.
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return { ...actual, appendAuditLog: vi.fn().mockResolvedValue(undefined) };
+});
 vi.mock("@/lib/groups", () => ({
   getUserGroupIds: vi.fn().mockResolvedValue([]),
   getAgentGroupIds: vi.fn().mockResolvedValue([]),
@@ -234,6 +240,68 @@ describe("PATCH /api/agents/[agentId] — config regeneration failure (#1095)", 
         }) as unknown,
       })
     );
+  });
+
+  it("caps the cause, so a long one cannot evict the diff from the row", async () => {
+    // appendAuditLog runs truncateDetail, and truncateDetail does NOT trim the
+    // offending field — it replaces the whole detail object with a summary
+    // blob. So an uncapped error string takes `changes` down with it, on the
+    // one row whose entire value is recording what changed. safeAuditPath's
+    // doc comment spells out this failure mode for caller-controlled fields.
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    const huge = new Error(`EACCES: ${"x".repeat(5000)}`);
+    vi.mocked(updateAgent).mockRejectedValueOnce(new AgentRuntimeUpdateError(PERSISTED_ROW, huge));
+
+    await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+    await flushAfter();
+
+    const entry = vi.mocked(appendAuditLog).mock.calls[0][0];
+    const detail = entry.detail as { changes: unknown; runtimeUpdate: { error: string } };
+    expect(Buffer.byteLength(detail.runtimeUpdate.error, "utf8")).toBeLessThanOrEqual(1024);
+    expect(detail.changes).toEqual({ model: { from: "old", to: "ollama-cloud/deepseek-v4-pro" } });
+  });
+
+  it("keeps an email address out of the audit detail", async () => {
+    // AGENTS.md: never write plaintext email addresses into audit `detail` —
+    // the row is immutable and HMAC-chained, so it cannot be rewritten later.
+    // Not hypothetical here: this code path exists because of TOOLS.md, the
+    // file that carries an agent's MAILBOX context, so a failure message from
+    // it is one of the likelier places for an address to appear.
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(
+      new AgentRuntimeUpdateError(
+        PERSISTED_ROW,
+        new Error("IMAP connection commercial@helmcraft.ai refused")
+      )
+    );
+
+    await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+    await flushAfter();
+
+    const entry = vi.mocked(appendAuditLog).mock.calls[0][0];
+    expect(JSON.stringify(entry.detail)).not.toContain("commercial@helmcraft.ai");
+  });
+
+  it("still gives the operator the unscrubbed cause in the response", async () => {
+    // The two channels get different treatment on purpose. The audit row is
+    // immutable, long-lived and subject to erasure requests; the response is
+    // ephemeral and goes only to the authenticated user who just triggered it
+    // — and stripping it there would undo the whole point of the change.
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Penny", model: "old", isPersonal: false, ownerId: null });
+    vi.mocked(updateAgent).mockRejectedValueOnce(
+      new AgentRuntimeUpdateError(
+        PERSISTED_ROW,
+        new Error("IMAP connection commercial@helmcraft.ai refused")
+      )
+    );
+
+    const res = await PATCH(patchModel(), { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    const { error } = (await res.json()) as { error: string };
+    expect(error).toContain("commercial@helmcraft.ai");
   });
 
   it("does not write an audit row when nothing was persisted", async () => {

--- a/packages/web/src/__tests__/components/agent-settings-save-error.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-save-error.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -120,9 +120,19 @@ async function save(user: ReturnType<typeof userEvent.setup>) {
   await user.click(dialogButtons[dialogButtons.length - 1]);
 }
 
+const realFetch = global.fetch;
+
 describe("agent settings save — surfacing why a save failed (#1095)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // `global.fetch` is process-wide. Vitest isolates test files today, so a
+    // leak would not cross into another file — but that is a property of the
+    // runner's config, not of this test, and it is one config flag away from
+    // being false.
+    global.fetch = realFetch;
   });
 
   it("shows the server's error message instead of a flat 'Failed to save'", async () => {

--- a/packages/web/src/__tests__/components/agent-settings-save-error.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-save-error.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// executeSave() checked `results.some((r) => !r.ok)` and threw the responses
+// away, so every failure — 400 validation, 403 permission, 500 EACCES — reached
+// the user as the same sentence: "Failed to save some settings".
+//
+// #1095 is what that costs. Production rejected every agent save for two days
+// because a root-owned TOOLS.md denied uid 999 the write; the response said so
+// and the client discarded it. The user retried four times, then asked us to
+// SSH into the box. AGENTS.md already states the rule this violates: "When a
+// client gives up on a response, it must say why. Quote the body."
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: () => ({ data: { user: { id: "u1", role: "admin" } } }) },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ agentId: "agent-1" }),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/chat/agent-1/settings",
+}));
+
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ triggerRestart: vi.fn() }),
+}));
+
+// The General tab is stubbed down to the one thing this test needs: a control
+// that marks the tab dirty, which is what enables the Save button.
+vi.mock("@/components/agent-settings-general", () => ({
+  AgentSettingsGeneral: ({
+    onChange,
+  }: {
+    onChange: (v: Record<string, unknown>, dirty: boolean) => void;
+  }) => (
+    <button
+      onClick={() =>
+        onChange(
+          {
+            name: "Penny",
+            tagline: null,
+            model: "ollama-cloud/deepseek-v4-pro",
+            starterPrompts: [],
+          },
+          true
+        )
+      }
+    >
+      change model
+    </button>
+  ),
+}));
+vi.mock("@/components/agent-settings-file", () => ({ AgentSettingsFile: () => <div /> }));
+vi.mock("@/components/agent-settings-personality", () => ({
+  AgentSettingsPersonality: () => <div />,
+}));
+vi.mock("@/components/agent-settings-permissions", () => ({
+  AgentSettingsPermissions: () => <div />,
+}));
+vi.mock("@/components/agent-settings-access", () => ({ AgentSettingsAccess: () => <div /> }));
+vi.mock("@/components/agent-settings-diagnostics", () => ({
+  AgentSettingsDiagnostics: () => <div />,
+}));
+vi.mock("@/components/agent-telegram-settings", () => ({ AgentTelegramSettings: () => <div /> }));
+
+import { AgentSettingsPageContent } from "@/components/agent-settings-page-content";
+
+const agent = {
+  id: "agent-1",
+  name: "Penny",
+  model: "ollama-cloud/deepseek-v4-pro",
+  allowedTools: [],
+  pluginConfig: null,
+  tagline: null,
+  avatarSeed: null,
+  personalityPresetId: null,
+  visibility: "restricted",
+  groupIds: [],
+  isPersonal: false,
+};
+
+/** GET everything, and answer the agent PATCH with `patchResponse`. */
+function mockFetch(patchResponse: { status: number; body: unknown }) {
+  global.fetch = vi.fn().mockImplementation((url: unknown, init?: { method?: string }) => {
+    if (init?.method === "PATCH") {
+      return Promise.resolve({
+        ok: false,
+        status: patchResponse.status,
+        json: () => Promise.resolve(patchResponse.body),
+        text: () => Promise.resolve(JSON.stringify(patchResponse.body)),
+      });
+    }
+    const path = String(url);
+    if (path.includes("/api/agents/agent-1")) {
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(agent) });
+    }
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) });
+  });
+}
+
+/** Dirty the General tab, then drive the Save + restart-confirm flow. */
+async function save(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole("button", { name: "change model" }));
+  await user.click(await screen.findByRole("button", { name: /Save & Restart/i }));
+  // A dirty General tab always needs a restart, so the confirm dialog opens.
+  const dialogButtons = await screen.findAllByRole("button", { name: /Save & Restart/i });
+  await user.click(dialogButtons[dialogButtons.length - 1]);
+}
+
+describe("agent settings save — surfacing why a save failed (#1095)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the server's error message instead of a flat 'Failed to save'", async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      status: 500,
+      body: {
+        error:
+          "Settings were saved, but the agent runtime was not updated: EACCES: permission denied, open '/openclaw-config/workspaces/agent-1/TOOLS.md'",
+      },
+    });
+
+    render(<AgentSettingsPageContent />);
+    await save(user);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+    expect(String(mockToastError.mock.calls[0][0])).toContain("EACCES");
+  });
+
+  it("surfaces a validation message the same way", async () => {
+    // Not an EACCES special case: any refusal the server explains must reach
+    // the user, or the next unfamiliar failure costs another debugging session.
+    const user = userEvent.setup();
+    mockFetch({ status: 400, body: { error: "Greeting message cannot be empty" } });
+
+    render(<AgentSettingsPageContent />);
+    await save(user);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+    expect(String(mockToastError.mock.calls[0][0])).toContain("Greeting message cannot be empty");
+  });
+
+  it("still reports a failure when the response carries no readable body", async () => {
+    // A crashed process or a proxy 502 answers with no JSON at all. The
+    // fallback must stay a failure — never a silent success.
+    const user = userEvent.setup();
+    global.fetch = vi.fn().mockImplementation((url: unknown, init?: { method?: string }) => {
+      if (init?.method === "PATCH") {
+        return Promise.resolve({
+          ok: false,
+          status: 502,
+          json: () => Promise.reject(new Error("Unexpected token < in JSON")),
+          text: () => Promise.resolve("<html>Bad Gateway</html>"),
+        });
+      }
+      const path = String(url);
+      if (path.includes("/api/agents/agent-1")) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(agent) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve([]) });
+    });
+
+    render(<AgentSettingsPageContent />);
+    await save(user);
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/agents-update.test.ts
+++ b/packages/web/src/__tests__/lib/agents-update.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/lib/openclaw-config", () => ({
 
 import { db } from "@/db";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
-import { updateAgent } from "@/lib/agents";
+import { updateAgent, AgentRuntimeUpdateError } from "@/lib/agents";
 
 describe("updateAgent", () => {
   beforeEach(() => {
@@ -80,5 +80,69 @@ describe("updateAgent", () => {
   it("does NOT call regenerateOpenClawConfig when only avatarSeed changes", async () => {
     await updateAgent("agent-1", { avatarSeed: "abc123" });
     expect(regenerateOpenClawConfig).not.toHaveBeenCalled();
+  });
+});
+
+// Two steps, two very different failures, and until #1095 the caller could not
+// tell them apart. The row is written FIRST and the runtime is told second, so:
+//
+//   - the write fails      → nothing persisted, the user must try again
+//   - the regeneration fails → the change IS persisted, the runtime is stale
+//
+// The first fix for #1095 caught both in one `catch` and answered "Settings
+// were saved, but the agent runtime was not updated" — true for the second,
+// and for the first the same class of unfounded claim as the flat "Failed to
+// save some settings" it replaced, only pointing the other way. A user who
+// believes it stops retrying a change that never landed.
+//
+// So the distinction lives in the type, not in string-matching an errno at the
+// route: only the regeneration failure is wrapped.
+describe("updateAgent — which half failed (#1095)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const returning = vi.fn().mockResolvedValue([mockAgent]);
+    const where = vi.fn().mockReturnValue({ returning });
+    const set = vi.fn().mockReturnValue({ where });
+    vi.mocked(db.update).mockReturnValue({ set } as never);
+  });
+
+  it("wraps a regeneration failure as AgentRuntimeUpdateError", async () => {
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(
+      new Error("EACCES: permission denied, open '/openclaw-config/workspaces/agent-1/TOOLS.md'")
+    );
+
+    await expect(updateAgent("agent-1", { model: "openai/gpt-5.4" })).rejects.toBeInstanceOf(
+      AgentRuntimeUpdateError
+    );
+  });
+
+  it("carries the row that WAS persisted, plus the original cause", async () => {
+    const cause = new Error(
+      "EACCES: permission denied, open '/openclaw-config/workspaces/agent-1/TOOLS.md'"
+    );
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(cause);
+
+    const thrown = await updateAgent("agent-1", { model: "openai/gpt-5.4" }).then(
+      () => null,
+      (e: unknown) => e
+    );
+
+    expect(thrown).toBeInstanceOf(AgentRuntimeUpdateError);
+    const err = thrown as AgentRuntimeUpdateError;
+    // The row matters: the caller needs it to build an honest audit diff for a
+    // change that really did happen.
+    expect(err.agent).toMatchObject({ id: "agent-1" });
+    expect(err.cause).toBe(cause);
+    // And the message must still name the errno — that text is the whole
+    // reason #1095 needed an SSH session to diagnose.
+    expect(err.message).toContain("EACCES");
+  });
+
+  it("does NOT wrap a failure of the row write itself — nothing was persisted", async () => {
+    const dbError = new Error("connection terminated unexpectedly");
+    const where = vi.fn().mockReturnValue({ returning: vi.fn().mockRejectedValue(dbError) });
+    vi.mocked(db.update).mockReturnValue({ set: vi.fn().mockReturnValue({ where }) } as never);
+
+    await expect(updateAgent("agent-1", { model: "openai/gpt-5.4" })).rejects.toBe(dbError);
   });
 });

--- a/packages/web/src/__tests__/lib/fix-config-permissions.test.ts
+++ b/packages/web/src/__tests__/lib/fix-config-permissions.test.ts
@@ -263,6 +263,19 @@ describe("fix_config_permissions — workspace bootstrap file ownership (#1095)"
     expect(chownedPaths()).toContain(join(stateDir, "workspaces", "agent-a"));
   });
 
+  it("chowns the workspaces/ root itself, so a NEW agent's workspace can be created", () => {
+    // `-maxdepth 1 -type d` matches depth 0 as well as depth 1, and that is
+    // deliberate rather than incidental. ensureWorkspace() mkdirs
+    // workspaces/<id> as uid 999, which needs write permission on the parent —
+    // so a root-owned workspaces/ breaks every agent that does not exist yet,
+    // a failure the per-agent repair below would never reach.
+    seedWorkspaceFile("agent-a", "TOOLS.md");
+
+    runFix();
+
+    expect(chownedPaths()).toContain(join(stateDir, "workspaces"));
+  });
+
   it("skips workspace files already owned by the pinchy uid", () => {
     // Same ctime argument as the agents/ gate above: at a 50 ms tick an
     // ungated chown is ~20 ctime bumps a second, per file, forever.

--- a/packages/web/src/__tests__/lib/fix-config-permissions.test.ts
+++ b/packages/web/src/__tests__/lib/fix-config-permissions.test.ts
@@ -187,6 +187,123 @@ describe("fix_config_permissions — per-agent directory ownership (#934)", () =
   });
 });
 
+// THE SECOND INVARIANT (#1095):
+//
+//   workspaces/<id>/<bootstrap file> must be OWNED by the pinchy uid.
+//
+// Same cross-uid trap as agents/<id>/agent above, one directory over, and it
+// reached production: on 2026-08-04 `pinchy.heypinchy.com` had two root-owned
+// TOOLS.md files, and every agent save had failed since 2026-08-02 08:25 — the
+// last successful `agent.updated` audit row. The user saw "Failed to save some
+// settings" and nothing else.
+//
+// The mechanism is a race that Pinchy itself opens. writeToolsFile() DELETES
+// TOOLS.md when an agent has no mailbox (rmSync — "no stale mailbox identity
+// survives a permission revocation"). OpenClaw creates the file from its own
+// bootstrap template whenever it is missing, as root, mode 0644. Grant the
+// agent an email connection afterwards and Pinchy's writeFileSync gets EACCES
+// forever — root-owned 0644 denies uid 999 the write, and root ignores mode
+// bits, so no chmod can substitute for ownership here either.
+//
+// The blast radius is the same as #934's and worth spelling out, because the
+// two user-visible symptoms look unrelated: the EACCES aborts
+// regenerateOpenClawConfig() BEFORE it pushes openclaw.json, so
+//   (a) the model the user just saved never reaches the runtime, and
+//   (b) pinchy-email never enters the plugin list, so the agent has no email_*
+//       tools at all and correctly answers "I have no access to a mailbox" —
+//       while the Permissions tab shows the mailbox connected and saved.
+describe("fix_config_permissions — workspace bootstrap file ownership (#1095)", () => {
+  /** Create a workspace the way OpenClaw does: root-owned bootstrap files. */
+  function seedWorkspaceFile(agentId: string, name: string): string {
+    const dir = join(stateDir, "workspaces", agentId);
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, name);
+    writeFileSync(file, "# placeholder\n");
+    return file;
+  }
+
+  it("chowns workspaces/<id>/TOOLS.md so Pinchy can write the mailbox context", () => {
+    const file = seedWorkspaceFile("025449c8-12b8-4919-a427-86a1ee7a4a77", "TOOLS.md");
+
+    runFix();
+
+    expect(chownedPaths()).toContain(file);
+  });
+
+  it.each(["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md", "HEARTBEAT.md"])(
+    "chowns workspaces/<id>/%s — OpenClaw bootstraps all of these, Pinchy writes them too",
+    (name) => {
+      const file = seedWorkspaceFile("agent-a", name);
+
+      runFix();
+
+      expect(chownedPaths()).toContain(file);
+    }
+  );
+
+  it("covers every workspace, not just the first one found", () => {
+    const a = seedWorkspaceFile("agent-a", "TOOLS.md");
+    const b = seedWorkspaceFile("agent-b", "TOOLS.md");
+
+    runFix();
+
+    const chowned = chownedPaths();
+    expect(chowned).toContain(a);
+    expect(chowned).toContain(b);
+  });
+
+  it("chowns the workspace directory itself, so a deleted file can be recreated", () => {
+    // writeToolsFile() removes TOOLS.md for an agent with no mailbox and
+    // recreates it when one is granted. Recreating needs write permission on
+    // the DIRECTORY, which a file-only repair would never grant.
+    seedWorkspaceFile("agent-a", "TOOLS.md");
+
+    runFix();
+
+    expect(chownedPaths()).toContain(join(stateDir, "workspaces", "agent-a"));
+  });
+
+  it("skips workspace files already owned by the pinchy uid", () => {
+    // Same ctime argument as the agents/ gate above: at a 50 ms tick an
+    // ungated chown is ~20 ctime bumps a second, per file, forever.
+    seedWorkspaceFile("agent-a", "TOOLS.md");
+
+    execFileSync("bash", ["-c", `source '${SCRIPT}'; fix_config_permissions`], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+        OPENCLAW_STATE_DIR: stateDir,
+        SECRETS_FILE: secretsFile,
+        PINCHY_UID: String(process.getuid?.() ?? 0),
+        PINCHY_GID: String(process.getgid?.() ?? 0),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+
+    expect(chownedPaths()).toEqual([]);
+  });
+
+  it("leaves agent-created content below the bootstrap level alone", () => {
+    // The tick runs every 50 ms. Workspaces hold uploads/ and memory/ with
+    // unbounded file counts, so the repair is scoped to the bootstrap files
+    // Pinchy actually writes — a recursive sweep would re-stat the whole
+    // corpus 20 times a second for no benefit.
+    const dir = join(stateDir, "workspaces", "agent-a", "uploads");
+    mkdirSync(dir, { recursive: true });
+    const upload = join(dir, "invoice.pdf");
+    writeFileSync(upload, "%PDF\n");
+
+    runFix();
+
+    expect(chownedPaths()).not.toContain(upload);
+  });
+
+  it("tolerates a missing workspaces/ directory (pre-first-agent boot)", () => {
+    expect(() => runFix()).not.toThrow();
+  });
+});
+
 describe("fix_config_permissions — behaviour carried over from start-openclaw.sh", () => {
   it("makes openclaw.json writable by Pinchy (mode 666)", () => {
     chmodSync(join(stateDir, "openclaw.json"), 0o600);

--- a/packages/web/src/__tests__/lib/workspace-write-reclaim-failure.test.ts
+++ b/packages/web/src/__tests__/lib/workspace-write-reclaim-failure.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// The reclaim's failure path, which its sibling file cannot reach.
+//
+// `workspace-write-reclaim.test.ts` proves the happy path against the real
+// filesystem: a file Pinchy may not overwrite gets replaced anyway. This file
+// asks the question that decides HOW: what happens when the replacement itself
+// cannot be written?
+//
+// It matters more than it looks. AGENTS.md and SOUL.md have no copy in the
+// database — `GET /api/agents/:id/files/:filename` reads the file, so the file
+// IS the user's instructions. A reclaim that removes the target first and then
+// fails has destroyed them. The window is small but not theoretical: a full
+// disk, or the OpenClaw container recreating the bootstrap file root-owned in
+// the moment it is missing, both land exactly there.
+//
+// So the reclaim goes through a same-directory temp file and rename(2).
+// `rename` replaces the target on the strength of the DIRECTORY's permissions —
+// the same POSIX rule `unlink` follows, which is what makes the reclaim
+// possible at all — and is atomic, so the target is never absent. Measured:
+//
+//   file 0444 in a writable dir:  write → EACCES,  rename over it → OK (mode 644)
+//   same file in a 0555 dir:      rename → EACCES, original intact
+//
+// Failure injection is the one thing mocked here; every filesystem effect below
+// is real. A test that mocked `fs` wholesale would be asserting against its own
+// model of POSIX, which is the thing actually under test.
+let denyWrites = false;
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    default: actual,
+    writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => {
+      if (denyWrites) {
+        const err: NodeJS.ErrnoException = new Error("EACCES: permission denied, open");
+        err.code = "EACCES";
+        err.errno = -13;
+        throw err;
+      }
+      return actual.writeFileSync(...args);
+    },
+  };
+});
+
+const TEST_ROOT = mkdtempSync(join(tmpdir(), "workspace-reclaim-fail-"));
+process.env.WORKSPACE_BASE_PATH = TEST_ROOT;
+
+let workspace: typeof import("@/lib/workspace");
+const AGENT_ID = "0d4b2f3a-7c19-4a5e-8b62-1f9e3c7d5a04";
+const INSTRUCTIONS = "# The user's instructions, with no copy anywhere else\n";
+
+beforeEach(async () => {
+  vi.resetModules();
+  workspace = await import("@/lib/workspace");
+  denyWrites = false;
+  mkdirSync(join(TEST_ROOT, AGENT_ID), { recursive: true });
+});
+
+afterEach(() => {
+  denyWrites = false;
+  rmSync(join(TEST_ROOT, AGENT_ID), { recursive: true, force: true });
+});
+
+afterAll(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe("a reclaim that cannot complete leaves the original alone (#1095)", () => {
+  it("keeps AGENTS.md intact when the replacement cannot be written", () => {
+    const filePath = join(TEST_ROOT, AGENT_ID, "AGENTS.md");
+    writeFileSync(filePath, INSTRUCTIONS, "utf-8");
+
+    denyWrites = true;
+    expect(() => workspace.writeWorkspaceFile(AGENT_ID, "AGENTS.md", "# replacement\n")).toThrow();
+    denyWrites = false;
+
+    // The assertion the rm-then-write shape fails: it unlinks the target before
+    // it knows the new content can be written, so this file would be gone.
+    expect(readFileSync(filePath, "utf-8")).toBe(INSTRUCTIONS);
+  });
+
+  it("keeps SOUL.md intact too — same absence of a database copy", () => {
+    const filePath = join(TEST_ROOT, AGENT_ID, "SOUL.md");
+    writeFileSync(filePath, INSTRUCTIONS, "utf-8");
+
+    denyWrites = true;
+    expect(() => workspace.writeWorkspaceFile(AGENT_ID, "SOUL.md", "# replacement\n")).toThrow();
+    denyWrites = false;
+
+    expect(readFileSync(filePath, "utf-8")).toBe(INSTRUCTIONS);
+  });
+
+  it("leaves no temp file behind when the reclaim fails", () => {
+    // A stray dotfile in the workspace is not inert: OpenClaw reads this
+    // directory, and a leftover would accumulate one entry per failed save.
+    const filePath = join(TEST_ROOT, AGENT_ID, "AGENTS.md");
+    writeFileSync(filePath, INSTRUCTIONS, "utf-8");
+
+    denyWrites = true;
+    expect(() => workspace.writeWorkspaceFile(AGENT_ID, "AGENTS.md", "# replacement\n")).toThrow();
+    denyWrites = false;
+
+    expect(readdirSync(join(TEST_ROOT, AGENT_ID))).toEqual(["AGENTS.md"]);
+  });
+
+  it("propagates the original cause rather than a cleanup error", () => {
+    // The caller renders this text — the route puts it in the 500 body. A
+    // cleanup failure masking the real reason would restore #1095's core
+    // problem: a failure that does not say why.
+    const filePath = join(TEST_ROOT, AGENT_ID, "TOOLS.md");
+    writeFileSync(filePath, "# placeholder\n", "utf-8");
+
+    denyWrites = true;
+    try {
+      workspace.writeToolsFile(AGENT_ID, [
+        { address: "a@example.com", label: "a@example.com", operations: ["read"] },
+      ]);
+      expect.unreachable("writeToolsFile should have thrown");
+    } catch (err) {
+      expect((err as NodeJS.ErrnoException).code).toBe("EACCES");
+    } finally {
+      denyWrites = false;
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/workspace-write-reclaim.test.ts
+++ b/packages/web/src/__tests__/lib/workspace-write-reclaim.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// #1095, the half that does not need root.
+//
+// The OpenClaw container repairs ownership on a 50 ms tick, but only root can
+// chown — so that repair reaches a customer's instance only when they upgrade
+// the OpenClaw image, and never through Pinchy alone. Pinchy can do better on
+// its own, because of a POSIX detail we measured in the production container:
+//
+//   file owner: 0, dir owner: 999
+//     overwrite: DENIED (EACCES — the production failure)
+//     unlink:    OK
+//     recreate:  OK (owner now 999)
+//
+// `unlink()` is authorized by write permission on the DIRECTORY, not on the
+// file, and the workspace directory is Pinchy's. So every one of these writes
+// can reclaim a file it no longer owns, at the moment the user hits Save,
+// without root and without a container upgrade on the other side.
+//
+// This is safe for ALL bootstrap files, not just the generated ones, and the
+// reason is worth stating precisely: the fallback only ever runs where Pinchy
+// is already replacing the file's entire contents. Deleting first destroys
+// nothing that the write itself would have kept. A file Pinchy merely reads
+// (MEMORY.md, uploads) never reaches this path.
+
+// Real filesystem, deliberately: the whole point is POSIX's split between
+// "may write this file" and "may unlink it from this directory", which a
+// mocked `fs` would model rather than exercise.
+const TEST_ROOT = mkdtempSync(join(tmpdir(), "workspace-reclaim-"));
+process.env.WORKSPACE_BASE_PATH = TEST_ROOT;
+
+let workspace: typeof import("@/lib/workspace");
+const AGENT_ID = "6f1c0f6e-9f7c-4f4e-9a1e-2f0d4b8c1a55";
+
+beforeEach(async () => {
+  vi.resetModules();
+  workspace = await import("@/lib/workspace");
+  mkdirSync(join(TEST_ROOT, AGENT_ID), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(join(TEST_ROOT, AGENT_ID), { recursive: true, force: true });
+});
+
+/**
+ * Reproduce the production shape without root: a file the process may not
+ * write, inside a directory it may. Mode 0444 denies the owner the write too —
+ * the kernel checks the mode bits for everyone except root, which is why this
+ * block is skipped when the suite happens to run as root (a root process would
+ * sail through the write and the assertion would prove nothing).
+ */
+function seedUnwritable(filename: string, content = "written by the other container\n"): string {
+  const filePath = join(TEST_ROOT, AGENT_ID, filename);
+  writeFileSync(filePath, content, "utf-8");
+  chmodSync(filePath, 0o444);
+  return filePath;
+}
+
+const runningAsRoot = process.getuid?.() === 0;
+
+describe.skipIf(runningAsRoot)(
+  "workspace writes reclaim a file they cannot overwrite (#1095)",
+  () => {
+    it("writeWorkspaceFile replaces an unwritable AGENTS.md", () => {
+      const filePath = seedUnwritable("AGENTS.md");
+
+      workspace.writeWorkspaceFile(AGENT_ID, "AGENTS.md", "# New instructions\n");
+
+      expect(readFileSync(filePath, "utf-8")).toBe("# New instructions\n");
+    });
+
+    it("writeWorkspaceFile replaces an unwritable SOUL.md", () => {
+      const filePath = seedUnwritable("SOUL.md");
+
+      workspace.writeWorkspaceFile(AGENT_ID, "SOUL.md", "# New personality\n");
+
+      expect(readFileSync(filePath, "utf-8")).toBe("# New personality\n");
+    });
+
+    it("writeToolsFile replaces the unwritable TOOLS.md that caused the incident", () => {
+      // The exact production case: OpenClaw's bootstrap placeholder sits where
+      // Pinchy needs to write the mailbox context.
+      const filePath = seedUnwritable("TOOLS.md", "# TOOLS.md - Local Notes\n");
+
+      workspace.writeToolsFile(AGENT_ID, [
+        {
+          address: "commercial@example.com",
+          label: "commercial@example.com",
+          operations: ["read"],
+        },
+      ]);
+
+      const written = readFileSync(filePath, "utf-8");
+      expect(written).toContain("commercial@example.com");
+      expect(written).not.toContain("Local Notes");
+    });
+
+    it("writeIdentityFile replaces an unwritable IDENTITY.md", () => {
+      const filePath = seedUnwritable("IDENTITY.md");
+
+      workspace.writeIdentityFile(AGENT_ID, { name: "Penny", tagline: "Track invoices" });
+
+      expect(readFileSync(filePath, "utf-8")).toContain("Penny");
+    });
+
+    it("writeWorkspaceFileInternal replaces an unwritable USER.md", () => {
+      const filePath = seedUnwritable("USER.md");
+
+      workspace.writeWorkspaceFileInternal(AGENT_ID, "USER.md", "# Context\n");
+
+      expect(readFileSync(filePath, "utf-8")).toBe("# Context\n");
+    });
+
+    it("leaves the file writable afterwards, so the next save needs no reclaim", () => {
+      // Reclaiming once must actually fix the state. If the new file inherited
+      // the old mode, every subsequent save would pay the same dance — and in
+      // production the ownership would never return to Pinchy.
+      const filePath = seedUnwritable("TOOLS.md");
+
+      workspace.writeToolsFile(AGENT_ID, [
+        { address: "a@example.com", label: "a@example.com", operations: ["read"] },
+      ]);
+      workspace.writeToolsFile(AGENT_ID, [
+        { address: "b@example.com", label: "b@example.com", operations: ["read"] },
+      ]);
+
+      expect(readFileSync(filePath, "utf-8")).toContain("b@example.com");
+    });
+
+    it("still throws when the DIRECTORY is the unwritable part", () => {
+      // Reclaiming works because the directory is Pinchy's. When it is not,
+      // unlink is denied too and there is nothing Pinchy can do without root —
+      // that case belongs to the OpenClaw-side repair tick, and must surface as
+      // an error rather than be swallowed into a silent no-op.
+      const dir = join(TEST_ROOT, AGENT_ID);
+      seedUnwritable("AGENTS.md");
+      chmodSync(dir, 0o555);
+
+      try {
+        expect(() => workspace.writeWorkspaceFile(AGENT_ID, "AGENTS.md", "x")).toThrow();
+      } finally {
+        chmodSync(dir, 0o755);
+      }
+    });
+  }
+);

--- a/packages/web/src/__tests__/lib/workspace-write-reclaim.test.ts
+++ b/packages/web/src/__tests__/lib/workspace-write-reclaim.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,14 +11,19 @@ import { join } from "node:path";
 // its own, because of a POSIX detail we measured in the production container:
 //
 //   file owner: 0, dir owner: 999
-//     overwrite: DENIED (EACCES — the production failure)
-//     unlink:    OK
-//     recreate:  OK (owner now 999)
+//     overwrite:      DENIED (EACCES — the production failure)
+//     unlink:         OK
+//     rename over it: OK (owner now 999)
 //
-// `unlink()` is authorized by write permission on the DIRECTORY, not on the
-// file, and the workspace directory is Pinchy's. So every one of these writes
-// can reclaim a file it no longer owns, at the moment the user hits Save,
-// without root and without a container upgrade on the other side.
+// Replacing a directory entry is authorized by write permission on the
+// DIRECTORY, not on the file, and the workspace directory is Pinchy's. So
+// every one of these writes can reclaim a file it no longer owns, at the
+// moment the user hits Save, without root and without a container upgrade on
+// the other side.
+//
+// The reclaim uses a temp file and rename(2) rather than unlink-then-write, so
+// the target is never briefly absent — see the failure path in
+// `workspace-write-reclaim-failure.test.ts`, which is where that matters.
 //
 // This is safe for ALL bootstrap files, not just the generated ones, and the
 // reason is worth stating precisely: the fallback only ever runs where Pinchy
@@ -43,6 +48,10 @@ beforeEach(async () => {
 
 afterEach(() => {
   rmSync(join(TEST_ROOT, AGENT_ID), { recursive: true, force: true });
+});
+
+afterAll(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
 });
 
 /**
@@ -112,6 +121,22 @@ describe.skipIf(runningAsRoot)(
       workspace.writeWorkspaceFileInternal(AGENT_ID, "USER.md", "# Context\n");
 
       expect(readFileSync(filePath, "utf-8")).toBe("# Context\n");
+    });
+
+    it("writeWorkspaceSkill replaces an unwritable SKILL.md one level down", () => {
+      // Skills live in skills/<id>/, not the workspace root, so the reclaim
+      // depends on a different directory being Pinchy's. It is — Pinchy
+      // mkdirs it — but that is worth proving rather than assuming, since
+      // this writer takes the same fallback as the rest.
+      const dir = join(TEST_ROOT, AGENT_ID, "skills", "invoice-filing");
+      mkdirSync(dir, { recursive: true });
+      const filePath = join(dir, "SKILL.md");
+      writeFileSync(filePath, "# bootstrapped elsewhere\n", "utf-8");
+      chmodSync(filePath, 0o444);
+
+      workspace.writeWorkspaceSkill(AGENT_ID, "invoice-filing", "# How to file invoices\n");
+
+      expect(readFileSync(filePath, "utf-8")).toBe("# How to file invoices\n");
     });
 
     it("leaves the file writable afterwards, so the next save needs no reclaim", () => {

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -2,7 +2,12 @@ import { NextResponse, after } from "next/server";
 import { revalidatePath } from "next/cache";
 import { eq, inArray } from "drizzle-orm";
 import { z } from "zod";
-import { updateAgent, deleteAgent, AGENT_NAME_MAX_LENGTH } from "@/lib/agents";
+import {
+  updateAgent,
+  deleteAgent,
+  AGENT_NAME_MAX_LENGTH,
+  AgentRuntimeUpdateError,
+} from "@/lib/agents";
 import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
 import { appendAuditLog } from "@/lib/audit";
@@ -166,30 +171,11 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   if (body.personalityPresetId !== undefined) data.personalityPresetId = body.personalityPresetId;
   if (body.visibility !== undefined) data.visibility = body.visibility;
 
-  // updateAgent writes the row and THEN calls regenerateOpenClawConfig(); the
-  // two are not in a transaction, so a regeneration failure leaves the change
-  // persisted while the runtime keeps the old value. Letting the throw escape
-  // hands Next.js a 500 whose body carries no `error` field, and the client can
-  // only say "Failed to save some settings" — which is wrong in both
-  // directions and is exactly how #1095 stayed invisible for two days: the
-  // cause (EACCES on a root-owned TOOLS.md) lived solely in the container log.
+  // Build from/to changes diff.
   //
-  // Answer both questions instead: what persisted, and why the rest did not.
-  let agent;
-  try {
-    agent = Object.keys(data).length > 0 ? await updateAgent(agentId, data) : existingAgent;
-  } catch (err) {
-    const cause = err instanceof Error ? err.message : String(err);
-    console.error(`[agents] config regeneration failed for agent ${agentId}:`, err);
-    return NextResponse.json(
-      {
-        error: `Settings were saved, but the agent runtime was not updated: ${cause}`,
-      },
-      { status: 500 }
-    );
-  }
-
-  // Build from/to changes diff
+  // Derived from `data` and `existingAgent` alone, so it is built BEFORE the
+  // write — a regeneration failure still changed the row, and the audit entry
+  // for that change needs this diff (see the catch below).
   const changes: Record<string, { from: unknown; to: unknown }> = {};
   const diffFields = [
     "name",
@@ -225,6 +211,51 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     if (JSON.stringify(oldConfig) !== JSON.stringify(newConfig)) {
       changes.pluginConfig = { from: oldConfig, to: newConfig };
     }
+  }
+
+  // updateAgent writes the row and THEN calls regenerateOpenClawConfig(); the
+  // two are not in a transaction. Letting the throw escape hands Next.js a 500
+  // whose body carries no `error` field, and the client can only say "Failed to
+  // save some settings" — which is exactly how #1095 stayed invisible for two
+  // days: the cause (EACCES on a root-owned TOOLS.md) lived solely in the
+  // container log.
+  //
+  // The two failures need opposite answers, and only `updateAgent` knows which
+  // one happened — hence the error type rather than an errno guess here:
+  //
+  //   AgentRuntimeUpdateError → the row IS written, the runtime is stale. Say
+  //     so, and audit it: a state change with no audit entry is what AGENTS.md
+  //     forbids, and `outcome: "failure"` exists for precisely this shape.
+  //   anything else → the write itself failed, nothing persisted. Claiming it
+  //     was saved would stop the user retrying a change that never landed.
+  let agent: typeof existingAgent;
+  try {
+    agent = Object.keys(data).length > 0 ? await updateAgent(agentId, data) : existingAgent;
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+
+    if (err instanceof AgentRuntimeUpdateError) {
+      console.error(`[agents] config regeneration failed for agent ${agentId}:`, err);
+      if (Object.keys(changes).length > 0) {
+        after(() =>
+          appendAuditLog({
+            actorType: "user",
+            actorId: session.user.id!,
+            eventType: "agent.updated",
+            resource: `agent:${agentId}`,
+            detail: { changes, runtimeUpdate: { applied: false, error: cause } },
+            outcome: "failure",
+          })
+        );
+      }
+      return NextResponse.json(
+        { error: `Settings were saved, but the agent runtime was not updated: ${cause}` },
+        { status: 500 }
+      );
+    }
+
+    console.error(`[agents] update failed for agent ${agentId}:`, err);
+    return NextResponse.json({ error: `Could not update the agent: ${cause}` }, { status: 500 });
   }
 
   // Capture old group IDs for audit diff (BEFORE delete/insert)

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/agents";
 import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
-import { appendAuditLog } from "@/lib/audit";
+import { appendAuditLog, safeProviderError } from "@/lib/audit";
 import type { UpdateDetail } from "@/lib/audit";
 import { isEnterprise } from "@/lib/enterprise";
 import { writeIdentityFile } from "@/lib/workspace";
@@ -243,7 +243,13 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
             actorId: session.user.id!,
             eventType: "agent.updated",
             resource: `agent:${agentId}`,
-            detail: { changes, runtimeUpdate: { applied: false, error: cause } },
+            // safeProviderError, not the raw string: an uncapped field would
+            // trip truncateDetail, which replaces the WHOLE detail with a
+            // summary blob rather than trimming the offender — taking
+            // `changes` with it, on the one row whose value is recording what
+            // changed. It also scrubs addresses, and this path exists because
+            // of TOOLS.md, the file carrying an agent's mailbox context.
+            detail: { changes, runtimeUpdate: { applied: false, error: safeProviderError(cause) } },
             outcome: "failure",
           })
         );

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -166,7 +166,28 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   if (body.personalityPresetId !== undefined) data.personalityPresetId = body.personalityPresetId;
   if (body.visibility !== undefined) data.visibility = body.visibility;
 
-  const agent = Object.keys(data).length > 0 ? await updateAgent(agentId, data) : existingAgent;
+  // updateAgent writes the row and THEN calls regenerateOpenClawConfig(); the
+  // two are not in a transaction, so a regeneration failure leaves the change
+  // persisted while the runtime keeps the old value. Letting the throw escape
+  // hands Next.js a 500 whose body carries no `error` field, and the client can
+  // only say "Failed to save some settings" — which is wrong in both
+  // directions and is exactly how #1095 stayed invisible for two days: the
+  // cause (EACCES on a root-owned TOOLS.md) lived solely in the container log.
+  //
+  // Answer both questions instead: what persisted, and why the rest did not.
+  let agent;
+  try {
+    agent = Object.keys(data).length > 0 ? await updateAgent(agentId, data) : existingAgent;
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    console.error(`[agents] config regeneration failed for agent ${agentId}:`, err);
+    return NextResponse.json(
+      {
+        error: `Settings were saved, but the agent runtime was not updated: ${cause}`,
+      },
+      { status: 500 }
+    );
+  }
 
   // Build from/to changes diff
   const changes: Record<string, { from: unknown; to: unknown }> = {};

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -113,6 +113,33 @@ function DirtyDot() {
   );
 }
 
+/**
+ * Turns a failed save response into a message that says WHY.
+ *
+ * This used to be the constant "Failed to save some settings" — the same
+ * sentence for a validation refusal, a permission refusal and a server fault,
+ * with the server's own explanation read and discarded. #1095 is the bill:
+ * production rejected every agent save for two days over a root-owned
+ * TOOLS.md, the 500 named the EACCES, and the only place that text survived
+ * was `docker compose logs`.
+ *
+ * The body is the primary source; status is the fallback, because a proxy 502
+ * or a crashed process answers with HTML or nothing at all. Never returns
+ * empty — the caller renders this as the sole feedback for a failed save.
+ */
+async function describeSaveFailure(response: Response): Promise<string> {
+  try {
+    const body: unknown = await response.json();
+    if (body && typeof body === "object" && "error" in body) {
+      const { error } = body as { error?: unknown };
+      if (typeof error === "string" && error.trim()) return error;
+    }
+  } catch {
+    // No JSON body (HTML error page, empty response, connection cut).
+  }
+  return `Failed to save settings (HTTP ${String(response.status)})`;
+}
+
 export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }) {
   const params = useParams();
   const router = useRouter();
@@ -371,8 +398,9 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
       const otherResults = await Promise.all(otherPromises);
       const results = [...integrationResults, ...otherResults];
 
-      if (results.some((r) => !r.ok)) {
-        toast.error("Failed to save some settings");
+      const failed = results.find((r) => !r.ok);
+      if (failed) {
+        toast.error(await describeSaveFailure(failed));
         return;
       }
 

--- a/packages/web/src/lib/agents.ts
+++ b/packages/web/src/lib/agents.ts
@@ -159,12 +159,45 @@ const OPENCLAW_CONFIG_FIELDS: (keyof UpdateAgentInput)[] = [
   "pluginConfig",
 ];
 
+/**
+ * The row was written; telling the runtime about it failed.
+ *
+ * `updateAgent` does two things that are not in a transaction, in this order:
+ * it updates the `agents` row, then regenerates `openclaw.json`. Both can
+ * throw, and the two failures need opposite handling — after the first nothing
+ * is persisted, after the second everything is, and only the runtime is stale.
+ *
+ * A caller that cannot tell them apart has to guess, and the first fix for
+ * #1095 guessed: it answered "Settings were saved, but the agent runtime was
+ * not updated" for both. For a failed row write that is the same class of
+ * unfounded claim as the flat "Failed to save some settings" it replaced —
+ * a user who believes it stops retrying a change that never landed.
+ *
+ * So the fact travels in the type. `agent` carries the row as persisted, which
+ * is what lets the caller write an honest audit entry for a change that really
+ * did happen.
+ */
+export class AgentRuntimeUpdateError extends Error {
+  readonly agent: typeof agents.$inferSelect;
+
+  constructor(agent: typeof agents.$inferSelect, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = "AgentRuntimeUpdateError";
+    this.agent = agent;
+  }
+}
+
 export async function updateAgent(id: string, data: UpdateAgentInput) {
   const [updated] = await db.update(agents).set(data).where(eq(agents.id, id)).returning();
 
   const touchesOpenClawConfig = OPENCLAW_CONFIG_FIELDS.some((field) => field in data);
   if (touchesOpenClawConfig) {
-    await regenerateOpenClawConfig();
+    try {
+      await regenerateOpenClawConfig();
+    } catch (err) {
+      // Past this point the row is committed — see AgentRuntimeUpdateError.
+      throw new AgentRuntimeUpdateError(updated, err);
+    }
   }
 
   return updated;

--- a/packages/web/src/lib/workspace.ts
+++ b/packages/web/src/lib/workspace.ts
@@ -92,6 +92,46 @@ export function getWorkspacePath(agentId: string): string {
   return join(getWorkspaceBasePath(), agentId);
 }
 
+/**
+ * Writes a workspace file, reclaiming it when Pinchy no longer owns it.
+ *
+ * The workspace volume is shared with the OpenClaw container, which runs as
+ * root and creates any missing bootstrap file from its own template. Pinchy
+ * runs as uid 999, so a file OpenClaw created is 0644 root-owned: readable,
+ * and permanently un-overwritable. That is #1095 — it denied every agent save
+ * on production for two days, because the EACCES aborts
+ * regenerateOpenClawConfig() before it pushes openclaw.json.
+ *
+ * `unlink()`, though, is authorized by write permission on the DIRECTORY, and
+ * the workspace directory is Pinchy's. Measured in the production container:
+ *
+ *   file owner: 0, dir owner: 999
+ *     overwrite: DENIED    unlink: OK    recreate: OK (owner now 999)
+ *
+ * So Pinchy repairs this itself, at the moment of the write — no root, and no
+ * dependency on the OpenClaw-side repair tick, which only reaches an instance
+ * when its OpenClaw image is upgraded. Recreating also returns the file to uid
+ * 999, so the reclaim happens once rather than on every save.
+ *
+ * Safe for every caller here, and the reason is narrow: this runs only where
+ * Pinchy is already replacing the file's entire contents, so deleting first
+ * destroys nothing the write itself would have kept. Files Pinchy only reads
+ * (MEMORY.md, uploads/) never pass through it.
+ *
+ * When the DIRECTORY is what Pinchy cannot write, unlink is denied too and the
+ * error propagates — nothing here may turn a failed write into a silent no-op.
+ * That case needs root, and belongs to config/fix-config-permissions.sh.
+ */
+function writeFileReclaiming(filePath: string, content: string): void {
+  try {
+    writeFileSync(filePath, content, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EACCES") throw err;
+    rmSync(filePath, { force: true });
+    writeFileSync(filePath, content, "utf-8");
+  }
+}
+
 // Canonical OpenClaw-side path resolver — the path OpenClaw itself sees and
 // the value written into openclaw.json's `agents[].workspace`. OpenClaw
 // resolves MEMORY.md / memory/ relative to this. See the top-of-file layout
@@ -170,7 +210,7 @@ export function writeWorkspaceFile(agentId: string, filename: string, content: s
     mkdirSync(workspacePath, { recursive: true });
   }
 
-  writeFileSync(join(workspacePath, filename), content, "utf-8");
+  writeFileReclaiming(join(workspacePath, filename), content);
 }
 
 export function writeWorkspaceFileInternal(
@@ -186,7 +226,7 @@ export function writeWorkspaceFileInternal(
     mkdirSync(workspacePath, { recursive: true });
   }
 
-  writeFileSync(join(workspacePath, filename), content, "utf-8");
+  writeFileReclaiming(join(workspacePath, filename), content);
 }
 
 // =============================================================================
@@ -213,7 +253,7 @@ export function writeWorkspaceSkill(agentId: string, skillId: string, content: s
 
   const dir = join(getWorkspacePath(agentId), "skills", skillId);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, "SKILL.md"), content, "utf-8");
+  writeFileReclaiming(join(dir, "SKILL.md"), content);
 }
 
 export function removeWorkspaceSkill(agentId: string, skillId: string): void {
@@ -352,7 +392,7 @@ export function writeToolsFile(agentId: string, mailboxes: MailboxContext[]): vo
   if (!existsSync(workspacePath)) {
     mkdirSync(workspacePath, { recursive: true });
   }
-  writeFileSync(filePath, content, "utf-8");
+  writeFileReclaiming(filePath, content);
 }
 
 export function generateIdentityContent(agent: { name: string; tagline: string | null }): string {
@@ -370,5 +410,5 @@ export function writeIdentityFile(
   if (!existsSync(workspacePath)) {
     mkdirSync(workspacePath, { recursive: true });
   }
-  writeFileSync(join(workspacePath, "IDENTITY.md"), generateIdentityContent(agent), "utf-8");
+  writeFileReclaiming(join(workspacePath, "IDENTITY.md"), generateIdentityContent(agent));
 }

--- a/packages/web/src/lib/workspace.ts
+++ b/packages/web/src/lib/workspace.ts
@@ -1,5 +1,5 @@
-import { writeFileSync, readFileSync, existsSync, mkdirSync, rmSync } from "fs";
-import { join } from "path";
+import { writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, renameSync } from "fs";
+import { join, dirname, basename } from "path";
 
 // =============================================================================
 // Agent on-disk layout — READ THIS before touching any code that resolves an
@@ -102,33 +102,59 @@ export function getWorkspacePath(agentId: string): string {
  * on production for two days, because the EACCES aborts
  * regenerateOpenClawConfig() before it pushes openclaw.json.
  *
- * `unlink()`, though, is authorized by write permission on the DIRECTORY, and
- * the workspace directory is Pinchy's. Measured in the production container:
+ * Replacing the DIRECTORY ENTRY, though, is authorized by write permission on
+ * the DIRECTORY rather than on the file — and the workspace directory is
+ * Pinchy's. Measured in the production container, and locally against the
+ * mode-based equivalent:
  *
  *   file owner: 0, dir owner: 999
- *     overwrite: DENIED    unlink: OK    recreate: OK (owner now 999)
+ *     overwrite: DENIED (EACCES)   unlink: OK   rename over it: OK (owner 999)
  *
  * So Pinchy repairs this itself, at the moment of the write — no root, and no
  * dependency on the OpenClaw-side repair tick, which only reaches an instance
- * when its OpenClaw image is upgraded. Recreating also returns the file to uid
- * 999, so the reclaim happens once rather than on every save.
+ * when its OpenClaw image is upgraded. The replacement is created by Pinchy, so
+ * the reclaim happens once rather than on every save.
  *
- * Safe for every caller here, and the reason is narrow: this runs only where
- * Pinchy is already replacing the file's entire contents, so deleting first
- * destroys nothing the write itself would have kept. Files Pinchy only reads
- * (MEMORY.md, uploads/) never pass through it.
+ * It goes through a temp file and `rename(2)` rather than unlink-then-write,
+ * and that choice is load-bearing rather than stylistic. AGENTS.md and SOUL.md
+ * have NO copy in the database — `GET /api/agents/:id/files/:filename` serves
+ * the file itself, so the file is the user's instructions. Unlinking first
+ * means that between the two calls the only copy does not exist, and a failed
+ * second write (a full disk; the OpenClaw container recreating the bootstrap
+ * file root-owned in exactly that gap) destroys it. `rename` is atomic: the
+ * target is never absent, and when it cannot proceed the original is untouched.
  *
- * When the DIRECTORY is what Pinchy cannot write, unlink is denied too and the
- * error propagates — nothing here may turn a failed write into a silent no-op.
- * That case needs root, and belongs to config/fix-config-permissions.sh.
+ * The temp file is a sibling, because rename cannot cross filesystems.
+ *
+ * When the DIRECTORY is what Pinchy cannot write, the temp write is denied too
+ * and the error propagates — nothing here may turn a failed write into a silent
+ * no-op. That case needs root, and belongs to config/fix-config-permissions.sh.
  */
+let reclaimCounter = 0;
+
 function writeFileReclaiming(filePath: string, content: string): void {
   try {
     writeFileSync(filePath, content, "utf-8");
+    return;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "EACCES") throw err;
-    rmSync(filePath, { force: true });
-    writeFileSync(filePath, content, "utf-8");
+  }
+
+  const tmpPath = join(
+    dirname(filePath),
+    `.${basename(filePath)}.${process.pid}.${++reclaimCounter}.tmp`
+  );
+  try {
+    writeFileSync(tmpPath, content, "utf-8");
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // Best-effort: the write's own error is the one worth reporting, and a
+      // cleanup failure masking it would be #1095's core problem again.
+    }
+    throw err;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

A root-owned `TOOLS.md` in the shared workspaces volume blocked **every agent save** on production, and silently disabled the email plugin with it. Active since **2026-08-02 08:25** — the timestamp of the last successful `agent.updated` audit row — and found on 2026-08-04 when saving a model change kept failing.

Same cross-uid trap as #934, one directory over: that fixed `agents/<id>/agent`, and `workspaces/<id>/` was never covered.

Closes #1095

### The mechanism

`workspaces/<id>/` holds the bootstrap files both sides write — Pinchy as uid 999, OpenClaw as root from its own bundled template. Pinchy opens the race itself:

1. `writeToolsFile()` **deletes** `TOOLS.md` for an agent with no mailbox (`rmSync`, so a revoked permission leaves no stale mailbox identity behind).
2. OpenClaw boots the agent, finds the file missing, creates it — root-owned, 0644.
3. The agent is granted an email connection. Pinchy's `writeFileSync` gets `EACCES`, forever. Root ignores mode bits, so no chmod substitutes for ownership.

### Two symptoms that did not look related

The `EACCES` aborts `regenerateOpenClawConfig()` **before** it pushes `openclaw.json`:

- **Saving agent settings failed.** `updateAgent()` writes the row and *then* regenerates, with no transaction around the pair — so the model was persisted while `openclaw.json` sat two days stale, no audit row was written, and the user was told the save failed.
- **The agent had no email tools.** `pinchy-email` never entered the plugin list, so the agent truthfully answered that it has no mailbox access — while the Permissions tab showed the connection saved. The generated `TOOLS.md` that would have briefed it on the mailbox is exactly the file that could not be written.

### Why it stayed invisible for two days

The cause lived only in `docker compose logs`:

```
⨯ Error: EACCES: permission denied, open '/openclaw-config/workspaces/<id>/TOOLS.md'
    at src/lib/workspace.ts:355
    at src/lib/openclaw-config/build.ts:415
    at async src/lib/agents.ts:64
    at async src/app/api/agents/[agentId]/route.ts:169
```

The route had no `try/catch`, so the throw escaped to Next.js, whose 500 body carries no `error` field. `executeSave()` then checked `results.some((r) => !r.ok)` and discarded every response — the same sentence for a validation refusal, a permission refusal and a server fault:

> Failed to save some settings

That violates the rule `AGENTS.md` already states for the plugin side of #599: *"When a client gives up on a response, it must say why. Quote the body."*

## What changed

| Commit | Change |
| --- | --- |
| `306e6f34` | `fix-config-permissions.sh` chowns `workspaces/<id>` and the six bootstrap files to the pinchy uid |
| `1d3b675d` | The route answers a regeneration failure with a JSON error; the client renders it |
| `cdaa044e` | Pinchy reclaims a file it no longer owns, **without root** |
| `bc7c3df0` | The API reference documents the new `500` |
| `972d2b40` | The reclaim replaces the file **atomically** — review follow-up |
| `bfa4d852` | The error says *which half* failed, and audits the half that changed state — review follow-up |
| `368eee7e` | Test pinning the `workspaces/` root chown `306e6f34` silently depends on |
| `96834d36` | The cause is scrubbed and capped before it enters the audit row — review follow-up |

### The self-healing half is the one that reaches customers

The tick in `306e6f34` runs in the OpenClaw container, because only root can chown — so it reaches an instance only when its **OpenClaw image** is upgraded, and never through Pinchy alone. For any install we cannot SSH into, that is a real gap.

POSIX closes it: replacing a directory entry is authorized by write permission on the **directory**, not on the file, and the workspace directory is Pinchy's. Measured in the production container, on the exact shape of the incident, and locally against the mode-based equivalent:

```
file owner: 0, dir owner: 999
  overwrite:      DENIED (EACCES — the production failure)
  unlink:         OK
  rename over it: OK (owner now 999)
```

So `writeFileReclaiming()` answers an `EACCES` by writing a sibling temp file and `rename(2)`-ing it over the target. The first save after upgrading *is* the repair, and the replacement belongs to uid 999 — once, not on every save. The tick stays: it still covers directories, and files Pinchy is not currently writing.

**Why `rename` and not unlink-then-write.** The first version of this did unlink first, and review caught what that costs. `AGENTS.md` and `SOUL.md` have **no copy in the database** — `GET /api/agents/:id/files/:filename` serves the file itself, so the file *is* the user's instructions. Unlinking first means the only copy briefly does not exist, and a failed second write destroys it: a full disk, or the OpenClaw container recreating the bootstrap file root-owned in exactly that gap — the very race this issue is about. `rename` is atomic, so the target is never absent, and when it cannot proceed the original is untouched.

Applied to every workspace writer. The safety argument is narrower than "Pinchy owns this file" and holds for all of them: the fallback only runs where Pinchy is **already replacing the file's entire contents**. Files Pinchy merely reads (`MEMORY.md`, `uploads/`) never reach that path, and the `if (!existsSync)` bootstrap write in `ensureWorkspace` is left alone — it cannot hit an owner `EACCES` by construction.

A denied **directory** still throws. Turning a failed write into a silent no-op would reproduce the original bug with the evidence removed.

### Two failures, two answers

`updateAgent()` throws from the row write *and* from the runtime regeneration that follows it outside any transaction. The first version of the error path caught both and said "Settings were saved, but the agent runtime was not updated" — true for the second, and for the first the same class of unfounded claim as the flat message it replaced, only pointing the other way. A user who believes it stops retrying a change that never landed.

`AgentRuntimeUpdateError` marks the second case only, and carries the row as persisted:

| | message | state |
| --- | --- | --- |
| runtime push failed | `Settings were saved, but the agent runtime was not updated: <cause>` | row written, runtime stale |
| anything else | `Could not update the agent: <cause>` | nothing persisted |

The first case is a state change, so it now writes an `agent.updated` audit row with `outcome: "failure"` — previously it returned 500 and left no trace at all, which is what `AGENTS.md` forbids. The cause reaches that row through `safeProviderError` — scrubbed and capped — because `truncateDetail` replaces the *whole* detail with a summary blob rather than trimming an oversized field, which would take `changes` down with it. The HTTP response keeps the unscrubbed text: different channel, different lifetime.

## Verified on production

The `chown` unblocked v0.9.1 by hand; the save that followed proved the whole chain:

| | before | after |
| --- | --- | --- |
| `openclaw.json` | 2026-08-02 08:25 | 2026-08-05 04:09 |
| `pinchy-email` | absent | `enabled: true` |
| `TOOLS.md` | OpenClaw placeholder, root-owned | mailbox context, uid 999 |
| `agent.updated` | last on 08-02 | 04:09:15, success |
| `EACCES` | 8 | 0 |

## Reviewer notes

- **The E2E stacks are structurally blind to this.** Both containers run as root there, so the uid split that causes it does not exist. The new coverage is unit-level for that reason.
- **`workspace-write-reclaim.test.ts` drives the real filesystem**, not a mocked `fs` — the behaviour under test *is* the POSIX split between writing a file and replacing its directory entry, which a mock would restate rather than prove. Mode `0444` reproduces the denial without root, and the block is `skipIf(root)` because a root process would sail through the write and assert nothing. Its sibling `-failure.test.ts` mocks exactly one thing — the injected write failure — and keeps every filesystem effect real; run against the unlink-then-write shape it fails with an empty directory.
- **Still not fixed, and stated in the issue:** `updateAgent()` remains non-transactional, so a runtime failure still leaves DB and runtime out of step. It is now *reported* honestly and *audited*, but not repaired. #934 solved the equivalent for auth profiles by pushing the config anyway and throwing an aggregate afterwards. Same treatment deserved, separate change.
- **Backport?** Production and customers run v0.9.x, where `fix-config-permissions.sh` does not exist at all (#934 is in no tag). Worth deciding whether this goes onto `release/0.9`.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

Gates run locally: `pnpm test` (10947 passed, 18 skipped), `pnpm test:scripts` (894), `pnpm -C packages/web typecheck`, `pnpm -C packages/web lint` (0 errors), `pnpm format:check`, and the docs build with `check:anchors` / `check:rendered` / `check:tables`.
