### PR TITLE
fix(config): stop a superseded push from writing its stale payload

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -4619,6 +4619,116 @@ describe("regenerateOpenClawConfig", () => {
       }
     });
 
+    it("does not write a superseded push's stale payload when the rate-limit budget runs out", async () => {
+      // The generation checks sit at the top of each retry iteration and right
+      // after config.get(), so a superseded coroutine can never reach
+      // config.apply. The two writeConfigAtomic fallbacks in the catch block
+      // had no check at all: supersede a push while its LAST rate-limited
+      // apply is still in flight, and the stale payload still lands on disk —
+      // overwriting whatever the newer push just applied. That is precisely
+      // the stale-payload-lands-anyway race the counter exists to prevent
+      // (#193), arriving through the fallback instead of through apply.
+      vi.useFakeTimers();
+      try {
+        const rateLimited = () => new Error("rate limit exceeded for config.apply; retry after 1s");
+        let rejectInFlightApply: ((err: Error) => void) | undefined;
+        mockConfigGet.mockResolvedValue({ hash: "h1" });
+        mockConfigApply
+          .mockRejectedValueOnce(rateLimited())
+          .mockRejectedValueOnce(rateLimited())
+          // The apply that exhausts the budget stays in flight until we reject
+          // it by hand — that pending window is where the newer push starts.
+          .mockImplementationOnce(
+            () =>
+              new Promise<void>((_resolve, reject) => {
+                rejectInFlightApply = reject;
+              })
+          )
+          // The newer push's own apply lands cleanly over WS.
+          .mockResolvedValue(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(JSON.stringify({ env: { OLD: "1" } }));
+        // Burn both rate-limit window waits; the third apply is now pending.
+        await vi.advanceTimersByTimeAsync(5_000);
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(mockConfigApply).toHaveBeenCalledTimes(3);
+        expect(rejectInFlightApply).toBeDefined();
+
+        // A newer push supersedes while that apply is still in flight.
+        pushConfigInBackground(JSON.stringify({ env: { NEW: "2" } }));
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Only now does the in-flight apply fail — budget exhausted, so the
+        // old code took the file-write fallback.
+        rejectInFlightApply?.(rateLimited());
+        for (let i = 0; i < 5; i++) {
+          await vi.advanceTimersByTimeAsync(0);
+        }
+
+        const openclawWrite = findOpenClawConfigWrite(mockedWriteFileSync);
+        expect(
+          openclawWrite,
+          "a superseded push must not write its stale payload — the newer push owns the file"
+        ).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not write a superseded push's stale payload when the retry budget runs out", async () => {
+      // Same gap, the other fallback: the retries-exhausted branch on the last
+      // backoff slot. A push superseded while its final apply is in flight
+      // must leave the file to the newer push.
+      vi.useFakeTimers();
+      try {
+        const applyFailed = () => new Error("INTERNAL_ERROR: config.apply failed");
+        let rejectInFlightApply: ((err: Error) => void) | undefined;
+        mockConfigGet.mockResolvedValue({ hash: "h1" });
+        mockConfigApply
+          .mockRejectedValueOnce(applyFailed())
+          .mockRejectedValueOnce(applyFailed())
+          .mockRejectedValueOnce(applyFailed())
+          .mockRejectedValueOnce(applyFailed())
+          // Fifth (last) backoff slot — held in flight until we reject it.
+          .mockImplementationOnce(
+            () =>
+              new Promise<void>((_resolve, reject) => {
+                rejectInFlightApply = reject;
+              })
+          )
+          .mockResolvedValue(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(JSON.stringify({ env: { OLD: "1" } }));
+        // backoffsMs = [100, 250, 500, 1000, 2000]: 1850 ms of sleeps reaches
+        // the fifth and final attempt.
+        await vi.advanceTimersByTimeAsync(2_000);
+        expect(mockConfigApply).toHaveBeenCalledTimes(5);
+        expect(rejectInFlightApply).toBeDefined();
+
+        pushConfigInBackground(JSON.stringify({ env: { NEW: "2" } }));
+        await vi.advanceTimersByTimeAsync(0);
+
+        rejectInFlightApply?.(applyFailed());
+        for (let i = 0; i < 5; i++) {
+          await vi.advanceTimersByTimeAsync(0);
+        }
+
+        const openclawWrite = findOpenClawConfigWrite(mockedWriteFileSync);
+        expect(
+          openclawWrite,
+          "a superseded push must not write its stale payload after its retries are exhausted"
+        ).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("uses generic backoff (not the stale-hash bypass) for unrelated config.apply errors", async () => {
       // Regression guard: only the OC-specific "config changed since last
       // load" message gets the immediate-refetch path. Any other error

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -4630,6 +4630,7 @@ describe("regenerateOpenClawConfig", () => {
       // (#193), arriving through the fallback instead of through apply.
       vi.useFakeTimers();
       try {
+        _resetConfigPushState();
         const rateLimited = () => new Error("rate limit exceeded for config.apply; retry after 1s");
         let rejectInFlightApply: ((err: Error) => void) | undefined;
         mockConfigGet.mockResolvedValue({ hash: "h1" });
@@ -4664,9 +4665,15 @@ describe("regenerateOpenClawConfig", () => {
         // Only now does the in-flight apply fail — budget exhausted, so the
         // old code took the file-write fallback.
         rejectInFlightApply?.(rateLimited());
-        for (let i = 0; i < 5; i++) {
+        // Drain until both coroutines have actually terminated, not for a
+        // fixed number of ticks. The assertion below is a NEGATIVE one, so a
+        // tick budget that runs out one await before the fallback would fire
+        // makes it pass for the wrong reason. The pending counter settles on
+        // every terminal exit, which is the real signal.
+        for (let tick = 0; tick < 50 && getPendingConfigPushCount() > 0; tick++) {
           await vi.advanceTimersByTimeAsync(0);
         }
+        expect(getPendingConfigPushCount(), "both push coroutines must have settled").toBe(0);
 
         const openclawWrite = findOpenClawConfigWrite(mockedWriteFileSync);
         expect(
@@ -4684,6 +4691,7 @@ describe("regenerateOpenClawConfig", () => {
       // must leave the file to the newer push.
       vi.useFakeTimers();
       try {
+        _resetConfigPushState();
         const applyFailed = () => new Error("INTERNAL_ERROR: config.apply failed");
         let rejectInFlightApply: ((err: Error) => void) | undefined;
         mockConfigGet.mockResolvedValue({ hash: "h1" });
@@ -4715,9 +4723,11 @@ describe("regenerateOpenClawConfig", () => {
         await vi.advanceTimersByTimeAsync(0);
 
         rejectInFlightApply?.(applyFailed());
-        for (let i = 0; i < 5; i++) {
+        // Same as above: wait on the coroutines terminating, not on a tick count.
+        for (let tick = 0; tick < 50 && getPendingConfigPushCount() > 0; tick++) {
           await vi.advanceTimersByTimeAsync(0);
         }
+        expect(getPendingConfigPushCount(), "both push coroutines must have settled").toBe(0);
 
         const openclawWrite = findOpenClawConfigWrite(mockedWriteFileSync);
         expect(

--- a/packages/web/src/__tests__/lib/openclaw-config/push-generation.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/push-generation.test.ts
@@ -1,0 +1,111 @@
+// The push-generation counter must be shared across module instances.
+//
+// `pushConfigInBackground` cancels an older push by comparing its own
+// generation against a counter that every push bumps. That only works if all
+// pushes in the process count on the SAME counter — and they do not, unless the
+// counter lives on globalThis: the custom server (`node --import tsx server.ts`)
+// and Next.js's route bundles are two module registries inside one process, so
+// `src/lib/openclaw-config/write.ts` is loaded twice.
+//
+// Measured in the dev stack rather than assumed — a module-load probe printed:
+//
+//   [probe] write.ts module loaded: instance=0d88ll all=["0d88ll"] pid=47
+//   [probe] write.ts module loaded: instance=ng8zfo all=["0d88ll","ng8zfo"] pid=47
+//
+// (first line at server boot, second on the first request to an API route that
+// imports the module — same pid, same globalThis, two instances).
+//
+// With a plain module-level counter each instance mints generations 1, 2, 3…
+// independently, so a route-triggered push cannot supersede a server-triggered
+// one: both reach `config.apply`, which is the restart storm the guard exists
+// to stop (#193). `vi.resetModules()` reproduces exactly that shape — a second,
+// independent instance of the module in one process.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockGetClient = vi.fn();
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => mockGetClient(),
+}));
+
+const mockWriteFileSync = vi.fn();
+vi.mock("fs", () => ({
+  existsSync: () => true,
+  mkdirSync: vi.fn(),
+  renameSync: vi.fn(),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  readFileSync: () => {
+    const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  },
+}));
+
+/** Let every pending microtask (the push coroutines) run to its next await. */
+async function drain() {
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("push generation across module instances", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("lets a push from one module instance supersede a push from another", async () => {
+    // Two independent instances of write.ts, as the custom server and a Next
+    // route bundle hold them.
+    const serverInstance = await import("@/lib/openclaw-config/write");
+    vi.resetModules();
+    const routeInstance = await import("@/lib/openclaw-config/write");
+    expect(
+      routeInstance.pushConfigInBackground,
+      "vi.resetModules must yield a genuinely separate module instance"
+    ).not.toBe(serverInstance.pushConfigInBackground);
+    // No reset of the generation here, on purpose: the counter is a monotonic
+    // cancellation token and this test only cares about the ORDER of the two
+    // pushes, never about their absolute numbers.
+
+    // The server's push parks on config.get(); the route's push resolves at once.
+    let resolveServerGet: ((value: { hash: string }) => void) | undefined;
+    const configGet = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ hash: string }>((resolve) => {
+            resolveServerGet = resolve;
+          })
+      )
+      .mockResolvedValue({ hash: "h-route" });
+    const configApply = vi.fn().mockResolvedValue(undefined);
+    mockGetClient.mockReturnValue({ config: { get: configGet, apply: configApply } });
+
+    serverInstance.pushConfigInBackground(JSON.stringify({ env: { OLD: "1" } }));
+    await drain();
+    expect(configGet).toHaveBeenCalledTimes(1);
+    expect(resolveServerGet).toBeDefined();
+
+    // A newer push starts from the OTHER instance and lands its payload.
+    routeInstance.pushConfigInBackground(JSON.stringify({ env: { NEW: "2" } }));
+    await drain();
+    expect(configApply).toHaveBeenCalledTimes(1);
+    expect(String(configApply.mock.calls[0][0])).toContain('"NEW"');
+
+    // Only now does the older push's config.get() resolve. It must recognise
+    // that it was superseded — by a push it can only see through a shared
+    // counter — and return without applying its stale payload.
+    resolveServerGet?.({ hash: "h-server" });
+    await drain();
+
+    const stalePayloadApplied = configApply.mock.calls.some((call) =>
+      String(call[0]).includes('"OLD"')
+    );
+    expect(
+      stalePayloadApplied,
+      "a push from another module instance must supersede this one — otherwise both apply and OC restarts (#193)"
+    ).toBe(false);
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/push-state.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/push-state.test.ts
@@ -20,12 +20,22 @@ import {
   trackConfigPushStarted,
   trackConfigPushSettled,
   getPendingConfigPushCount,
+  nextConfigPushGeneration,
+  getCurrentConfigPushGeneration,
   _resetConfigPushState,
 } from "@/lib/openclaw-config/push-state";
 
 describe("config push pending-state tracker", () => {
   beforeEach(() => {
     _resetConfigPushState();
+    // The generation is a monotonic cancellation token and there is no reset
+    // for it, on purpose (see push-state.ts). The tests below that need a
+    // known starting value seed the globalThis object directly — which is what
+    // a contract test for this cell should be doing in any case.
+    (globalThis as Record<string, unknown>).__pinchyConfigPushState = {
+      pending: 0,
+      generation: 0,
+    };
   });
 
   it("starts at zero pending", () => {
@@ -63,5 +73,59 @@ describe("config push pending-state tracker", () => {
     // is visible through our getter.
     state.pending = 3;
     expect(getPendingConfigPushCount()).toBe(3);
+  });
+
+  it("shares the generation counter through the same globalThis key", () => {
+    // Same contract for the push-generation counter, and it carries more
+    // weight: `pushConfigInBackground` cancels an older push by comparing its
+    // own generation against this one, so a per-instance counter means a
+    // route-triggered push cannot supersede a server-triggered one — both
+    // reach config.apply, which is the restart storm #193 is about.
+    expect(nextConfigPushGeneration()).toBe(1);
+    const state = (globalThis as Record<string, unknown>).__pinchyConfigPushState as {
+      generation: number;
+    };
+    expect(state.generation).toBe(1);
+    // A push claimed from a foreign module instance is visible here.
+    state.generation = 7;
+    expect(getCurrentConfigPushGeneration()).toBe(7);
+    expect(nextConfigPushGeneration()).toBe(8);
+  });
+
+  it("normalizes a state object written before a field existed", () => {
+    // globalThis outlives a module reload — that is the whole reason the state
+    // lives here rather than in a module variable. So a dev server that was
+    // already running when `generation` was added to this shape holds the
+    // PREVIOUS version's object, and `??=` leaves an existing object alone.
+    //
+    // `generation` then reads as undefined, `++undefined` is NaN, and
+    // `NaN !== NaN` is true — so every push takes the superseded branch at the
+    // top of its very first retry iteration and returns. No config change
+    // reaches config.apply, none reaches the file fallback either, for the
+    // life of the process, with only a `gen=NaN` line in the log to say so.
+    // Normalize the FIELDS, not just the object.
+    (globalThis as Record<string, unknown>).__pinchyConfigPushState = { pending: 2 };
+
+    expect(nextConfigPushGeneration()).toBe(1);
+    expect(getCurrentConfigPushGeneration()).toBe(1);
+    // A generation must be comparable to itself — the whole guard is `!==`.
+    const claimed = nextConfigPushGeneration();
+    expect(claimed === getCurrentConfigPushGeneration()).toBe(true);
+    // …and the pre-existing field is carried over, not reset.
+    expect(getPendingConfigPushCount()).toBe(2);
+  });
+
+  it("normalizes a state object that is missing the pending count", () => {
+    // The mirror image, for whichever field a future shape adds next:
+    // `Math.max(0, undefined - 1)` is NaN too, and a NaN pending count makes
+    // `/api/health/openclaw` report `configPushesPending: null` while the E2E
+    // stability gates wait for a 0 that can never arrive.
+    (globalThis as Record<string, unknown>).__pinchyConfigPushState = { generation: 4 };
+
+    expect(getPendingConfigPushCount()).toBe(0);
+    trackConfigPushStarted();
+    trackConfigPushSettled();
+    expect(getPendingConfigPushCount()).toBe(0);
+    expect(getCurrentConfigPushGeneration()).toBe(4);
   });
 });

--- a/packages/web/src/lib/openclaw-config/push-state.ts
+++ b/packages/web/src/lib/openclaw-config/push-state.ts
@@ -1,4 +1,7 @@
-// Pending-state tracker for `pushConfigInBackground` coroutines.
+// Process-wide state for `pushConfigInBackground` coroutines: how many are in
+// flight, and which generation is the newest. Both must be shared by every
+// module instance in the process, which is what puts them on globalThis (see
+// the note at the bottom of this comment).
 //
 // Why: config pushes are fire-and-forget, and under OC 5.3's `config.apply`
 // rate-limit (~3 calls / 45 s) a push coroutine can be PARKED for 33–53 s
@@ -17,12 +20,22 @@
 //
 // globalThis-backed for the same reason as `server/openclaw-client.ts`:
 // Next.js API routes (which serve the health endpoint) and the custom server
-// (which also triggers regenerates) can load SEPARATE instances of this
-// module, so a plain module-level counter would give the route a counter the
-// server's pushes never touch.
+// (which also triggers regenerates) load SEPARATE instances of this module, so
+// a plain module-level counter would give the route a counter the server's
+// pushes never touch.
+//
+// Measured, not assumed — a module-load probe in `write.ts` on the dev stack
+// printed two instance ids under ONE pid: the first at server boot (custom
+// server, `node --import tsx server.ts`), the second on the first request to an
+// API route that imports it (Next's route registry). Same process, same
+// globalThis, two module instances. That is why `generation` lives here too:
+// with a module-level counter each instance mints 1, 2, 3… in private, so a
+// route push cannot supersede a server push and both reach `config.apply` —
+// the restart storm the generation guard exists to stop (#193).
 
 interface ConfigPushState {
   pending: number;
+  generation: number;
 }
 
 declare global {
@@ -30,7 +43,7 @@ declare global {
 }
 
 function state(): ConfigPushState {
-  globalThis.__pinchyConfigPushState ??= { pending: 0 };
+  globalThis.__pinchyConfigPushState ??= { pending: 0, generation: 0 };
   return globalThis.__pinchyConfigPushState;
 }
 
@@ -54,7 +67,38 @@ export function getPendingConfigPushCount(): number {
   return state().pending;
 }
 
-/** Test-only: reset between tests. Do not call in app code. */
+/**
+ * Claim the next push generation. `pushConfigInBackground` stamps every
+ * coroutine with one and abandons itself as soon as a newer one exists, so a
+ * stale payload can never land on top of a newer one (#193).
+ *
+ * It lives here, next to the pending counter, for the same globalThis reason:
+ * the custom server and Next's route bundles each hold their OWN instance of
+ * `write.ts` (measured — one pid, two module-load probes), so a plain
+ * module-level counter would let each mint generations 1, 2, 3… in private.
+ * A route-triggered push then cannot supersede a server-triggered one: both
+ * reach `config.apply`, which is the restart storm the counter exists to stop.
+ */
+export function nextConfigPushGeneration(): number {
+  return ++state().generation;
+}
+
+/** The newest generation any module instance in this process has claimed. */
+export function getCurrentConfigPushGeneration(): number {
+  return state().generation;
+}
+
+/** Test-only: reset the pending counter between tests. Do not call in app code. */
 export function _resetConfigPushState(): void {
   state().pending = 0;
 }
+
+// There is deliberately NO reset for `generation`. It is a cancellation token
+// whose only guarantee is monotonicity — a number minted once must never be
+// minted again, or a coroutine parked at gen 1 compares equal to a later
+// push's gen 1 and sails through the supersede check (see
+// `_supersedePendingPushes` in write.ts, and the flake it was written for).
+// Now that the counter is process-wide, a reset would recycle tokens held by
+// the other module instance's coroutines as well. Tests that need a known
+// starting value seed the globalThis object directly, which is what a
+// contract test for this cell should be doing anyway.

--- a/packages/web/src/lib/openclaw-config/push-state.ts
+++ b/packages/web/src/lib/openclaw-config/push-state.ts
@@ -43,8 +43,27 @@ declare global {
 }
 
 function state(): ConfigPushState {
-  globalThis.__pinchyConfigPushState ??= { pending: 0, generation: 0 };
-  return globalThis.__pinchyConfigPushState;
+  // Normalize the FIELDS, not just the object. globalThis outlives a module
+  // reload — that is the whole reason this state lives here — so the object
+  // found here can have been written by a PREVIOUS version of this module,
+  // and `??=` leaves an existing object untouched. A dev server that was
+  // already running when `generation` was added holds `{ pending: N }`; the
+  // missing field then reads as undefined, `++undefined` is NaN, and
+  // `NaN !== NaN` makes every push take the superseded branch on its very
+  // first retry iteration. No config change reaches config.apply, none
+  // reaches the file fallback either, for the life of the process — with a
+  // `gen=NaN` log line as the only trace. Same shape in the other field: a
+  // NaN pending count makes `/api/health/openclaw` serve
+  // `configPushesPending: null` while the E2E stability gates wait for a 0
+  // that can never arrive.
+  const existing = globalThis.__pinchyConfigPushState as Partial<ConfigPushState> | undefined;
+  if (!existing) {
+    globalThis.__pinchyConfigPushState = { pending: 0, generation: 0 };
+    return globalThis.__pinchyConfigPushState;
+  }
+  existing.pending ??= 0;
+  existing.generation ??= 0;
+  return existing as ConfigPushState;
 }
 
 /** Record that a `pushConfigInBackground` coroutine has started. */

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -8,7 +8,12 @@ import {
   configsAreEquivalentUpToOpenClawMetadata,
 } from "./normalize";
 import { CONFIG_PATH } from "./paths";
-import { trackConfigPushStarted, trackConfigPushSettled } from "./push-state";
+import {
+  trackConfigPushStarted,
+  trackConfigPushSettled,
+  nextConfigPushGeneration,
+  getCurrentConfigPushGeneration,
+} from "./push-state";
 
 /** Atomic write: tmp file + rename to prevent OpenClaw reading a truncated config */
 export function writeConfigAtomic(content: string) {
@@ -123,11 +128,16 @@ export function readExistingConfig(): Record<string, unknown> {
 // actual agent create all in quick succession with a slow CI event loop), the
 // retry window of an early call can extend into a later one's territory.
 //
-// Cancellation scope: the counter is checked between awaits in the retry loop
-// and again right before client.config.apply(). It does NOT cancel an in-flight
-// apply() RPC — once that call starts, it runs to completion. The newer call's
-// payload simply overwrites through its own config.apply or writeConfigAtomic.
-let _pushGeneration = 0;
+// The counter itself lives in `push-state.ts`, on globalThis: this module is
+// loaded TWICE in one Pinchy process (custom server via tsx + Next's route
+// bundles), and a module-level counter would give each instance a private
+// sequence that the other's pushes never touch.
+//
+// Cancellation scope: the counter is checked between awaits in the retry loop,
+// right before client.config.apply(), and once more when an attempt fails, so a
+// superseded coroutine never applies NOR file-writes its stale payload. It does
+// NOT cancel an in-flight apply() RPC — once that call starts, it runs to
+// completion; only its aftermath is abandoned.
 
 /**
  * Test-only: cancel every push coroutine that is currently in flight, by
@@ -146,9 +156,13 @@ let _pushGeneration = 0;
  * purpose: it was the only way a stale coroutine could get past the guard at
  * all. Guarded by "a push parked since an earlier test can never reach
  * config.apply" in that file.
+ *
+ * Which is also why `push-state.ts` exports no reset for the generation, only
+ * `nextConfigPushGeneration()`: now that the counter is process-wide, a reset
+ * would recycle tokens held by coroutines in the OTHER module instance too.
  */
 export function _supersedePendingPushes() {
-  _pushGeneration++;
+  nextConfigPushGeneration();
 }
 
 // OC's explicit recovery hint when the file-watcher reloaded openclaw.json
@@ -241,7 +255,7 @@ export interface PushConfigOptions {
 
 export function pushConfigInBackground(newContent: string, options: PushConfigOptions = {}): void {
   const { onChangeApplied } = options;
-  const generation = ++_pushGeneration;
+  const generation = nextConfigPushGeneration();
 
   // Make the in-flight push observable (health endpoint `configPushesPending`,
   // consumed by the E2E stability gates): a rate-limited apply can park this
@@ -306,9 +320,9 @@ export function pushConfigInBackground(newContent: string, options: PushConfigOp
     for (let i = 0; i < backoffsMs.length; i++) {
       // Check before each attempt — a newer pushConfigInBackground call
       // may have started while we were sleeping.
-      if (generation !== _pushGeneration) {
+      if (generation !== getCurrentConfigPushGeneration()) {
         console.log(
-          `[openclaw-config] push gen=${String(generation)}: superseded by newer push (gen=${String(_pushGeneration)}) before attempt ${String(i)}`
+          `[openclaw-config] push gen=${String(generation)}: superseded by newer push (gen=${String(getCurrentConfigPushGeneration())}) before attempt ${String(i)}`
         );
         return;
       }
@@ -319,9 +333,9 @@ export function pushConfigInBackground(newContent: string, options: PushConfigOp
         };
 
         // Newer call started while we were awaiting config.get()
-        if (generation !== _pushGeneration) {
+        if (generation !== getCurrentConfigPushGeneration()) {
           console.log(
-            `[openclaw-config] push gen=${String(generation)}: superseded by newer push (gen=${String(_pushGeneration)}) during config.get`
+            `[openclaw-config] push gen=${String(generation)}: superseded by newer push (gen=${String(getCurrentConfigPushGeneration())}) during config.get`
           );
           return;
         }
@@ -402,6 +416,27 @@ export function pushConfigInBackground(newContent: string, options: PushConfigOp
         return;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+
+        // A newer push can have started while this attempt's RPC was in
+        // flight. Both terminal branches below end in writeConfigAtomic, and a
+        // superseded coroutine writing its stale payload is exactly the
+        // stale-payload-lands-anyway race the counter exists to prevent (#193)
+        // — it would overwrite on disk what the newer push just applied to
+        // OC's runtime. From here the newer push owns both.
+        //
+        // Checked once at the top of the catch rather than in front of each
+        // fallback: the retry branches below only ever `continue` into the
+        // loop-top check anyway, so returning here just skips a sleep they
+        // would spend on a decision already made. `onChangeApplied` stays
+        // unfired, same as at the other two supersede checks — a push that
+        // delivered nothing must not report a landed change.
+        if (generation !== getCurrentConfigPushGeneration()) {
+          console.log(
+            `[openclaw-config] push gen=${String(generation)}: superseded by newer push (gen=${String(getCurrentConfigPushGeneration())}) during attempt ${String(i)} — skipping fallback write:`,
+            message
+          );
+          return;
+        }
 
         // Rate-limit handling: OC 5.3 rejects apply calls over the budget with
         // an explicit "retry after Ns" hint. Because the no-op guard above


### PR DESCRIPTION
## What does this PR do?

Closes two gaps in `pushConfigInBackground`'s generation-counter guard (`packages/web/src/lib/openclaw-config/write.ts`). Both let a superseded push land on top of a newer one — the exact race the counter exists to prevent (#193). Found while root-causing an `openclaw-config.test.ts` flake; neither was in scope of that fix.

**1. The file-write fallbacks had no generation check.**

The guard runs at the top of each retry iteration and again right after `config.get()`, so a superseded coroutine can never reach `config.apply`. But a coroutine superseded *while its apply RPC was in flight*, whose apply then failed — rate-limit budget exhausted, or the last backoff slot — still ran `writeConfigAtomic` with its now-stale payload, overwriting on disk what the newer push had just applied to OC's runtime.

The check now sits once at the top of the `catch` block, covering both fallbacks. Putting it there rather than in front of each `writeConfigAtomic` also covers the retry branches, which only ever `continue` into the loop-top check anyway — returning early just skips a sleep spent on a decision already made. A superseded push writes nothing and leaves `onChangeApplied` unfired, same as at the two existing supersede checks: the newer push owns both the runtime and the file.

**2. The counter was not shared across module instances.**

`let _pushGeneration = 0` was a plain module-level counter. This module is loaded **twice in one Pinchy process** — verified on the dev stack with a temporary module-load probe rather than reasoned about:

```
[probe] write.ts module loaded: instance=0d88ll all=["0d88ll"] pid=47
[probe] write.ts module loaded: instance=ng8zfo all=["0d88ll","ng8zfo"] pid=47
```

First line at server boot (custom server, `node --import tsx server.ts`), second on the first request to an API route that imports it (`GET /api/agents` → 401; the route module loads regardless). One pid, one globalThis, two module instances.

So each instance minted generations 1, 2, 3… in private, and a route-triggered push could not supersede a server-triggered one: both reached `config.apply`, which is the restart storm the guard is there to stop. The counter moves to `push-state.ts` — already globalThis-backed for exactly this reason, and its header now records the measurement.

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated the documentation (if applicable) — no user-visible surface changes (no API route, tool, template, audit event or settings nav); this is internal config-push behaviour
- [x] All existing tests pass

## Notes for the reviewer

Three tests, each watched fail on the old code first:

- two in `openclaw-config.test.ts` that supersede a push while its **final** apply is still in flight and only then let it fail — one per fallback (rate-limit budget, retry budget). Both wrote `{"env":{"OLD":"1"}}` to disk before the fix.
- `__tests__/lib/openclaw-config/push-generation.test.ts`, which reproduces the double load with `vi.resetModules()` (two genuine module instances in one process) and asserts the older push abandons itself.

Behaviour change worth a second opinion: a superseded push now drops its change entirely instead of file-writing it. That is deliberate — a newer push carries a payload rebuilt from the same DB state, and the alternative is a stale payload overwriting a newer one — and it matches what the two pre-existing supersede checks already did.

Gates: `pnpm test` 11173 passed / 18 skipped, `pnpm -C packages/web lint` 0 errors, `typecheck` clean, `format:check` clean.