### PR TITLE
fix(api): answer 404, not 403, for an agent the caller may not see

### DIFF
--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -214,7 +214,9 @@ Get a single agent by ID.
 
 **Response:** The agent object, or `404` if not found.
 
-An agent you may not see answers `404` as well, with the same body — someone else's personal agent, or a restricted agent outside your groups, is deliberately indistinguishable from an ID that was never issued. This holds for admins too: nobody can list another user's personal agents, so nobody gets to confirm one exists. The same applies to every `/api/agents/:id/*` endpoint below.
+An agent you may not see answers `404` as well, with the same body — someone else's personal agent, or a restricted agent outside your groups, is deliberately indistinguishable from an ID that was never issued. This holds for admins too: nobody can list another user's personal agents, so nobody gets to confirm one exists.
+
+Every endpoint below that gates on **your access to the agent** answers the same way, over the WebSocket chat bridge as well as over HTTP. Two groups under this prefix do not, and it is worth knowing which: the admin-only management endpoints (`knowledge/*`, `integrations`, and connecting a Telegram bot) apply no visibility rule at all — they are restricted to admins and return `404` only when no agent has the ID. And `GET`/`POST /api/automations`, which is keyed by `agentId`, still answers `403` for an agent you may not manage.
 
 ### `PATCH /api/agents/:id`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -214,6 +214,8 @@ Get a single agent by ID.
 
 **Response:** The agent object, or `404` if not found.
 
+An agent you may not see answers `404` as well, with the same body — someone else's personal agent, or a restricted agent outside your groups, is deliberately indistinguishable from an ID that was never issued. This holds for admins too: nobody can list another user's personal agents, so nobody gets to confirm one exists. The same applies to every `/api/agents/:id/*` endpoint below.
+
 ### `PATCH /api/agents/:id`
 
 Update an agent's settings. Any combination of fields can be included.
@@ -245,7 +247,7 @@ Update an agent's settings. Any combination of fields can be included.
 - `400` — cannot change permissions for personal agents
 - `401` — not authenticated
 - `403` — only admins can change `allowedTools` or `pluginConfig`
-- `404` — agent not found
+- `404` — agent not found, or you have no access to it (the two are indistinguishable)
 - `500` — the update failed, either before or after it was stored
 
 The `500` is worth handling deliberately, because it covers two outcomes that
@@ -289,7 +291,7 @@ Delete an agent. **Admin only.** Personal agents (auto-created Smithers) cannot 
 - `400` — attempting to delete a personal agent
 - `401` — not authenticated
 - `403` — not an admin
-- `404` — agent not found
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
 
 ### `POST /api/agents/:agentId/uploads`
 
@@ -322,7 +324,7 @@ Send `id` in the chat message's `attachmentIds` (up to **10** attachments per me
 
 - `400` — missing or invalid `x-pinchy-draft-id`, malformed form data, missing `file` field, or invalid filename
 - `401` — not authenticated
-- `403` / `404` — no access to the agent
+- `404` — no such agent, or no access to it (the two answer alike)
 - `413` — file exceeds the 15 MB limit
 - `415` — unsupported or mismatched file type
 
@@ -1993,7 +1995,7 @@ Report that a chat run finished while the user was away from the chat page. Call
 | `agentId`    | string | Yes      | Agent the run belongs to. The caller must have access to it.    |
 | `durationMs` | number | Yes      | Wall-clock run duration, in milliseconds. Capped at 10 minutes. |
 
-**Response:** `204 No Content`. Returns `400` if `durationMs` is negative or above the cap, `404` if the agent doesn't exist, and `403` if the caller has no access to it.
+**Response:** `204 No Content`. Returns `400` if `durationMs` is negative or above the cap, and `404` if the agent doesn't exist **or** the caller has no access to it — one answer for both, so this endpoint cannot be used to probe which agent IDs are real.
 
 ### `GET /api/audit/export`
 

--- a/packages/web/e2e/10-agent-permissions.spec.ts
+++ b/packages/web/e2e/10-agent-permissions.spec.ts
@@ -142,7 +142,9 @@ test.describe.serial("Agent permissions — restricted visibility", () => {
       // source of truth and the sidebar is a derived view of it. We assert
       // both sides of the contract via the API:
       //   1) the agent is absent from the user's agent list
-      //   2) a direct fetch of the agent resource returns 403
+      //   2) a direct fetch of the agent resource returns 404 — the same
+      //      answer an unknown id gets, so a member outside the group cannot
+      //      even confirm the agent exists (see getAgentWithAccess).
 
       const memberAgents = await memberPage.context().request.get("/api/agents");
       expect(memberAgents.ok()).toBeTruthy();
@@ -153,9 +155,26 @@ test.describe.serial("Agent permissions — restricted visibility", () => {
       ).toBe(false);
 
       const direct = await memberPage.context().request.get(`/api/agents/${agentId}`);
-      expect(direct.status()).toBe(403);
+      expect(direct.status()).toBe(404);
     } finally {
       await memberContext.close();
+    }
+
+    // A 404 on its own is a weak assertion: it is also what a deleted agent or
+    // a mistyped id would return, which is exactly why this test asserted 403
+    // before the status changed. Anchor it — an admin, who bypasses visibility
+    // filtering, must still get the agent. That pins the 404 above to the
+    // access gate rather than to the agent having gone missing.
+    const adminContext = await browser.newContext();
+    try {
+      await apiSignInAsAdmin(adminContext.request);
+      const adminDirect = await adminContext.request.get(`/api/agents/${agentId}`);
+      expect(
+        adminDirect.status(),
+        `Agent ${agentId} must still exist — otherwise the member's 404 proves nothing`
+      ).toBe(200);
+    } finally {
+      await adminContext.close();
     }
   });
 

--- a/packages/web/e2e/13-knowledge-base.spec.ts
+++ b/packages/web/e2e/13-knowledge-base.spec.ts
@@ -14,8 +14,15 @@ import {
  * These tests verify:
  *  1. Admin can write SOUL.md via the UI and the new content is readable back
  *     via the API (file write + API read-back).
- *  2. A non-admin member cannot write to a shared agent's SOUL.md (403
- *     permission boundary).
+ *  2. A non-admin member is refused that same file, with an answer that does
+ *     not reveal whether the agent exists.
+ *
+ * Item 2 was described as the shared-agent WRITE boundary and asserted 403. It
+ * never tested that: `beforeAll` prefers the admin's Smithers, which is a
+ * PERSONAL agent, so the member is stopped by the READ gate long before any
+ * write check is reached — and that 403 was precisely the existence disclosure
+ * `getAgentWithAccess` now closes. The shared-agent write boundary is covered
+ * deterministically in `src/__tests__/api/agent-files.test.ts`.
  *
  * End-to-end "agent answers using uploaded file" is left to the integration
  * test suite (packages/web/e2e/integration/).
@@ -109,7 +116,19 @@ test.describe.serial("Knowledge base file editing", () => {
     expect(content).toBe(uniqueContent);
   });
 
-  test("non-admin cannot write to a shared agent SOUL.md (403)", async ({ page }) => {
+  test("a non-admin is refused SOUL.md on an agent they cannot see — 404, not 403", async ({
+    page,
+  }) => {
+    // Anchor the assertion before switching users: beforeEach left this page
+    // logged in as the admin, who can read the agent, so it demonstrably
+    // exists. Without this the 404 below is also what a mistyped id returns,
+    // and the test would pass against a route that had stopped working.
+    const adminRes = await page.context().request.get(`/api/agents/${agentId}`);
+    expect(
+      adminRes.status(),
+      `Agent ${agentId} must exist — otherwise the member's 404 proves nothing`
+    ).toBe(200);
+
     // Switch from admin (set by beforeEach) to the non-admin via the auth API
     // directly. UI-based loginAs has racy form-state interactions when chained
     // after a prior login on the same page; switchUser is deterministic.
@@ -120,7 +139,12 @@ test.describe.serial("Knowledge base file editing", () => {
       data: { content: "Hacked" },
     });
 
-    // Non-admins cannot write shared agent files — expect 403
-    expect(putRes.status()).toBe(403);
+    // The read gate answers before the write gate, and it withholds the agent's
+    // existence. This holds for either branch of beforeAll: the admin's
+    // personal Smithers (the preferred one) is invisible to a non-owner, and a
+    // freshly created agent sits at the DB default `restricted` visibility with
+    // the member in no group.
+    expect(putRes.status()).toBe(404);
+    expect(await putRes.json()).toEqual({ error: "Agent not found" });
   });
 });

--- a/packages/web/e2e/14-agent-visibility.spec.ts
+++ b/packages/web/e2e/14-agent-visibility.spec.ts
@@ -92,11 +92,19 @@ test.describe.serial("Agent visibility — personal vs shared", () => {
     );
     expect(secondSeesAdminsSmithers).toBe(false);
 
-    // Direct fetch of the agent resource must return 403 (Forbidden).
-    // Accepting 404 here would mask a regression where the privacy check
-    // silently degrades to a not-found path. Match the second test exactly.
+    // Direct fetch of the agent resource must return 404 — the same answer an
+    // id that was never issued gets, so this cannot be used to confirm the
+    // agent exists (see the docblock on getAgentWithAccess).
+    //
+    // The original worry behind this assertion still stands and is still
+    // covered: a 404 must not be allowed to mask "the privacy check degraded
+    // into a not-found path" or "the id is simply wrong". What rules that out
+    // is the assertion above — the admin saw this exact id in their OWN
+    // /api/agents list moments ago, so the agent demonstrably exists and the
+    // 404 can only come from the access gate. Keep those two together; the
+    // status check alone would prove nothing.
     const directRes = await page.context().request.get(`/api/agents/${adminSmithersId}`);
-    expect(directRes.status()).toBe(403);
+    expect(directRes.status()).toBe(404);
 
     // Sidebar: admin's Smithers link must not be present
     // Both users have a Smithers agent, so we check by agentId in the href
@@ -131,9 +139,13 @@ test.describe.serial("Agent visibility — personal vs shared", () => {
     );
     expect(adminSeesSecondSmithers).toBe(false);
 
-    // Direct fetch should also return 403 (not just absent from list)
+    // Direct fetch should also return 404 (not just absent from list) — and
+    // note this caller is an ADMIN. Admins cannot list other users' personal
+    // agents either, so a 403 would hand even them an existence oracle.
+    // As in the first test, the id is proven real by the assertion above:
+    // the second user saw it in their own list before the switch.
     const directRes = await page.context().request.get(`/api/agents/${secondUserSmithersId}`);
-    expect(directRes.status()).toBe(403);
+    expect(directRes.status()).toBe(404);
 
     // UI: second user's Smithers link must not be present in admin's sidebar
     // /chat is not a route on its own — only /chat/[agentId]. Use /agents

--- a/packages/web/src/__tests__/api/agent-files.test.ts
+++ b/packages/web/src/__tests__/api/agent-files.test.ts
@@ -112,7 +112,10 @@ describe("GET /api/agents/[agentId]/files/[filename]", () => {
     expect(data.error).toBe("Unauthorized");
   });
 
-  it("should return 403 when user has no access to agent", async () => {
+  it("forwards the getAgentWithAccess denial verbatim, whatever its status", async () => {
+    // Synthetic 403 sentinel — the helper really denies with 404 (see its
+    // docblock). A status it never emits keeps this distinct from the route's
+    // own 404 paths, so the test proves forwarding rather than coincidence.
     vi.mocked(getAgentWithAccess).mockResolvedValueOnce(
       NextResponse.json({ error: "Forbidden" }, { status: 403 })
     );
@@ -237,7 +240,8 @@ describe("PUT /api/agents/[agentId]/files/[filename]", () => {
     expect(data.error).toBe("Unauthorized");
   });
 
-  it("should return 403 when user has no access to agent", async () => {
+  it("forwards the getAgentWithAccess denial verbatim on write, whatever its status", async () => {
+    // Synthetic 403 sentinel — see the GET case above.
     vi.mocked(getAgentWithAccess).mockResolvedValueOnce(
       NextResponse.json({ error: "Forbidden" }, { status: 403 })
     );

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -72,6 +72,13 @@ vi.mock("@/db", () => ({
   },
 }));
 
+// DELETE gates through the shared read gate (GET/POST are admin-only and look
+// the agent up themselves), so the denial response is the helper's to produce.
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
 vi.mock("drizzle-orm", async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -536,6 +543,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
     mockRequireAdmin.mockResolvedValue(adminSession);
     mockGetSession.mockResolvedValue(adminSession);
     vi.mocked(db.query.agents.findFirst).mockResolvedValue(mockAgent as any);
+    mockGetAgentWithAccess.mockResolvedValue(mockAgent);
   });
 
   it("removes token, clears account store, patches config, logs audit event", async () => {
@@ -615,11 +623,11 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("allows an admin to disconnect a personal agent's bot (#476 gap 2)", async () => {
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+    mockGetAgentWithAccess.mockResolvedValueOnce({
       ...mockAgent,
       isPersonal: true,
       ownerId: "someone-else",
-    } as any);
+    });
 
     const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
@@ -629,11 +637,11 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("allows a personal agent's owner (non-admin) to disconnect their own bot (#476 gap 2)", async () => {
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+    mockGetAgentWithAccess.mockResolvedValueOnce({
       ...mockAgent,
       isPersonal: true,
       ownerId: "user-2",
-    } as any);
+    });
     mockGetSession.mockResolvedValueOnce({
       user: { id: "user-2", role: "member" },
     });
@@ -645,12 +653,15 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
     expect(deleteSetting).toHaveBeenCalledWith("telegram_bot_token:agent-1");
   });
 
-  it("forbids a non-admin who is not the personal agent's owner (#476 gap 2)", async () => {
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
-      ...mockAgent,
-      isPersonal: true,
-      ownerId: "user-2",
-    } as any);
+  it("forwards the read gate's refusal instead of answering 403 itself (#476 gap 2)", async () => {
+    // The real case behind this mock is a member aiming at someone else's
+    // personal agent. The route used to look the agent up on its own — 404 when
+    // the row was missing, 403 here — which confirmed to any logged-in member
+    // that the id was real, for agents nobody can list. Now the read gate
+    // answers first and the route never gets to disagree with it.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
     mockGetSession.mockResolvedValueOnce({
       user: { id: "user-3", role: "member" },
     });
@@ -658,15 +669,19 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
     const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
+    expect((await response.json()).error).toBe("Agent not found");
     expect(deleteSetting).not.toHaveBeenCalled();
   });
 
   it("forbids a non-admin from disconnecting a shared agent's bot (#476 gap 2)", async () => {
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+    // 403 survives here, and this is the case it was chosen for: the read gate
+    // let the caller through, so they can see this agent — being told they may
+    // not disconnect it reveals nothing they did not already know.
+    mockGetAgentWithAccess.mockResolvedValueOnce({
       ...mockAgent,
       isPersonal: false,
-    } as any);
+    });
     mockGetSession.mockResolvedValueOnce({
       user: { id: "user-3", role: "member" },
     });
@@ -679,7 +694,9 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("returns 404 for non-existent agent", async () => {
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce(undefined as any);
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
 
     const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,

--- a/packages/web/src/__tests__/api/agent-workspace-file.test.ts
+++ b/packages/web/src/__tests__/api/agent-workspace-file.test.ts
@@ -304,7 +304,10 @@ describe("GET /api/agents/[agentId]/workspace-file", () => {
     expect(mockDeferAuditLog).not.toHaveBeenCalled();
   });
 
-  it("returns 403 when the user is not authorized for the agent", async () => {
+  it("forwards the getAgentWithAccess denial verbatim, whatever its status", async () => {
+    // Synthetic 403 sentinel — the helper really denies with 404 (see its
+    // docblock); a status it never emits proves the route forwards rather than
+    // producing an answer of its own.
     mockGetAgentWithAccess.mockResolvedValue(
       NextResponse.json({ error: "Forbidden" }, { status: 403 })
     );

--- a/packages/web/src/__tests__/api/agents-delete.test.ts
+++ b/packages/web/src/__tests__/api/agents-delete.test.ts
@@ -122,7 +122,7 @@ describe("GET /api/agents/[agentId]", () => {
     expect(body.name).toBe("Test Agent");
   });
 
-  it("returns 403 when non-owner user tries to access personal agent of another user", async () => {
+  it("returns 404 when non-owner user tries to access personal agent of another user", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "user-2", role: "member" },
       expires: "",
@@ -140,10 +140,14 @@ describe("GET /api/agents/[agentId]", () => {
     const response = await GET(request, {
       params: Promise.resolve({ agentId: "agent-1" }),
     });
-    expect(response.status).toBe(403);
+    // 404, not 403: someone else's personal agent must be indistinguishable
+    // from an id that was never issued. Nobody — admins included — can list
+    // these agents, so a 403 would confirm an existence the caller could not
+    // otherwise establish. See the docblock on getAgentWithAccess.
+    expect(response.status).toBe(404);
 
     const body = await response.json();
-    expect(body.error).toBe("Forbidden");
+    expect(body.error).toBe("Agent not found");
   });
 });
 
@@ -206,7 +210,7 @@ describe("PATCH /api/agents/[agentId]", () => {
     expect(body.name).toBe("New Name");
   });
 
-  it("returns 403 when non-owner user tries to update personal agent of another user", async () => {
+  it("returns 404 when non-owner user tries to update personal agent of another user", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "user-2", role: "member" },
       expires: "",
@@ -227,10 +231,12 @@ describe("PATCH /api/agents/[agentId]", () => {
     const response = await PATCH(request, {
       params: Promise.resolve({ agentId: "agent-1" }),
     });
-    expect(response.status).toBe(403);
+    // The READ gate runs first and answers 404 — the caller never reaches the
+    // write gate, so they cannot tell "not yours to change" from "no such id".
+    expect(response.status).toBe(404);
 
     const body = await response.json();
-    expect(body.error).toBe("Forbidden");
+    expect(body.error).toBe("Agent not found");
   });
 
   it("returns 404 when agent not found for update", async () => {
@@ -575,10 +581,16 @@ describe("DELETE /api/agents/[agentId]", () => {
     expect(body.error).toBe("Personal agents cannot be deleted");
   });
 
-  it("returns 403 when admin tries to delete another user's personal agent", async () => {
-    // After the security fix: admins cannot access personal agents owned by other users.
-    // The isPersonal privacy check runs before the admin fast-path, so the route
-    // returns 403 (access denied) rather than 400 (personal agents cannot be deleted).
+  it("returns 404 when admin tries to delete another user's personal agent", async () => {
+    // Admins cannot access personal agents owned by other users. The isPersonal
+    // privacy check runs before the admin fast-path, so the route answers on the
+    // access gate rather than with 400 ("personal agents cannot be deleted").
+    //
+    // That answer is 404, and for admins specifically: `getVisibleAgents` keeps
+    // other people's personal agents out of an admin's list too, so an admin
+    // cannot enumerate them either — a 403 would hand even them an existence
+    // oracle. This mirrors DELETE /api/v1/agents/[agentId], which 404s a
+    // personal agent for exactly this reason.
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "admin-1", role: "admin" },
       expires: "",
@@ -598,10 +610,10 @@ describe("DELETE /api/agents/[agentId]", () => {
     const response = await DELETE(request, {
       params: Promise.resolve({ agentId: "agent-1" }),
     });
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
 
     const body = await response.json();
-    expect(body.error).toBe("Forbidden");
+    expect(body.error).toBe("Agent not found");
   });
 
   it("returns 404 when agent not found", async () => {

--- a/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
@@ -213,8 +213,10 @@ describe("POST /api/diagnostics/export (integration)", () => {
     mockSession(intruder);
 
     const response = await POST(makeRequest({ agentId: agent.id }), routeContext());
-    // getAgentWithAccess returns 403 for personal agents owned by someone else.
-    expect(response.status).toBe(403);
+    // getAgentWithAccess answers 404 for personal agents owned by someone else —
+    // the same answer an unknown id gets, so the export route cannot be used to
+    // confirm that a given agent exists. See the docblock on getAgentWithAccess.
+    expect(response.status).toBe(404);
   });
 
   it("writes a diagnostics.exported audit entry on success", async () => {

--- a/packages/web/src/__tests__/api/uploads-post.integration.test.ts
+++ b/packages/web/src/__tests__/api/uploads-post.integration.test.ts
@@ -162,22 +162,42 @@ describe("POST /api/agents/[agentId]/uploads", () => {
     expect(body.error).toBe("Unauthorized");
   });
 
-  it("returns 403 when the user does not have access to the agent", async () => {
+  it("answers another user's personal agent exactly as it answers an unknown id", async () => {
     const user = await seedUser({ role: "member" });
     mockGetSession.mockResolvedValue({
       user: { id: user.id, email: user.email, role: "member" },
     });
 
-    // Create a personal agent owned by a different user.
+    // A personal agent owned by somebody else. Nobody can list these — not even
+    // an admin — so a distinguishable error would confirm an existence the
+    // caller has no other way to establish. This route used to answer 403 here
+    // and 404 for an id nobody ever issued, which is exactly that confirmation.
+    // See the docblock on getAgentWithAccess.
     const owner = await seedUser({
       email: "owner@example.com",
     });
     const agent = await seedAgent(owner.id, { isPersonal: true });
 
-    const file = new File([VALID_PDF], "doc.pdf", { type: "application/pdf" });
-    const resp = await POST(makeRequest(agent.id, { file }), makeParams(agent.id));
+    const denied = await POST(
+      makeRequest(agent.id, {
+        file: new File([VALID_PDF], "doc.pdf", { type: "application/pdf" }),
+      }),
+      makeParams(agent.id)
+    );
+    const unknown = await POST(
+      makeRequest("no-such-agent", {
+        file: new File([VALID_PDF], "doc.pdf", { type: "application/pdf" }),
+      }),
+      makeParams("no-such-agent")
+    );
 
-    expect(resp.status).toBe(403);
+    // Asserting the literal AND the equality: the first pins which answer it is,
+    // the second is the actual contract and survives a later change of wording.
+    // The access gate runs before header and form validation, so both requests
+    // short-circuit in the same place.
+    expect(denied.status).toBe(404);
+    expect(denied.status).toBe(unknown.status);
+    expect(await denied.json()).toEqual(await unknown.json());
   });
 
   // ── Form data validation ───────────────────────────────────────────────

--- a/packages/web/src/__tests__/lib/agent-access.test.ts
+++ b/packages/web/src/__tests__/lib/agent-access.test.ts
@@ -185,7 +185,7 @@ describe("getAgentWithAccess", () => {
     expect((result as NextResponse).status).toBe(404);
   });
 
-  it("returns 404 — not 403 — when user has no access, matching the missing-agent answer byte for byte", async () => {
+  it("returns 404 — not 403 — when user has no access, with the missing-agent body", async () => {
     mockSelectChain([{ id: "a1", ownerId: "other-user", isPersonal: true }]);
 
     const result = await getAgentWithAccess("a1", "user-1", "member");
@@ -196,6 +196,21 @@ describe("getAgentWithAccess", () => {
     // oracle this closes. Someone else's personal agent must be indis-
     // tinguishable from an id that was never issued.
     expect(await (result as NextResponse).json()).toEqual({ error: "Agent not found" });
+  });
+
+  it("gives a denied agent the very same answer as a missing one", async () => {
+    // Neither test above can see the two branches drift apart: each pins its own
+    // branch against a literal, so a later edit to the `!agent` body alone keeps
+    // both green while the invariant the docblock states is already broken.
+    // Compare the two answers against each other, which is the actual contract.
+    mockSelectChain([]);
+    const missing = (await getAgentWithAccess("nope", "user-1", "member")) as NextResponse;
+
+    mockSelectChain([{ id: "a1", ownerId: "other-user", isPersonal: true }]);
+    const denied = (await getAgentWithAccess("a1", "user-1", "member")) as NextResponse;
+
+    expect(denied.status).toBe(missing.status);
+    expect(await denied.json()).toEqual(await missing.json());
   });
 
   it("returns agent when access is granted", async () => {

--- a/packages/web/src/__tests__/lib/agent-access.test.ts
+++ b/packages/web/src/__tests__/lib/agent-access.test.ts
@@ -185,13 +185,17 @@ describe("getAgentWithAccess", () => {
     expect((result as NextResponse).status).toBe(404);
   });
 
-  it("returns 403 when user has no access", async () => {
+  it("returns 404 — not 403 — when user has no access, matching the missing-agent answer byte for byte", async () => {
     mockSelectChain([{ id: "a1", ownerId: "other-user", isPersonal: true }]);
 
     const result = await getAgentWithAccess("a1", "user-1", "member");
 
     expect(result).toBeInstanceOf(NextResponse);
-    expect((result as NextResponse).status).toBe(403);
+    expect((result as NextResponse).status).toBe(404);
+    // Status alone is not the contract — a differing body would re-open the
+    // oracle this closes. Someone else's personal agent must be indis-
+    // tinguishable from an id that was never issued.
+    expect(await (result as NextResponse).json()).toEqual({ error: "Agent not found" });
   });
 
   it("returns agent when access is granted", async () => {
@@ -216,7 +220,7 @@ describe("getAgentWithAccess", () => {
     expect(result).toEqual(groupsAgent);
   });
 
-  it("returns 403 when member is NOT in matching group for 'restricted' visibility", async () => {
+  it("returns 404 when member is NOT in matching group for 'restricted' visibility", async () => {
     const groupsAgent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
     mockSelectChain([groupsAgent]);
     vi.mocked(getUserGroupIds).mockResolvedValueOnce(["g1"]);
@@ -225,17 +229,17 @@ describe("getAgentWithAccess", () => {
     const result = await getAgentWithAccess("a1", "user-1", "member");
 
     expect(result).toBeInstanceOf(NextResponse);
-    expect((result as NextResponse).status).toBe(403);
+    expect((result as NextResponse).status).toBe(404);
   });
 
-  it("returns 403 for member accessing restricted agent with no groups", async () => {
+  it("returns 404 for member accessing restricted agent with no groups", async () => {
     const adminOnlyAgent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
     mockSelectChain([adminOnlyAgent]);
 
     const result = await getAgentWithAccess("a1", "user-1", "member");
 
     expect(result).toBeInstanceOf(NextResponse);
-    expect((result as NextResponse).status).toBe(403);
+    expect((result as NextResponse).status).toBe(404);
   });
 
   it("admin bypasses group checks for 'restricted' visibility", async () => {
@@ -294,7 +298,9 @@ describe("getAgentWithAccess", () => {
     const result = await getAgentWithAccess("a1", "user-1", "member");
 
     expect(result).toBeInstanceOf(NextResponse);
-    expect((result as NextResponse).status).toBe(403);
+    // Denial is a 404 (see the helper's docblock); what this test pins is that
+    // the restriction is still ENFORCED after expiry, not which status says so.
+    expect((result as NextResponse).status).toBe(404);
     expect(getUserGroupIds).toHaveBeenCalled();
   });
 

--- a/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-artifacts-route.test.ts
@@ -125,7 +125,12 @@ describe("GET /api/agents/[agentId]/artifacts/[filename]", () => {
     expect(res.status).toBe(401);
   });
 
-  it("forwards the getAgentWithAccess denial response verbatim (403 → 403)", async () => {
+  it("forwards the getAgentWithAccess denial response verbatim, whatever its status", async () => {
+    // The 403 below is a SYNTHETIC sentinel: the helper really denies with 404
+    // (see its docblock), and the agent gate now matches the file gate two
+    // tests up. Mocking a status the helper never emits is deliberate — a 404
+    // would collide with the route's own missing-file answer and prove nothing
+    // about forwarding.
     const { NextResponse } = await import("next/server");
     mockGetAgentWithAccess.mockResolvedValue(
       NextResponse.json({ error: "forbidden" }, { status: 403 })

--- a/packages/web/src/__tests__/server/agent-uploads-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-uploads-route.test.ts
@@ -120,8 +120,12 @@ describe("GET /api/agents/[agentId]/uploads/[filename]", () => {
     expect(res.status).toBe(404);
   });
 
-  it("forwards the getAgentWithAccess denial response verbatim (403 from helper → 403 to caller)", async () => {
-    // getAgentWithAccess returns a NextResponse on denial.
+  it("forwards the getAgentWithAccess denial response verbatim, whatever its status", async () => {
+    // getAgentWithAccess returns a NextResponse on denial. The 403 below is a
+    // SYNTHETIC sentinel, not the helper's real answer — it really denies with
+    // 404 (see its docblock). A status the helper never emits is what makes
+    // this test meaningful: a 404 here would also be produced by the route's
+    // own missing-file path, so it could not tell forwarding from minting.
     const { NextResponse } = await import("next/server");
     mockGetAgentWithAccess.mockResolvedValue(
       NextResponse.json({ error: "forbidden" }, { status: 403 })

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -657,7 +657,7 @@ describe("ClientRouter", () => {
     expect(messages[0].message).toBe("Agent not found");
   });
 
-  it("should return access denied for unauthorized user", async () => {
+  it("answers a denied agent exactly as it answers a missing one", async () => {
     const clientWs = createMockClientWs();
     mockFindFirst.mockResolvedValue({
       id: "agent-1",
@@ -675,7 +675,10 @@ describe("ClientRouter", () => {
     const messages = clientWs.sent.map((s) => JSON.parse(s));
     expect(messages).toHaveLength(1);
     expect(messages[0].type).toBe("error");
-    expect(messages[0].message).toBe("Access denied");
+    // Deliberately the same string the "nonexistent-agent" test above asserts:
+    // over the socket as over HTTP, a personal agent owned by someone else must
+    // not be distinguishable from an id that was never issued.
+    expect(messages[0].message).toBe("Agent not found");
   });
 
   describe("multi-device live-sync subscription is gated on access (Lane B)", () => {
@@ -713,7 +716,7 @@ describe("ClientRouter", () => {
       // to a user who may not access the agent; this pins the ordering.
       expect(pokeBridge.view).not.toHaveBeenCalled();
       const messages = clientWs.sent.map((s) => JSON.parse(s));
-      expect(messages[0].message).toBe("Access denied");
+      expect(messages[0].message).toBe("Agent not found");
     });
 
     it("registers the socket to its OWN server-built session key once access is granted", async () => {

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -17,6 +17,7 @@ import { agents, channelLinks, settings } from "@/db/schema";
 import { eq, like } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
 import { setBotTokenSchema } from "@/lib/schemas/telegram";
+import { getAgentWithAccess } from "@/lib/agent-access";
 
 export async function GET(req: Request, { params }: { params: Promise<{ agentId: string }> }) {
   const admin = await requireAdmin();
@@ -199,12 +200,14 @@ export const DELETE = withAuth<{ params: Promise<{ agentId: string }> }>(
   async (_req, { params }, session) => {
     const { agentId } = await params;
 
-    const agent = await db.query.agents.findFirst({
-      where: eq(agents.id, agentId),
-    });
-    if (!agent) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
+    // Read gate first, write gate second. This route used to look the agent up
+    // itself — 404 when the row was missing, 403 when the caller was neither
+    // admin nor owner — which handed any logged-in member the existence oracle
+    // `getAgentWithAccess` exists to close: someone else's personal agent is
+    // enumerable by nobody, so 403 confirmed what no list would tell them.
+    const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+    if (agentOrError instanceof NextResponse) return agentOrError;
+    const agent = agentOrError;
 
     // Gap 2 (#476): a personal agent's owner may disconnect its own bot without
     // an admin — the org-wide "Remove Telegram for everyone" was the only prior
@@ -212,6 +215,9 @@ export const DELETE = withAuth<{ params: Promise<{ agentId: string }> }>(
     // any agent (shared or personal). The connect path stays admin-only.
     const isOwner = agent.isPersonal && agent.ownerId === session.user.id;
     if (session.user.role !== "admin" && !isOwner) {
+      // Still 403, and for the reason the helper's docblock gives: the gate above
+      // already answered 404 for anything this caller cannot see, so reaching
+      // here means they can — "not yours to disconnect" reveals nothing further.
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -143,7 +143,22 @@ export function requireAgentWriteAccess(
  * WRITE denial stays 403 (`requireAgentWriteAccess`), and that is the same
  * rule rather than an exception to it: a caller who reaches the write gate has
  * already passed this one, so they can see the agent, and "you may not change
- * it" tells them nothing they did not know.
+ * it" tells them nothing they did not know. Routes that gate by hand rather
+ * than through this helper must run the read gate FIRST for the same reason —
+ * `DELETE /api/agents/[agentId]/channels/telegram` is the worked example.
+ *
+ * Two things this does NOT close, said plainly so the next reader does not
+ * mistake "byte-identical" for "indistinguishable":
+ *
+ * - **Timing.** The denial path runs a license lookup and, for a restricted
+ *   agent, two group queries that the `!agent` path never reaches. Equalising
+ *   that costs a query on every miss and buys little against a UUID keyspace.
+ * - **Routes that do not use this helper.** `GET`/`POST /api/automations` still
+ *   answer 403 for an agent the caller may not manage, and the admin-only
+ *   `/api/agents/:id/knowledge/*` and `/integrations` endpoints apply no
+ *   visibility rule at all. Both are separate verdicts, not oversights of this
+ *   one; `reference/api.mdx` describes what each endpoint really does rather
+ *   than claiming the prefix as a whole.
  */
 export async function getAgentWithAccess(agentId: string, userId: string, userRole: string) {
   const rows = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId));

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -115,6 +115,36 @@ export function requireAgentWriteAccess(
   }
 }
 
+/**
+ * Load an agent and gate READ access: returns the agent, or the response the
+ * route should send back.
+ *
+ * **A denied agent answers 404, byte-identical to an agent that does not
+ * exist.** Both paths return the same status and the same body on purpose, so
+ * the answer cannot be read as "this id exists, but not for you".
+ *
+ * The criterion is the one `DELETE /api/v1/agents/[agentId]` already writes
+ * down: a distinguishable error is fine when the caller **can already
+ * enumerate** the resource, and is an oracle when they cannot. Nobody can
+ * enumerate someone else's personal agent — `getVisibleAgents` withholds them
+ * from every caller including admins — so 403-vs-404 here was the oracle case.
+ * Three places in the product had already settled on 404 for this exact
+ * denial: the chat page (`notFound()`), the key-authenticated
+ * `GET /api/v1/agents/[agentId]`, and the FILE layer of the very routes this
+ * helper guards, where `agent-uploads-route.test.ts` spells out "a non-owner
+ * must not even be able to confirm the file exists". The agent above those
+ * files disclosed what they withheld.
+ *
+ * `agents.id` is `crypto.randomUUID()`, so there is no scanning either way —
+ * but that bounds the RATE, not the disclosure. Agent ids travel in shared
+ * links and outlive group membership, so the caller holding one is the
+ * ordinary case, not the exotic one.
+ *
+ * WRITE denial stays 403 (`requireAgentWriteAccess`), and that is the same
+ * rule rather than an exception to it: a caller who reaches the write gate has
+ * already passed this one, so they can see the agent, and "you may not change
+ * it" tells them nothing they did not know.
+ */
 export async function getAgentWithAccess(agentId: string, userId: string, userRole: string) {
   const rows = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId));
   const agent = rows[0];
@@ -136,7 +166,10 @@ export async function getAgentWithAccess(agentId: string, userId: string, userRo
   try {
     assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
   } catch {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    // Same response as the `!agent` branch above — see the docblock. Keep the
+    // two literals identical; a divergent body re-opens the oracle that equal
+    // statuses close.
+    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
   }
 
   return agent;

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -330,7 +330,12 @@ export class ClientRouter {
         licenseState
       );
     } catch {
-      this.sendToClient(clientWs, { type: "error", message: "Access denied" });
+      // Same message as the missing-agent branch above, for the reason spelled
+      // out on getAgentWithAccess: the HTTP routes stopped distinguishing the
+      // two, and a socket that still says "Access denied" hands back the exact
+      // fact they withhold. The audit row below keeps the distinction where it
+      // belongs — on the server, not in the answer.
+      this.sendToClient(clientWs, { type: "error", message: "Agent not found" });
       const auditEntry = {
         actorType: "user" as const,
         actorId: this.userId,


### PR DESCRIPTION
## What does this PR do?

`getAgentWithAccess` answered `404` when no agent had the id, but `403` when `assertAgentAccess` denied — so on the ~10 member-reachable routes that gate through it, the status confirmed the existence of agents the caller has no way to see: someone else's personal agent, or a restricted one outside their groups. Both cases now answer `404`, with an identical body.

Raised as a review finding while looking at the Automations scope gate, which deliberately stays at `403` — partly on the argument that an Automations-only `404` would close nothing while this helper behaved as it did. This is that helper.

No issue number: found in review, fixed in place.

## Why `404` rather than "accept and document"

The starting assumption was that `agents.id` is `crypto.randomUUID()`, so there is no enumeration and the answer only ever speaks about an id the caller already holds — which may well make "accept and document" the honest verdict. Two findings moved it:

**1. The repo already writes the criterion down.** From the docblock on `DELETE /api/v1/agents/[agentId]`:

> that route is admin-authenticated and its caller **can already enumerate every agent**, so a distinguishable error tells them nothing new. A key cannot (`GET /api/v1/agents` omits personal agents), so here 400-vs-404 would be an oracle.

The test is not "are ids guessable" — it is "can this caller establish the resource exists by other means". Nobody can enumerate another user's personal agent: `getVisibleAgents` withholds them from **admins** too. So this fell on the oracle side of a line the codebase had already drawn.

**2. Three places had already settled on `404` for this exact denial:**

| Where | Behaviour |
| --- | --- |
| `app/(app)/chat/[agentId]/page.tsx` | `notFound()` on `assertAgentAccess` denial |
| `GET /api/v1/agents/[agentId]` | `404` — documented in `api.mdx` as "a personal agent's id answers `404` indistinguishably" |
| The **file** layer of these very routes | `agent-uploads-route.test.ts`: "404, not 403 — a non-owner must not even be able to confirm the file exists" |

The third is the sharpest: in one test file, one case withheld a *file's* existence while the case ten lines below forwarded the *agent's*. The agent above those files disclosed what they were careful to hide.

The UUID argument still holds as far as it goes — there is no scanning either way. But it bounds the *rate*, not the disclosure, and agent ids travel in shared links and outlive group membership.

## What did not change

**Write denial stays `403`** (`requireAgentWriteAccess`), and that is the same rule rather than an exception to it: a caller who reaches the write gate has already passed the read gate, so they can see the agent, and "you may not change it" tells them nothing new.

## Review follow-up (second commit)

A review of the first commit found the fix incomplete in a way that undid its point: the helper stopped distinguishing "denied" from "missing", but two other doors still handed any logged-in member the same fact.

- **`DELETE /api/agents/:id/channels/telegram`** (`withAuth`, so any member) looked the agent up itself — `404` for a missing row, `403` for a caller who is neither admin nor owner. It now runs the read gate first and keeps `403` only for what that gate lets through: a shared agent the caller can see but may not disconnect. Same layering the PR already describes, applied by hand where a route does not use the helper.
- **The WebSocket bridge** answered `"Agent not found"` vs `"Access denied"`. Same fact, different transport. Both now say `"Agent not found"`; the `tool.denied` audit row keeps the distinction server-side, where it belongs.

Two further findings, fixed rather than argued:

- **The docs paragraph overclaimed.** It said the `404` rule holds for "every `/api/agents/:id/*` endpoint", which is false for the four admin-only management families (`knowledge/*`, `integrations`, Telegram connect — they run no visibility gate at all, so an admin gets `200` on another user's personal agent) and for `GET`/`POST /api/automations`, which is agent-keyed and still `403`s. It now describes what each group really does.
- **A test claimed more than it pinned.** The case named "byte for byte" compared against a hard-coded literal, so editing the `!agent` body alone would have kept it green while the invariant broke. A new case compares the two answers against each other.

Still open, deliberately, and now named in the `getAgentWithAccess` docblock rather than implied shut:

- **`GET`/`POST /api/automations`** leaks the same fact. The correct fix is the same read-gate-first layering, but its tests are integration-only and their `seedAgent` leaves `visibility` at the DB default `restricted` — so two tests that pin `403` for a *scope* reason would flip to `404` for a *visibility* reason and quietly stop guarding what they were written for. That needs test redesign, not a status flip.
- **Admin reach into other users' personal agents** on the four admin-only families is a product question, not a status-code one.
- **Timing.** The denial path runs a license lookup and two group queries the missing path never reaches. Stated in the docblock so nobody reads "byte-identical" as "indistinguishable".

## Reviewer notes

- **The `403` mocks in the route tests are kept on purpose.** Those tests assert that a route forwards the helper's response verbatim. A status the helper never emits is what makes them meaningful — mocking `404` would collide with each route's own missing-file/missing-agent paths and could no longer tell forwarding from minting. The test names and comments that asserted real helper behaviour were corrected; the sentinel value was not.
- **Four tests were genuinely red and are updated**, three in `agents-delete.test.ts` and one in `diagnostics-export.integration.test.ts` — the latter only runs under `test:db`, so it would otherwise have gone red later and elsewhere.
- **The E2E specs pinned `403` deliberately**, with a comment warning that accepting `404` "would mask a regression where the privacy check silently degrades to a not-found path". That objection is right and is now answered rather than dropped: a bare `404` is also what a deleted agent or a mistyped id returns. In `14-agent-visibility.spec.ts` the anchor was already in the test (a permitted caller saw the id in their own list moments earlier); `10-agent-permissions.spec.ts` had no anchor, so it now also asserts that an admin still gets `200` for the same agent. That spec is stronger than before.
- **No tests were removed** — counts are unchanged, so no `Allow-test-deletion` trailer is needed.
- Verdict and reasoning live in the docblock on `getAgentWithAccess`, so the next reader gets the argument rather than the conclusion.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable) — existing tests updated to the new contract, plus a new existence-anchor assertion in the permissions E2E
- [x] I've updated the documentation (if applicable) — five places in `reference/api.mdx`, including that this holds for admins
- [x] All existing tests pass

## Verification

`pnpm test` 781 files / 11171 tests green, `pnpm test:scripts` 966/966, `tsc --noEmit -p tsconfig.typecheck.json` clean, eslint clean, whole-tree `prettier --check` clean.

Three limits, stated plainly:

- **The E2E specs were not executed** — they need the Docker stack. They are adjusted by reading, not by reproduction.
- **`diagnostics-export.integration.test.ts` was not executed either** — it runs under `test:db`, which needs a Postgres stack. CI's `vitest-integration` job covers it.
- The first full run showed 25 failures that were **not** from this change: the local shell defaults to Node v24 while the repo pins 22, and `better-sqlite3`'s ABI mismatch surfaces through `pinchy-files` as failing *product* assertions rather than an environment error. Under Node 22 the same files pass in 2.3s. Called out in case CI or another reviewer trips over the same shape.
