### PR TITLE
docs: record why Automations refuse with 403 where chat pages answer 404

### DIFF
--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -552,19 +552,18 @@ Scoped to the folders that agent is granted, exactly like search itself, so the 
 
 Standing email workflows an agent runs on its own — see [the Automations tab](/concepts/agent-settings/#automations-tab). You can manage automations on a personal agent you own; admins can manage them on any agent.
 
-The three agent-scoped endpoints below (`GET`, `POST`, and the connection picker) share one scope check, so they share their errors:
-
-**Errors:**
-
-- `400` — `agentId` is missing
-- `403` — the agent exists, but its automations are outside your scope: a shared agent is admin-only, and a personal agent's automations belong to its owner
-- `404` — no agent has that id
-
-The `403` is deliberate, and it differs from how a chat page answers: opening an agent you may not see gives you a plain "not found", because a refusal there would tell you the agent exists. Automations refuse a scope you lack on an agent you can normally see and use, so they say so instead of pretending it is missing.
+Every endpoint here answers `403` when what you asked for is outside your scope, and that deliberately differs from how a chat page answers. Opening an agent you may not see gives you a plain "not found", because a refusal there would tell you the agent exists. Automations refuse a scope you lack on an agent you can normally see and use, so they say so instead of pretending it is missing.
 
 ### `GET /api/automations?agentId=<agentId>`
 
 List the agent's email workflows.
+
+**Errors:**
+
+- `400` — `agentId` is missing from the query string
+- `401` — not authenticated
+- `403` — the agent exists, but its automations are outside your scope: a shared agent is admin-only, and a personal agent's automations belong to its owner
+- `404` — no agent has that id
 
 ### `POST /api/automations`
 
@@ -585,6 +584,13 @@ Create a workflow. It is always created **disabled** and `pending`, whatever the
 
 **Response:** `201 Created`
 
+**Errors:**
+
+- `400` — the body fails validation, or a requested connection is one the agent has no email **read** access to. The response names those connection ids; an id that doesn't exist lands here too, since it has no permission row either
+- `401` — not authenticated
+- `403` — you may not create a workflow on this agent (same scope rule as the list)
+- `404` — no agent has that id
+
 ### `PATCH /api/automations/:id`
 
 Enable or disable a workflow — the human-gated step that turns a proposal into a live automation, and the way to pause one without deleting it.
@@ -593,17 +599,37 @@ Enable or disable a workflow — the human-gated step that turns a proposal into
 
 **Response:** `{ "id": "...", "enabled": true }`
 
+Toggling to the state it already has is a no-op: still `200`, no audit entry — an unchanged state is not an event.
+
+**Errors:**
+
+- `400` — the body has no boolean `enabled`
+- `401` — not authenticated
+- `403` — the workflow's agent is outside your scope
+- `404` — no workflow has that id. This endpoint addresses a workflow, not an agent, so a malformed id lands here as well: it definitionally matches nothing
+
 ### `DELETE /api/automations/:id`
 
 Delete a workflow for good.
 
 **Response:** `{ "id": "..." }`
 
-Both endpoints address a workflow directly rather than an agent, so they answer `404` when no workflow has that id, and `403` when the workflow's agent is outside your scope.
+**Errors:**
+
+- `401` — not authenticated
+- `403` — the workflow's agent is outside your scope
+- `404` — no workflow has that id (as with `PATCH`, a malformed id matches nothing)
 
 ### `GET /api/automations/connections?agentId=<agentId>`
 
 The email connections this agent can watch — what the create form offers in its mailbox picker.
+
+**Errors:**
+
+- `400` — `agentId` is missing from the query string
+- `401` — not authenticated
+- `403` — the agent exists, but its automations are outside your scope
+- `404` — no agent has that id
 
 ## Templates
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -552,6 +552,16 @@ Scoped to the folders that agent is granted, exactly like search itself, so the 
 
 Standing email workflows an agent runs on its own — see [the Automations tab](/concepts/agent-settings/#automations-tab). You can manage automations on a personal agent you own; admins can manage them on any agent.
 
+The three agent-scoped endpoints below (`GET`, `POST`, and the connection picker) share one scope check, so they share their errors:
+
+**Errors:**
+
+- `400` — `agentId` is missing
+- `403` — the agent exists, but its automations are outside your scope: a shared agent is admin-only, and a personal agent's automations belong to its owner
+- `404` — no agent has that id
+
+The `403` is deliberate, and it differs from how a chat page answers: opening an agent you may not see gives you a plain "not found", because a refusal there would tell you the agent exists. Automations refuse a scope you lack on an agent you can normally see and use, so they say so instead of pretending it is missing.
+
 ### `GET /api/automations?agentId=<agentId>`
 
 List the agent's email workflows.
@@ -588,6 +598,8 @@ Enable or disable a workflow — the human-gated step that turns a proposal into
 Delete a workflow for good.
 
 **Response:** `{ "id": "..." }`
+
+Both endpoints address a workflow directly rather than an agent, so they answer `404` when no workflow has that id, and `403` when the workflow's agent is outside your scope.
 
 ### `GET /api/automations/connections?agentId=<agentId>`
 

--- a/packages/web/src/__tests__/lib/email-workflows/resolve-agent.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/resolve-agent.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/db", () => ({ db: { select: vi.fn() } }));
 
 import { db } from "@/db";
+import { assertAgentAccess } from "@/lib/agent-access";
 import {
   resolveWorkflowAgent,
   resolveWorkflowAgentFromQuery,
@@ -93,6 +94,45 @@ describe("resolveWorkflowAgent", () => {
   });
 
   it("refuses someone else's personal agent", async () => {
+    mockLookup(personalAgent);
+    const result = await resolveWorkflowAgent("agent-1", { id: OTHER, role: "user" });
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(result.error.status).toBe(403);
+  });
+});
+
+/**
+ * This gate answers 403 where `loadChatPageAgent` answers 404 for a refusal,
+ * which reads as a contradiction now that both live one directory apart. It is
+ * deliberate, and the reasoning is on `resolveWorkflowAgent` — but reasoning in
+ * a comment is not a check, so pin the two legs it rests on. Both assert the
+ * SAME (agent, actor) pair against BOTH gates: what would silently rot here is
+ * not the status code, it is the visibility fact the argument is built on.
+ */
+describe("the deliberate 403-not-404 split", () => {
+  const visibleSharedAgent = { ...sharedAgent, visibility: "all" };
+
+  it("answers 403 for an agent the visibility gate lets the actor see", async () => {
+    // The honest leg. A 404 here would deny an agent this member has in their
+    // sidebar and chats with — `assertAgentAccess` throws on denial, so this
+    // not throwing IS the claim that they can see it.
+    expect(() =>
+      assertAgentAccess(visibleSharedAgent, OWNER, "user", [], [], "paid")
+    ).not.toThrow();
+
+    mockLookup(visibleSharedAgent);
+    const result = await resolveWorkflowAgent("agent-2", { id: OWNER, role: "user" });
+    if (!("error" in result)) throw new Error("expected an error response");
+    expect(result.error.status).toBe(403);
+  });
+
+  it("answers 403 for an agent the visibility gate hides — the knowingly-open leg", async () => {
+    // Someone else's personal agent: refused by both gates, so 403-vs-404 here
+    // really does confirm existence. Left open on the reasoning in the
+    // docblock, and asserted rather than assumed so that "this leg is the
+    // hidden one" cannot quietly stop being true.
+    expect(() => assertAgentAccess(personalAgent, OTHER, "user", [], [], "paid")).toThrow();
+
     mockLookup(personalAgent);
     const result = await resolveWorkflowAgent("agent-1", { id: OTHER, role: "user" });
     if (!("error" in result)) throw new Error("expected an error response");

--- a/packages/web/src/lib/chats/load-chat-agent.ts
+++ b/packages/web/src/lib/chats/load-chat-agent.ts
@@ -42,6 +42,11 @@ export async function loadChatAgentName(agentId: string): Promise<string | undef
  * than a 403 on purpose: a member who cannot see an agent should not learn that
  * it exists.
  *
+ * The Automations gate (`resolveWorkflowAgent`) answers 403 for its refusals,
+ * which looks like the opposite call. It gates *manage scope*, not visibility,
+ * so its ordinary refusal is an agent the member demonstrably can see — the
+ * reasoning, and the one leg left knowingly open, are on that function.
+ *
  * Group ids are fetched only when they can change the answer (a non-admin
  * hitting a restricted agent), which is what keeps the common case at one
  * query.

--- a/packages/web/src/lib/email-workflows/resolve-agent.ts
+++ b/packages/web/src/lib/email-workflows/resolve-agent.ts
@@ -33,6 +33,33 @@ export type WorkflowAgentResult = { agent: WorkflowAgent } | { error: NextRespon
  * The 403 wording is a parameter because it is user-visible copy that legitimately
  * differs per route ("access to this agent" when reading, "permission to create a
  * workflow" when writing). Sharing the gate must not silently rewrite either.
+ *
+ * **A refusal answers 403, and that deliberately differs from `loadChatPageAgent`,
+ * which answers 404** ("a member who cannot see an agent should not learn that it
+ * exists"). The two are not the same question. That one is a *visibility* gate
+ * (`assertAgentAccess`): whoever fails it cannot reach the agent anywhere, so the
+ * only thing a 403 would tell them is that it exists. This is a *manage-scope*
+ * gate (`canManageAgentWorkflows`), and its ordinary refusal is a shared agent the
+ * member sees in their sidebar and chats with daily. "Agent not found" about an
+ * agent on their screen is simply false, and it sends them checking the id instead
+ * of asking an admin.
+ *
+ * The other leg — someone else's personal agent, or a restricted one outside the
+ * actor's groups — is refused by both gates, so there 403-vs-404 really does
+ * confirm existence. It stays 403 knowingly, for two reasons:
+ *
+ * - There is nothing to enumerate. `agents.id` is `crypto.randomUUID()`, so the
+ *   answer only ever speaks about an id the caller already holds; it reveals none
+ *   they don't. Holding a foreign agent's id is itself the leak worth chasing, and
+ *   this function is not where that happened.
+ * - 404 here would close nothing. `getAgentWithAccess` answers 403 for exactly
+ *   that invisible agent on every `/api/agents/[agentId]/*` route a plain member
+ *   can reach, so an Automations-only 404 would trade a worse error message for a
+ *   property the instance does not actually have. Closing the oracle means
+ *   changing `getAgentWithAccess` (and the ~10 routes built on it), not this.
+ *
+ * Both legs are pinned in resolve-agent.test.ts against `assertAgentAccess`
+ * itself, so the visibility facts this rests on cannot rot unnoticed.
  */
 export async function resolveWorkflowAgent(
   agentId: string,


### PR DESCRIPTION
## What does this PR do?

Answers a question #1123 surfaced but deliberately did not settle: the Automations scope gate refuses with **403**, while the chat gate one directory away turns a denied `assertAgentAccess` into **404** — its docblock says why, in as many words ("a member who cannot see an agent should not learn that it exists"). Side by side that reads as a contradiction, and it looks like an enumeration oracle.

**The decision is to keep the 403, and to write down why** — so the next review does not re-open it from scratch. No behaviour changes here; #1123 was a pure refactor and inherited this untouched, so the verdict belongs in its own change.

Stacked on #1123 (base is `claude/review-1087-fixes-cc5367`, since `resolveWorkflowAgent` only exists there). GitHub will retarget to `main` when #1123 merges.

### Why 403 is right here

**The two gates are not asking the same question.** `loadChatPageAgent` gates *visibility* (`assertAgentAccess`): whoever fails it cannot reach the agent anywhere, so a 403 would be the only thing they learned. `resolveWorkflowAgent` gates *manage scope* (`canManageAgentWorkflows`), and its ordinary refusal is a **shared agent the member has in their sidebar and chats with daily**. "Agent not found" about an agent on their screen is false, and it sends them checking the id instead of asking an admin.

The leg that genuinely *is* an existence oracle — someone else's personal agent, or a restricted one outside the actor's groups — stays 403 knowingly, for two reasons:

- **There is nothing to enumerate.** `agents.id` is `crypto.randomUUID()`, so the answer only ever speaks about an id the caller already holds; it reveals none they don't. Holding a foreign agent's id is itself the leak worth chasing, and this function is not where that happened.
- **404 here would close nothing.** `getAgentWithAccess` answers 403 for that same invisible agent on every `/api/agents/[agentId]/*` route a plain member can reach (~10 routes). An Automations-only 404 would trade a worse error message for a security property the instance does not have.

### What is in the diff

- **`resolve-agent.ts`** — the reasoning, including the leg left knowingly open and where it would actually be closed.
- **`load-chat-agent.ts`** — a back-reference, so the contradiction resolves from either side.
- **`resolve-agent.test.ts`** — two new cases. A comment is not a check, and what would rot here is not the status code but the *visibility fact* the argument rests on. Both drive the **same `(agent, actor)` pair against both gates**: one asserts `assertAgentAccess` admits the actor and the gate still answers 403 (the honest leg), the other asserts it denies them and the gate answers 403 anyway (the knowingly-open leg).
- **`reference/api.mdx`** — a per-endpoint **Errors** block for all five Automations endpoints, which the section had been missing entirely, plus a section-level note on why a 403 here is not the 404 a chat page gives.
  - Corrected in `8438cf45` after review: the first version put one shared block at section level, which (a) attributed the query-string `400 — agentId is missing` to `POST`, whose `agentId` comes from the **body** and whose real 400 ("no email access to connection(s)") went unlisted, (b) said "the three endpoints below" while `PATCH`/`DELETE` sit between them and resolve by *workflow* id, and (c) omitted `401`, which all 39 sibling blocks list. All 39 live inside their own `###` block — following that convention removes the cross-endpoint span that caused (b).

### Reviewer notes

- **No test was removed or weakened.** The three integration suites keep their 403 cases exactly as they were.
- **UI checked:** `agent-settings-automations.tsx` renders the server message via `ApiError` into a toast. A 404 would arrive as "Failed to load automations: Agent not found" for an agent the user is looking at — which is the argument above, from the user's side.
- **Follow-up, deliberately not done here:** the real oracle is `getAgentWithAccess`. That is ~10 routes and a genuine behaviour change; given `crypto.randomUUID()` the honest outcome there may also be "accept and document". Either way it is a separate change.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

### Verification

| Check | Result |
| --- | --- |
| `resolve-agent.test.ts` | 11 passed (was 9) |
| **Canary:** flipped the 403 to 404 | both new cases went red, then reverted |
| 3 Automations integration suites (real Postgres) | 33 passed |
| `pnpm test` | 777 files, 10966 passed |
| `pnpm test:scripts` | 913 passed |
| `pnpm -C packages/web typecheck`, prettier | clean |

`pnpm build` was not run locally — production code gained comments only, no import or module-boundary change, so there is nothing for the bundling check to see. CI covers it.

