### PR TITLE
fix(eval): normalise typography in structure, keep paths exact

### DIFF
--- a/packages/web/e2e/telegram/chats.spec.ts
+++ b/packages/web/e2e/telegram/chats.spec.ts
@@ -421,13 +421,24 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
     // merely until the transcript is non-empty. OpenClaw can surface the
     // assistant's reply (or an older turn) a beat before the just-sent user
     // message is queryable, so a loop that exits on "any message" races the
-    // specific-text assertion below — the intermittent failure this guards. If
-    // the fallback genuinely drops the message, this now fails deterministically
-    // (the loop exhausts its budget) instead of flaking.
+    // specific-text assertion below.
+    //
+    // And WIPE AGAIN each round, which is the half a single delete cannot cover.
+    // The exchange produces TWO captured rows — the inbound message and the
+    // agent's reply — written independently, and the precondition above exits on
+    // the first of them. A delete that lands between the two leaves the reply
+    // behind, `channel_messages` is then non-empty, and the route takes the DB
+    // path where HIDDEN_MSG no longer exists: the fallback never runs at all, so
+    // polling for it cannot succeed no matter how long it waits. That is the
+    // 2026-08-05 failure exactly — `messages.length > 0` passed, the text
+    // assertion failed, and the 20s budget was spent on a branch the request was
+    // never going to take. "Pinchy captured nothing" has to hold for the whole
+    // window, not for the instant of one DELETE.
     const fallbackHasSentMessage = (r: { status: number; messages: { text: string }[] }) =>
       r.status === 200 && r.messages.some((m) => m.text.includes(HIDDEN_MSG));
     let after = await getTelegramChatAs(adminCookie, agentId);
     for (let i = 0; i < 20 && !fallbackHasSentMessage(after); i++) {
+      await deleteCapturedTelegramMessages(TG_PEER_ID);
       await new Promise((r) => setTimeout(r, 1000));
       after = await getTelegramChatAs(adminCookie, agentId);
     }
@@ -438,10 +449,15 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
     ).toBeGreaterThan(0);
 
     // It renders the ACTUAL conversation, not just "something non-empty": the
-    // exact message we sent must come back through the history fallback.
+    // exact message we sent must come back through the history fallback. The
+    // message names what came back instead — without it the failure says only
+    // "false", and telling a fallback that dropped the message apart from a
+    // capture row that beat the wipe means downloading the trace.
     expect(
       after.messages.some((m) => m.text.includes(HIDDEN_MSG)),
-      "the fallback must render the real message text from OpenClaw history"
+      `the fallback must render the real message text from OpenClaw history; got ${JSON.stringify(
+        after.messages.map((m) => `${m.role}: ${m.text.slice(0, 80)}`)
+      )}`
     ).toBe(true);
 
     // ...and in chronological order (oldest→newest), matching the live chat and

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   citedSourcePaths,
+  sourcesListCandidates,
   composeKbGraderResults,
   gradeAttribution,
   gradeCitationResolution,
@@ -787,5 +788,104 @@ describe("citedSourcePaths", () => {
 
   it("returns an empty array for an answer with no Sources list (e.g. an abstention)", () => {
     expect(citedSourcePaths("I couldn't find this in the knowledge base.")).toEqual([]);
+  });
+});
+
+/**
+ * The line the 2026-08-04 sweep forced: normalise typography in what identifies
+ * STRUCTURE, never in what identifies a DOCUMENT.
+ *
+ * `gpt-oss:120b` does not write ASCII punctuation. Across its 12 runs it
+ * substituted U+3010/U+3011 for `[`/`]`, U+2011 for `-`, U+2013 for `–` and
+ * U+201C for `"`. Eight of its runs therefore carried no inline citation this
+ * parser could see, so `citedNumbers` was empty: every Sources entry read as
+ * listed-but-uncited, the premise set came back empty, and `ungrounded-claim`
+ * followed. Its 0/12 measured Unicode, not grounding.
+ *
+ * The heading half is the same shape in another language: asked in German, all
+ * four models answer in German and title the list `Quellen`.
+ *
+ * Where the line does NOT move: a PATH. `retention‑correct.md` with U+2011 is
+ * not the path the tool showed, `source-links.ts` will not linkify it, and a
+ * reader who clicks gets nothing — so the citation axis is right to charge it.
+ * The product already draws this line itself: `TRAILING_PAGE` in
+ * `source-links.ts` accepts `—`, `–` and `-` alike for the page suffix while
+ * requiring the path to match exactly.
+ */
+describe("typography in structure, exactness in paths", () => {
+  it("reads a fullwidth citation marker as the citation it is", () => {
+    // Verbatim shape from gpt-oss:120b: 【1】 inline, [1] in the list.
+    const input: AttributionInput = {
+      answer: `Laptops are replaced on a 3-year cycle【1】.
+
+**Sources:**
+
+- [1] it-equipment-policy.md — p. 1`,
+      retrieved: [src(1, "/data/it-equipment-policy.md")],
+    };
+
+    expect(gradeAttribution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it.each([
+    ["bold with a colon", "**Quellen:**"],
+    ["a hash heading", "### Quellen"],
+    ["bold, singular, no colon", "**Quelle**"],
+  ])("recognises a German Sources heading (%s)", (_label, heading) => {
+    const input: AttributionInput = {
+      answer: `Vollzeitbeschäftigte sammeln 2,5 Urlaubstage pro Monat [1].
+
+${heading}
+
+- [1] urlaub-policy-de.md — p. 1`,
+      retrieved: [src(1, "/data/urlaub-policy-de.md")],
+    };
+
+    expect(gradeAttribution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("still charges a path written with a non-breaking hyphen", () => {
+    // U+2011 inside the filename. The document is obvious to a human and the
+    // citation is still unusable — this is the half that must NOT be
+    // normalised, and normalising the markers must not drag it along.
+    const input: AttributionInput = {
+      answer: `Tickets are retained for 24 months【1】.
+
+**Sources:**
+
+- [1] retention‑correct.md — p. 1`,
+      retrieved: [src(1, "/data/retention-correct.md")],
+    };
+
+    expect(gradePathCitation(input).tags).toEqual(["path-not-cited"]);
+  });
+
+  it("does not read ordinary German prose as a heading", () => {
+    // Every German noun is capitalised, so `Quellen` appears in prose in a way
+    // `sources` does not. The line-start + delimiter rules are what tell them
+    // apart, and they have to keep doing so.
+    const answer = `Laut unseren Quellen: die Richtlinie verlangt eine Prüfung [1].
+
+**Sources:**
+
+- [1] urlaub-policy-de.md — p. 1`;
+
+    // Assert the property, not the fragment shape: the real list is the one
+    // that got split off, so no candidate carries the prose. (Candidates split
+    // before each `[N]`, so the bullet arrives as `-` plus `[1] …` — an
+    // incidental detail this test must not pin, or it fails on a change that
+    // breaks nothing.)
+    const candidates = sourcesListCandidates(answer);
+
+    expect(candidates.join(" ")).not.toMatch(/Richtlinie verlangt/);
+    expect(candidates.join(" ")).toContain("urlaub-policy-de.md");
   });
 });

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -888,4 +888,108 @@ ${heading}
     expect(candidates.join(" ")).not.toMatch(/Richtlinie verlangt/);
     expect(candidates.join(" ")).toContain("urlaub-policy-de.md");
   });
+
+  it("does not read a German sentence that OPENS with the noun as a heading", () => {
+    // The discriminating case, and the one the `Quellen?` widening actually
+    // creates: German puts the noun first far more readily than English, so a
+    // sentence really can begin the line with `Quellen `. It sits AFTER the
+    // real list on purpose — `parseAnswer` takes the LAST heading match, so a
+    // prose line before the list is saved by that rule rather than by the
+    // delimiter rule under test here. Were it read as a heading, the split
+    // would move to it, the real bullet would fall into the body, and [1] would
+    // be charged `citation-unresolved`.
+    const input: AttributionInput = {
+      answer: `Die Regelung gilt ab 2024 [1].
+
+**Quellen:**
+
+- [1] urlaub-policy-de.md — p. 1
+
+Quellen für weitere Angaben nennt der Anhang.`,
+      retrieved: [src(1, "/data/urlaub-policy-de.md")],
+    };
+
+    expect(gradeAttribution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("lets the real list win over an earlier German caption line", () => {
+    // `Quelle: <Herausgeber>` under a figure is standard German, and accepting
+    // the singular heading means it matches. The last-match rule is what keeps
+    // that harmless, and this pins the pairing. The bound is worth stating: a
+    // caption written AFTER the Sources list would win the split. Nothing in
+    // the sweep writes one there, and the alternative — dropping the singular —
+    // would refuse a single-source list titled `Quelle`.
+    const input: AttributionInput = {
+      answer: `Die Regelung gilt ab 2024 [1].
+
+Quelle: Statistisches Bundesamt
+
+**Quellen:**
+
+- [1] urlaub-policy-de.md — p. 1`,
+      retrieved: [src(1, "/data/urlaub-policy-de.md")],
+    };
+
+    expect(gradeAttribution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("reads the fullwidth-form brackets too, not only the lenticular ones", () => {
+    // U+FF3B/U+FF3D. `MARKER_BRACKETS` carries them beside the U+3010/U+3011
+    // the sweep produced, so the branch that admits them needs a case of its
+    // own — an untested member of a character class is a claim, not a check.
+    const input: AttributionInput = {
+      answer: `Laptops are replaced on a 3-year cycle［1］.
+
+**Sources:**
+
+- [1] it-equipment-policy.md — p. 1`,
+      retrieved: [src(1, "/data/it-equipment-policy.md")],
+    };
+
+    expect(gradeAttribution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("splits an en-dash page suffix off the path instead of gluing it on", () => {
+    // Same model, same habit: U+2013 where the template writes `—`. The
+    // separator delimits rather than identifies, so it is normalised like the
+    // markers. `gradePathCitation` would survive gluing it on (the matcher
+    // scans the whole entry), which is exactly why this asserts the parsed path
+    // — `gradeNoDuplicateCorroboration` compares that string by equality and
+    // would silently stop matching.
+    const answer = `Laptops are replaced on a 3-year cycle [1].
+
+**Sources:**
+
+- [1] handbook-2012/it-equipment-policy.md – p. 1`;
+
+    expect(citedSourcePaths(answer)).toEqual(["handbook-2012/it-equipment-policy.md"]);
+  });
+
+  it("charges a run-on Sources list written entirely in fullwidth markers", () => {
+    // The half of this change that moves numbers the OTHER way, so it is pinned
+    // rather than left as a surprise in the next sweep: `gradeSourcesFormat`
+    // returns early on zero markers, so before normalisation this run-on had
+    // none it could see and passed. The same typography that emptied the
+    // premise set was excusing the formatting defect.
+    const input: AttributionInput = {
+      answer: `Laptops are replaced on a 3-year cycle【1】 and monitors every four【2】.
+
+**Sources:** 【1】 it-equipment-policy.md — p. 1 【2】 display-policy.md — p. 2`,
+      retrieved: [src(1, "/data/it-equipment-policy.md"), src(2, "/data/display-policy.md")],
+    };
+
+    expect(gradeSourcesFormat(input).tags).toEqual(["sources-format"]);
+  });
 });

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -134,10 +134,55 @@ interface SourcesEntry {
  * the parser rather than the model.
  */
 const SOURCES_HEADING =
-  /^[ \t]*(?:#{0,3}[ \t]*\*{0,2}[ \t]*Sources[ \t]*(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:)|\*{2}[ \t]*Sources[ \t]*\*{2}[ \t]*$|#{1,3}[ \t]*Sources[ \t]*$)/gm;
+  /^[ \t]*(?:#{0,3}[ \t]*\*{0,2}[ \t]*(?:Sources|Quellen?)[ \t]*(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:)|\*{2}[ \t]*(?:Sources|Quellen?)[ \t]*\*{2}[ \t]*$|#{1,3}[ \t]*(?:Sources|Quellen?)[ \t]*$)/gm;
 
 /** Any `[N]` marker, inline citation or Sources-bullet citation number alike. */
 const INLINE_CITATION = /\[(\d+)\]/g;
+
+/**
+ * Bracket forms a model substitutes for `[` and `]` around a citation number.
+ *
+ * `gpt-oss:120b` does not write ASCII punctuation. Across the 2026-08-04 sweep
+ * it used U+3010/U+3011 for brackets, U+2011 for `-`, U+2013 for `–` and
+ * U+201C for `"` — consistently, not occasionally. Eight of its twelve runs
+ * therefore had no inline citation `INLINE_CITATION` could see, so
+ * `citedNumbers` was empty: every Sources entry read as listed-but-uncited, the
+ * premise set came back empty, and `ungrounded-claim` followed on answers that
+ * quote the retrieved passage word for word. Its 0/12 measured Unicode.
+ *
+ * Only the two bracket pairs, and only around the marker. U+FF3B/U+FF3D are by
+ * definition the fullwidth forms of `[`/`]`; U+3010/U+3011 is what the sweep
+ * actually produced. Nothing else is guessed at — a variant nobody has written
+ * would be speculation, and this list is cheap to extend when one shows up.
+ */
+const MARKER_BRACKETS: [RegExp, string][] = [
+  [/[【［]/g, "["],
+  [/[】］]/g, "]"],
+];
+
+/**
+ * The answer with citation-marker brackets in ASCII, and NOTHING else touched.
+ *
+ * The line this draws is the whole point, so it is worth stating twice:
+ * normalise what identifies STRUCTURE, never what identifies a DOCUMENT. A
+ * marker is a delimiter — the reader pairs `…per day【1】` with `[1] policy.md`
+ * without help, and nothing in the product parses inline markers at all
+ * (`source-links.ts` keys off the path). A PATH is identity: `retention‑correct
+ * .md` with U+2011 is not the path `knowledge_search` showed, `source-links.ts`
+ * will not linkify it, and a reader who clicks gets nothing — so `path-not-
+ * cited` is right to charge it and this function must not sand that off.
+ *
+ * The product already draws the same line: `TRAILING_PAGE` in `source-links.ts`
+ * accepts `—`, `–` and `-` alike for the page suffix while requiring the path
+ * to match exactly.
+ */
+export function normalizeCitationMarkers(answer: string): string {
+  let normalized = answer;
+  for (const [pattern, replacement] of MARKER_BRACKETS) {
+    normalized = normalized.replace(pattern, replacement);
+  }
+  return normalized;
+}
 
 /**
  * A Sources-list bullet: `- [N] <rest of line>` (or `*` bullets), one per
@@ -207,16 +252,25 @@ function parseSourcesEntries(sourcesText: string): SourcesEntry[] {
 
 /** Splits `answer` into its cited-body and Sources-list halves and parses both. */
 function parseAnswer(answer: string): ParsedAnswer {
+  // Marker brackets in ASCII before anything is located or counted, so every
+  // reader below — the heading split, `citedNumbers`, `BULLET_LINE`,
+  // `gradeSourcesFormat`'s two counts — sees one spelling. Applied to the whole
+  // answer rather than per-region because the split itself depends on it: a
+  // body whose citations are invisible is what made a Sources list read as
+  // entirely uncited. Path text is untouched by construction — the replacement
+  // is two bracket pairs, and no path in this corpus contains one.
+  const text = normalizeCitationMarkers(answer);
+
   // Take the LAST line-start heading match: the real Sources list is always
   // the trailing block, so an earlier mid-prose "Sources:" mention never wins
   // the split. `matchAll` (not `.exec`) avoids the stateful-`lastIndex`
   // footgun of a `g`-flagged regex.
-  const headingMatches = [...answer.matchAll(SOURCES_HEADING)];
+  const headingMatches = [...text.matchAll(SOURCES_HEADING)];
   const headingMatch = headingMatches.at(-1) ?? null;
   const hasSourcesList = headingMatch !== null;
   const headingIndex = headingMatch?.index ?? 0;
-  const body = hasSourcesList ? answer.slice(0, headingIndex) : answer;
-  const sourcesText = hasSourcesList ? answer.slice(headingIndex + headingMatch[0].length) : "";
+  const body = hasSourcesList ? text.slice(0, headingIndex) : text;
+  const sourcesText = hasSourcesList ? text.slice(headingIndex + headingMatch[0].length) : "";
 
   const citedNumbers = new Set<number>();
   for (const match of body.matchAll(INLINE_CITATION)) {

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -174,9 +174,13 @@ const MARKER_BRACKETS: [RegExp, string][] = [
  *
  * The product already draws the same line: `TRAILING_PAGE` in `source-links.ts`
  * accepts `—`, `–` and `-` alike for the page suffix while requiring the path
- * to match exactly.
+ * to match exactly, and `PAGE_SUFFIX` below follows it.
+ *
+ * Module-private on purpose: every export in this file names the consumer it
+ * exists for, and this one has none — `parseAnswer` is its only caller, and the
+ * behaviour is asserted through the public graders that read its output.
  */
-export function normalizeCitationMarkers(answer: string): string {
+function normalizeCitationMarkers(answer: string): string {
   let normalized = answer;
   for (const [pattern, replacement] of MARKER_BRACKETS) {
     normalized = normalized.replace(pattern, replacement);
@@ -198,13 +202,21 @@ const BULLET_LINE = /^[ \t]*[-*][ \t]+\[(\d+)\]\s*(.+)$/gm;
  * a hyphen inside the path itself (e.g. "/data/handbook-2012/policy.md") is not
  * mistaken for the dash separator — the required "p."/"pp." literal after the
  * dash disambiguates. Accepts a single page (`— p. 12`), a page range
- * (`— p. 12-14`), and the `pp.` plural (`— pp. 12-14`); the alternative
- * en-dash separator is tolerated inside the range too. A Sources entry with no
+ * (`— p. 12-14`), and the `pp.` plural (`— pp. 12-14`). A Sources entry with no
  * page suffix at all (a legitimate, if degraded, shape) leaves `pageMatch`
  * null and parses with `page: null` — the point of widening this is to keep a
  * range from folding into `entry.path` and spuriously failing the exact
  * path-match in `gradePathCitation`. `page` stores the FIRST page number
  * (`parseInt` of the range) — it is not asserted downstream yet.
+ *
+ * The SEPARATOR takes em dash, en dash and hyphen alike, for the same reason
+ * the markers above take fullwidth brackets: it delimits, it does not identify.
+ * `gpt-oss:120b` writes U+2013 where the template writes `—`, and an
+ * unrecognised separator leaves `– p. 1` glued to `entry.path` — where the
+ * whole-entry matcher in `cited-path-match.ts` still resolves the document, but
+ * `gradeNoDuplicateCorroboration`, which compares `entry.path` by string
+ * equality against its near-duplicate groups, silently stops matching. The
+ * product's own `TRAILING_PAGE` (`source-links.ts`) already accepts all three.
  *
  * Only pages, deliberately, and only correct while only pages exist. Since
  * #933 the anchor is a `ChunkLocator` and the contract asks for a POSITION:
@@ -216,7 +228,7 @@ const BULLET_LINE = /^[ \t]*[-*][ \t]+\[(\d+)\]\s*(.+)$/gm;
  * generalise this parser in the same change. #982 has the trap and the reason
  * a naive "split on any dash" fix would move committed eval numbers.
  */
-const PAGE_SUFFIX = /^(.*?)\s*[—-]\s*pp?\.?\s*(\d+(?:\s*[-–]\s*\d+)?)\s*$/i;
+const PAGE_SUFFIX = /^(.*?)\s*[—–-]\s*pp?\.?\s*(\d+(?:\s*[-–]\s*\d+)?)\s*$/i;
 
 interface ParsedAnswer {
   /** Raw text BEFORE the Sources heading (or the whole answer if there is none). */
@@ -498,6 +510,13 @@ export function gradePathCitation(input: AttributionInput): KbGraderResult {
  *
  * If the answer legitimately abstained and has NO Sources list at all, this
  * grader passes — there is no list to format-check.
+ *
+ * The `looseCount === 0` early return is why marker normalisation moves this
+ * axis too, and in the FAILING direction: a run-on written entirely in
+ * fullwidth brackets ("**Sources:** 【1】 a.md 【2】 b.md") had zero markers this
+ * grader could see, so it took that return and passed — a run-on excused by the
+ * same typography that emptied the premise set. It is charged now. Both
+ * directions are one fix, not a regression traded for an improvement.
  */
 export function gradeSourcesFormat(input: AttributionInput): KbGraderResult {
   const { hasSourcesList, sourcesText } = parseAnswer(input.answer);


### PR DESCRIPTION
## Why

The 2026-08-04 sweep left **17 of 48 runs with an empty premise set**, and reading them showed one model behaviour behind most of it: **`gpt-oss:120b` does not write ASCII punctuation.** Across its 12 runs it used U+3010/U+3011 for brackets, U+2011 for `-`, U+2013 for `–` and U+201C for `"` — consistently, not occasionally.

Eight of those runs therefore carried no inline citation this parser could see. `citedNumbers` came back empty, so every Sources entry read as listed-but-uncited, so the premise set was empty, so `ungrounded-claim` followed — on answers quoting the retrieved passage word for word. **Its 0/12 measured Unicode.**

Five more runs, spread across all four models, titled the list `Quellen` because the question was German — which the gold set asks on purpose.

## The line

Normalise what identifies **structure**, never what identifies a **document**.

| | treatment | why |
|---|---|---|
| citation marker | `【1】` / `［1］` → `[1]` | a delimiter. A reader pairs `…per day【1】` with `[1] policy.md` unaided, and **nothing in the product parses inline markers** — `source-links.ts` keys off the path |
| heading | `**Quellen:**`, `### Quellen`, `**Quelle**` accepted | a label. Same line-start and delimiter rules as English |
| **path** | **unchanged, exact** | identity. `retention‑correct.md` with U+2011 is not the path the tool showed, `source-links.ts` will not linkify it, and a reader who clicks gets nothing |

Normalisation runs *before* anything is located or counted, so the heading split, `citedNumbers`, `BULLET_LINE` and `gradeSourcesFormat`'s two counts all see one spelling.

The product already draws this same line: `TRAILING_PAGE` in `source-links.ts` accepts `—`, `–` and `-` alike for the page suffix while requiring the path to match exactly.

Two tests guard the edges specifically: a U+2011 path is still charged `path-not-cited` (normalising markers must not drag that along), and `"Laut unseren Quellen: …"` still does not win the heading split — which matters more in German, where every noun is capitalised.

## Verification

Replay over the last sweep's 48 answers, through the production functions:

| model | empty premise sets before | after |
|---|---|---|
| kimi-k2.6 | 3 | 2 |
| glm-5.2 | 2 | 1 |
| qwen3.5:397b | 1 | 0 |
| gpt-oss:120b | 11 | 5 |
| **total** | **17** | **8** |

## Seven of the remaining eight are correct behaviour

- **2** are abstentions with no Sources list at all.
- **2** are the U+2011 paths above, charged on purpose.
- **3** are gpt-oss asserting with a Sources list it never cites into — no inline citation exists, so the `citesInline` guard skips the fallback exactly as designed.

The **eighth** is a shape this PR deliberately does not cover: glm-5.2 writes `[1, 2]` and `[3, 4]`, comma-grouped, and `INLINE_CITATION` matches only `[N]`. That is a citation *convention* rather than typography, so it is named rather than folded in.

## Test plan

- [x] `pnpm test` — 781 files, 11176 tests green
- [x] `pnpm -C packages/web typecheck`, `pnpm format:check`, lint (0 errors)
- [x] Replay of the 48 archived answers through the production functions
- [ ] Fresh sweep once this lands

Refs #869