### PR TITLE
fix(test): supersede pending config pushes instead of recycling their generation

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -291,6 +291,20 @@ beforeEach(() => {
   mockGetClient.mockImplementation(() => {
     throw new Error("OpenClaw client not initialized");
   });
+  // Same cross-describe class, one layer deeper. A push coroutine OUTLIVES the
+  // test that spawned it — the not-connected path naps 2 s at a time for up to
+  // 60 s, the rate-limit path parks 33–53 s — and on resume it calls into
+  // whatever mocks are current. Cancelling belongs here rather than in the
+  // individual describes: only three of the eighteen used to call it, so the
+  // guarantee rested on an audit of which tests happen to leak today instead of
+  // on an invariant, while `restart-state integration` and `pinchy-web config`
+  // push config with no cancellation at all.
+  //
+  // This BUMPS the generation counter and must never reset it — a reset
+  // recycles the very tokens the parked coroutines hold, and is the only way
+  // one gets past the supersede check at all. See `_supersedePendingPushes`
+  // in write.ts.
+  _supersedePendingPushes();
 });
 
 // Drift guard: re-export the shared `isOpenClawLocalBaseUrl` (see
@@ -368,12 +382,6 @@ describe("regenerateOpenClawConfig", () => {
     mockGetClient.mockImplementation(() => {
       throw new Error("OpenClaw client not initialized");
     });
-    // Cancel every push coroutine still parked from a previous test, so none
-    // can resume into this test's mocks. This BUMPS the generation counter and
-    // must never reset it — a reset recycles the very tokens the parked
-    // coroutines hold and is the only way one gets past the supersede check at
-    // all. See `_supersedePendingPushes` in write.ts.
-    _supersedePendingPushes();
   });
 
   it("should write config with shared-volume file permissions (Pinchy + OpenClaw both r/w)", async () => {
@@ -3894,9 +3902,9 @@ describe("regenerateOpenClawConfig", () => {
       // this test: "Not connected" takes the extended WS-reconnect path, not
       // the ~3.5 s backoff ladder — it naps 2 s at a time for up to 60 s
       // before the writeConfigAtomic fallback, so it is still parked when the
-      // next test starts. The next `_supersedePendingPushes()` is what cancels
-      // it; that hook understating this leak as bounded is what let it flake
-      // the sibling tests below.
+      // next test starts. The top-level `beforeEach`'s
+      // `_supersedePendingPushes()` is what cancels it; that hook understating
+      // this leak as bounded is what let it flake the sibling tests below.
     });
 
     it("does not call config.apply at cold start before the OpenClaw client is initialised", async () => {
@@ -4148,9 +4156,9 @@ describe("regenerateOpenClawConfig", () => {
       // and applies test N's payload against test N+1's mocks. That is exactly
       // how the "rate-limit conservation" test above flaked under suite load —
       // the coroutine of "does not throw when the client is connected but
-      // config.apply fails" parks on the 2 s not-connected retry nap (its own
-      // header still says ~3.5 s; the not-connected path extends it to 60 s),
-      // and whichever test happens to be running ~2 s later inherits its
+      // config.apply fails" parks on the 2 s not-connected retry nap (that
+      // path bypasses the ~3.5 s backoff ladder and extends to 60 s), and
+      // whichever test happens to be running ~2 s later inherits its
       // `config.apply`. That landing point is pure scheduling luck, which is
       // why it reproduced only in the full run and never in isolation.
       //
@@ -8001,7 +8009,6 @@ describe("regenerateOpenClawConfig size-drop guard (#311)", () => {
     mockGetClient.mockImplementation(() => {
       throw new Error("OpenClaw client not initialized");
     });
-    _supersedePendingPushes();
   });
 
   it("refuses to write a config that would shrink the file by more than 50%", async () => {
@@ -8265,7 +8272,6 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     mockGetClient.mockImplementation(() => {
       throw new Error("OpenClaw client not initialized");
     });
-    _supersedePendingPushes();
   });
 
   it("auto-sets agents.defaults.imageModel.primary when Anthropic is configured", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -226,7 +226,7 @@ import {
   MEMORY_EMBEDDING_MODEL_PATH,
 } from "@/lib/openclaw-config";
 import { MAX_EFFECTIVE_CONTEXT_TOKENS } from "@/lib/openclaw-config/effective-context";
-import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-config/write";
+import { pushConfigInBackground, _supersedePendingPushes } from "@/lib/openclaw-config/write";
 import { getPendingConfigPushCount, _resetConfigPushState } from "@/lib/openclaw-config/push-state";
 import { db } from "@/db";
 import { getSetting } from "@/lib/settings";
@@ -368,10 +368,12 @@ describe("regenerateOpenClawConfig", () => {
     mockGetClient.mockImplementation(() => {
       throw new Error("OpenClaw client not initialized");
     });
-    // Reset the push-generation counter so stale background coroutines from a
-    // previous test's pushConfigInBackground retry loop cannot sneak past the
-    // generation check during the 300ms readExistingConfig async retry window.
-    _resetPushGeneration();
+    // Cancel every push coroutine still parked from a previous test, so none
+    // can resume into this test's mocks. This BUMPS the generation counter and
+    // must never reset it — a reset recycles the very tokens the parked
+    // coroutines hold and is the only way one gets past the supersede check at
+    // all. See `_supersedePendingPushes` in write.ts.
+    _supersedePendingPushes();
   });
 
   it("should write config with shared-volume file permissions (Pinchy + OpenClaw both r/w)", async () => {
@@ -3888,8 +3890,13 @@ describe("regenerateOpenClawConfig", () => {
       });
 
       await expect(regenerateOpenClawConfig()).resolves.not.toThrow();
-      // The fallback writeConfigAtomic fires asynchronously after all retry
-      // backoffs (~3.5 s total); only verify no throw here.
+      // Only verify no throw here. Note the coroutine deliberately OUTLIVES
+      // this test: "Not connected" takes the extended WS-reconnect path, not
+      // the ~3.5 s backoff ladder — it naps 2 s at a time for up to 60 s
+      // before the writeConfigAtomic fallback, so it is still parked when the
+      // next test starts. The next `_supersedePendingPushes()` is what cancels
+      // it; that hook understating this leak as bounded is what let it flake
+      // the sibling tests below.
     });
 
     it("does not call config.apply at cold start before the OpenClaw client is initialised", async () => {
@@ -4126,6 +4133,60 @@ describe("regenerateOpenClawConfig", () => {
       // No config.apply call — supplement made the payload equivalent to
       // OC's runtime, so we conserved the rate-limit slot.
       expect(mockConfigApply).not.toHaveBeenCalled();
+    });
+
+    it("a push parked since an earlier test can never reach config.apply, whatever generation the next push mints", async () => {
+      // The generation counter is a MONOTONIC cancellation token: a coroutine
+      // captures its own number and bails the moment `_pushGeneration` has
+      // moved on. Monotonicity is the whole guarantee — a number that is minted
+      // once can never be minted again, so a parked coroutine's `generation`
+      // can never compare equal to a later push's.
+      //
+      // The per-test hook used to RESET the counter to 0, which recycles live
+      // tokens: a coroutine parked at gen 1 in test N sails straight through
+      // `generation !== _pushGeneration` the moment test N+1 mints gen 1 again,
+      // and applies test N's payload against test N+1's mocks. That is exactly
+      // how the "rate-limit conservation" test above flaked under suite load —
+      // the coroutine of "does not throw when the client is connected but
+      // config.apply fails" parks on the 2 s not-connected retry nap (its own
+      // header still says ~3.5 s; the not-connected path extends it to 60 s),
+      // and whichever test happens to be running ~2 s later inherits its
+      // `config.apply`. That landing point is pure scheduling luck, which is
+      // why it reproduced only in the full run and never in isolation.
+      //
+      // Parking inside `config.get` rather than on a timer keeps this
+      // deterministic: same defect, no wall clock.
+      let releaseParkedGet!: (value: unknown) => void;
+      mockConfigGet.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseParkedGet = resolve;
+          })
+      );
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+
+      pushConfigInBackground(JSON.stringify({ env: { STALE: "1" } }));
+      await new Promise((r) => setImmediate(r));
+      expect(mockConfigApply).not.toHaveBeenCalled(); // parked, not yet applied
+
+      // Everything below is what the NEXT test does: the hook runs, then the
+      // test configures its own mocks and pushes its own payload.
+      _supersedePendingPushes();
+      mockConfigGet.mockResolvedValue({ hash: "h-fresh" });
+      mockConfigApply.mockResolvedValue(undefined);
+      pushConfigInBackground(JSON.stringify({ env: { FRESH: "2" } }));
+
+      // The parked RPC finally answers — the load that stalled it clears.
+      releaseParkedGet({ hash: "h-stale" });
+      await drainBackgroundCoroutine();
+      await drainBackgroundCoroutine();
+
+      // Only the newer push reached OpenClaw. The parked one was superseded.
+      expect(mockConfigApply).toHaveBeenCalledTimes(1);
+      expect(String(mockConfigApply.mock.calls[0][0])).toContain('"FRESH"');
+      expect(String(mockConfigApply.mock.calls[0][0])).not.toContain('"STALE"');
     });
 
     it("applies config via config.apply even when OC in-memory config and file both lack meta (no obsolete meta-guard)", async () => {
@@ -7940,7 +8001,7 @@ describe("regenerateOpenClawConfig size-drop guard (#311)", () => {
     mockGetClient.mockImplementation(() => {
       throw new Error("OpenClaw client not initialized");
     });
-    _resetPushGeneration();
+    _supersedePendingPushes();
   });
 
   it("refuses to write a config that would shrink the file by more than 50%", async () => {
@@ -8204,7 +8265,7 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     mockGetClient.mockImplementation(() => {
       throw new Error("OpenClaw client not initialized");
     });
-    _resetPushGeneration();
+    _supersedePendingPushes();
   });
 
   it("auto-sets agents.defaults.imageModel.primary when Anthropic is configured", async () => {

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -129,9 +129,26 @@ export function readExistingConfig(): Record<string, unknown> {
 // payload simply overwrites through its own config.apply or writeConfigAtomic.
 let _pushGeneration = 0;
 
-/** Exposed only for unit-testing the cancellation path; do not call in app code. */
-export function _resetPushGeneration() {
-  _pushGeneration = 0;
+/**
+ * Test-only: cancel every push coroutine that is currently in flight, by
+ * moving the token past whatever generation they captured. Do not call in app
+ * code.
+ *
+ * It BUMPS; it must never reset. The counter's only guarantee is monotonicity:
+ * a generation minted once is never minted again, so a parked coroutine's
+ * captured number can never compare equal to a later push's. This helper set
+ * it back to 0 instead, which recycles live tokens — a per-test hook that
+ * resets and then lets the test mint gen 1 again hands a coroutine parked at
+ * gen 1 in the PREVIOUS test a matching number. It sails through the supersede
+ * check and applies the previous test's payload against the current test's
+ * mocks, which is how `openclaw-config.test.ts`'s "rate-limit conservation"
+ * test saw a config.apply it never made. The reset inverted the hook's stated
+ * purpose: it was the only way a stale coroutine could get past the guard at
+ * all. Guarded by "a push parked since an earlier test can never reach
+ * config.apply" in that file.
+ */
+export function _supersedePendingPushes() {
+  _pushGeneration++;
 }
 
 // OC's explicit recovery hint when the file-watcher reloaded openclaw.json


### PR DESCRIPTION
## What

`_resetPushGeneration()` — the test-only helper called from `openclaw-config.test.ts`'s `beforeEach` — set the push-generation counter back to `0`. It now **bumps** it, and is renamed `_supersedePendingPushes()` so the wrong operation is no longer reachable from the call sites.

## Why

`_pushGeneration` in `packages/web/src/lib/openclaw-config/write.ts` is a **monotonic cancellation token**. A `pushConfigInBackground` coroutine captures its number and bails at the next `generation !== _pushGeneration` check. The entire guarantee is monotonicity: a number minted once must never be minted again.

Resetting to `0` recycles live tokens. A coroutine parked at `gen 1` in test N sails straight through the supersede check the moment test N+1 mints `gen 1` again — and applies **test N's payload against test N+1's mocks**. The hook's own comment claimed it existed so "stale background coroutines … cannot sneak past the generation check"; the reset was in fact the only way one ever could.

That is the reported flake in `skips config.apply when supplemented payload is semantically equivalent to OC's current config (rate-limit conservation)`:

- `does not throw when the client is connected but config.apply fails` rejects with `Not connected to OpenClaw Gateway`, which takes the **extended WS-reconnect path** — 2 s naps for up to 60 s, not the "~3.5 s" its comment claimed — and the test does not drain it.
- Whichever test runs ~2 s later inherits its `config.apply`. At ~270 ms/test that lands 5–7 tests downstream, which is the reported one; under load it shifts to a sibling.
- The landing point is pure scheduling luck. Hence green in isolation, red only in the full run — and, when it moves, it can just as well break four other tests in that cluster.

## Evidence

Root cause proven twice, deterministically — no reliance on reproducing under load:

1. A standalone repro parking the coroutine inside `config.get` instead of on a timer reproduced the exact assertion, with the previous test's payload visible in `mock.calls[0][0]`.
2. **In the real file, by timing alone**: stretching the reported test to wait 2500 ms instead of three `setImmediate` rounds — no logic change whatsoever — turned it red (`1 failed | 239 passed`), with the log showing two coroutines announcing `push gen=1`. After the fix, that same stretched timeline is green.

## Notes for the reviewer

- **Production behaviour is unchanged.** `_pushGeneration` is never reset in app code; this is a test-harness defect only.
- The regression test (`a push parked since an earlier test can never reach config.apply, whatever generation the next push mints`) pins the invariant **without a wall clock** — it parks the stale coroutine inside `config.get` rather than on a timer, so it is deterministic. It fails against the old reset semantics.
- Two misleading comments are corrected in the same commit: the `beforeEach` one that inverted the helper's effect, and the "~3.5 s" that understated a 60 s leak as bounded. Both are what made the leak look harmless.
- The file still takes ~52 s. That is real waiting (`readExistingConfig`'s busy-wait, the 2 s naps, `vi.waitFor` polling), not the defect — it is only what made the landing point load-dependent. Out of scope here.

### Found while investigating, deliberately NOT fixed here

Both are production-behaviour questions in the same guard and want their own tests:

- The `writeConfigAtomic` fallbacks inside the `catch` block have **no** generation check, so a superseded push can still write its stale payload to disk.
- `_pushGeneration` is a plain module-level counter, while its sibling `push-state.ts` is `globalThis`-backed precisely because Next.js can load separate module instances.

## Verification

- `pnpm test` — 796 files, **11429 passed | 18 skipped, 0 failed** (clean run, nothing else on the machine)
- `pnpm test:scripts` — 1081 passed, 0 failed
- `pnpm -C packages/web typecheck` — clean
- `pnpm format:check` — clean
- `pnpm -C packages/web lint` — 0 errors

One caveat worth stating: an earlier full run showed `knowledge-reindex-section.test.tsx` failing. That was **my own parallel load** (I had `test:scripts` running against the suite, exactly what AGENTS.md § "One Full Suite At A Time" warns about). It passes in isolation and in the clean full run above.

---

## Follow-up after review (commit 2)

The first commit fixed the *semantics* of the hook but left its *placement* as it found it: three of the eighteen top-level describes called it. So "no coroutine from an earlier test can reach this test's mocks" held only where someone had remembered to write it — an audit of which tests happen to leak today, not an invariant. `restart-state integration` and `pinchy-web config` both drive `regenerateOpenClawConfig` with no cancellation at all.

The file already has a top-level `beforeEach` created for exactly this cross-describe pollution class (it re-stubs `mockGetClient` so a connected client cannot leak into a sibling describe). A parked push coroutine is the same class one layer deeper, so the call moved there and the three duplicates are gone.

Also corrected a comment this branch had just invalidated: the regression test still said the leaky test's header "says ~3.5 s", which was true until the commit before it fixed that very header.

**Verified by reproduction, not by reading:** flipping `_supersedePendingPushes` back to a reset fails the regression test with 2 applies instead of 1, with the hook in its new position.

Honest limit: the *placement* is hardening with no test of its own — no current test leaks into a describe that lacked the call, so there is nothing to go red. What is pinned by a test is the semantics (bump, never reset).
