### PR TITLE
feat(audit): record instruction and personality edits

### DIFF
--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -111,7 +111,9 @@ The detail never contains file contents — only counts and the relative filenam
 
 The sibling of `agent.memory_changed`, and the more consequential half. Memory is what the agent wrote about itself; Instructions and Personality are the rules a person gave it — which records it may reach for, which customer it puts first, what tone it takes. Both reach the model at the start of every conversation, and only one of them used to leave a trace.
 
-Written whenever someone saves the [Instructions](/concepts/agent-settings/#instructions-tab) or [Personality](/concepts/agent-settings/#personality-tab) tab. Only admins, and the owner of a personal agent, can do that.
+Written when someone saves the [Instructions](/concepts/agent-settings/#instructions-tab) or [Personality](/concepts/agent-settings/#personality-tab) tab **and the file's text actually differs**. Only admins, and the owner of a personal agent, can do that.
+
+The "actually differs" part matters when reading the trail: the Personality tab also holds the avatar and the personality preset, and saving it re-sends `SOUL.md` even when only the avatar moved. A row here therefore always means the text changed — an avatar swap shows up as `agent.updated`, not as an instruction edit.
 
 - `actorType`: `"user"` — the person who saved the change.
 - `resource`: `agent:<agentId>`.
@@ -119,7 +121,9 @@ Written whenever someone saves the [Instructions](/concepts/agent-settings/#inst
   - `agent`: `{ id, name }` — snapshot at the time of the change.
   - `file`: `"AGENTS.md"` or `"SOUL.md"`.
   - `addedLines` / `removedLines`: compared to the previous content.
-  - `byteSize`: size after the change.
+  - `byteSize`: size of the file in bytes after the change.
+
+`outcome` is `"failure"` when the save passed every access check and the write itself failed — a disk error, or a file Pinchy could not reclaim. The detail then describes the change that was _attempted_; the file on disk is unchanged.
 
 As with memory, the detail never contains the text. An audit row is immutable and hash-chained, so anything written into it cannot be corrected or erased later — and instructions are free text that may name customers or internal rules.
 

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -77,13 +77,14 @@ exports too.
 
 ### Agent management
 
-| Event Type                | Description                                                                                                                                                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent.created`           | A new agent was created                                                                                                                                                                                                                                 |
-| `agent.updated`           | An agent's settings or permissions were changed                                                                                                                                                                                                         |
-| `agent.deleted`           | An agent was deleted                                                                                                                                                                                                                                    |
-| `agent.memory_changed`    | A file in the agent's durable long-term memory (`MEMORY.md` or `memory/*.md`) was created, modified, or deleted                                                                                                                                         |
-| `agent.model_unavailable` | The agent's configured model returned an HTTP 5xx (server-side failure or discontinuation). One entry per `(agent, model)` per 5 minutes — repeated failures inside the window are aggregated to avoid log spam. Detail captures the upstream `ref` ID. |
+| Event Type                   | Description                                                                                                                                                                                                                                             |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent.created`              | A new agent was created                                                                                                                                                                                                                                 |
+| `agent.updated`              | An agent's settings or permissions were changed                                                                                                                                                                                                         |
+| `agent.deleted`              | An agent was deleted                                                                                                                                                                                                                                    |
+| `agent.memory_changed`       | A file in the agent's durable long-term memory (`MEMORY.md` or `memory/*.md`) was created, modified, or deleted                                                                                                                                         |
+| `agent.instructions_changed` | A person edited the agent's Instructions (`AGENTS.md`) or Personality (`SOUL.md`)                                                                                                                                                                       |
+| `agent.model_unavailable`    | The agent's configured model returned an HTTP 5xx (server-side failure or discontinuation). One entry per `(agent, model)` per 5 minutes — repeated failures inside the window are aggregated to avoid log spam. Detail captures the upstream `ref` ID. |
 
 #### `agent.memory_changed`
 
@@ -105,6 +106,22 @@ Pinchy watches these files and emits an audit entry on every change so an audito
   - `byteSize`: size of the file in bytes after the change (`0` for deletions).
 
 The detail never contains file contents — only counts and the relative filename. Deletions surface as `byteSize: 0` and `removedLines` equal to the previous line count.
+
+#### `agent.instructions_changed`
+
+The sibling of `agent.memory_changed`, and the more consequential half. Memory is what the agent wrote about itself; Instructions and Personality are the rules a person gave it — which records it may reach for, which customer it puts first, what tone it takes. Both reach the model at the start of every conversation, and only one of them used to leave a trace.
+
+Written whenever someone saves the [Instructions](/concepts/agent-settings/#instructions-tab) or [Personality](/concepts/agent-settings/#personality-tab) tab. Only admins, and the owner of a personal agent, can do that.
+
+- `actorType`: `"user"` — the person who saved the change.
+- `resource`: `agent:<agentId>`.
+- `detail`: the same shape as `agent.memory_changed`, so one query answers "what changed about this agent's behaviour" across both:
+  - `agent`: `{ id, name }` — snapshot at the time of the change.
+  - `file`: `"AGENTS.md"` or `"SOUL.md"`.
+  - `addedLines` / `removedLines`: compared to the previous content.
+  - `byteSize`: size after the change.
+
+As with memory, the detail never contains the text. An audit row is immutable and hash-chained, so anything written into it cannot be corrected or erased later — and instructions are free text that may name customers or internal rules.
 
 ### Chat runtime
 

--- a/packages/web/src/__tests__/api/agent-files.test.ts
+++ b/packages/web/src/__tests__/api/agent-files.test.ts
@@ -22,6 +22,9 @@ vi.mock("@/lib/workspace", () => ({
   writeWorkspaceFile: vi.fn(),
 }));
 
+const { mockAppendAuditLog } = vi.hoisted(() => ({ mockAppendAuditLog: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ appendAuditLog: mockAppendAuditLog }));
+
 const { mockRequireAgentWriteAccess } = vi.hoisted(() => ({
   // Returns null when write is allowed; returns a NextResponse(403) when denied.
   mockRequireAgentWriteAccess: vi.fn(),
@@ -350,5 +353,158 @@ describe("PUT /api/agents/[agentId]/files/[filename]", () => {
 
     expect(response.status).toBe(200);
     expect(writeWorkspaceFile).toHaveBeenCalledWith("agent-1", "AGENTS.md", "# Valid update");
+  });
+});
+
+// An agent's instructions decide how it behaves — which records it touches,
+// which customer it prioritises. Until this landed, the route carried an
+// `audit-exempt` comment and the memory-audit watcher covered MEMORY.md and
+// memory/** only. So Pinchy audited what an agent wrote about itself and not
+// the rules a person gave it, which is the governance story backwards.
+describe("PUT /api/agents/[agentId]/files/[filename] — audit trail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: "1", email: "admin@test.com" },
+    } as any);
+    vi.mocked(getAgentWithAccess).mockResolvedValue(defaultAgent);
+    mockRequireAgentWriteAccess.mockReturnValue(null);
+    mockAppendAuditLog.mockResolvedValue(undefined);
+  });
+
+  it("records an agent.instructions_changed entry with the line diff", async () => {
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce("# Old\nkeep\ndrop\n");
+
+    const request = makePutRequest("agent-1", "AGENTS.md", {
+      content: "# Old\nkeep\nadded one\nadded two\n",
+    });
+    const response = await PUT(request, makeParams("agent-1", "AGENTS.md"));
+
+    expect(response.status).toBe(200);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith({
+      actorType: "user",
+      actorId: "1",
+      eventType: "agent.instructions_changed",
+      resource: "agent:agent-1",
+      detail: {
+        agent: { id: "agent-1", name: "Smithers" },
+        file: "AGENTS.md",
+        addedLines: 2,
+        removedLines: 1,
+        byteSize: "# Old\nkeep\nadded one\nadded two\n".length,
+      },
+      outcome: "success",
+    });
+  });
+
+  it("names SOUL.md as the file rather than assuming instructions", async () => {
+    // ALLOWED_FILES holds both, and they are different surfaces (Personality vs
+    // Instructions). One event with the file in `detail` mirrors how
+    // agent.memory_changed covers MEMORY.md and the notes under memory/.
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce("");
+
+    await PUT(
+      makePutRequest("agent-1", "SOUL.md", { content: "warm\n" }),
+      makeParams("agent-1", "SOUL.md")
+    );
+
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: expect.objectContaining({ file: "SOUL.md" }) })
+    );
+  });
+
+  it("never puts the instruction text itself in the audit detail", async () => {
+    // The row is immutable and hash-chained, so anything written here cannot be
+    // corrected later. Instructions are free text a user authored and may name
+    // customers or internal rules; the diff shape says what changed without
+    // copying it into a row nobody can edit.
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce("before\n");
+
+    await PUT(
+      makePutRequest("agent-1", "AGENTS.md", { content: "Call ACME before anyone else\n" }),
+      makeParams("agent-1", "AGENTS.md")
+    );
+
+    const detail = JSON.stringify(mockAppendAuditLog.mock.calls[0][0].detail);
+    expect(detail).not.toContain("ACME");
+    expect(detail).not.toContain("before");
+  });
+
+  it("blocks the response until the entry is written", async () => {
+    // An idempotent state change awaits its audit write (AGENTS.md § audit
+    // rules): a fire-and-forget row can be lost exactly when the write it
+    // describes succeeded.
+    let resolveAudit: () => void = () => {};
+    mockAppendAuditLog.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveAudit = resolve;
+      })
+    );
+
+    let settled = false;
+    const pending = PUT(
+      makePutRequest("agent-1", "AGENTS.md", { content: "x\n" }),
+      makeParams("agent-1", "AGENTS.md")
+    ).then((res) => {
+      settled = true;
+      return res;
+    });
+
+    // Drain the microtask queue past the route's own awaits (params,
+    // parseRequestBody). A single `await Promise.resolve()` would still be
+    // pending for a fire-and-forget route and prove nothing.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(settled).toBe(false);
+
+    resolveAudit();
+    expect((await pending).status).toBe(200);
+  });
+
+  it("writes no entry when the caller may not write the file", async () => {
+    mockRequireAgentWriteAccess.mockReturnValueOnce(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    );
+
+    const response = await PUT(
+      makePutRequest("agent-1", "AGENTS.md", { content: "# Hacked" }),
+      makeParams("agent-1", "AGENTS.md")
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockAppendAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("records a failure entry when the write itself fails", async () => {
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce("before\n");
+    vi.mocked(writeWorkspaceFile).mockImplementationOnce(() => {
+      throw new Error("EACCES: permission denied");
+    });
+
+    const response = await PUT(
+      makePutRequest("agent-1", "AGENTS.md", { content: "after\n" }),
+      makeParams("agent-1", "AGENTS.md")
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "failure" })
+    );
+  });
+
+  it("writes no entry when the filename is not an allowed file", async () => {
+    // A rejected filename changes nothing on disk and is a client-side typo,
+    // not an action on the agent. Auditing it would fill the trail with rows
+    // that describe no state.
+    vi.mocked(readWorkspaceFile).mockImplementationOnce(() => {
+      throw new Error("File not allowed: SECRET.md");
+    });
+
+    const response = await PUT(
+      makePutRequest("agent-1", "SECRET.md", { content: "x" }),
+      makeParams("agent-1", "SECRET.md")
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockAppendAuditLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/api/agent-files.test.ts
+++ b/packages/web/src/__tests__/api/agent-files.test.ts
@@ -25,6 +25,9 @@ vi.mock("@/lib/workspace", () => ({
 const { mockAppendAuditLog } = vi.hoisted(() => ({ mockAppendAuditLog: vi.fn() }));
 vi.mock("@/lib/audit", () => ({ appendAuditLog: mockAppendAuditLog }));
 
+const { mockRecordAuditFailure } = vi.hoisted(() => ({ mockRecordAuditFailure: vi.fn() }));
+vi.mock("@/lib/audit-deferred", () => ({ recordAuditFailure: mockRecordAuditFailure }));
+
 const { mockRequireAgentWriteAccess } = vi.hoisted(() => ({
   // Returns null when write is allowed; returns a NextResponse(403) when denied.
   mockRequireAgentWriteAccess: vi.fn(),
@@ -397,6 +400,50 @@ describe("PUT /api/agents/[agentId]/files/[filename] — audit trail", () => {
     });
   });
 
+  it("sizes the file in UTF-8 bytes, like the memory sibling does", async () => {
+    // The whole argument for this detail shape is that one query reads both
+    // families. agent.memory_changed measures Buffer.byteLength(…, "utf8");
+    // String.length counts UTF-16 code units, so the two disagree on every
+    // non-ASCII file — and instructions written in German, or carrying a
+    // single emoji, are the ordinary case rather than the exotic one.
+    const content = "Prüfe die Rechnung für Kunde ☕\n";
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce("");
+
+    await PUT(
+      makePutRequest("agent-1", "AGENTS.md", { content }),
+      makeParams("agent-1", "AGENTS.md")
+    );
+
+    expect(Buffer.byteLength(content, "utf8")).not.toBe(content.length);
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ byteSize: Buffer.byteLength(content, "utf8") }),
+      })
+    );
+  });
+
+  it("writes no entry when the save left the file unchanged", async () => {
+    // The settings page PUTs SOUL.md whenever the Personality tab is dirty,
+    // and that tab is dirty for an avatar or preset change too
+    // (agent-settings-page-content.tsx). Auditing the write rather than the
+    // change would therefore file "someone edited this agent's Personality"
+    // against someone who picked a new avatar. A row that describes no change
+    // is worse than no row: an auditor cannot tell it from a real edit.
+    const unchanged = "# Same\ncontent\n";
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce(unchanged);
+
+    const response = await PUT(
+      makePutRequest("agent-1", "SOUL.md", { content: unchanged }),
+      makeParams("agent-1", "SOUL.md")
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockAppendAuditLog).not.toHaveBeenCalled();
+    // The write still happens — it is what reclaims a root-owned file (#1095),
+    // and skipping it would trade an audit fix for a production regression.
+    expect(writeWorkspaceFile).toHaveBeenCalledWith("agent-1", "SOUL.md", unchanged);
+  });
+
   it("names SOUL.md as the file rather than assuming instructions", async () => {
     // ALLOWED_FILES holds both, and they are different surfaces (Personality vs
     // Instructions). One event with the file in `detail` mirrors how
@@ -489,6 +536,50 @@ describe("PUT /api/agents/[agentId]/files/[filename] — audit trail", () => {
     expect(mockAppendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: "failure" })
     );
+  });
+
+  it("keeps the write's own error when the failure row cannot be stored", async () => {
+    // Two things fail here: the file write, then the audit write describing it.
+    // Only the first is the caller's problem, and it is the one that names the
+    // cause (#1095 surfaces as EACCES). Awaiting the failure row the way the
+    // success row is awaited would replace a 400 that explains itself with an
+    // unhandled rejection — a 500 that explains nothing, over a row the caller
+    // can do nothing about. The dropped row goes to recordAuditFailure instead,
+    // which is the AGENTS.md pattern for an audit write that must not sink the
+    // response.
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce("before\n");
+    vi.mocked(writeWorkspaceFile).mockImplementationOnce(() => {
+      throw new Error("EACCES: permission denied");
+    });
+    mockAppendAuditLog.mockRejectedValueOnce(new Error("audit db unreachable"));
+
+    const response = await PUT(
+      makePutRequest("agent-1", "AGENTS.md", { content: "after\n" }),
+      makeParams("agent-1", "AGENTS.md")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "EACCES: permission denied" });
+    expect(mockRecordAuditFailure).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ eventType: "agent.instructions_changed", outcome: "failure" })
+    );
+  });
+
+  it("fails the request when the success row cannot be stored", async () => {
+    // The other half of "awaited, not deferred": rewriting a file is
+    // idempotent, so a request that cannot be audited is one the caller may
+    // safely retry. Answering 200 would report a change Pinchy has no record
+    // of — which is the failure the audit trail exists to prevent.
+    vi.mocked(readWorkspaceFile).mockReturnValueOnce("before\n");
+    mockAppendAuditLog.mockRejectedValueOnce(new Error("audit db unreachable"));
+
+    await expect(
+      PUT(
+        makePutRequest("agent-1", "AGENTS.md", { content: "after\n" }),
+        makeParams("agent-1", "AGENTS.md")
+      )
+    ).rejects.toThrow("audit db unreachable");
   });
 
   it("writes no entry when the filename is not an allowed file", async () => {

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -31,6 +31,19 @@ describe("AuditLogEntry agent.memory_changed", () => {
   });
 });
 
+describe("AuditLogEntry agent.instructions_changed", () => {
+  it("types the detail shape and keeps the event in the curated union", () => {
+    // Identical to agent.memory_changed by design, so one query answers "what
+    // changed about this agent's behaviour" across both families. If the two
+    // shapes ever diverge, that argument stops holding — and this is where it
+    // shows up, rather than in a dashboard nobody re-checks.
+    expectTypeOf<
+      Extract<AuditLogEntry, { eventType: "agent.instructions_changed" }>["detail"]
+    >().toEqualTypeOf<Extract<AuditLogEntry, { eventType: "agent.memory_changed" }>["detail"]>();
+    expectTypeOf<"agent.instructions_changed">().toExtend<AuditEventType>();
+  });
+});
+
 describe("AuditLogEntry channel.auto_disabled (#477 layer 2)", () => {
   it("types the detail shape and keeps the event in the curated union", () => {
     expectTypeOf<

--- a/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
@@ -1,10 +1,11 @@
-// audit-exempt: knowledge base file edits are per-agent content changes, not admin actions
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
 import { parseRequestBody } from "@/lib/api-validation";
+import { appendAuditLog } from "@/lib/audit";
+import { computeLineDiff } from "@/lib/memory-audit-watcher/compute-diff";
 
 const writeFileSchema = z.object({ content: z.string() });
 
@@ -39,11 +40,57 @@ export const PUT = withAuth<Params>(async (request, { params }, session) => {
   if ("error" in parsed) return parsed.error;
   const { content } = parsed.data;
 
+  // Read BEFORE writing, for two reasons that happen to coincide: the previous
+  // content is what turns the audit entry into a diff rather than a bare
+  // "changed", and readWorkspaceFile runs the same allowed-file assertion the
+  // write does — so a disallowed filename still 400s, one step earlier, without
+  // ever reaching an audit call. A rejected filename changed nothing on disk
+  // and must not mint a row.
+  let previous: string;
   try {
-    writeWorkspaceFile(agentId, filename, content);
-    return NextResponse.json({ success: true });
+    previous = readWorkspaceFile(agentId, filename);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Invalid file";
     return NextResponse.json({ error: message }, { status: 400 });
   }
+
+  const { addedLines, removedLines } = computeLineDiff(previous, content);
+  const auditDetail = {
+    agent: { id: agentOrError.id, name: agentOrError.name },
+    file: filename,
+    addedLines,
+    removedLines,
+    byteSize: content.length,
+  };
+
+  try {
+    writeWorkspaceFile(agentId, filename, content);
+  } catch (error: unknown) {
+    // Awaited like the success path: a write that failed after passing every
+    // access check is the interesting row, not the one worth dropping.
+    await appendAuditLog({
+      actorType: "user",
+      actorId: session.user.id!,
+      eventType: "agent.instructions_changed",
+      resource: `agent:${agentId}`,
+      detail: auditDetail,
+      outcome: "failure",
+    });
+    const message = error instanceof Error ? error.message : "Invalid file";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  // Awaited rather than deferred: rewriting a file is idempotent, so letting a
+  // failed audit write fail the request is safe — the caller retries and lands
+  // on the same content (AGENTS.md § audit rules).
+  await appendAuditLog({
+    actorType: "user",
+    actorId: session.user.id!,
+    eventType: "agent.instructions_changed",
+    resource: `agent:${agentId}`,
+    detail: auditDetail,
+    outcome: "success",
+  });
+
+  return NextResponse.json({ success: true });
 });

--- a/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
@@ -4,7 +4,8 @@ import { withAuth } from "@/lib/api-auth";
 import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
 import { parseRequestBody } from "@/lib/api-validation";
-import { appendAuditLog } from "@/lib/audit";
+import { appendAuditLog, type AuditLogEntry } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
 import { computeLineDiff } from "@/lib/memory-audit-watcher/compute-diff";
 
 const writeFileSchema = z.object({ content: z.string() });
@@ -54,43 +55,64 @@ export const PUT = withAuth<Params>(async (request, { params }, session) => {
     return NextResponse.json({ error: message }, { status: 400 });
   }
 
+  // A save that changes nothing is not an edit, and must not read like one.
+  // The settings page PUTs SOUL.md whenever the Personality tab is dirty —
+  // which an avatar or preset change makes it (agent-settings-page-content.tsx),
+  // without touching a word of the file. Auditing the write rather than the
+  // change would file "someone edited this agent's Personality" against
+  // someone who picked a new avatar, and nothing in the row would let an
+  // auditor tell that apart from a real edit. The write itself still runs: it
+  // is what reclaims a root-owned file (#1095), and skipping it would trade an
+  // audit fix for a production regression.
+  const contentChanged = previous !== content;
+
   const { addedLines, removedLines } = computeLineDiff(previous, content);
-  const auditDetail = {
-    agent: { id: agentOrError.id, name: agentOrError.name },
-    file: filename,
-    addedLines,
-    removedLines,
-    byteSize: content.length,
-  };
-
-  try {
-    writeWorkspaceFile(agentId, filename, content);
-  } catch (error: unknown) {
-    // Awaited like the success path: a write that failed after passing every
-    // access check is the interesting row, not the one worth dropping.
-    await appendAuditLog({
-      actorType: "user",
-      actorId: session.user.id!,
-      eventType: "agent.instructions_changed",
-      resource: `agent:${agentId}`,
-      detail: auditDetail,
-      outcome: "failure",
-    });
-    const message = error instanceof Error ? error.message : "Invalid file";
-    return NextResponse.json({ error: message }, { status: 400 });
-  }
-
-  // Awaited rather than deferred: rewriting a file is idempotent, so letting a
-  // failed audit write fail the request is safe — the caller retries and lands
-  // on the same content (AGENTS.md § audit rules).
-  await appendAuditLog({
+  const auditEntry = (outcome: "success" | "failure"): AuditLogEntry => ({
     actorType: "user",
     actorId: session.user.id!,
     eventType: "agent.instructions_changed",
     resource: `agent:${agentId}`,
-    detail: auditDetail,
-    outcome: "success",
+    detail: {
+      agent: { id: agentOrError.id, name: agentOrError.name },
+      file: filename,
+      addedLines,
+      removedLines,
+      // Bytes, not UTF-16 code units — `content.length` would disagree with
+      // agent.memory_changed on every non-ASCII file, and the point of sharing
+      // this detail shape is that one query reads both families.
+      byteSize: Buffer.byteLength(content, "utf8"),
+    },
+    outcome,
   });
+
+  try {
+    writeWorkspaceFile(agentId, filename, content);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Invalid file";
+    if (contentChanged) {
+      // Awaited like the success row, but its own failure is caught rather
+      // than propagated. The write has already failed and the 400 below names
+      // the cause (#1095 surfaces as EACCES); letting a second failure escape
+      // would replace that with an unhandled rejection — a 500 explaining
+      // nothing, over a row the caller can do nothing about.
+      // recordAuditFailure is AGENTS.md's pattern for exactly this: an audit
+      // write that must not sink the response.
+      const entry = auditEntry("failure");
+      try {
+        await appendAuditLog(entry);
+      } catch (auditError: unknown) {
+        recordAuditFailure(auditError, entry);
+      }
+    }
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  if (contentChanged) {
+    // Awaited rather than deferred: rewriting a file is idempotent, so letting
+    // a failed audit write fail the request is safe — the caller retries and
+    // lands on the same content (AGENTS.md § audit rules).
+    await appendAuditLog(auditEntry("success"));
+  }
 
   return NextResponse.json({ success: true });
 });

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -156,6 +156,11 @@ export type AuditEventType =
   | "chat.image_model_fallback"
   | "agent.model_unavailable"
   | "agent.memory_changed"
+  // A person edited an agent's SOUL.md (Personality) or AGENTS.md
+  // (Instructions) through the API. The sibling of agent.memory_changed, and
+  // the more consequential half: memory is what the agent wrote about itself,
+  // instructions are the rules it operates under.
+  | "agent.instructions_changed"
   | "audit.exported"
   | "audit.integrity_check"
   | "diagnostics.exported"
@@ -561,6 +566,24 @@ export type AuditLogEntry =
     })
   | (AuditLogBase & {
       eventType: "agent.memory_changed";
+      detail: {
+        agent: { id: string; name: string };
+        file: string;
+        addedLines: number;
+        removedLines: number;
+        byteSize: number;
+      };
+    })
+  | (AuditLogBase & {
+      // Same shape as agent.memory_changed on purpose: an analyst asking "what
+      // changed about this agent's behaviour" reads both families with one
+      // query. `file` distinguishes SOUL.md from AGENTS.md.
+      //
+      // The line counts are the whole payload — the text never is. An audit row
+      // is immutable and hash-chained, so anything written here cannot be
+      // corrected or erased later, and instructions are free text a user
+      // authored that may name customers or internal rules.
+      eventType: "agent.instructions_changed";
       detail: {
         agent: { id: string; name: string };
         file: string;


### PR DESCRIPTION
## What does this PR do?

Adds `agent.instructions_changed` — an audit entry for edits to an agent's **Instructions** (`AGENTS.md`) and **Personality** (`SOUL.md`).

### The hole

Pinchy audited what an agent wrote about **itself**, and not the rules a person gave it.

`agent.memory_changed` has existed since #345. The route that writes the two instruction files carried `// audit-exempt: knowledge base file edits are per-agent content changes, not admin actions`, and the memory-audit watcher covers `MEMORY.md` + `memory/**` only. So the trail recorded the agent's own notes and stayed silent on the rules it operates under — which records it may reach for, which customer it puts first.

Both files reach the model at the start of every conversation. Only one of them left a trace.

This came out of a design discussion about promoting a working method the user and agent developed together into the agent's Instructions. The argument for that move is "Instructions are the reviewed, attributable store". That was only half true, and this is the half that was missing.

### The entry

Same detail shape as `agent.memory_changed`, deliberately — one query answers "what changed about this agent's behaviour" across both families:

```
{ agent: { id, name }, file, addedLines, removedLines, byteSize }
```

`file` distinguishes `AGENTS.md` from `SOUL.md`. `computeLineDiff` is reused from the memory watcher rather than reimplemented.

**The text itself is never written.** An audit row is immutable and hash-chained, so anything put there cannot be corrected or erased later, and instructions are free text a user authored that may name customers or internal rules. A test asserts the content does not reach `detail`.

### Three decisions worth reading

- **Awaited, not deferred.** Rewriting a file is idempotent, so letting a failed audit write fail the request is safe — the caller retries and lands on the same content (AGENTS.md § audit rules). A test drains the microtask queue past the route's own awaits to prove it, since a single `await Promise.resolve()` would pass for a fire-and-forget route too.
- **The previous content is read before the write.** That is what makes the entry a diff, and it moves the allowed-file assertion one step earlier as a side effect — so a rejected filename still `400`s, without minting a row for a change that never happened.
- **A denied caller writes nothing.** The 403 path is unchanged and asserted.

## Type of change

- [x] ✨ New feature (audit coverage)
- [x] 📝 Documentation
- [x] 🧪 Tests

## Reviewer notes

Seven tests in `agent-files.test.ts`, including the two negative ones (403, disallowed filename) — a guard that only checks the happy path would not notice either regression.

Docs: `concepts/audit-trail.mdx` gains the table row and a `#### agent.instructions_changed` section next to its memory sibling. The `docs-coverage` guard requires every `AuditEventType` to appear there, so this is enforced rather than remembered.

Gates run: full suite (794 files / 11 367 tests), `test:scripts` (1043), typecheck incl. tests, ESLint (0 errors), `format:check`, `pnpm build`, docs build + anchor + table checks. `test:db` not run — no schema or migration change.

## Follow-ups (not in this PR)

Message action **"Save as instruction"**, so a working method developed in chat reaches the Instructions tab without hand-copying prose out of a chat bubble. Filed separately; this PR is its prerequisite, not part of it.

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated the documentation
- [x] All existing tests pass
