### PR TITLE
fix(ci): buildkit mirror config was never applied, and lint workflows with actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,20 +293,26 @@ jobs:
       # into a job holding a GHCR-write token, so an unpinned download would
       # be a supply-chain hole. Bump the two together; a stale checksum fails
       # loudly at the verify step rather than silently skipping the lint.
+      # Nothing proposes that bump — dependabot's github-actions ecosystem
+      # reads `uses:`, not a curl'd tarball — so it is a manual bump, and the
+      # coverage step below is what tells you when one is overdue.
       #
-      # shellcheck integration is OFF (`-shellcheck=`), and that is a design
-      # decision rather than a deferred cleanup — do not "finish the job" by
-      # switching it on without also pinning shellcheck.
+      # `--retry` because this gates every merge: a transient GitHub Releases
+      # blip must not turn a REQUIRED check red with nothing broken.
       #
-      # actionlint is pinned above by version and checksum, so it can only
-      # change its verdict when somebody edits this file. shellcheck is NOT:
-      # actionlint shells out to whatever binary the `ubuntu-latest` image
-      # happens to ship. Wiring that into `quality` — a REQUIRED check —
-      # means a runner-image bump that adds one SC rule turns main red with
-      # no commit behind it. AGENTS.md makes exactly this call for the
-      # docs-freshness sweep ("a check that can go red between two identical
-      # commits does not belong in front of a merge button"), and it applies
-      # with more force here, because this check gates every merge.
+      # BOTH external-linter integrations are off (`-shellcheck=`,
+      # `-pyflakes=`), and that is a design decision rather than a deferred
+      # cleanup — do not "finish the job" by switching either on without also
+      # pinning the tool. actionlint is pinned above, so it can only change
+      # its verdict when somebody edits this file. shellcheck and pyflakes are
+      # NOT: actionlint shells out to whatever the `ubuntu-latest` image
+      # happens to ship, so a runner-image bump that adds one rule turns main
+      # red with no commit behind it. AGENTS.md makes exactly this call for
+      # the docs-freshness sweep ("a check that can go red between two
+      # identical commits does not belong in front of a merge button"), and it
+      # applies with more force here, because this check gates every merge.
+      # (`-pyflakes` is inert today — no workflow uses `shell: python` — which
+      # is precisely why it would have stayed on its default unnoticed.)
       #
       # The cost is real and worth naming: 15 shellcheck findings in `run:`
       # blocks go unreported, most of them deliberate word-splitting, one of
@@ -322,12 +328,36 @@ jobs:
         run: |
           set -euo pipefail
           cd "$RUNNER_TEMP"
-          curl -sSfL -o actionlint.tar.gz \
+          curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors \
+            -o actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check --strict
           tar -xzf actionlint.tar.gz actionlint
           cd "$GITHUB_WORKSPACE"
-          "$RUNNER_TEMP/actionlint" -color -shellcheck=
+          "$RUNNER_TEMP/actionlint" -color -shellcheck= -pyflakes=
+
+      # The step above only validates a `with:` key for action versions
+      # actionlint has a bundled schema for. For anything else it reports
+      # NOTHING — and silence is indistinguishable from clean. Measured with
+      # the pinned 1.7.12:
+      #
+      #   docker/setup-buildx-action@v4 + `config-inline:` -> exit 1, named
+      #   docker/setup-buildx-action@v5 + `config-inline:` -> exit 0, silent
+      #
+      # `config-inline` is the exact bug the step above was added for, so its
+      # protection would expire at the next major bump of the very action it
+      # protects — and dependabot proposes those weekly, grouped under
+      # `patterns: ["*"]`. A major bump is also when an input gets renamed.
+      # There is no flag for it: actionlint cannot be told to error on an
+      # action it does not know. So coverage gets measured instead of assumed,
+      # and an unchecked action must be accepted with a written reason.
+      #
+      # ACTIONLINT_BIN points at the binary verified above rather than at
+      # PATH, so this reports on the version CI actually runs.
+      - name: Check actionlint input coverage
+        env:
+          ACTIONLINT_BIN: ${{ runner.temp }}/actionlint
+        run: node scripts/check-actionlint-coverage.mjs
 
       - name: Typecheck plugins
         # The pinchy-* plugins run via tsx with no ahead-of-time type checking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,71 @@ jobs:
       - name: Format check (repo)
         run: pnpm format:check
 
+      # The one thing in this repo that CI could not read: its own workflow
+      # files. Two bugs shipped straight through that gap.
+      #
+      # PR #1063 landed a ci.yml GitHub could not parse. Nothing failed —
+      # the required checks reported "Expected — Waiting for status" instead,
+      # which is the unmergeable-with-nothing-broken shape AGENTS.md already
+      # documents twice (§ "CI Path Filtering Is Job-Level" and § "Never Put
+      # A Required Check In A Matrix"), arriving here from a third direction.
+      #
+      # And release.yml / pre-release.yml both passed `config-inline:` to
+      # docker/setup-buildx-action, an input renamed to
+      # `buildkitd-config-inline` back in v3. An unknown `with:` key is
+      # handed to the action as an INPUT_* env var it never reads, so the
+      # buildkit registry-mirror config was dead from those workflows' first
+      # commit until 2026-08-05 — a green step whose only trace was one
+      # `##[warning]Unexpected input(s)` line buried in the step log.
+      #
+      # Neither is a YAML error nor a shell error. Both are *schema* errors,
+      # and actionlint is the only checker here that reads the schema.
+      #
+      # It lives in `quality` because `quality` is ungated (it is required),
+      # so this runs on every PR. A gated job would skip on a docs-only PR —
+      # and `.github/**` is not docs, so that is precisely a PR that can
+      # break a workflow. Same argument as the docs checks below.
+      #
+      # Pinned by version AND sha256 on purpose: this fetches an executable
+      # into a job holding a GHCR-write token, so an unpinned download would
+      # be a supply-chain hole. Bump the two together; a stale checksum fails
+      # loudly at the verify step rather than silently skipping the lint.
+      #
+      # shellcheck integration is OFF (`-shellcheck=`), and that is a design
+      # decision rather than a deferred cleanup — do not "finish the job" by
+      # switching it on without also pinning shellcheck.
+      #
+      # actionlint is pinned above by version and checksum, so it can only
+      # change its verdict when somebody edits this file. shellcheck is NOT:
+      # actionlint shells out to whatever binary the `ubuntu-latest` image
+      # happens to ship. Wiring that into `quality` — a REQUIRED check —
+      # means a runner-image bump that adds one SC rule turns main red with
+      # no commit behind it. AGENTS.md makes exactly this call for the
+      # docs-freshness sweep ("a check that can go red between two identical
+      # commits does not belong in front of a merge button"), and it applies
+      # with more force here, because this check gates every merge.
+      #
+      # The cost is real and worth naming: 15 shellcheck findings in `run:`
+      # blocks go unreported, most of them deliberate word-splitting, one of
+      # them a malformed `disable=` directive that silently suppresses
+      # nothing (ci.yml's Squawk step). `actionlint` with no flags, run
+      # locally, still reports all of them — that is the intended place for
+      # them. What this gate owns is workflow *schema*, which nothing else
+      # in this repo reads at all.
+      - name: Lint GitHub Actions workflows (actionlint)
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          curl -sSfL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check --strict
+          tar -xzf actionlint.tar.gz actionlint
+          cd "$GITHUB_WORKSPACE"
+          "$RUNNER_TEMP/actionlint" -color -shellcheck=
+
       - name: Typecheck plugins
         # The pinchy-* plugins run via tsx with no ahead-of-time type checking
         # elsewhere (root `pnpm build` is `next build`, which only typechecks

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -36,10 +36,13 @@ jobs:
         id: tags
         run: node scripts/moving-tag.mjs "$GITHUB_REF_NAME"
 
+      # Defense-in-depth pull-through cache for Docker Hub. See the longer
+      # comment on the same step in release.yml for why the input is spelled
+      # `buildkitd-config-inline` and what the old `config-inline` did (nothing).
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
-          config-inline: |
+          buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,23 @@ jobs:
       # Hub (same reason as .github/actions/docker-mirror in CI — avoids the
       # 200 pulls/6h rate limit). buildx runs in its own buildkit container,
       # so /etc/docker/daemon.json doesn't apply; we configure it here.
+      #
+      # This is defense-in-depth, NOT the primary mechanism: every `FROM` in
+      # Dockerfile.pinchy / Dockerfile.openclaw already names
+      # mirror.gcr.io/library/node:22-slim explicitly. It catches the next
+      # `FROM` that forgets the prefix, and any transitive docker.io ref.
+      #
+      # The input is `buildkitd-config-inline`, NOT `config-inline` — the
+      # action renamed it in v3 and an unknown `with:` key is passed as an
+      # INPUT_* env var the action never reads. It ran that way from the
+      # workflow's first commit until 2026-08-05: green step, dead config,
+      # and the only trace was an `##[warning]Unexpected input(s)` line
+      # buried in the step log. The `actionlint` step in ci.yml's `quality`
+      # job is what makes the next such rename fail loudly instead.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
-          config-inline: |
+          buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,14 @@ jobs:
       # INPUT_* env var the action never reads. It ran that way from the
       # workflow's first commit until 2026-08-05: green step, dead config,
       # and the only trace was an `##[warning]Unexpected input(s)` line
-      # buried in the step log. The `actionlint` step in ci.yml's `quality`
-      # job is what makes the next such rename fail loudly instead.
+      # buried in the step log.
+      #
+      # The `actionlint` step in ci.yml's `quality` job catches that class —
+      # but only while actionlint's bundled schema DB knows the pinned major.
+      # At a version it does not know it reports nothing, so bumping this
+      # `@v4` is not a routine dependabot merge: the coverage check next to
+      # that step goes red on the bump, and the honest fix is a newer
+      # actionlint rather than an acceptance.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,33 @@ Three details worth knowing before editing the guard:
 - **The baseline is a snapshot, so a rebase can re-open it.** The fingerprints pin `main` as of the moment they were taken. Any commit to `upgrading.mdx` that lands first — including a legitimate one — invalidates the entry it touches, and the guard says so with the new fingerprint. That is the correct behaviour and it is a one-time cost: once this guard is on `main`, such a commit needs its own authorization instead.
 - **`KNOWN_PRE_GUARD_DRIFT` pins a body, not a section.** The eight pre-guard drifts are accepted by sha256 of the exact accepted text, so those sections are not left open — the next edit to one of them fails like any other, and the failure prints the new fingerprint. Entries are classified: `retro-correction` (a legitimate fix that predates the trailer, e.g. the `git checkout` → `docker compose pull` rewrite across v0.2.0–v0.4.0) or `misplaced-note` (the bug itself, still to be moved — those must cite a tracking issue).
 
+## The Workflow Files Are Linted, And The Linter's Coverage Is Measured
+
+Nothing in this repo read `.github/workflows/*.yml`, and two bugs went through that gap. PR #1063 landed a `ci.yml` GitHub could not parse — which did not fail, it left the required checks on "Expected — Waiting for status" forever, the same unmergeable-with-nothing-broken shape as a workflow-level `paths-ignore` or a matrix on a required job. And `release.yml` / `pre-release.yml` both passed `config-inline:` to `docker/setup-buildx-action`, an input renamed to `buildkitd-config-inline` in v3: an unknown `with:` key is handed to the action as an `INPUT_*` env var it never reads, so the buildkit registry-mirror config was dead from those workflows' first commit until 2026-08-05. Neither is a YAML error nor a shell error — both are _schema_ errors, and `actionlint` is the only checker here that reads the schema.
+
+It runs in `quality` (ungated, so it reports on every PR — and `.github/**` is not docs, which is exactly the PR that can break a workflow), pinned by version **and** sha256 because the step fetches an executable into a job holding a GHCR-write token.
+
+**Both external-linter integrations are off (`-shellcheck=`, `-pyflakes=`), by design.** actionlint is pinned, so it can only change its verdict when someone edits `ci.yml`. shellcheck and pyflakes are not — actionlint shells out to whatever the `ubuntu-latest` image ships, so a runner-image bump that adds one rule turns main red with no commit behind it. Same call AGENTS.md makes for the docs-freshness sweep, with more force, because this gates every merge. The cost is 15 unreported shellcheck findings in `run:` blocks; plain `actionlint`, run locally, still reports them.
+
+**The load-bearing half is the coverage check, not the lint.** actionlint validates a `with:` key only for action versions in its bundled schema database, and for anything else it reports _nothing_ — a silence indistinguishable from a clean pass, with no flag to turn it into an error. Measured with the pinned 1.7.12:
+
+```
+docker/setup-buildx-action@v4 + `config-inline:`  ->  exit 1, named
+docker/setup-buildx-action@v5 + `config-inline:`  ->  exit 0, silent
+```
+
+`config-inline` is the exact bug the lint was added for, so its protection would expire at the next major bump of the very action it protects — and `.github/dependabot.yml` proposes those weekly, grouped under `patterns: ["*"]`. A major bump is also precisely when an input gets renamed.
+
+So `scripts/check-actionlint-coverage.mjs` measures it: one throwaway workflow per action, each carrying an input that cannot exist, fed to the binary CI just verified (`ACTIONLINT_BIN`). Today 12 of 19 refs are validated. The other 7 need an `ACCEPTED_UNCHECKED` entry in `scripts/lib/actionlint-coverage.mjs` **with a written reason**, and it fails in both directions — an entry for an action actionlint now checks, or one naming a ref no workflow uses, fails like any other drift. Pure logic is unit-tested in `scripts/lib/actionlint-coverage.test.mjs` (`pnpm test:scripts`); the probe itself is not, because it needs the binary.
+
+Three things to know before editing it:
+
+- **When a dependabot action bump turns this red, the fix is a newer actionlint — not an acceptance.** An acceptance there would silence the gate on precisely the change it exists to inspect. Nothing proposes the actionlint bump itself (dependabot's `github-actions` ecosystem reads `uses:`, not a curl'd tarball), so this check is also the only thing that tells you the pin has gone stale.
+- **The probe must match the ref's legal shape.** A remote reusable workflow (`owner/repo/.github/workflows/x.yml@ref`) is used at job level, not as a step; probing it as a step reads "unchecked" because the probe is malformed rather than because actionlint is silent, and the acceptance would then rest on a broken measurement. `isReusableWorkflowRef` is that branch. The osv-scanner entry is genuinely unchecked — verified at job level.
+- **It sees remote refs only.** Local composite actions (`.github/actions/docker-mirror`) get no input validation from actionlint either — verified with a probe — so they are excluded rather than listed as acceptances that assert nothing.
+
+Verify a change to any of it by canary, never by reading: bump `setup-buildx-action` to a major actionlint does not know and watch the coverage check name it; add an acceptance for an action that _is_ checked and watch it fail the other way.
+
 ## No Untracked Sleeps In E2E
 
 Every Playwright config here pins `retries: 0, workers: 1` on purpose: a flake is a signal, not something a rerun hides. A fixed sleep quietly trades that away. It is green on a fast host and red on a loaded runner, and when it does fail it says "timeout" instead of naming what was slow.

--- a/scripts/check-actionlint-coverage.mjs
+++ b/scripts/check-actionlint-coverage.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * actionlint input-coverage guard (CI, and runnable locally).
+ *
+ * The actionlint step in ci.yml's `quality` job catches a wrong `with:` key —
+ * but only for action versions actionlint has a schema for. For anything else
+ * it says nothing, and nothing is indistinguishable from clean.
+ *
+ * This measures which is which: one throwaway workflow per action, each with an
+ * input that cannot exist, fed to the same actionlint binary CI runs. An action
+ * whose coverage is missing must either be fixed (bump actionlint) or accepted
+ * with a reason in scripts/lib/actionlint-coverage.mjs.
+ *
+ * Usage:
+ *   node scripts/check-actionlint-coverage.mjs
+ *   ACTIONLINT_BIN=/path/to/actionlint node scripts/check-actionlint-coverage.mjs
+ *
+ * Not a vitest guard: it needs the actionlint binary, which `pnpm test:scripts`
+ * has no way to guarantee. The pure logic it depends on IS unit-tested there
+ * (scripts/lib/actionlint-coverage.test.mjs).
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildProbeWorkflow,
+  classifyCoverage,
+  extractActionRefs,
+  formatFailure,
+  probeReportedInput,
+} from "./lib/actionlint-coverage.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const actionlintBin = process.env.ACTIONLINT_BIN || "actionlint";
+
+/** Every *.yml / *.yaml under .github/, recursively. */
+function collectYamlFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectYamlFiles(full));
+    } else if (/\.ya?ml$/.test(entry)) {
+      out.push({ path: full, content: readFileSync(full, "utf8") });
+    }
+  }
+  return out;
+}
+
+const files = collectYamlFiles(path.join(repoRoot, ".github"));
+const used = extractActionRefs(files);
+
+// A synthetic workflow needs its own .github/workflows/ — actionlint resolves
+// the project root from the file's path and refuses a bare file elsewhere.
+const probeRoot = mkdtempSync(path.join(tmpdir(), "actionlint-coverage-"));
+const probeDir = path.join(probeRoot, ".github", "workflows");
+mkdirSync(probeDir, { recursive: true });
+const probeFile = path.join(probeDir, "probe.yml");
+
+const checked = [];
+for (const ref of used) {
+  writeFileSync(probeFile, buildProbeWorkflow(ref));
+  let output = "";
+  try {
+    output = execFileSync(
+      actionlintBin,
+      ["-no-color", "-oneline", "-shellcheck=", "-pyflakes=", probeFile],
+      { encoding: "utf8", cwd: probeRoot },
+    );
+  } catch (err) {
+    // actionlint exits non-zero whenever it reports anything, which is the
+    // expected outcome for a covered action. Its findings are on stdout.
+    if (err.stdout === undefined && err.stderr === undefined) {
+      console.error(
+        `Could not run '${actionlintBin}': ${err.message}\n` +
+          `Install actionlint, or point ACTIONLINT_BIN at the binary.`,
+      );
+      process.exit(1);
+    }
+    output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+  }
+  if (probeReportedInput(output)) checked.push(ref);
+}
+
+const { failures } = classifyCoverage({ used, checked });
+
+if (failures.length > 0) {
+  console.error(formatFailure(failures));
+  process.exit(1);
+}
+
+console.log(
+  `actionlint input coverage: ${checked.length}/${used.length} actions validated ` +
+    `(${used.length - checked.length} accepted as unchecked).`,
+);

--- a/scripts/lib/actionlint-coverage.mjs
+++ b/scripts/lib/actionlint-coverage.mjs
@@ -1,0 +1,229 @@
+/**
+ * actionlint input-coverage guard.
+ *
+ * `actionlint` only validates a step's `with:` keys for actions it has a schema
+ * for, and those schemas are baked into the actionlint release. For an action
+ * version it does not know it reports *nothing* — and a silent pass is
+ * indistinguishable from a clean one.
+ *
+ * That is not academic here. Measured with the pinned actionlint 1.7.12:
+ *
+ *   docker/setup-buildx-action@v4 + `config-inline:`  -> exit 1, named
+ *   docker/setup-buildx-action@v5 + `config-inline:`  -> exit 0, silent
+ *
+ * `config-inline` is the exact bug the actionlint step was added for. So the
+ * protection expires at the next major bump of the very action it protects —
+ * and `.github/dependabot.yml` proposes those weekly, grouped under
+ * `patterns: ["*"]`. A major bump is also precisely when an input gets renamed.
+ *
+ * There is no flag for this: `actionlint -h` offers no way to error on an
+ * action it does not recognise. So the coverage has to be measured, which is
+ * what `scripts/check-actionlint-coverage.mjs` does — it feeds actionlint one
+ * throwaway workflow per action with a bogus input and records whether it
+ * complains.
+ *
+ * This module is the pure half: what to probe, and how to judge the results.
+ *
+ * See AGENTS.md § "A Hand-Maintained List That Mirrors Code Will Be Wrong" —
+ * an accepted-list is only honest when it fails in BOTH directions.
+ */
+
+/**
+ * The bogus input fed to each action. Deliberately unlikely to ever become a
+ * real input name; if one ever does, every probe silently reports "checked".
+ */
+export const PROBE_INPUT = "zzz-actionlint-coverage-probe";
+
+/**
+ * Actions the pinned actionlint does not input-check, accepted with a reason.
+ *
+ * Keyed by the FULL ref including the version, on purpose. actionlint knows
+ * `actions/checkout` — just not `@v7` — so an acceptance keyed on the repo
+ * alone would outlive the version it was made for. A bump re-opens the
+ * question, which is the point: that is the moment coverage changes.
+ *
+ * An entry whose action IS checked, or is no longer used, fails too. A verdict
+ * must not outlive its evidence.
+ */
+export const ACCEPTED_UNCHECKED = {
+  "actions/checkout@v7":
+    "actionlint 1.7.12's schema DB stops at checkout v4; v7 is newer than the pin.",
+  "actions/upload-pages-artifact@v5":
+    "Not in actionlint's popular-actions DB at any version.",
+  "anchore/sbom-action@v0":
+    "Third-party, not in actionlint's popular-actions DB.",
+  "lycheeverse/lychee-action@v2":
+    "Third-party, not in actionlint's popular-actions DB.",
+  "pnpm/action-setup@v6":
+    "actionlint's DB stops at pnpm/action-setup v2; v6 is newer than the pin.",
+  "softprops/action-gh-release@v3":
+    "actionlint's DB stops at action-gh-release v1; v3 is newer than the pin.",
+  "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8":
+    "A REMOTE reusable workflow. actionlint validates the inputs of local " +
+    "reusable workflows by reading the file, but never fetches a remote one — " +
+    "probed at job level (its legal shape) and it reports nothing. A permanent " +
+    "gap of its own class, not a version-DB gap.",
+};
+
+/**
+ * A corpus floor. A broken extractor that finds nothing would otherwise pass in
+ * silence, which is how a coverage gate becomes decoration.
+ */
+export const MIN_EXPECTED_ACTIONS = 10;
+
+/**
+ * Pull every remote action reference out of workflow / action YAML.
+ *
+ * Local refs (`./.github/actions/...`) and `docker://` images are skipped:
+ * actionlint does not input-check either (verified — a bogus input on a local
+ * composite action is not reported), so listing them here would only produce
+ * accepted-entries that assert nothing.
+ *
+ * @param {Array<{path: string, content: string}>} files
+ * @returns {string[]} sorted, unique `owner/repo[/subpath]@ref` strings
+ */
+export function extractActionRefs(files) {
+  const refs = new Set();
+  for (const { content } of files) {
+    for (const line of content.split("\n")) {
+      // `- uses: owner/repo@ref` — the leading `-` and quoting are optional.
+      const match = line.match(
+        /^\s*-?\s*uses:\s*["']?([A-Za-z0-9][\w.-]*\/[\w./-]+@[\w./-]+)["']?\s*(?:#.*)?$/,
+      );
+      if (match) refs.add(match[1]);
+    }
+  }
+  return [...refs].sort();
+}
+
+/**
+ * A remote reusable workflow (`owner/repo/.github/workflows/x.yml@ref`) is used
+ * at job level, not as a step. Probing one as a step would make it look
+ * unchecked because the probe is malformed rather than because actionlint is
+ * silent — an acceptance resting on a broken measurement.
+ *
+ * @param {string} ref
+ * @returns {boolean}
+ */
+export function isReusableWorkflowRef(ref) {
+  return /\.ya?ml@/.test(ref);
+}
+
+/**
+ * A minimal workflow that uses `ref` with one input that cannot exist, in the
+ * shape that `ref` is legally used in.
+ *
+ * @param {string} ref
+ * @returns {string} workflow YAML
+ */
+export function buildProbeWorkflow(ref) {
+  const head = [
+    "name: actionlint-coverage-probe",
+    "on: push",
+    "jobs:",
+    "  probe:",
+  ];
+  const body = isReusableWorkflowRef(ref)
+    ? [`    uses: ${ref}`, "    with:", `      ${PROBE_INPUT}: "x"`]
+    : [
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        `      - uses: ${ref}`,
+        "        with:",
+        `          ${PROBE_INPUT}: "x"`,
+      ];
+  return [...head, ...body, ""].join("\n");
+}
+
+/**
+ * Did actionlint report the probe input for this action?
+ *
+ * Matches on the probe input name rather than on the exit code: actionlint may
+ * legitimately report other things about a synthetic workflow, and an exit code
+ * cannot tell those apart from the answer we want.
+ *
+ * @param {string} output combined stdout+stderr from actionlint
+ * @returns {boolean}
+ */
+export function probeReportedInput(output) {
+  return output.includes(PROBE_INPUT);
+}
+
+/**
+ * Judge a completed probe run.
+ *
+ * @param {{used: string[], checked: string[], accepted?: Record<string,string>}} input
+ * @returns {{failures: string[]}}
+ */
+export function classifyCoverage({
+  used,
+  checked,
+  accepted = ACCEPTED_UNCHECKED,
+}) {
+  const failures = [];
+
+  if (used.length < MIN_EXPECTED_ACTIONS) {
+    failures.push(
+      `Found only ${used.length} action reference(s) under .github/ — expected at least ` +
+        `${MIN_EXPECTED_ACTIONS}. The extractor is probably broken; a coverage check ` +
+        `that inspects nothing passes in silence.`,
+    );
+    return { failures };
+  }
+
+  const usedSet = new Set(used);
+  const checkedSet = new Set(checked);
+
+  for (const ref of used) {
+    if (checkedSet.has(ref) || Object.hasOwn(accepted, ref)) continue;
+    failures.push(
+      `${ref}: actionlint does not validate this action's inputs, and there is no ` +
+        `ACCEPTED_UNCHECKED entry for it.\n` +
+        `    A wrong \`with:\` key on it would ship green — that is exactly the bug ` +
+        `this gate exists to catch.\n` +
+        `    Fix by bumping the pinned actionlint in ci.yml (its schema DB may have ` +
+        `caught up), or\n` +
+        `    accept it in scripts/lib/actionlint-coverage.mjs with a reason.`,
+    );
+  }
+
+  for (const [ref, reason] of Object.entries(accepted)) {
+    if (!reason || !reason.trim()) {
+      failures.push(`${ref}: ACCEPTED_UNCHECKED entry has no reason.`);
+      continue;
+    }
+    if (!usedSet.has(ref)) {
+      failures.push(
+        `${ref}: ACCEPTED_UNCHECKED names an action no workflow uses at this version. ` +
+          `Drop the entry (or update it to the version now in use) — a stale acceptance ` +
+          `is the same drift one level up.`,
+      );
+      continue;
+    }
+    if (checkedSet.has(ref)) {
+      failures.push(
+        `${ref}: ACCEPTED_UNCHECKED says actionlint cannot check this, but it now does. ` +
+          `Drop the entry — a verdict must not outlive its evidence.`,
+      );
+    }
+  }
+
+  return { failures };
+}
+
+/**
+ * @param {string[]} failures
+ * @returns {string}
+ */
+export function formatFailure(failures) {
+  return [
+    "actionlint input-coverage check failed:",
+    "",
+    ...failures.map((f) => `  - ${f}`),
+    "",
+    "actionlint only validates `with:` keys for action versions in its bundled",
+    "schema database. For anything else it reports nothing, and a silent pass",
+    "looks exactly like a clean one. See AGENTS.md and the comment in",
+    "scripts/lib/actionlint-coverage.mjs.",
+  ].join("\n");
+}

--- a/scripts/lib/actionlint-coverage.test.mjs
+++ b/scripts/lib/actionlint-coverage.test.mjs
@@ -1,0 +1,239 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  ACCEPTED_UNCHECKED,
+  MIN_EXPECTED_ACTIONS,
+  PROBE_INPUT,
+  buildProbeWorkflow,
+  classifyCoverage,
+  extractActionRefs,
+  formatFailure,
+  isReusableWorkflowRef,
+  probeReportedInput,
+} from "./actionlint-coverage.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function collectYaml(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...collectYaml(full));
+    else if (/\.ya?ml$/.test(entry))
+      out.push({ path: full, content: readFileSync(full, "utf8") });
+  }
+  return out;
+}
+
+test("extractActionRefs finds remote refs in the shapes workflows actually use", () => {
+  const refs = extractActionRefs([
+    {
+      path: "w.yml",
+      content: [
+        "      - uses: actions/checkout@v7",
+        "        uses: docker/build-push-action@v7",
+        '      - uses: "docker/login-action@v4"',
+        "      - uses: github/codeql-action/init@v4 # subpath action",
+      ].join("\n"),
+    },
+  ]);
+  assert.deepEqual(refs, [
+    "actions/checkout@v7",
+    "docker/build-push-action@v7",
+    "docker/login-action@v4",
+    "github/codeql-action/init@v4",
+  ]);
+});
+
+test("extractActionRefs skips refs actionlint cannot input-check anyway", () => {
+  // Local composite actions and reusable workflows get no input validation
+  // (verified with a probe), so listing them would only produce acceptances
+  // that assert nothing. `docker://` is not an action at all.
+  const refs = extractActionRefs([
+    {
+      path: "w.yml",
+      content: [
+        "      - uses: ./.github/actions/docker-mirror",
+        "    uses: ./.github/workflows/screenshots.yml",
+        "      - uses: docker://alpine:3.20",
+        "      - uses: actions/cache@v5",
+      ].join("\n"),
+    },
+  ]);
+  assert.deepEqual(refs, ["actions/cache@v5"]);
+});
+
+test("extractActionRefs dedupes across files and sorts", () => {
+  const refs = extractActionRefs([
+    { path: "a.yml", content: "      - uses: actions/checkout@v7" },
+    { path: "b.yml", content: "      - uses: actions/cache@v5" },
+    { path: "c.yml", content: "      - uses: actions/checkout@v7" },
+  ]);
+  assert.deepEqual(refs, ["actions/cache@v5", "actions/checkout@v7"]);
+});
+
+test("extractActionRefs finds a quoted job-level remote reusable workflow", () => {
+  // The shape a hand-written grep misses: quoted, at job level, with `.yml@`
+  // in the middle of the ref. ci.yml's osv-scanner job is exactly this, and it
+  // was missing from the first enumeration of this repo's actions.
+  const refs = extractActionRefs([
+    {
+      path: "ci.yml",
+      content:
+        '    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"',
+    },
+  ]);
+  assert.deepEqual(refs, [
+    "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8",
+  ]);
+});
+
+test("buildProbeWorkflow carries the probe input under the given action", () => {
+  const yaml = buildProbeWorkflow("docker/setup-buildx-action@v4");
+  assert.match(yaml, /uses: docker\/setup-buildx-action@v4/);
+  assert.match(yaml, new RegExp(`${PROBE_INPUT}: "x"`));
+  assert.match(yaml, /runs-on: ubuntu-latest/);
+  assert.match(yaml, /steps:/);
+});
+
+test("buildProbeWorkflow probes a reusable workflow at job level, not as a step", () => {
+  // A reusable workflow used as a step is illegal YAML-for-Actions, so the
+  // probe would read "unchecked" because it is malformed rather than because
+  // actionlint is silent — an acceptance resting on a broken measurement.
+  const ref = "o/r/.github/workflows/w.yml@v1";
+  assert.equal(isReusableWorkflowRef(ref), true);
+  assert.equal(isReusableWorkflowRef("docker/login-action@v4"), false);
+
+  const yaml = buildProbeWorkflow(ref);
+  assert.doesNotMatch(yaml, /steps:/);
+  assert.doesNotMatch(yaml, /runs-on:/);
+  assert.match(
+    yaml,
+    new RegExp(`^ {4}uses: ${ref.replace(/\//g, "\\/")}$`, "m"),
+  );
+  assert.match(yaml, new RegExp(`^ {6}${PROBE_INPUT}: "x"$`, "m"));
+});
+
+test("probeReportedInput keys on the input name, not on the exit code", () => {
+  // actionlint may report unrelated things about a synthetic workflow; an exit
+  // code cannot tell those apart from the answer we want.
+  assert.equal(
+    probeReportedInput(
+      `probe.yml:9:11: input "${PROBE_INPUT}" is not defined in action "x" [action]`,
+    ),
+    true,
+  );
+  assert.equal(
+    probeReportedInput('probe.yml:5:5: "runs-on" is not valid [runner-label]'),
+    false,
+  );
+  assert.equal(probeReportedInput(""), false);
+});
+
+test("classifyCoverage fails on an action nothing validates and nothing accepts", () => {
+  const used = Array.from({ length: 12 }, (_, i) => `o/r${i}@v1`);
+  const { failures } = classifyCoverage({
+    used,
+    checked: used.slice(1),
+    accepted: {},
+  });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /o\/r0@v1/);
+  assert.match(failures[0], /ACCEPTED_UNCHECKED/);
+});
+
+test("classifyCoverage passes when the gap is accepted with a reason", () => {
+  const used = Array.from({ length: 12 }, (_, i) => `o/r${i}@v1`);
+  const { failures } = classifyCoverage({
+    used,
+    checked: used.slice(1),
+    accepted: { "o/r0@v1": "not in actionlint's DB at any version" },
+  });
+  assert.deepEqual(failures, []);
+});
+
+test("classifyCoverage rejects an acceptance with no reason", () => {
+  const used = Array.from({ length: 12 }, (_, i) => `o/r${i}@v1`);
+  const { failures } = classifyCoverage({
+    used,
+    checked: used.slice(1),
+    accepted: { "o/r0@v1": "   " },
+  });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /no reason/);
+});
+
+test("classifyCoverage fails when an acceptance outlives its evidence", () => {
+  const used = Array.from({ length: 12 }, (_, i) => `o/r${i}@v1`);
+
+  // actionlint caught up and now checks it.
+  const nowChecked = classifyCoverage({
+    used,
+    checked: used,
+    accepted: { "o/r0@v1": "was unchecked" },
+  });
+  assert.equal(nowChecked.failures.length, 1);
+  assert.match(nowChecked.failures[0], /but it now does/);
+
+  // The action (at that version) is gone from the workflows.
+  const gone = classifyCoverage({
+    used,
+    checked: used,
+    accepted: { "o/removed@v9": "was unchecked" },
+  });
+  assert.equal(gone.failures.length, 1);
+  assert.match(gone.failures[0], /no workflow uses/);
+});
+
+test("classifyCoverage fails on an empty corpus rather than passing in silence", () => {
+  // A broken extractor is the one mutation every other assertion here is blind
+  // to: zero actions means zero coverage failures, i.e. a green decoration.
+  const { failures } = classifyCoverage({
+    used: [],
+    checked: [],
+    accepted: {},
+  });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /expected at least/);
+});
+
+test("formatFailure names every failure", () => {
+  const text = formatFailure(["first thing", "second thing"]);
+  assert.match(text, /first thing/);
+  assert.match(text, /second thing/);
+});
+
+test("every ACCEPTED_UNCHECKED entry is an action this repo still uses", () => {
+  // The half of the both-directions rule that can be checked without the
+  // binary: an acceptance naming a ref no workflow contains is stale on its
+  // face, and would otherwise only surface in CI.
+  const used = new Set(
+    extractActionRefs(collectYaml(join(REPO_ROOT, ".github"))),
+  );
+  assert.ok(
+    used.size >= MIN_EXPECTED_ACTIONS,
+    `expected at least ${MIN_EXPECTED_ACTIONS} action refs under .github/, found ${used.size}`,
+  );
+  for (const [ref, reason] of Object.entries(ACCEPTED_UNCHECKED)) {
+    assert.ok(
+      used.has(ref),
+      `ACCEPTED_UNCHECKED names ${ref}, which no workflow under .github/ uses`,
+    );
+    assert.ok(reason.trim().length > 0, `${ref} has no reason`);
+  }
+});
+
+test("ci.yml runs the coverage check with the actionlint it just verified", () => {
+  // The wiring assertion. A coverage guard nothing invokes is the failure mode
+  // it exists to prevent, one level up.
+  const ci = readFileSync(join(REPO_ROOT, ".github/workflows/ci.yml"), "utf8");
+  assert.match(ci, /scripts\/check-actionlint-coverage\.mjs/);
+  assert.match(
+    ci,
+    /ACTIONLINT_BIN:\s*\$\{\{\s*runner\.temp\s*\}\}\/actionlint/,
+    "the check must run the pinned binary, not whatever the runner image ships",
+  );
+});


### PR DESCRIPTION
## What

Two commits: a dead config in the release workflows, and the check that would have caught it.

### 1. `config-inline` → `buildkitd-config-inline`

`release.yml` and `pre-release.yml` passed `config-inline:` to `docker/setup-buildx-action`. The input was renamed to `buildkitd-config-inline` in v3; both workflows pin v4, whose `action.yml` declares no `config-inline` — and neither does its `dist/`, so it is not a legacy alias.

An unknown `with:` key is not an error. GitHub passes it as an `INPUT_*` env var the action never reads, so the step stayed green with a dead config since the workflows were written.

Verified on run [30959751249](https://github.com/heypinchy/pinchy/actions/runs/30959751249):

```
##[warning]Unexpected input(s) 'config-inline', valid inputs are ['version', 'driver', ... 'buildkitd-config-inline', ...]
```

and the `docker buildx create` it then runs carries no `--config` flag — which is what the input would have produced.

**Impact is smaller than "the mirror was off" suggests**, and it is worth saying so plainly so nobody reads a build-time fix into this: every `FROM` in `Dockerfile.pinchy` / `Dockerfile.openclaw` already names `mirror.gcr.io/library/node:22-slim` directly, so the base images never went to docker.io regardless. The registry mirror is defense-in-depth for the next `FROM` that forgets the prefix.

**Not switched to `.github/actions/docker-mirror`**: that action configures the Docker *daemon* and pre-pulls images named in `docker-compose*.yml`. buildx runs buildkit in its own container, which reads neither the daemon config nor the daemon's image store, and the Dockerfile base images are not in the compose files. Right tool for the E2E stacks, wrong one for an image build.

### 2. `actionlint` in `quality`

Nothing in this repo read `.github/workflows/*.yml`, and two bugs went through that gap: the one above, and #1063 shipping a `ci.yml` GitHub could not parse — which did not fail, it left the required checks on "Expected — Waiting for status" forever. Same unmergeable-with-nothing-broken shape AGENTS.md documents for a workflow-level `paths-ignore` and for a matrix on a required job, reached from a third direction.

Neither is a YAML error nor a shell error. Both are *schema* errors, and actionlint is the only checker available that reads the schema.

- In `quality` because it is ungated and required, so it runs on every PR. A `changes`-gated job would skip on docs-only PRs, and `.github/**` is not docs.
- Pinned by version **and** sha256: the step fetches an executable into a job holding a GHCR-write token.
- **shellcheck integration is off, by design, not as a deferred cleanup.** actionlint is pinned so it can only change its verdict when someone edits the workflow; shellcheck is whatever the `ubuntu-latest` image ships. Wiring an unpinned linter into a *required* check means a runner-image bump can turn main red with no commit behind it. The cost — 15 unreported findings in `run:` blocks — is named in the step comment, and `actionlint` with no flags still reports them locally.

## Verification

Canary, not code-reading, per AGENTS.md:

- revert the rename → `exit 1`, names `release.yml:49` and the valid input list
- add a bogus job key to `ci.yml` (the #1063 class) → `exit 1`, `syntax-check`
- restored tree → `actionlint -shellcheck=` exits 0

`pnpm test:scripts` 913 pass / 0 fail · `pnpm format:check` clean.

## Follow-up, not in this PR

The wide build-time spread on these workflows is **not** explained by the mirror. Both images in both workflows share one unscoped `type=gha` cache and evict each other — measured, both builds import the same manifest id in a given run (`gha:545876786137920731` in the fast run, 9 CACHED layers; `gha:8806450649261263758` in the slow one, 2 CACHED). Separate PR: the naive per-image `scope=` would add four more `mode=max` layer sets to the same 10 GB budget `ci.yml` already calls tight, so the fix likely wants `type=registry` on GHCR instead — which is what `ci.yml`'s own comment recommends for exactly this case.

---

## Review round (commit 3)

Reviewing the two commits above turned up that the actionlint step makes a promise it cannot keep, plus two smaller gaps.

### The lint expires at the next major bump of the action it protects

actionlint validates a `with:` key only for action versions in its bundled schema database. For anything else it reports **nothing**, and `actionlint -h` offers no flag to turn that silence into an error. Measured with the pinned 1.7.12:

| probe | result |
|---|---|
| `docker/setup-buildx-action@v4` + `config-inline:` | **exit 1**, named |
| `docker/setup-buildx-action@v5` + `config-inline:` | **exit 0, silent** |

`config-inline` is the exact bug this PR exists for. `.github/dependabot.yml` proposes action bumps weekly, grouped under `patterns: ["*"]` — and a major bump is precisely when an input gets renamed. So the protection would disarm itself on the change that most needs it, silently.

Six refs were **already** unvalidated with nothing saying so: `actions/checkout@v7`, `actions/upload-pages-artifact@v5`, `anchore/sbom-action@v0`, `lycheeverse/lychee-action@v2`, `pnpm/action-setup@v6`, `softprops/action-gh-release@v3`.

`release.yml`'s comment claimed actionlint "makes the next such rename fail loudly instead" — corrected.

### The fix: measure the coverage

`scripts/check-actionlint-coverage.mjs` feeds one throwaway workflow per action to the binary CI just verified (`ACTIONLINT_BIN`), each carrying an input that cannot exist. Today **12 of 19** refs are validated; the other 7 need an `ACCEPTED_UNCHECKED` entry with a written reason. Both directions fail — an entry for an action actionlint now checks, or one naming a ref no workflow uses. Pure logic is unit-tested (`pnpm test:scripts`, +15 tests → 928 pass / 0 fail).

**The probe matches each ref's legal shape.** A remote reusable workflow is used at job level, not as a step; a step-shaped probe would read "unchecked" because the probe is malformed rather than because actionlint is silent — an acceptance resting on a broken measurement. `ci.yml`'s osv-scanner job is exactly that shape, was missing from this PR's original enumeration (it is quoted), and is genuinely unchecked — verified at job level.

**When a dependabot bump turns this red, the fix is a newer actionlint, not an acceptance.** Nothing else proposes that bump: dependabot's `github-actions` ecosystem reads `uses:`, not a curl'd tarball, so this check is also the only thing that reports the pin has gone stale.

### Two smaller gaps in the step

- **`-pyflakes=`** alongside `-shellcheck=`. The step argues at length that no unpinned external linter may gate a *required* check, then left `-pyflakes` on its default `"pyflakes"`. Inert today (no `shell: python` anywhere) — which is exactly why it would have stayed unnoticed.
- **`curl --retry 3 --retry-all-errors`**. This gates every merge; a transient GitHub Releases blip must not redden a required check with nothing broken.

### Canary-verified, not read

- bump `setup-buildx-action` to `@v5` → coverage check fails naming it
- accept an action that **is** checked → fails with "but it now does"
- acceptance naming an unused ref → fails as stale
- restored tree → both checks green

`pnpm format:check` clean · `actionlint -shellcheck= -pyflakes=` exit 0 · `pnpm test:scripts` 928 pass / 0 fail.
