### PR TITLE
docs: name pinchy-knowledge in the Repository Map, and guard the list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Status: early development. The core is working: setup wizard, authentication, pr
 ## Repository Map
 
 - `packages/web/` - Next.js app, API routes, WebSocket bridge, Drizzle schema/migrations, tests.
-- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-context`, `pinchy-docs`, `pinchy-audit`, `pinchy-email`, `pinchy-odoo`, `pinchy-transcript`, `pinchy-web`.
+- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-context`, `pinchy-docs`, `pinchy-audit`, `pinchy-email`, `pinchy-odoo`, `pinchy-transcript`, `pinchy-web`, `pinchy-knowledge`. Guarded against the directory listing by `scripts/lib/agents-md-repository-map.test.mjs`.
 - `config/` - OpenClaw config support, startup scripts, mock services for integration/E2E tests.
 - `docs/` - Astro Starlight documentation. It is standalone and has its own `package.json` and lockfile.
 - `plans/` - Design and implementation records for larger features, committed on purpose: the reasoning behind a decision outlives the PR that carried it, and a review that revisits one needs it. Not to be confused with `docs/plans/`, which `.gitignore` drops — those are scratch, these are the record.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Status: early development. The core is working: setup wizard, authentication, pr
 ## Repository Map
 
 - `packages/web/` - Next.js app, API routes, WebSocket bridge, Drizzle schema/migrations, tests.
-- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-context`, `pinchy-docs`, `pinchy-audit`, `pinchy-email`, `pinchy-odoo`, `pinchy-transcript`, `pinchy-web`, `pinchy-knowledge`. Guarded against the directory listing by `scripts/lib/agents-md-repository-map.test.mjs`.
+- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-context`, `pinchy-docs`, `pinchy-audit`, `pinchy-email`, `pinchy-odoo`, `pinchy-transcript`, `pinchy-web`, `pinchy-knowledge`, `pinchy-approvals`. Guarded against the directory listing by `scripts/lib/agents-md-repository-map.test.mjs`.
 - `config/` - OpenClaw config support, startup scripts, mock services for integration/E2E tests.
 - `docs/` - Astro Starlight documentation. It is standalone and has its own `package.json` and lockfile.
 - `plans/` - Design and implementation records for larger features, committed on purpose: the reasoning behind a decision outlives the PR that carried it, and a review that revisits one needs it. Not to be confused with `docs/plans/`, which `.gitignore` drops — those are scratch, these are the record.

--- a/scripts/lib/agents-md-repository-map.mjs
+++ b/scripts/lib/agents-md-repository-map.mjs
@@ -15,6 +15,13 @@
  * to a reader — an omitted plugin costs a `ls`, a phantom one costs a search
  * for something that is not there.
  *
+ * Scope: this reads ONE bullet. The Repository Map names eight other paths
+ * (`config/`, `plans/`, `sample-data/`, `marketplace/`, …) and nothing checks
+ * that any of them still exists — a green run here is not a statement about
+ * the section as a whole. The plugin list is singled out because it is the one
+ * that enumerates a directory's contents rather than naming a single path, and
+ * so is the one that goes stale by addition, silently.
+ *
  * Sibling of `agents-md-commands.mjs`, which reads the same file's bash blocks.
  */
 
@@ -22,21 +29,31 @@ import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const SECTION_NAME = "Repository Map";
-const SECTION_HEADING = `## ${SECTION_NAME}`;
+// Built from the name so the two cannot drift apart. Safe as a pattern: the
+// heading is plain words, with nothing a regex reads as syntax.
+const SECTION_HEADING = new RegExp(`^## ${SECTION_NAME}[ \\t]*$`, "m");
+const NEXT_SECTION = /^## /m;
 const PLUGINS_BULLET = /^-\s+`packages\/plugins\/`.*$/m;
 const MARKER = "Current Pinchy plugins:";
 const BACKTICKED = /`([^`]+)`/g;
 
-/** The `## Repository Map` section, up to the next `## ` heading. */
+/**
+ * The `## Repository Map` section, up to the next `## ` heading.
+ *
+ * Both ends are anchored to a line start. An unanchored search for the heading
+ * would accept `### Repository Map` — which contains it as a substring — and
+ * then stop at the real heading, so the guard would report on a subsection in
+ * place of the section it names.
+ */
 function repositoryMapSection(markdown) {
-  const start = markdown.indexOf(SECTION_HEADING);
-  if (start === -1) {
+  const heading = markdown.match(SECTION_HEADING);
+  if (!heading) {
     throw new Error(
       `AGENTS.md has no "${SECTION_NAME}" section — this guard cannot read it`,
     );
   }
-  const rest = markdown.slice(start + SECTION_HEADING.length);
-  const end = rest.search(/^## /m);
+  const rest = markdown.slice(heading.index + heading[0].length);
+  const end = rest.search(NEXT_SECTION);
   return end === -1 ? rest : rest.slice(0, end);
 }
 
@@ -131,6 +148,11 @@ export function discoverPluginPackages(repoRoot) {
     .sort();
 }
 
+/** `` `a`, `b` `` — the names as the bullet would spell them. */
+function quoted(names) {
+  return names.map((name) => `\`${name}\``).join(", ");
+}
+
 /**
  * @param {string[]} documented names from AGENTS.md § "Repository Map"
  * @param {string[]} actual plugin directories on disk
@@ -138,26 +160,25 @@ export function discoverPluginPackages(repoRoot) {
  */
 export function checkRepositoryMapPlugins(documented, actual) {
   const problems = [];
+  const section = `AGENTS.md § "${SECTION_NAME}"`;
 
   const missing = actual.filter((name) => !documented.includes(name));
   if (missing.length > 0) {
+    const [is, them] =
+      missing.length === 1 ? ["is a plugin", "it"] : ["are plugins", "them"];
     problems.push(
-      `AGENTS.md § "${SECTION_NAME}" does not name ${missing
-        .map((name) => `\`${name}\``)
-        .join(
-          ", ",
-        )}, which ${missing.length === 1 ? "is a plugin" : "are plugins"} in packages/plugins/. Add ${missing.length === 1 ? "it" : "them"} to the "${MARKER}" list.`,
+      `${section} does not name ${quoted(missing)}, which ${is} in ` +
+        `packages/plugins/. Add ${them} to the "${MARKER}" list.`,
     );
   }
 
   const phantom = documented.filter((name) => !actual.includes(name));
   if (phantom.length > 0) {
+    const [exists, them] =
+      phantom.length === 1 ? ["exists", "it"] : ["exist", "them"];
     problems.push(
-      `AGENTS.md § "${SECTION_NAME}" names ${phantom
-        .map((name) => `\`${name}\``)
-        .join(
-          ", ",
-        )}, which no longer ${phantom.length === 1 ? "exists" : "exist"} under packages/plugins/. Remove ${phantom.length === 1 ? "it" : "them"} from the "${MARKER}" list.`,
+      `${section} names ${quoted(phantom)}, which no longer ${exists} under ` +
+        `packages/plugins/. Remove ${them} from the "${MARKER}" list.`,
     );
   }
 

--- a/scripts/lib/agents-md-repository-map.mjs
+++ b/scripts/lib/agents-md-repository-map.mjs
@@ -1,0 +1,165 @@
+/**
+ * Drift guard for the plugin list in AGENTS.md § "Repository Map".
+ *
+ * That bullet is a hand-maintained list mirroring a directory listing, sitting
+ * in the very file that argues such lists will be wrong (§ "A Hand-Maintained
+ * List That Mirrors Code Will Be Wrong") — and it was: `pinchy-knowledge`
+ * shipped with its own manifest, the `knowledge_search` tool and E2E coverage,
+ * and the sentence naming "current Pinchy plugins" named eight of nine. Every
+ * agent session starts by reading that sentence, so the cost is paid over and
+ * over, and nothing else in CI reads this file.
+ *
+ * The list is checked in BOTH directions: a plugin on disk the prose omits, and
+ * a name the prose keeps after its directory is gone. The second half is the
+ * one a code → docs check is structurally blind to, and the more expensive one
+ * to a reader — an omitted plugin costs a `ls`, a phantom one costs a search
+ * for something that is not there.
+ *
+ * Sibling of `agents-md-commands.mjs`, which reads the same file's bash blocks.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SECTION_NAME = "Repository Map";
+const SECTION_HEADING = `## ${SECTION_NAME}`;
+const PLUGINS_BULLET = /^-\s+`packages\/plugins\/`.*$/m;
+const MARKER = "Current Pinchy plugins:";
+const BACKTICKED = /`([^`]+)`/g;
+
+/** The `## Repository Map` section, up to the next `## ` heading. */
+function repositoryMapSection(markdown) {
+  const start = markdown.indexOf(SECTION_HEADING);
+  if (start === -1) {
+    throw new Error(
+      `AGENTS.md has no "${SECTION_NAME}" section — this guard cannot read it`,
+    );
+  }
+  const rest = markdown.slice(start + SECTION_HEADING.length);
+  const end = rest.search(/^## /m);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+/**
+ * The list is a sentence, not a line: everything up to the first period outside
+ * a code span. A bullet may carry more prose after the list — the pointer at
+ * this guard does — and reading to the line end takes the backticks out of it
+ * as further plugin names.
+ */
+function listSentence(text) {
+  let inCode = false;
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "`") inCode = !inCode;
+    else if (text[i] === "." && !inCode) return text.slice(0, i);
+  }
+  return text;
+}
+
+/**
+ * The plugin names documented in AGENTS.md § "Repository Map".
+ *
+ * Throws rather than returning a short list on input it cannot read: a guard
+ * that answers "none documented" to a reworded sentence reports every plugin as
+ * missing, and one that answers "all documented" reports nothing at all. Both
+ * are verdicts about the prose that the guard is in no position to give.
+ *
+ * @param {string} markdown contents of AGENTS.md
+ * @returns {string[]} plugin directory names, in the order the prose lists them
+ */
+export function extractRepositoryMapPlugins(markdown) {
+  const section = repositoryMapSection(markdown);
+
+  const bullet = section.match(PLUGINS_BULLET)?.[0];
+  if (!bullet) {
+    throw new Error(
+      `AGENTS.md § "${SECTION_NAME}" has no \`packages/plugins/\` bullet — this guard cannot read it`,
+    );
+  }
+
+  const markerAt = bullet.indexOf(MARKER);
+  if (markerAt === -1) {
+    throw new Error(
+      `AGENTS.md's \`packages/plugins/\` bullet no longer says "${MARKER}" — this guard cannot read it:\n  ${bullet}`,
+    );
+  }
+
+  const names = [
+    ...listSentence(bullet.slice(markerAt + MARKER.length)).matchAll(
+      BACKTICKED,
+    ),
+  ].map(([, name]) => name);
+  if (names.length === 0) {
+    throw new Error(
+      `AGENTS.md's \`packages/plugins/\` bullet says "${MARKER}" but lists no plugin names:\n  ${bullet}`,
+    );
+  }
+  return names;
+}
+
+/**
+ * Every plugin directory under `packages/plugins/`.
+ *
+ * A directory counts as a plugin when it carries an `openclaw.plugin.json` —
+ * what actually makes it one — rather than by matching `pinchy-*`. A plugin
+ * added under a different name would otherwise be exempt from the prose by
+ * virtue of its name, which is the drift one level up.
+ *
+ * @param {string} repoRoot
+ * @returns {string[]} directory names, sorted
+ */
+export function discoverPluginPackages(repoRoot) {
+  const pluginsDir = join(repoRoot, "packages", "plugins");
+  let entries;
+  try {
+    entries = readdirSync(pluginsDir, { withFileTypes: true });
+  } catch (err) {
+    throw new Error(`cannot read packages/plugins: ${err.message}`);
+  }
+
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => {
+      try {
+        return statSync(
+          join(pluginsDir, name, "openclaw.plugin.json"),
+        ).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+/**
+ * @param {string[]} documented names from AGENTS.md § "Repository Map"
+ * @param {string[]} actual plugin directories on disk
+ * @returns {string[]} problems (empty = ok)
+ */
+export function checkRepositoryMapPlugins(documented, actual) {
+  const problems = [];
+
+  const missing = actual.filter((name) => !documented.includes(name));
+  if (missing.length > 0) {
+    problems.push(
+      `AGENTS.md § "${SECTION_NAME}" does not name ${missing
+        .map((name) => `\`${name}\``)
+        .join(
+          ", ",
+        )}, which ${missing.length === 1 ? "is a plugin" : "are plugins"} in packages/plugins/. Add ${missing.length === 1 ? "it" : "them"} to the "${MARKER}" list.`,
+    );
+  }
+
+  const phantom = documented.filter((name) => !actual.includes(name));
+  if (phantom.length > 0) {
+    problems.push(
+      `AGENTS.md § "${SECTION_NAME}" names ${phantom
+        .map((name) => `\`${name}\``)
+        .join(
+          ", ",
+        )}, which no longer ${phantom.length === 1 ? "exists" : "exist"} under packages/plugins/. Remove ${phantom.length === 1 ? "it" : "them"} from the "${MARKER}" list.`,
+    );
+  }
+
+  return problems;
+}

--- a/scripts/lib/agents-md-repository-map.test.mjs
+++ b/scripts/lib/agents-md-repository-map.test.mjs
@@ -46,6 +46,31 @@ test("extractRepositoryMapPlugins reads only the Repository Map section", () => 
   assert.ok(!plugins.includes("pinchy-ghost"));
 });
 
+test("extractRepositoryMapPlugins ignores a heading that only looks like the section", () => {
+  // The end of the section is found with an anchored `^## `. The start must be
+  // recognised the same way, or a `### Repository Map` subsection — whose
+  // heading contains `## Repository Map` as a substring — is read in place of
+  // the real one, and the guard reports on a section nobody wrote.
+  const md = [
+    "# AGENTS.md - Pinchy",
+    "",
+    "### Repository Map",
+    "",
+    "- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-ghost`.",
+    "",
+    "## Repository Map",
+    "",
+    REAL_SHAPE,
+    "",
+    "## Tech Stack",
+  ].join("\n");
+  assert.deepEqual(extractRepositoryMapPlugins(md), [
+    "pinchy-files",
+    "pinchy-context",
+    "pinchy-web",
+  ]);
+});
+
 test("extractRepositoryMapPlugins stops at the end of the list sentence", () => {
   // The list is a sentence, not a line. Reading to the line end swallows the
   // backticks of anything written after it — the bullet's own pointer at this
@@ -102,8 +127,9 @@ test("extractRepositoryMapPlugins throws when the marker is followed by no names
 });
 
 test("checkRepositoryMapPlugins passes when both sides name the same set", () => {
-  // Order is prose's business (the list groups internal before external), so
-  // only the set is checked.
+  // Order is prose's business — the real list is neither sorted nor grouped
+  // (`pinchy-transcript` is internal and sits after `pinchy-odoo`), so pinning
+  // it would be this guard inventing a convention. Only the set is checked.
   assert.deepEqual(
     checkRepositoryMapPlugins(
       ["pinchy-web", "pinchy-files"],

--- a/scripts/lib/agents-md-repository-map.test.mjs
+++ b/scripts/lib/agents-md-repository-map.test.mjs
@@ -1,0 +1,162 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  extractRepositoryMapPlugins,
+  discoverPluginPackages,
+  checkRepositoryMapPlugins,
+} from "./agents-md-repository-map.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+/** A Repository Map section shaped like the real one. */
+function repositoryMap(pluginsBullet) {
+  return [
+    "# AGENTS.md - Pinchy",
+    "",
+    "## Repository Map",
+    "",
+    "- `packages/web/` - Next.js app.",
+    pluginsBullet,
+    "- `config/` - OpenClaw config support.",
+    "",
+    "## Tech Stack",
+    "",
+    "- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-ghost`.",
+  ].join("\n");
+}
+
+const REAL_SHAPE =
+  "- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-context`, `pinchy-web`.";
+
+test("extractRepositoryMapPlugins reads the backticked names after the marker", () => {
+  assert.deepEqual(extractRepositoryMapPlugins(repositoryMap(REAL_SHAPE)), [
+    "pinchy-files",
+    "pinchy-context",
+    "pinchy-web",
+  ]);
+});
+
+test("extractRepositoryMapPlugins reads only the Repository Map section", () => {
+  // The decoy bullet below "## Tech Stack" must not contribute: a guard that
+  // reads the whole file would accept a list that lives anywhere at all.
+  const plugins = extractRepositoryMapPlugins(repositoryMap(REAL_SHAPE));
+  assert.ok(!plugins.includes("pinchy-ghost"));
+});
+
+test("extractRepositoryMapPlugins stops at the end of the list sentence", () => {
+  // The list is a sentence, not a line. Reading to the line end swallows the
+  // backticks of anything written after it — the bullet's own pointer at this
+  // guard was read as a ninth plugin the moment it was added.
+  assert.deepEqual(
+    extractRepositoryMapPlugins(
+      repositoryMap(
+        "- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-web`. Guarded by `scripts/lib/agents-md-repository-map.test.mjs`.",
+      ),
+    ),
+    ["pinchy-files", "pinchy-web"],
+  );
+});
+
+test("extractRepositoryMapPlugins throws when the section is gone", () => {
+  const md = [
+    "# AGENTS.md - Pinchy",
+    "",
+    "## Tech Stack",
+    "",
+    "- Next.js",
+  ].join("\n");
+  assert.throws(() => extractRepositoryMapPlugins(md), /Repository Map/);
+});
+
+test("extractRepositoryMapPlugins throws when the plugins bullet is gone", () => {
+  const md = ["## Repository Map", "", "- `config/` - stuff.", ""].join("\n");
+  assert.throws(() => extractRepositoryMapPlugins(md), /packages\/plugins/);
+});
+
+test("extractRepositoryMapPlugins throws when the bullet is reworded past the marker", () => {
+  // Reading a reworded bullet as "no plugins documented" would report every
+  // plugin as missing; reading it as an empty corpus would report none. Both
+  // are worse than saying the sentence no longer parses.
+  assert.throws(
+    () =>
+      extractRepositoryMapPlugins(
+        repositoryMap("- `packages/plugins/` - OpenClaw plugins live here."),
+      ),
+    /Current Pinchy plugins/,
+  );
+});
+
+test("extractRepositoryMapPlugins throws when the marker is followed by no names", () => {
+  assert.throws(
+    () =>
+      extractRepositoryMapPlugins(
+        repositoryMap(
+          "- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: none yet.",
+        ),
+      ),
+    /no plugin names/,
+  );
+});
+
+test("checkRepositoryMapPlugins passes when both sides name the same set", () => {
+  // Order is prose's business (the list groups internal before external), so
+  // only the set is checked.
+  assert.deepEqual(
+    checkRepositoryMapPlugins(
+      ["pinchy-web", "pinchy-files"],
+      ["pinchy-files", "pinchy-web"],
+    ),
+    [],
+  );
+});
+
+test("checkRepositoryMapPlugins flags a plugin on disk the map omits", () => {
+  // The exact drift this guard exists to catch: pinchy-knowledge shipped with a
+  // manifest, a tool and its own E2E coverage, and never reached the prose.
+  const problems = checkRepositoryMapPlugins(
+    ["pinchy-files"],
+    ["pinchy-files", "pinchy-knowledge"],
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /pinchy-knowledge/);
+  assert.match(problems[0], /packages\/plugins/);
+});
+
+test("checkRepositoryMapPlugins flags a name the map keeps after the directory is gone", () => {
+  const problems = checkRepositoryMapPlugins(
+    ["pinchy-files", "pinchy-retired"],
+    ["pinchy-files"],
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /pinchy-retired/);
+});
+
+test("discoverPluginPackages reads the real plugin directories off disk", () => {
+  const plugins = discoverPluginPackages(REPO_ROOT);
+  assert.ok(plugins.includes("pinchy-files"));
+  assert.ok(plugins.includes("pinchy-knowledge"));
+  // A corpus floor: a walker that found nothing would otherwise agree with a
+  // map that documented nothing.
+  assert.ok(plugins.length >= 8, `only found ${plugins.length} plugins`);
+});
+
+test("discoverPluginPackages throws when the plugins directory is unreadable", () => {
+  assert.throws(
+    () => discoverPluginPackages(join(REPO_ROOT, "does-not-exist")),
+    /packages\/plugins/,
+  );
+});
+
+test("the real AGENTS.md Repository Map names exactly the plugins on disk", () => {
+  const markdown = readFileSync(join(REPO_ROOT, "AGENTS.md"), "utf8");
+  assert.deepEqual(
+    checkRepositoryMapPlugins(
+      extractRepositoryMapPlugins(markdown),
+      discoverPluginPackages(REPO_ROOT),
+    ),
+    [],
+  );
+});


### PR DESCRIPTION
## What does this PR do?

AGENTS.md § "Repository Map" named eight of the nine plugin directories: `pinchy-knowledge` has its own `openclaw.plugin.json`, backs `knowledge_search`, and never reached the sentence that claims to name the current Pinchy plugins. AGENTS.md is the first file every agent session reads, so the omission was paid for repeatedly — and nothing in CI read this file's prose.

It is a hand-maintained list mirroring a directory listing, sitting in the very file that argues such lists will be wrong (§ "A Hand-Maintained List That Mirrors Code Will Be Wrong" — which cites `knowledge_search` by name as the v0.9.0 example). So it gets the same treatment `contracts.tools` gets: a drift guard.

Found while reviewing #1122 (issue #1082) and deliberately left out of that PR to keep it focused.

## What the guard does

`scripts/lib/agents-md-repository-map.mjs` + its test, run by `pnpm test:scripts` in the existing `quality` job — no new CI wiring.

It reads `packages/plugins/` off disk and compares it against the prose **in both directions**: a plugin the list omits, and a name the list keeps after its directory is gone. The second half is the one a code → docs check is structurally blind to.

Design decisions worth a reviewer's attention:

- **A directory counts as a plugin when it carries an `openclaw.plugin.json`**, not by matching `pinchy-*`. A plugin added under a different name would otherwise be exempt from the prose by virtue of its name — the same drift one level up.
- **Set comparison, not order.** The prose groups roughly internal-before-external and is not sorted; ordering is the text's business.
- **The extractor throws on prose it cannot read** (section gone, bullet gone, marker reworded, marker followed by no names) rather than returning a short list. A guard that answers "none documented" reports every plugin as missing; one that answers "all documented" reports nothing at all. Neither verdict is the guard's to give.
- **A corpus floor on the disk side**, so a walker that found nothing cannot agree with a map that documented nothing.

## Verification

Canaries against the real file, both directions — and they earned their keep. The first red run named exactly `pinchy-knowledge`. Then the guard pointer I had added to that same bullet was read as a **ninth plugin**: the list is a sentence, not a line. The extractor now stops at the first period outside a code span, with a test pinning it. Reverse canaries (`pinchy-ghost` into the prose; a `pinchy-canary` directory onto disk) both went red and were removed.

- `pnpm test:scripts` — 979/979 green
- `pnpm format:check` (whole-tree) — clean

## Type of change

- [x] 📝 Documentation
- [x] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass
