### PR TITLE
feat(chat): save a message as an instruction

### DIFF
--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -83,6 +83,16 @@ The Instructions tab provides an editor for the agent's **AGENTS.md** file. This
 
 Think of AGENTS.md as the agent's job description. Use it to define what the agent should do, how it should handle specific tasks, and any domain-specific rules it should follow.
 
+### Saving a rule straight from a conversation
+
+The best instructions usually aren't written at a desk — they come out of working with the agent. When you and the agent settle on a way of working worth keeping, ask it to write the rule up, then open the `⋯` menu on that message and choose **Save as instruction**.
+
+The text lands in this editor, appended below what's already there, with nothing saved yet: you can edit it, cut it down, or drop it, and it takes effect when you press **Save**.
+
+The action appears only for people who can edit this agent — an admin, or the owner of a personal agent. If you can't edit a shared agent, ask an admin to add the rule.
+
+Why not just let the agent remember it? Because memory isn't loaded by scheduled runs, so a working rule kept there quietly stops applying the moment the same work happens on a schedule. [Instructions vs. Memory](/explanation/instructions-vs-memory/) has the full heuristic.
+
 The agent reads both files at the start of every conversation. Separating personality from instructions makes it easy to change one without affecting the other — for example, switching an agent from "The Butler" to "The Pilot" personality without rewriting its task instructions.
 
 Not sure whether a piece of knowledge belongs here or in Memory? See [Instructions vs. Memory](/explanation/instructions-vs-memory/) for the heuristic.

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -83,6 +83,10 @@ The Instructions tab provides an editor for the agent's **AGENTS.md** file. This
 
 Think of AGENTS.md as the agent's job description. Use it to define what the agent should do, how it should handle specific tasks, and any domain-specific rules it should follow.
 
+The agent reads both files at the start of every conversation. Separating personality from instructions makes it easy to change one without affecting the other — for example, switching an agent from "The Butler" to "The Pilot" personality without rewriting its task instructions.
+
+Not sure whether a piece of knowledge belongs here or in Memory? See [Instructions vs. Memory](/explanation/instructions-vs-memory/) for the heuristic.
+
 ### Saving a rule straight from a conversation
 
 The best instructions usually aren't written at a desk — they come out of working with the agent. When you and the agent settle on a way of working worth keeping, ask it to write the rule up, then open the `⋯` menu on that message and choose **Save as instruction**.
@@ -91,11 +95,7 @@ The text lands in this editor, appended below what's already there, with nothing
 
 The action appears only for people who can edit this agent — an admin, or the owner of a personal agent. If you can't edit a shared agent, ask an admin to add the rule.
 
-Why not just let the agent remember it? Because memory isn't loaded by scheduled runs, so a working rule kept there quietly stops applying the moment the same work happens on a schedule. [Instructions vs. Memory](/explanation/instructions-vs-memory/) has the full heuristic.
-
-The agent reads both files at the start of every conversation. Separating personality from instructions makes it easy to change one without affecting the other — for example, switching an agent from "The Butler" to "The Pilot" personality without rewriting its task instructions.
-
-Not sure whether a piece of knowledge belongs here or in Memory? See [Instructions vs. Memory](/explanation/instructions-vs-memory/) for the heuristic.
+Why not just let the agent remember it? Because memory isn't loaded by scheduled runs, so a working rule kept there quietly stops applying the moment the same work happens on a schedule.
 
 ## Permissions tab
 

--- a/packages/web/src/__tests__/components/agent-settings-file.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-file.test.tsx
@@ -117,3 +117,81 @@ describe("AgentSettingsFile", () => {
     });
   });
 });
+
+// #1144: "Save as instruction" carries a draft from a chat message into this
+// editor. The subtlety is the BASELINE — the tab has to open dirty, or the
+// user's Save is skipped as a no-op and the draft is silently lost.
+describe("AgentSettingsFile with a carried-over draft", () => {
+  it("appends the draft to the saved content rather than replacing it", () => {
+    render(
+      <AgentSettingsFile
+        agentId="agent-1"
+        filename="AGENTS.md"
+        content="Answer in English."
+        appendDraft="Score leads by VUE."
+        onChange={vi.fn()}
+      />
+    );
+
+    const editor = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(editor.value).toBe("Answer in English.\n\nScore leads by VUE.\n");
+  });
+
+  it("opens dirty, so the pending Save actually writes", () => {
+    const onChange = vi.fn();
+
+    render(
+      <AgentSettingsFile
+        agentId="agent-1"
+        filename="AGENTS.md"
+        content="Answer in English."
+        appendDraft="Score leads by VUE."
+        onChange={onChange}
+      />
+    );
+
+    expect(onChange).toHaveBeenCalledWith(
+      "Answer in English.\n\nScore leads by VUE.\n",
+      /* isDirty */ true
+    );
+  });
+
+  it("keeps the SAVED content as the baseline, so deleting the draft is clean again", () => {
+    // The regression this guards: folding the draft into the baseline would
+    // make the appended text read as always-having-been-there — and then
+    // reverting it by hand would look like an edit rather than an undo.
+    const onChange = vi.fn();
+
+    render(
+      <AgentSettingsFile
+        agentId="agent-1"
+        filename="AGENTS.md"
+        content="Answer in English."
+        appendDraft="Score leads by VUE."
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Answer in English." },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith("Answer in English.", false);
+  });
+
+  it("behaves exactly as before when no draft was carried in", () => {
+    const onChange = vi.fn();
+
+    render(
+      <AgentSettingsFile
+        agentId="agent-1"
+        filename="AGENTS.md"
+        content="Answer in English."
+        onChange={onChange}
+      />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveValue("Answer in English.");
+    expect(onChange).toHaveBeenCalledWith("Answer in English.", false);
+  });
+});

--- a/packages/web/src/__tests__/components/agent-settings-page-content-instruction-draft.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-page-content-instruction-draft.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// #1144: the seam between "Save as instruction" in chat and the Instructions
+// editor. Each half has its own unit tests; this is the only place that checks
+// they meet — a stashed draft actually reaching the textarea, appended to the
+// saved instructions rather than replacing them, and consumed on the way so it
+// cannot reappear during an unrelated edit later.
+
+const mockSession = vi.fn();
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: () => mockSession() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ agentId: "agent-1" }),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/chat/agent-1/settings",
+}));
+
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ triggerRestart: vi.fn() }),
+}));
+
+// Every tab body except the one under test — AgentSettingsFile stays real,
+// because "the draft lands in the editor" is the claim.
+vi.mock("@/components/agent-settings-general", () => ({ AgentSettingsGeneral: () => <div /> }));
+vi.mock("@/components/agent-settings-personality", () => ({
+  AgentSettingsPersonality: () => <div />,
+}));
+vi.mock("@/components/agent-settings-permissions", () => ({
+  AgentSettingsPermissions: () => <div />,
+}));
+vi.mock("@/components/agent-settings-access", () => ({ AgentSettingsAccess: () => <div /> }));
+vi.mock("@/components/agent-settings-diagnostics", () => ({
+  AgentSettingsDiagnostics: () => <div />,
+}));
+vi.mock("@/components/agent-telegram-settings", () => ({ AgentTelegramSettings: () => <div /> }));
+vi.mock("@/components/agent-settings-automations", () => ({
+  AgentSettingsAutomations: () => <div />,
+}));
+
+import { AgentSettingsPageContent } from "@/components/agent-settings-page-content";
+import { stashInstructionDraft } from "@/lib/instruction-handoff";
+
+const SAVED = "Answer in English.";
+
+function mockFetch() {
+  global.fetch = vi.fn().mockImplementation((url: unknown) => {
+    if (url === "/api/agents/agent-1") {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: "agent-1",
+            name: "Smithers",
+            model: "anthropic/claude-haiku-4-5-20251001",
+            allowedTools: [],
+            pluginConfig: null,
+            tagline: null,
+            avatarSeed: null,
+            personalityPresetId: null,
+            visibility: "restricted",
+            groupIds: [],
+            isPersonal: true,
+          }),
+      });
+    }
+    if (url === "/api/agents/agent-1/files/AGENTS.md") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ content: SAVED }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  }) as unknown as typeof fetch;
+}
+
+async function renderSettings() {
+  render(<AgentSettingsPageContent initialTab="instructions" />);
+  return waitFor(() => screen.getByRole("textbox"));
+}
+
+describe("AgentSettingsPageContent — a draft carried over from chat (#1144)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    mockSession.mockReturnValue({ data: { user: { id: "u1", role: "admin" } }, isPending: false });
+    mockFetch();
+  });
+
+  it("appends the stashed draft to the saved instructions in the editor", async () => {
+    stashInstructionDraft("agent-1", "Score leads by VUE.");
+
+    const editor = (await renderSettings()) as HTMLTextAreaElement;
+
+    expect(editor.value).toBe("Answer in English.\n\nScore leads by VUE.\n");
+  });
+
+  it("consumes the draft, so re-opening the tab shows only what is saved", async () => {
+    stashInstructionDraft("agent-1", "Score leads by VUE.");
+
+    const { unmount } = render(<AgentSettingsPageContent initialTab="instructions" />);
+    await waitFor(() => screen.getByRole("textbox"));
+    expect(window.sessionStorage.getItem("pinchy:instruction-draft:agent-1")).toBeNull();
+    unmount();
+
+    const editor = (await renderSettings()) as HTMLTextAreaElement;
+    expect(editor.value).toBe(SAVED);
+  });
+
+  it("leaves the editor untouched when nothing was carried over", async () => {
+    const editor = (await renderSettings()) as HTMLTextAreaElement;
+
+    expect(editor.value).toBe(SAVED);
+  });
+
+  it("ignores a draft stashed for a different agent", async () => {
+    stashInstructionDraft("agent-2", "meant for someone else");
+
+    const editor = (await renderSettings()) as HTMLTextAreaElement;
+
+    expect(editor.value).toBe(SAVED);
+    // and it is still waiting for the agent it was meant for
+    expect(window.sessionStorage.getItem("pinchy:instruction-draft:agent-2")).toBe(
+      "meant for someone else"
+    );
+  });
+});

--- a/packages/web/src/__tests__/components/smithers-model-info-line.test.tsx
+++ b/packages/web/src/__tests__/components/smithers-model-info-line.test.tsx
@@ -5,13 +5,13 @@ import "@testing-library/jest-dom";
 import { SmithersModelInfoLine } from "@/components/setup/smithers-model-info-line";
 
 describe("SmithersModelInfoLine", () => {
-  it("displays the model display name and link to agent settings", () => {
+  it("displays the model display name and links to a page that exists", () => {
+    // It linked to `/settings/agents` — a 404 — from the last screen of the
+    // setup wizard, and this assertion pinned it there. `app-route-link-coverage`
+    // is what makes that shape of green test impossible now.
     render(<SmithersModelInfoLine modelId="anthropic/claude-sonnet-4-6" />);
     expect(screen.getByText(/Claude Sonnet 4\.6/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Agent Settings/i })).toHaveAttribute(
-      "href",
-      "/settings/agents"
-    );
+    expect(screen.getByRole("link", { name: /Agents/i })).toHaveAttribute("href", "/agents");
   });
 
   it("renders with openai model id", () => {

--- a/packages/web/src/__tests__/components/thread-report-issue.test.tsx
+++ b/packages/web/src/__tests__/components/thread-report-issue.test.tsx
@@ -309,6 +309,28 @@ describe('Per-message "Save as instruction" menu entry', () => {
     expect(window.sessionStorage.getItem("pinchy:instruction-draft:agt_42")).toBe(
       "Score leads by VUE."
     );
-    expect(mockRouterPush).toHaveBeenCalledWith("/agents/agt_42/settings?tab=instructions");
+    // `/chat/<id>/settings` is the agent settings page this app serves. It
+    // shipped as `/agents/<id>/settings` — a route that has never existed —
+    // with this very assertion pinning the 404. `app-route-link-coverage`
+    // now reads the route tree, so the two cannot agree on a fiction again.
+    expect(mockRouterPush).toHaveBeenCalledWith("/chat/agt_42/settings?tab=instructions");
+  });
+
+  it("is absent when no agent id is in context", async () => {
+    // `AgentIdContext` falls back to "" in the action bar. Offering the item
+    // then would stash under a keyless entry and push `/chat//settings` —
+    // the same defensive guard the model-switch deep link carries.
+    const { AssistantMessage } = await import("@/components/assistant-ui/thread");
+    const { AgentNameContext, CanEditAgentContext } = await import("@/components/chat");
+
+    render(
+      <AgentNameContext.Provider value="Smithers">
+        <CanEditAgentContext.Provider value={true}>
+          <AssistantMessage />
+        </CanEditAgentContext.Provider>
+      </AgentNameContext.Provider>
+    );
+
+    expect(screen.queryByText("Save as instruction")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/components/thread-report-issue.test.tsx
+++ b/packages/web/src/__tests__/components/thread-report-issue.test.tsx
@@ -140,6 +140,13 @@ vi.mock("@/hooks/use-model-capabilities", () => ({
   })),
 }));
 
+// The action bar navigates to the agent's Instructions tab (#1144). JSDOM has
+// no Next app router mounted, so the hook is stubbed and the push asserted.
+const { mockRouterPush } = vi.hoisted(() => ({ mockRouterPush: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
 vi.mock("@/components/chat", async () => {
   const React = await import("react");
   return {
@@ -147,6 +154,7 @@ vi.mock("@/components/chat", async () => {
     AgentIdContext: React.createContext<string | null>(null),
     ChatIdContext: React.createContext<string | null>(null),
     AgentNameContext: React.createContext<string | null>(null),
+    CanEditAgentContext: React.createContext<boolean>(false),
     RetryResendContext: React.createContext<(messageId: string) => void>(() => {}),
     RetryContinueContext: React.createContext<() => void>(() => {}),
     ChatStatusContext: React.createContext<{ kind: string; reason?: string }>({ kind: "ready" }),
@@ -194,6 +202,7 @@ describe("Per-message Report issue menu entry", () => {
     const fakeMessageState = {
       id: "msg-assistant-1",
       isLast: true,
+      content: [{ type: "text", text: "Score leads by VUE." }],
       metadata: { custom: {} },
     } as unknown as MessageState;
     vi.mocked(useMessage).mockImplementation(
@@ -236,5 +245,70 @@ describe("Per-message Report issue menu entry", () => {
     expect(dialog).toHaveAttribute("data-anchor-message-id", "msg-assistant-1");
     expect(dialog).toHaveAttribute("data-agent-id", "agt_42");
     expect(dialog).toHaveAttribute("data-agent-name", "Smithers");
+  });
+});
+
+// #1144: promoting a working method the user and agent developed together into
+// the agent's Instructions, where it is reviewed, versioned, and — unlike
+// memory — loaded by scheduled runs too.
+describe('Per-message "Save as instruction" menu entry', () => {
+  beforeEach(async () => {
+    const { useMessage } = await import("@assistant-ui/react");
+    type UseMessageSelector = (state: MessageState) => unknown;
+    const fakeMessageState = {
+      id: "msg-assistant-1",
+      isLast: true,
+      content: [{ type: "text", text: "Score leads by VUE." }],
+      metadata: { custom: {} },
+    } as unknown as MessageState;
+    vi.mocked(useMessage).mockImplementation(((selector: UseMessageSelector) =>
+      selector(fakeMessageState)) as typeof useMessage);
+    window.sessionStorage.clear();
+    mockRouterPush.mockClear();
+  });
+
+  async function renderWith(canEdit: boolean) {
+    const { AssistantMessage } = await import("@/components/assistant-ui/thread");
+    const { AgentIdContext, AgentNameContext, CanEditAgentContext } =
+      await import("@/components/chat");
+
+    render(
+      <AgentIdContext.Provider value="agt_42">
+        <AgentNameContext.Provider value="Smithers">
+          <CanEditAgentContext.Provider value={canEdit}>
+            <AssistantMessage />
+          </CanEditAgentContext.Provider>
+        </AgentNameContext.Provider>
+      </AgentIdContext.Provider>
+    );
+  }
+
+  it("is offered to someone who may save it", async () => {
+    await renderWith(true);
+
+    expect(screen.getByText("Save as instruction")).toBeInTheDocument();
+  });
+
+  it("is absent for a member who may not write this agent", async () => {
+    // The API refuses the write for anyone but an admin or a personal agent's
+    // owner. A menu item that leads to a 403 is worse than one that isn't
+    // there; #1145 is the real path for a member's proposal.
+    await renderWith(false);
+
+    expect(screen.queryByText("Save as instruction")).not.toBeInTheDocument();
+  });
+
+  it("carries the message into the Instructions tab without writing anything", async () => {
+    // The draft travels in sessionStorage rather than the URL — it is free text
+    // from a conversation and can name a customer, and a query string lands in
+    // history, referrers and proxy logs. Nothing is saved here: the settings
+    // page opens dirty and the user presses Save.
+    await renderWith(true);
+    fireEvent.click(screen.getByText("Save as instruction"));
+
+    expect(window.sessionStorage.getItem("pinchy:instruction-draft:agt_42")).toBe(
+      "Score leads by VUE."
+    );
+    expect(mockRouterPush).toHaveBeenCalledWith("/agents/agt_42/settings?tab=instructions");
   });
 });

--- a/packages/web/src/__tests__/lib/app-route-extraction.ts
+++ b/packages/web/src/__tests__/lib/app-route-extraction.ts
@@ -1,0 +1,175 @@
+// Pure extraction helpers for the in-app link guard
+// (`app-route-link-coverage.test.ts`). Kept in their own module so the parsing
+// can be unit-tested against fixtures rather than only against the live tree.
+import { readdirSync, statSync, existsSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/**
+ * Removes comments while leaving every string and template literal intact.
+ *
+ * A plain regex over the source reads `router.push("/\t/evil.com")` inside a
+ * JSDoc block as a real navigation — `src/lib/return-to.ts` documents that
+ * exact attack in prose. This is the same rule the Dockerfile toolchain guard
+ * follows: strip the explanation before matching, or the explanation of a link
+ * gets reported as the link.
+ *
+ * Known limitation: a backslash in code position is copied together with the
+ * character after it, which is what keeps a regex literal such as
+ * `/^https?:\/\//` from being read as the start of a line comment. An
+ * unescaped `//` inside a regex would still truncate the line — no such
+ * literal exists in this tree, and the failure direction is a missed link
+ * rather than a false report.
+ */
+export function stripComments(source: string): string {
+  let out = "";
+  let i = 0;
+  const n = source.length;
+
+  while (i < n) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === "/" && next === "/") {
+      while (i < n && source[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(source[i] === "*" && source[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    if (ch === "\\") {
+      out += ch + (next ?? "");
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < n) {
+        if (source[i] === "\\") {
+          out += source[i] + (source[i + 1] ?? "");
+          i += 2;
+          continue;
+        }
+        out += source[i];
+        if (source[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Every navigable route the App Router serves, as a segment pattern: route
+ * groups `(app)` disappear, `[agentId]` becomes `*`, `[...rest]` becomes `**`.
+ *
+ * `route.ts` counts as well as `page.tsx` — `src/app/share-target/route.ts` is
+ * a real destination a link may name, and a page-only reading would report it
+ * as broken. `app/api/**` is left out because those are never link targets and
+ * ~100 of them would bury the failure message.
+ */
+export function collectServedRoutes(appDir: string): string[] {
+  const routes = walk(appDir)
+    .filter((file) => !relative(appDir, file).startsWith(`api${sep}`))
+    .filter((file) => /(^|[/\\])(page|route)\.tsx?$/.test(file))
+    .map((file) => {
+      const segments = relative(appDir, file)
+        .split(sep)
+        .slice(0, -1)
+        .filter((segment) => !/^\(.*\)$/.test(segment))
+        .map((segment) => {
+          if (/^\[\.\.\..+\]$/.test(segment)) return "**";
+          if (/^\[.+\]$/.test(segment)) return "*";
+          return segment;
+        });
+      return "/" + segments.join("/");
+    });
+  return [...new Set(routes)].sort();
+}
+
+export interface LinkReference {
+  /** The path with `${…}` collapsed to `*`, query and hash removed. */
+  path: string;
+  /** Repo-relative file the reference was written in. */
+  file: string;
+  /** The literal as written, for the failure message. */
+  raw: string;
+}
+
+/**
+ * `href=`, `router.push(`, `router.replace(` and `redirect(` with a literal
+ * (or template-literal) target. A computed target is deliberately not
+ * reported — guessing what a variable holds is how a guard starts lying.
+ */
+const LINK_PATTERN =
+  /(?:href=|router\.(?:push|replace)\(|\bredirect\()\s*[{(]?\s*(?:`((?:[^`\\]|\\.)*)`|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)')/g;
+
+export function extractLinkReferences(source: string, file: string): LinkReference[] {
+  const found: LinkReference[] = [];
+  const code = stripComments(source);
+  let match: RegExpExecArray | null;
+
+  while ((match = LINK_PATTERN.exec(code)) !== null) {
+    const raw = match[1] ?? match[2] ?? match[3];
+    if (!raw || !raw.startsWith("/")) continue;
+    const path =
+      raw
+        .split("?")[0]
+        .split("#")[0]
+        .replace(/\$\{[^}]*\}/g, "*")
+        .replace(/\/+$/, "") || "/";
+    found.push({ path, file, raw });
+  }
+
+  return found;
+}
+
+/** Whether a referenced path is served from `public/` rather than by a route. */
+export function isPublicAsset(path: string, publicDir: string): boolean {
+  const first = path.split("/")[1];
+  if (!first || first.includes("*")) return false;
+  return existsSync(join(publicDir, first));
+}
+
+export function matchesRoute(path: string, routes: string[]): boolean {
+  const parts = path.split("/").filter(Boolean);
+  return routes.some((route) => {
+    const routeParts = route.split("/").filter(Boolean);
+    const catchAllAt = routeParts.indexOf("**");
+    if (catchAllAt >= 0) {
+      if (parts.length < catchAllAt) return false;
+      return routeParts
+        .slice(0, catchAllAt)
+        .every((segment, i) => segment === "*" || segment === parts[i]);
+    }
+    if (routeParts.length !== parts.length) return false;
+    return routeParts.every((segment, i) => segment === "*" || segment === parts[i]);
+  });
+}
+
+export function collectSourceFiles(srcDir: string): string[] {
+  return walk(srcDir).filter(
+    (file) => /\.tsx?$/.test(file) && !file.includes(`${sep}__tests__${sep}`)
+  );
+}

--- a/packages/web/src/__tests__/lib/app-route-link-coverage.test.ts
+++ b/packages/web/src/__tests__/lib/app-route-link-coverage.test.ts
@@ -1,0 +1,116 @@
+// packages/web/src/__tests__/lib/app-route-link-coverage.test.ts
+//
+// Every in-app link and `router.push` must name a page the App Router really
+// serves.
+//
+// A route that does not exist is a 404 with nothing red behind it: the build
+// succeeds, the type checker has no opinion about a string, and a unit test
+// written next to the navigation asserts the very path the implementation
+// invented. #1149 shipped `router.push("/agents/<id>/settings?tab=instructions")`
+// with a passing test pinning that exact URL, against a tree whose only agent
+// settings page is `/chat/<id>/settings`. The whole feature landed on a 404,
+// twice green.
+//
+// This is the same rule as § "Embeddable Serving Routes Need A next.config
+// Entry" in AGENTS.md, one layer up: assert what a concrete URL resolves to,
+// not what a component asked for.
+//
+// Known limitations, so nobody reads a green run as more than it is:
+//   - Only literal and template-literal targets are checked. `router.push(url)`
+//     with a computed value is invisible, and guessing what a variable holds is
+//     how a guard starts lying.
+//   - Only page routes. `/api/**` is skipped — those are route handlers, with
+//     their own guards.
+//   - A dynamic segment matches anything, so a link that puts a chat id where
+//     an agent id belongs still passes. This catches a path that cannot
+//     resolve, not one that resolves to the wrong record.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  collectServedRoutes,
+  collectSourceFiles,
+  extractLinkReferences,
+  isPublicAsset,
+  matchesRoute,
+  stripComments,
+} from "./app-route-extraction";
+
+const SRC_DIR = resolve(__dirname, "../..");
+const APP_DIR = resolve(SRC_DIR, "app");
+const PUBLIC_DIR = resolve(SRC_DIR, "../public");
+const REPO_WEB = resolve(SRC_DIR, "..");
+
+describe("in-app links resolve to a real page route", () => {
+  const routes = collectServedRoutes(APP_DIR);
+  const references = collectSourceFiles(SRC_DIR).flatMap((file) =>
+    extractLinkReferences(readFileSync(file, "utf8"), file.slice(REPO_WEB.length + 1))
+  );
+
+  it("found a real corpus on both sides", () => {
+    // A walker that stops finding things would otherwise pass in silence,
+    // which is how a coverage gate becomes decoration.
+    expect(routes.length).toBeGreaterThan(10);
+    expect(references.length).toBeGreaterThan(30);
+  });
+
+  it("has no link to a page that does not exist", () => {
+    const broken = references
+      .filter(({ path }) => !path.startsWith("/api/"))
+      .filter(({ path }) => !isPublicAsset(path, PUBLIC_DIR))
+      .filter(({ path }) => !matchesRoute(path, routes))
+      .map(({ file, raw, path }) => `${file}: ${raw}  (resolves to ${path})`);
+
+    expect(broken, `Known page routes:\n  ${routes.join("\n  ")}`).toEqual([]);
+  });
+});
+
+describe("stripComments", () => {
+  it("drops a navigation written inside a comment", () => {
+    // `src/lib/return-to.ts` documents a phishing payload as prose, complete
+    // with a `router.push(...)` call. Reporting that would be reporting the
+    // explanation instead of the code.
+    const code = stripComments(`
+      /** Next turns router.push("/\\t/evil.com") into a hard navigation. */
+      const real = "/settings";
+    `);
+    expect(code).not.toContain("evil.com");
+    expect(code).toContain('"/settings"');
+  });
+
+  it("keeps a URL that merely contains a double slash", () => {
+    expect(stripComments(`const u = "https://example.com/x";`)).toContain("https://example.com/x");
+  });
+
+  it("does not truncate a line at a regex literal's escaped slashes", () => {
+    // `/^https?:\/\//i` is real code in three modules. Reading its second
+    // escaped slash as a line comment would silently blind the scan to
+    // everything after it.
+    const code = stripComments(`if (/^https?:\\/\\//i.test(u)) push("/settings");`);
+    expect(code).toContain('push("/settings")');
+  });
+
+  it("leaves a comment marker inside a string alone", () => {
+    expect(stripComments(`const s = "a // b";`)).toContain("a // b");
+  });
+});
+
+describe("matchesRoute", () => {
+  const routes = ["/", "/agents", "/agents/new", "/chat/*", "/chat/*/settings", "/share/**"];
+
+  it("matches a dynamic segment", () => {
+    expect(matchesRoute("/chat/*/settings", routes)).toBe(true);
+  });
+
+  it("rejects a path with the right shape under the wrong prefix", () => {
+    expect(matchesRoute("/agents/*/settings", routes)).toBe(false);
+  });
+
+  it("rejects a path with an extra segment", () => {
+    expect(matchesRoute("/agents/new/extra", routes)).toBe(false);
+  });
+
+  it("matches anything below a catch-all", () => {
+    expect(matchesRoute("/share/a/b/c", routes)).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/instruction-handoff.test.ts
+++ b/packages/web/src/__tests__/lib/instruction-handoff.test.ts
@@ -4,7 +4,6 @@ import {
   canOfferInstructionHandoff,
   stashInstructionDraft,
   takeInstructionDraft,
-  clearInstructionDraft,
   appendInstructionDraft,
 } from "@/lib/instruction-handoff";
 
@@ -67,12 +66,11 @@ describe("instruction draft handoff", () => {
     expect(takeInstructionDraft("agent-1")).toBeNull();
   });
 
-  it("clears without consuming into the caller", () => {
-    stashInstructionDraft("agent-1", "abandoned");
-
-    clearInstructionDraft("agent-1");
-
-    expect(takeInstructionDraft("agent-1")).toBeNull();
+  it("refuses to stash without an agent id", () => {
+    // The key would collapse to the bare prefix and every agent would share
+    // one drawer.
+    expect(stashInstructionDraft("", "orphan")).toBe(false);
+    expect(takeInstructionDraft("")).toBeNull();
   });
 
   describe("when the browser refuses storage", () => {
@@ -103,19 +101,26 @@ describe("instruction draft handoff", () => {
 
 describe("canOfferInstructionHandoff", () => {
   it("offers the handoff to someone who may save it", () => {
-    expect(canOfferInstructionHandoff(true, "Score leads by VUE.")).toBe(true);
+    expect(canOfferInstructionHandoff(true, "agent-1", "Score leads by VUE.")).toBe(true);
   });
 
   it("withholds it from a member on a shared agent", () => {
     // `canWriteAgent` is admin-or-personal-owner. Offering the action to
     // everyone and letting the API answer 403 would be the worse UI, and
     // #1145 is the real path for a member's proposal.
-    expect(canOfferInstructionHandoff(false, "Score leads by VUE.")).toBe(false);
+    expect(canOfferInstructionHandoff(false, "agent-1", "Score leads by VUE.")).toBe(false);
   });
 
   it("withholds it from a message with no text to carry", () => {
     // A pure tool-call or image turn has nothing to promote.
-    expect(canOfferInstructionHandoff(true, "")).toBe(false);
-    expect(canOfferInstructionHandoff(true, "  \n\t ")).toBe(false);
+    expect(canOfferInstructionHandoff(true, "agent-1", "")).toBe(false);
+    expect(canOfferInstructionHandoff(true, "agent-1", "  \n\t ")).toBe(false);
+  });
+
+  it("withholds it when there is no agent to carry it to", () => {
+    // `AgentIdContext` falls back to "" in the action bar. Without this the
+    // item would stash under a keyless entry and navigate to `/chat//settings`
+    // — the same defensive guard the model-switch deep link carries.
+    expect(canOfferInstructionHandoff(true, "", "Score leads by VUE.")).toBe(false);
   });
 });

--- a/packages/web/src/__tests__/lib/instruction-handoff.test.ts
+++ b/packages/web/src/__tests__/lib/instruction-handoff.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  canOfferInstructionHandoff,
+  stashInstructionDraft,
+  takeInstructionDraft,
+  clearInstructionDraft,
+  appendInstructionDraft,
+} from "@/lib/instruction-handoff";
+
+describe("appendInstructionDraft", () => {
+  it("appends rather than replacing, so the existing instructions survive", () => {
+    // The whole point of the handover is adding one rule to everything the
+    // agent was already told. A replace would silently drop the rest.
+    expect(appendInstructionDraft("Answer in English.", "Score leads by VUE.")).toBe(
+      "Answer in English.\n\nScore leads by VUE.\n"
+    );
+  });
+
+  it("separates the two blocks with a blank line", () => {
+    // Without it, two Markdown paragraphs render as one.
+    expect(appendInstructionDraft("a", "b")).toContain("a\n\nb");
+  });
+
+  it("does not open empty instructions with a blank line", () => {
+    expect(appendInstructionDraft("", "First rule.")).toBe("First rule.\n");
+    expect(appendInstructionDraft("   \n\n", "First rule.")).toBe("First rule.\n");
+  });
+
+  it("collapses the existing trailing whitespace instead of stacking blank lines", () => {
+    expect(appendInstructionDraft("a\n\n\n", "b")).toBe("a\n\nb\n");
+  });
+
+  it("returns the existing content unchanged for a blank draft", () => {
+    expect(appendInstructionDraft("a\n", "   \n ")).toBe("a\n");
+  });
+});
+
+describe("instruction draft handoff", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("round-trips a draft for one agent", () => {
+    expect(stashInstructionDraft("agent-1", "Score leads by VUE.")).toBe(true);
+    expect(takeInstructionDraft("agent-1")).toBe("Score leads by VUE.");
+  });
+
+  it("is keyed per agent, so a draft cannot surface in another agent's settings", () => {
+    stashInstructionDraft("agent-1", "for one");
+
+    expect(takeInstructionDraft("agent-2")).toBeNull();
+    expect(takeInstructionDraft("agent-1")).toBe("for one");
+  });
+
+  it("consumes the draft, so re-opening the tab does not resurrect it", () => {
+    // A stale draft reappearing during an unrelated edit is worse than losing
+    // it: the user saves without noticing what came along.
+    stashInstructionDraft("agent-1", "once");
+
+    expect(takeInstructionDraft("agent-1")).toBe("once");
+    expect(takeInstructionDraft("agent-1")).toBeNull();
+  });
+
+  it("refuses to stash a blank draft", () => {
+    expect(stashInstructionDraft("agent-1", "   \n ")).toBe(false);
+    expect(takeInstructionDraft("agent-1")).toBeNull();
+  });
+
+  it("clears without consuming into the caller", () => {
+    stashInstructionDraft("agent-1", "abandoned");
+
+    clearInstructionDraft("agent-1");
+
+    expect(takeInstructionDraft("agent-1")).toBeNull();
+  });
+
+  describe("when the browser refuses storage", () => {
+    // Safari private mode reports a quota of 0 and THROWS on setItem; a
+    // storage-blocking policy throws on read. Neither is a reason to break the
+    // chat — the text is still on screen and can be copied.
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("reports a failed stash instead of throwing", () => {
+      vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new DOMException("QuotaExceededError");
+      });
+
+      expect(stashInstructionDraft("agent-1", "x")).toBe(false);
+    });
+
+    it("reads as no handoff instead of throwing", () => {
+      vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new DOMException("SecurityError");
+      });
+
+      expect(takeInstructionDraft("agent-1")).toBeNull();
+    });
+  });
+});
+
+describe("canOfferInstructionHandoff", () => {
+  it("offers the handoff to someone who may save it", () => {
+    expect(canOfferInstructionHandoff(true, "Score leads by VUE.")).toBe(true);
+  });
+
+  it("withholds it from a member on a shared agent", () => {
+    // `canWriteAgent` is admin-or-personal-owner. Offering the action to
+    // everyone and letting the API answer 403 would be the worse UI, and
+    // #1145 is the real path for a member's proposal.
+    expect(canOfferInstructionHandoff(false, "Score leads by VUE.")).toBe(false);
+  });
+
+  it("withholds it from a message with no text to carry", () => {
+    // A pure tool-call or image turn has nothing to promote.
+    expect(canOfferInstructionHandoff(true, "")).toBe(false);
+    expect(canOfferInstructionHandoff(true, "  \n\t ")).toBe(false);
+  });
+});

--- a/packages/web/src/components/agent-settings-file.tsx
+++ b/packages/web/src/components/agent-settings-file.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { appendInstructionDraft } from "@/lib/instruction-handoff";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { DocsLink } from "@/components/docs-link";
 
@@ -19,6 +20,12 @@ interface AgentSettingsFileProps {
   agentId: string;
   filename: Filename;
   content: string;
+  /**
+   * A draft carried over from chat by "Save as instruction" (#1144), appended
+   * to the editor's text but deliberately NOT to the saved baseline: the tab
+   * has to open dirty, or the user's Save would have nothing to write.
+   */
+  appendDraft?: string;
   onChange: (content: string, isDirty: boolean) => void;
 }
 
@@ -26,14 +33,21 @@ export function AgentSettingsFile({
   agentId: _agentId,
   filename,
   content: initialContent,
+  appendDraft,
   onChange,
 }: AgentSettingsFileProps) {
-  const [content, setContent] = useState(initialContent);
+  const [content, setContent] = useState(() =>
+    appendDraft ? appendInstructionDraft(initialContent, appendDraft) : initialContent
+  );
+  // The baseline is what is SAVED, never what was carried over. Folding the
+  // draft in here would make the appended text look like it had always been
+  // there, and the save would be skipped as a no-op.
   const initialRef = useRef(initialContent);
+  const mountedContentRef = useRef(content);
 
-  // Notify parent on mount with isDirty=false
+  // Notify parent on mount — dirty exactly when a draft was carried in.
   useEffect(() => {
-    onChange(initialRef.current, false);
+    onChange(mountedContentRef.current, mountedContentRef.current !== initialRef.current);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/web/src/components/agent-settings-file.tsx
+++ b/packages/web/src/components/agent-settings-file.tsx
@@ -43,11 +43,12 @@ export function AgentSettingsFile({
   // draft in here would make the appended text look like it had always been
   // there, and the save would be skipped as a no-op.
   const initialRef = useRef(initialContent);
-  const mountedContentRef = useRef(content);
 
-  // Notify parent on mount — dirty exactly when a draft was carried in.
+  // Notify parent on mount — dirty exactly when a draft was carried in. The
+  // empty dep list closes over the first render's `content`, which is the
+  // state the initialiser above produced.
   useEffect(() => {
-    onChange(mountedContentRef.current, mountedContentRef.current !== initialRef.current);
+    onChange(content, content !== initialRef.current);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -31,6 +31,7 @@ import { normalizeStarterPrompts } from "@/lib/schemas/starter-prompts";
 import { apiPatch, apiPut, apiDelete, ApiError, errorMessage } from "@/lib/api-client";
 import type { UpdateAgentInput, WriteAgentFileInput } from "@/lib/schemas/agents";
 import type { SetAgentIntegrationsInput } from "@/lib/schemas/agent-integrations";
+import { takeInstructionDraft } from "@/lib/instruction-handoff";
 import type { AgentPluginConfig } from "@/db/schema";
 import type { AgentVisibility } from "@/db/enums";
 
@@ -188,6 +189,16 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
   const generalDraft = useRef<GeneralValues | null>(null);
   const personalityDraft = useRef<PersonalityValues | null>(null);
   const instructionsDraft = useRef<string | null>(null);
+  /**
+   * A draft carried over from chat by "Save as instruction" (#1144).
+   *
+   * Read ONCE, before the first paint, and removed from sessionStorage in the
+   * same step: a draft that survived its own consumption would reappear the
+   * next time someone opened this tab for an unrelated edit, and they would
+   * save it without noticing. Nothing is written to the agent here — the text
+   * lands in the editor, dirty, and the user still presses Save.
+   */
+  const [carriedDraft] = useState(() => takeInstructionDraft(agentId));
   const permissionsDraft = useRef<PermissionsValues | null>(null);
   const accessDraft = useRef<AccessValues | null>(null);
 
@@ -518,6 +529,7 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
               agentId={agentId}
               filename="AGENTS.md"
               content={agentsContent}
+              appendDraft={carriedDraft ?? undefined}
               onChange={handleInstructionsChange}
             />
           </TabsContent>

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -230,6 +230,7 @@ vi.mock("@/components/chat", async () => {
     AgentAvatarContext: React.createContext<string | null>(null),
     AgentIdContext: React.createContext<string | null>(null),
     AgentNameContext: React.createContext<string | null>(null),
+    CanEditAgentContext: React.createContext<boolean>(false),
     ChatIdContext: React.createContext<string | null>(null),
     AgentModelContext: React.createContext<string | null>(null),
     RetryResendContext: React.createContext<(messageId: string) => void>(() => {}),

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -775,7 +775,7 @@ const AssistantActionBar: FC = () => {
               Export as Markdown
             </ActionBarMorePrimitive.Item>
           </ActionBarPrimitive.ExportMarkdown>
-          {canOfferInstructionHandoff(canEditAgent, messageText) && (
+          {canOfferInstructionHandoff(canEditAgent, agentId, messageText) && (
             <ActionBarMorePrimitive.Item
               onSelect={() => {
                 // Stash first, navigate second: a browser that refuses storage
@@ -784,7 +784,10 @@ const AssistantActionBar: FC = () => {
                   toast.error("Couldn't carry the draft over — copy the message instead.");
                   return;
                 }
-                router.push(`/agents/${agentId}/settings?tab=instructions`);
+                // `/chat/<id>/settings` — the same page the header's gear icon
+                // opens. It shipped as `/agents/<id>/settings`, a route this app
+                // has never served, and every test agreed with the typo.
+                router.push(`/chat/${agentId}/settings?tab=instructions`);
               }}
               data-testid="save-as-instruction-menu-item"
               className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -28,6 +28,7 @@ import {
   AlertCircle,
   ArrowDownIcon,
   ArrowUpIcon,
+  BookmarkIcon,
   BugIcon,
   CheckCircle,
   CheckIcon,
@@ -45,6 +46,7 @@ import {
   AgentIdContext,
   ChatIdContext,
   AgentNameContext,
+  CanEditAgentContext,
   RetryResendContext,
   RetryContinueContext,
   ChatStatusContext,
@@ -65,6 +67,9 @@ import { GatedRetry } from "@/components/chat/gated-retry";
 import { useComposerRuntime } from "@assistant-ui/react";
 import { getDraft, saveDraft, draftKey } from "@/lib/draft-store";
 import { useShareIntake } from "@/components/share/use-share-intake";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { canOfferInstructionHandoff, stashInstructionDraft } from "@/lib/instruction-handoff";
 
 function formatTimestamp(iso: string): string {
   const date = new Date(iso);
@@ -711,6 +716,22 @@ const AssistantActionBar: FC = () => {
   const messageId = useMessage((s) => s.id);
   const agentId = useContext(AgentIdContext) ?? "";
   const agentName = useContext(AgentNameContext) ?? "Unknown";
+  // Only offered to someone who may actually save it — `canWriteAgent`,
+  // resolved server-side. The route enforces the same rule; this keeps the menu
+  // from advertising an action that would come back 403.
+  const canEditAgent = useContext(CanEditAgentContext);
+  // `?? []` rather than trusting the type: this selector runs inside the action
+  // bar of every assistant message, so throwing here blanks the whole message
+  // for a field it only ever reads to decide whether to show a menu item. A
+  // message with no text parts is a tool-call or image turn — nothing to
+  // promote, which `canOfferInstructionHandoff` already treats as "don't offer".
+  const messageText = useMessage((s) =>
+    (s.content ?? [])
+      .filter((part): part is { type: "text"; text: string } => part.type === "text")
+      .map((part) => part.text)
+      .join("\n\n")
+  );
+  const router = useRouter();
   // The active chat (null = default/legacy) so the export dialog preselects the
   // chat the user is actually looking at, not the default one (#639).
   const chatId = useContext(ChatIdContext);
@@ -754,6 +775,24 @@ const AssistantActionBar: FC = () => {
               Export as Markdown
             </ActionBarMorePrimitive.Item>
           </ActionBarPrimitive.ExportMarkdown>
+          {canOfferInstructionHandoff(canEditAgent, messageText) && (
+            <ActionBarMorePrimitive.Item
+              onSelect={() => {
+                // Stash first, navigate second: a browser that refuses storage
+                // must not drop the user on a settings page with nothing in it.
+                if (!stashInstructionDraft(agentId, messageText)) {
+                  toast.error("Couldn't carry the draft over — copy the message instead.");
+                  return;
+                }
+                router.push(`/agents/${agentId}/settings?tab=instructions`);
+              }}
+              data-testid="save-as-instruction-menu-item"
+              className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+            >
+              <BookmarkIcon className="size-4" />
+              Save as instruction
+            </ActionBarMorePrimitive.Item>
+          )}
           <ActionBarMorePrimitive.Item
             onSelect={() => setReportIssueOpen(true)}
             data-testid="report-issue-menu-item"

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -61,6 +61,13 @@ export const AgentIdContext = createContext<string | null>(null);
  */
 export const ChatIdContext = createContext<string | null>(null);
 export const AgentNameContext = createContext<string | null>(null);
+/**
+ * Whether the viewer may edit this agent's files — `canWriteAgent`, resolved
+ * server-side in `loadChatPageAgent` and handed down rather than re-derived.
+ * Read by the assistant action bar to decide whether "Save as instruction"
+ * exists: a menu item that leads to a 403 is worse than one that isn't there.
+ */
+export const CanEditAgentContext = createContext<boolean>(false);
 export const AgentModelContext = createContext<string | null>(null);
 /**
  * Which serving route a file chip fetches from (#703). User attachments live in
@@ -240,114 +247,116 @@ export function Chat({
     <AgentIdContext.Provider value={agentId}>
       <ChatIdContext.Provider value={chatId ?? null}>
         <AgentNameContext.Provider value={displayName}>
-          <AgentModelContext.Provider value={liveAgent?.model ?? null}>
-            <AssistantRuntimeProvider runtime={runtime}>
-              <ChatStatusContext.Provider value={chatStatus}>
-                <RetryContinueContext.Provider value={onRetryContinue}>
-                  <RetryResendContext.Provider value={onRetryResend}>
-                    <PendingUploadsContext.Provider value={pendingUploads}>
-                      <AddPendingUploadContext.Provider value={addPendingUpload}>
-                        <RemovePendingUploadContext.Provider value={removePendingUpload}>
-                          <RetryPendingUploadContext.Provider value={retryPendingUpload}>
-                            <AgentAvatarContext.Provider value={displayAvatar ?? null}>
-                              <div className="flex flex-col h-full min-h-0">
-                                <MobileChatHeader
-                                  agentId={agentId}
-                                  agentName={displayName}
-                                  chatId={chatId ?? null}
-                                  avatarUrl={displayAvatar}
-                                  canEdit={canEdit}
-                                />
-                                <header className="hidden md:flex px-4 py-2.5 border-b items-center justify-between shrink-0">
-                                  <div className="flex items-center gap-2 min-w-0 flex-1 animate-in fade-in duration-300">
-                                    {displayAvatar && (
-                                      // eslint-disable-next-line @next/next/no-img-element
-                                      <img
-                                        src={displayAvatar}
-                                        alt=""
-                                        className="size-10 rounded-full shrink-0"
+          <CanEditAgentContext.Provider value={canEdit}>
+            <AgentModelContext.Provider value={liveAgent?.model ?? null}>
+              <AssistantRuntimeProvider runtime={runtime}>
+                <ChatStatusContext.Provider value={chatStatus}>
+                  <RetryContinueContext.Provider value={onRetryContinue}>
+                    <RetryResendContext.Provider value={onRetryResend}>
+                      <PendingUploadsContext.Provider value={pendingUploads}>
+                        <AddPendingUploadContext.Provider value={addPendingUpload}>
+                          <RemovePendingUploadContext.Provider value={removePendingUpload}>
+                            <RetryPendingUploadContext.Provider value={retryPendingUpload}>
+                              <AgentAvatarContext.Provider value={displayAvatar ?? null}>
+                                <div className="flex flex-col h-full min-h-0">
+                                  <MobileChatHeader
+                                    agentId={agentId}
+                                    agentName={displayName}
+                                    chatId={chatId ?? null}
+                                    avatarUrl={displayAvatar}
+                                    canEdit={canEdit}
+                                  />
+                                  <header className="hidden md:flex px-4 py-2.5 border-b items-center justify-between shrink-0">
+                                    <div className="flex items-center gap-2 min-w-0 flex-1 animate-in fade-in duration-300">
+                                      {displayAvatar && (
+                                        // eslint-disable-next-line @next/next/no-img-element
+                                        <img
+                                          src={displayAvatar}
+                                          alt=""
+                                          className="size-10 rounded-full shrink-0"
+                                        />
+                                      )}
+                                      <ChatSwitcher
+                                        agentId={agentId}
+                                        chatId={chatId ?? null}
+                                        agentName={displayName}
                                       />
-                                    )}
-                                    <ChatSwitcher
-                                      agentId={agentId}
-                                      chatId={chatId ?? null}
-                                      agentName={displayName}
-                                    />
-                                    <TooltipProvider>
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <Badge
-                                            variant="outline"
-                                            className="text-xs font-normal shrink-0"
-                                          >
-                                            {displayIsPersonal ? "Private" : "Shared"}
-                                          </Badge>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                          {displayIsPersonal
-                                            ? "Your conversations are private and not shared with anyone."
-                                            : "Your conversations help build team knowledge that's available to all team members."}
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    </TooltipProvider>
-                                    <AiDisclosureLabel />
+                                      <TooltipProvider>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <Badge
+                                              variant="outline"
+                                              className="text-xs font-normal shrink-0"
+                                            >
+                                              {displayIsPersonal ? "Private" : "Shared"}
+                                            </Badge>
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            {displayIsPersonal
+                                              ? "Your conversations are private and not shared with anyone."
+                                              : "Your conversations help build team knowledge that's available to all team members."}
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                      <AiDisclosureLabel />
+                                    </div>
+                                    <div className="flex items-center gap-3 shrink-0">
+                                      {canEdit && (
+                                        <Link
+                                          href={`/chat/${agentId}/settings`}
+                                          aria-label="Settings"
+                                          className="text-muted-foreground hover:text-foreground transition-colors"
+                                        >
+                                          <Settings className="size-5" />
+                                        </Link>
+                                      )}
+                                      <TooltipProvider delayDuration={200}>
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <button
+                                              type="button"
+                                              aria-label={indicator.label}
+                                              className="cursor-default p-1.5 -m-1.5 inline-flex items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                            >
+                                              <span
+                                                className={`size-2 rounded-full shrink-0 ${indicator.colorClass}`}
+                                              />
+                                            </button>
+                                          </TooltipTrigger>
+                                          <TooltipContent>{indicator.label}</TooltipContent>
+                                        </Tooltip>
+                                      </TooltipProvider>
+                                    </div>
+                                  </header>
+                                  <ChatErrorBanner
+                                    agentId={agentId}
+                                    chatId={chatId}
+                                    onRetry={() => onRetryContinue("partial_stream_failure")}
+                                  />
+                                  <div className="flex-1 min-h-0 animate-in fade-in duration-300">
+                                    <ChatCrashBoundary>
+                                      <Thread isReconcilingMessages={isReconcilingMessages} />
+                                    </ChatCrashBoundary>
                                   </div>
-                                  <div className="flex items-center gap-3 shrink-0">
-                                    {canEdit && (
-                                      <Link
-                                        href={`/chat/${agentId}/settings`}
-                                        aria-label="Settings"
-                                        className="text-muted-foreground hover:text-foreground transition-colors"
-                                      >
-                                        <Settings className="size-5" />
-                                      </Link>
-                                    )}
-                                    <TooltipProvider delayDuration={200}>
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <button
-                                            type="button"
-                                            aria-label={indicator.label}
-                                            className="cursor-default p-1.5 -m-1.5 inline-flex items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                          >
-                                            <span
-                                              className={`size-2 rounded-full shrink-0 ${indicator.colorClass}`}
-                                            />
-                                          </button>
-                                        </TooltipTrigger>
-                                        <TooltipContent>{indicator.label}</TooltipContent>
-                                      </Tooltip>
-                                    </TooltipProvider>
-                                  </div>
-                                </header>
-                                <ChatErrorBanner
-                                  agentId={agentId}
-                                  chatId={chatId}
-                                  onRetry={() => onRetryContinue("partial_stream_failure")}
-                                />
-                                <div className="flex-1 min-h-0 animate-in fade-in duration-300">
-                                  <ChatCrashBoundary>
-                                    <Thread isReconcilingMessages={isReconcilingMessages} />
-                                  </ChatCrashBoundary>
+                                  {!displayIsPersonal && (
+                                    <p className="text-xs text-muted-foreground px-3 py-1">
+                                      Files uploaded here are visible to anyone with access to this
+                                      agent.
+                                    </p>
+                                  )}
+                                  <ChatStatusBanner status={chatStatus} isDelayed={isDelayed} />
                                 </div>
-                                {!displayIsPersonal && (
-                                  <p className="text-xs text-muted-foreground px-3 py-1">
-                                    Files uploaded here are visible to anyone with access to this
-                                    agent.
-                                  </p>
-                                )}
-                                <ChatStatusBanner status={chatStatus} isDelayed={isDelayed} />
-                              </div>
-                            </AgentAvatarContext.Provider>
-                          </RetryPendingUploadContext.Provider>
-                        </RemovePendingUploadContext.Provider>
-                      </AddPendingUploadContext.Provider>
-                    </PendingUploadsContext.Provider>
-                  </RetryResendContext.Provider>
-                </RetryContinueContext.Provider>
-              </ChatStatusContext.Provider>
-            </AssistantRuntimeProvider>
-          </AgentModelContext.Provider>
+                              </AgentAvatarContext.Provider>
+                            </RetryPendingUploadContext.Provider>
+                          </RemovePendingUploadContext.Provider>
+                        </AddPendingUploadContext.Provider>
+                      </PendingUploadsContext.Provider>
+                    </RetryResendContext.Provider>
+                  </RetryContinueContext.Provider>
+                </ChatStatusContext.Provider>
+              </AssistantRuntimeProvider>
+            </AgentModelContext.Provider>
+          </CanEditAgentContext.Provider>
         </AgentNameContext.Provider>
       </ChatIdContext.Provider>
     </AgentIdContext.Provider>

--- a/packages/web/src/components/setup/smithers-model-info-line.tsx
+++ b/packages/web/src/components/setup/smithers-model-info-line.tsx
@@ -9,8 +9,8 @@ export function SmithersModelInfoLine({ modelId }: SmithersModelInfoLineProps) {
   return (
     <p className="text-sm text-muted-foreground mt-2">
       Smithers will use {getModelDisplayName(modelId)}. You can change this in{" "}
-      <Link href="/settings/agents" className="underline">
-        Agent Settings
+      <Link href="/agents" className="underline">
+        Agents
       </Link>
       .
     </p>

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -79,13 +79,17 @@ export function assertAgentAccess(
  * - Personal agent owners can modify their own agents
  * - Non-admin users CANNOT modify shared agents
  */
+export function canWriteAgent(agent: AgentForAccess, userId: string, userRole: string): boolean {
+  if (userRole === "admin") return true;
+  return Boolean(agent.isPersonal && agent.ownerId === userId);
+}
+
 export function assertAgentWriteAccess(
   agent: AgentForAccess,
   userId: string,
   userRole: string
 ): void {
-  if (userRole === "admin") return;
-  if (agent.isPersonal && agent.ownerId === userId) return;
+  if (canWriteAgent(agent, userId, userRole)) return;
 
   throw new Error("Access denied");
 }

--- a/packages/web/src/lib/chats/load-chat-agent.ts
+++ b/packages/web/src/lib/chats/load-chat-agent.ts
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import { db } from "@/db";
 import { activeAgents } from "@/db/schema";
 import { requireAuth } from "@/lib/require-auth";
-import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
+import { assertAgentAccess, canWriteAgent, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
 import { getLicenseState } from "@/lib/enterprise";
 import { getAgentAvatarSvg } from "@/lib/avatar";
@@ -80,7 +80,9 @@ export async function loadChatPageAgent(agentId: string) {
   }
 
   const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
-  const canEdit = userRole === "admin" || (agent.isPersonal && agent.ownerId === userId);
+  // The same predicate the write routes enforce, not a second spelling of it:
+  // the UI must never offer an edit the API refuses, nor withhold one it allows.
+  const canEdit = canWriteAgent(agent, userId, userRole);
 
   return { agent, userId, userRole, avatarUrl, canEdit };
 }

--- a/packages/web/src/lib/instruction-handoff.ts
+++ b/packages/web/src/lib/instruction-handoff.ts
@@ -1,0 +1,106 @@
+/**
+ * Carries a drafted instruction from a chat message to the agent's Instructions
+ * tab (#1144).
+ *
+ * A user and an agent work out a way of working during a conversation. The
+ * agent can write its memory but not its own Instructions — deliberately — so
+ * the rule ends up in the one store it can reach, where it is unreviewed and,
+ * worse, absent from scheduled runs (OpenClaw serves those from a bootstrap set
+ * that excludes MEMORY.md). "Save as instruction" is the handover: the agent
+ * drafts, the person accepts, and the rule lands in the store that is versioned
+ * and that every session reads.
+ *
+ * ## Why sessionStorage and not a query parameter
+ *
+ * The draft is free text out of a conversation. It can name a customer, a
+ * price, an internal rule. A query string is written to browser history, sent
+ * as a `Referer` to whatever the next page loads, and logged by every proxy in
+ * between — none of which is an acceptable place for it. sessionStorage stays
+ * in the tab, survives the one navigation this needs, and is cleared as soon as
+ * it is read.
+ *
+ * It is keyed per agent so a draft prepared for one agent can never surface in
+ * another's settings, and `take` is destructive for the same reason a stale
+ * draft must not reappear the next time someone opens the tab for an unrelated
+ * edit.
+ */
+
+const KEY_PREFIX = "pinchy:instruction-draft:";
+
+function storageKey(agentId: string): string {
+  return `${KEY_PREFIX}${agentId}`;
+}
+
+/**
+ * sessionStorage throws rather than returning null in two real cases: Safari's
+ * private mode (quota 0) and a browser configured to block storage. Neither is
+ * a reason to break the chat, so every access here degrades to "no handoff" —
+ * the user still has the text in front of them and can copy it.
+ */
+function safely<T>(fn: () => T, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Whether to offer "Save as instruction" on a message.
+ *
+ * Two conditions, and the first is the one that matters: the viewer must be
+ * allowed to save. `canWriteAgent` is resolved server-side and handed down
+ * through `CanEditAgentContext` rather than re-derived here — a menu item that
+ * leads to a 403 is worse than one that isn't there. The second keeps the item
+ * off a message with nothing to carry (a pure tool-call or image turn).
+ */
+export function canOfferInstructionHandoff(canEditAgent: boolean, messageText: string): boolean {
+  return canEditAgent && messageText.trim().length > 0;
+}
+
+export function stashInstructionDraft(agentId: string, draft: string): boolean {
+  const trimmed = draft.trim();
+  if (!trimmed) return false;
+  return safely(() => {
+    window.sessionStorage.setItem(storageKey(agentId), trimmed);
+    return true;
+  }, false);
+}
+
+/** Reads the pending draft and removes it. Returns null when there is none. */
+export function takeInstructionDraft(agentId: string): string | null {
+  return safely(() => {
+    const key = storageKey(agentId);
+    const value = window.sessionStorage.getItem(key);
+    if (value === null) return null;
+    window.sessionStorage.removeItem(key);
+    return value.trim() || null;
+  }, null);
+}
+
+export function clearInstructionDraft(agentId: string): void {
+  safely(() => {
+    window.sessionStorage.removeItem(storageKey(agentId));
+    return true;
+  }, false);
+}
+
+/**
+ * Appends a draft to the saved instructions.
+ *
+ * Append, never replace: what the agent drafted is one rule, and the file is
+ * everything the agent was already told. Replacing would silently drop the rest
+ * — and a refinement of an existing rule is a judgement about prose that
+ * belongs to the person reading the diff, not to a merge routine.
+ *
+ * A blank separator line keeps two Markdown blocks from running together; empty
+ * instructions get the draft on its own, with no leading blank line to delete.
+ */
+export function appendInstructionDraft(existing: string, draft: string): string {
+  const base = existing.replace(/\s+$/, "");
+  const addition = draft.trim();
+  if (!addition) return existing;
+  if (!base) return `${addition}\n`;
+  return `${base}\n\n${addition}\n`;
+}

--- a/packages/web/src/lib/instruction-handoff.ts
+++ b/packages/web/src/lib/instruction-handoff.ts
@@ -49,19 +49,26 @@ function safely<T>(fn: () => T, fallback: T): T {
 /**
  * Whether to offer "Save as instruction" on a message.
  *
- * Two conditions, and the first is the one that matters: the viewer must be
+ * Three conditions, and the first is the one that matters: the viewer must be
  * allowed to save. `canWriteAgent` is resolved server-side and handed down
  * through `CanEditAgentContext` rather than re-derived here — a menu item that
  * leads to a 403 is worse than one that isn't there. The second keeps the item
- * off a message with nothing to carry (a pure tool-call or image turn).
+ * off a message with nothing to carry (a pure tool-call or image turn), and the
+ * third off a message with no agent to carry it to: `AgentIdContext` falls back
+ * to "" in the action bar, and an empty id would key the draft under the bare
+ * prefix and navigate to `/chat//settings`.
  */
-export function canOfferInstructionHandoff(canEditAgent: boolean, messageText: string): boolean {
-  return canEditAgent && messageText.trim().length > 0;
+export function canOfferInstructionHandoff(
+  canEditAgent: boolean,
+  agentId: string,
+  messageText: string
+): boolean {
+  return canEditAgent && agentId.length > 0 && messageText.trim().length > 0;
 }
 
 export function stashInstructionDraft(agentId: string, draft: string): boolean {
   const trimmed = draft.trim();
-  if (!trimmed) return false;
+  if (!trimmed || !agentId) return false;
   return safely(() => {
     window.sessionStorage.setItem(storageKey(agentId), trimmed);
     return true;
@@ -77,13 +84,6 @@ export function takeInstructionDraft(agentId: string): string | null {
     window.sessionStorage.removeItem(key);
     return value.trim() || null;
   }, null);
-}
-
-export function clearInstructionDraft(agentId: string): void {
-  safely(() => {
-    window.sessionStorage.removeItem(storageKey(agentId));
-    return true;
-  }, false);
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Adds `⋯ → **Save as instruction**` on an assistant message. It carries the text to the agent's **Instructions** tab, appended below what's already there, dirty and unsaved — the person still presses Save.

Closes #1144

### Why

A user and an agent work out a way of working during a conversation: a scoring framework for leads, the order to reconcile things in. The agent files it in **memory**, because memory is the only store it can write. That's the wrong store twice over:

- it's unreviewed prose the agent wrote about itself, where a business rule wants a diff and a history; and
- OpenClaw serves cron and subagent sessions from `MINIMAL_BOOTSTRAP_ALLOWLIST`, which **excludes `MEMORY.md`** — so a working rule kept there quietly stops applying the moment the same work runs on a schedule, and nothing reports a failure.

#1136 shipped the prompt half (the agent now offers to draft the wording). This is the last twenty metres: no more selecting prose out of a chat bubble, switching tabs, and pasting.

It's the shape the comparable tools converged on — Cursor's `/Generate Cursor Rules`, Copilot's `/init`, Claude Code's `#`: the agent drafts, the human accepts, the result lands in the reviewed store.

### Three decisions worth reading

- **The draft travels in `sessionStorage`, not a query parameter.** It is free text out of a conversation and can name a customer or a price; a query string is written to browser history, sent as a `Referer` to whatever loads next, and logged by every proxy in between. Keyed per agent, and **consumed on read** — a stale draft resurfacing during an unrelated edit is worse than losing it, because the user saves without noticing.
- **The appended text is NOT folded into the editor's baseline.** Folding it in would make it read as always-having-been-there, and the save would be skipped as a no-op — the draft silently lost. `initialRef` stays the *saved* content, so the tab opens dirty and deleting the draft by hand reads as an undo rather than an edit.
- **The rule for who sees the item is not spelled twice.** `canEdit` in `load-chat-agent.ts` was an inline copy of `assertAgentWriteAccess`; both now call `canWriteAgent`. The UI cannot drift into offering an action the API refuses.

### Scope

Append, never replace. No new tool, no new grant, no storage, no expiry: when the proposer is the person allowed to save, the draft is already on screen. A **member on a shared agent** doesn't get the action — that's the maker-checker case, filed as #1145 against #124 Tier 3.

## Type of change

- [x] ✨ New feature
- [x] 📝 Documentation
- [x] 🧪 Tests

## Reviewer notes

**A pre-existing trap surfaced while adding the context.** Two test files mock `@/components/chat` with a hand-written list of contexts, so adding one broke both with a `No "CanEditAgentContext" export` error. Both were extended. It is the mirror-list pattern AGENTS.md keeps naming, one level down in a test mock; worth knowing before adding a third context.

**`s.content ?? []` in the action bar is deliberate, not defensive noise.** Two independent test fakes omit `content` — the selector runs in the action bar of *every* assistant message, so throwing there blanks the whole message over a field only read to decide whether to show a menu item. A message with no text parts is a tool-call or image turn: nothing to promote, which `canOfferInstructionHandoff` already treats as "don't offer".

Tests: 15 for the handoff module (round-trip, per-agent keying, consume-once, blank drafts, and the Safari-private-mode / storage-blocked paths where `sessionStorage` throws), 4 for the editor's baseline behaviour, 3 for the menu item (offered, withheld, and the click that stashes + navigates without writing).

Gates run: full suite (11 597 tests), `test:scripts` (1081), typecheck incl. tests, ESLint (0 errors), `format:check`, `pnpm build`, docs build + anchor + table checks. `test:db` not run — no schema or migration change.

## Follow-ups (not in this PR)

- **#1145** — a member on a shared agent proposing a change for an admin to approve.
- **Pruning the memory copy** after a successful promotion. The agent can overwrite a memory file but not delete one, so the rule sits in both stores until someone edits it down.

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated the documentation
- [x] All existing tests pass
