### PR TITLE
fix(api): reject a wrongly shaped API key before paying for the lookup

### DIFF
--- a/docs/src/content/docs/reference/agent-provisioning-api.mdx
+++ b/docs/src/content/docs/reference/agent-provisioning-api.mdx
@@ -269,7 +269,9 @@ Pinchy applies its own limits instead, in-process, per running container:
 | Verified key        | the key's own id | 300 requests / minute | `429 Too Many Requests` with `Retry-After: 60` |
 | Invalid-key attempt | the caller's IP  | 20 attempts / minute  | `429 Too Many Requests` with `Retry-After: 60` |
 
-The per-key limit is deliberately generous — it exists to bound a compromised or malfunctioning key, not to throttle normal automation traffic. The invalid-key limit is deliberately strict: it only ever counts requests that never verified (missing key, unknown key, expired/disabled/revoked key), which is the shape of a brute-force or key-guessing attempt, not of legitimate use.
+The per-key limit is deliberately generous — it exists to bound a compromised or malfunctioning key, not to throttle normal automation traffic. The invalid-key limit is deliberately strict: it only ever counts requests that never verified (missing key, malformed key, unknown key, expired/disabled/revoked key), which is the shape of a brute-force or key-guessing attempt, not of legitimate use.
+
+A **malformed** key — anything not starting with `pinchy_`, which is every key Pinchy has ever issued — is rejected on the spot, before the hash and database lookup a real verification costs. It still counts against the limit above; it just doesn't cost us anything to say no. That covers the bulk of what a public endpoint actually receives: scanners spraying other products' token formats.
 
 ```json
 { "error": "Too many requests" }

--- a/packages/web/src/__tests__/lib/api-key-format.test.ts
+++ b/packages/web/src/__tests__/lib/api-key-format.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The cheap shape check that runs before `verifyApiKey` (#1086).
+ *
+ * `withApiKey` reaches key verification through `auth.api.*`, which hashes the
+ * candidate and does a database lookup. Anyone on the internet can trigger
+ * that with a made-up string, so the one filter that costs nothing is worth
+ * having: a key that cannot possibly be one of ours is rejected before the
+ * round trip.
+ *
+ * The load-bearing property is that `API_KEY_PREFIX` is the SAME constant
+ * `auth.ts` hands the plugin as `defaultPrefix`. If those two ever became two
+ * strings that merely agreed, this filter would start rejecting valid keys the
+ * day one of them changed — a self-inflicted outage on the whole API.
+ */
+import { describe, it, expect } from "vitest";
+
+import { API_KEY_PREFIX, looksLikeApiKey } from "@/lib/api-key-format";
+
+describe("looksLikeApiKey", () => {
+  it("accepts a key carrying the prefix Pinchy issues", () => {
+    expect(looksLikeApiKey(`${API_KEY_PREFIX}abcdef0123456789`)).toBe(true);
+  });
+
+  it("rejects a string without the prefix, so a sprayed bearer token costs no lookup", () => {
+    // What a credential scanner actually sends: someone else's token format.
+    expect(looksLikeApiKey("sk-live-4eC39HqLyjWDarjtT1zdp7dc")).toBe(false);
+    expect(looksLikeApiKey("ghp_16C7e42F292c6912E7710c838347Ae178B4a")).toBe(false);
+    expect(looksLikeApiKey("")).toBe(false);
+  });
+
+  it("is case-sensitive — the prefix is a literal, not a scheme name", () => {
+    // Unlike the `Bearer` scheme (RFC 7235 makes that case-insensitive), the
+    // prefix is part of the secret's bytes: better-auth hashes the whole
+    // string, so `PINCHY_x` would never verify anyway. Accepting it here would
+    // only buy the attacker back the database lookup.
+    expect(looksLikeApiKey("PINCHY_abcdef0123456789")).toBe(false);
+  });
+
+  it("rejects a prefix that merely appears somewhere in the string", () => {
+    expect(looksLikeApiKey(`junk${API_KEY_PREFIX}abcdef`)).toBe(false);
+  });
+
+  it("does not accept the bare prefix with nothing after it", () => {
+    expect(looksLikeApiKey(API_KEY_PREFIX)).toBe(false);
+  });
+
+  it("keeps the prefix Pinchy has always issued", () => {
+    // Not decoration: every key ever minted carries this, and the reference
+    // documents it as a promise ("Keys are always prefixed `pinchy_`"). A
+    // change here invalidates every key in every deployment at once.
+    expect(API_KEY_PREFIX).toBe("pinchy_");
+  });
+});

--- a/packages/web/src/__tests__/lib/with-api-key.test.ts
+++ b/packages/web/src/__tests__/lib/with-api-key.test.ts
@@ -358,6 +358,73 @@ describe("withApiKey", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  // ── Shape check before verification ─────────────────────────────────────
+  //
+  // The invalid-key limiter bounds the RESPONSE, not the work: `verifyApiKey`
+  // runs one line above `denyInvalidApiKeyAttempt`, so before this check every
+  // sprayed string bought a hash and a database round trip whether or not the
+  // caller's IP had any budget left.
+
+  it("rejects a key of the wrong shape without paying for verification", async () => {
+    const handler = vi.fn(OK);
+
+    const res = await withApiKey(["agents:read"], handler)(
+      // What a credential scanner actually sprays at a public endpoint:
+      // somebody else's token format.
+      reqWith({ Authorization: "Bearer sk-live-4eC39HqLyjWDarjtT1zdp7dc" }),
+      {}
+    );
+
+    expect(res.status).toBe(401);
+    // The assertion that matters. Dropping the check would fail no other test
+    // in this file: every one of them would still answer 401 — just after the
+    // round trip this exists to avoid.
+    expect(mockVerifyApiKey).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("still charges a wrongly shaped key to the invalid-attempt budget", async () => {
+    // The load-bearing one. Answering a bare 401 here would be cheaper AND a
+    // regression: a wrongly shaped key would then never trip the per-IP
+    // limiter, so spraying `sk-live-…` forever would cost an attacker nothing
+    // and leave no `auth.rate_limited` row. Skipping verification must not
+    // mean skipping the accounting.
+    const spray = () =>
+      withApiKey(["agents:read"], vi.fn(OK))(
+        reqWith({ Authorization: "Bearer ghp_notours", "x-forwarded-for": "9.9.9.9" }),
+        {}
+      );
+
+    for (let i = 0; i < INVALID_API_KEY_RATE_LIMIT_MAX_ATTEMPTS; i++) {
+      expect((await spray()).status).toBe(401);
+    }
+
+    const throttled = await spray();
+
+    expect(throttled.status).toBe(429);
+    expect(throttled.headers.get("Retry-After")).toBe(
+      String(INVALID_API_KEY_RATE_LIMIT_WINDOW_MS / 1000)
+    );
+    // Never verified, all 21 times.
+    expect(mockVerifyApiKey).not.toHaveBeenCalled();
+  });
+
+  it("still verifies a correctly shaped key — the filter must not become the gate", async () => {
+    mockVerifyApiKey.mockResolvedValue(verified({ permissions: { agents: ["read"] } }));
+    const handler = vi.fn(OK);
+
+    const res = await withApiKey(["agents:read"], handler)(
+      reqWith({ Authorization: "Bearer pinchy_correctly_shaped" }),
+      {}
+    );
+
+    // The check says a string is NOT one of ours, never that it is.
+    // A well-formed string still has to verify.
+    expect(mockVerifyApiKey).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
   // ── Auditing denials (#572) ─────────────────────────────────────────────
 
   it("audits a scope denial with the key as actor and what it tried to do", async () => {
@@ -455,13 +522,13 @@ describe("withApiKey", () => {
     mockVerifyApiKey.mockResolvedValue(
       verified({ id: "key-noisy", name: "Noisy", permissions: { agents: ["read"] } })
     );
-    await withApiKey(["agents:delete"], handler)(reqWith({ Authorization: "Bearer a" }), {});
-    await withApiKey(["agents:delete"], handler)(reqWith({ Authorization: "Bearer a" }), {});
+    await withApiKey(["agents:delete"], handler)(reqWith({ Authorization: "Bearer pinchy_a" }), {});
+    await withApiKey(["agents:delete"], handler)(reqWith({ Authorization: "Bearer pinchy_a" }), {});
 
     mockVerifyApiKey.mockResolvedValue(
       verified({ id: "key-other", name: "Other", permissions: { agents: ["read"] } })
     );
-    await withApiKey(["agents:delete"], handler)(reqWith({ Authorization: "Bearer b" }), {});
+    await withApiKey(["agents:delete"], handler)(reqWith({ Authorization: "Bearer pinchy_b" }), {});
 
     // A shared window would let a flood from one key swallow the first — and
     // only — denial from another. Two keys, two rows.

--- a/packages/web/src/lib/api-auth.ts
+++ b/packages/web/src/lib/api-auth.ts
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { getSession, auth, type Session } from "@/lib/auth";
 import { extractScopes, type ApiKeyScope } from "@/lib/api-key-scopes";
 import { appendAuditLog, safeAuditPath } from "@/lib/audit";
+import { looksLikeApiKey } from "@/lib/api-key-format";
 import {
   tryAcquireApiKeySlot,
   claimApiKeyRateLimitAuditSlot,
@@ -336,6 +337,18 @@ export function withApiKey<C = unknown>(
   return async (req: NextRequest, ctx: C): Promise<NextResponse> => {
     const key = readApiKey(req);
     if (!key) return denyInvalidApiKeyAttempt(req);
+
+    // Cheap shape check before the expensive one. `verifyApiKey` below hashes
+    // the candidate and does a database lookup, and it runs BEFORE the
+    // invalid-attempt limiter gets to say anything — so that limiter bounds
+    // the 429s and the audit rows, not the work. Without this line every
+    // sprayed `sk-live-…` bought a hash and a round trip, budget or no budget.
+    //
+    // Routed through `denyInvalidApiKeyAttempt` rather than a bare 401 on
+    // purpose: skipping verification must not also skip the accounting, or a
+    // wrongly shaped key would be the one attempt that never trips the per-IP
+    // limiter. Same response, same audit trail — just no round trip.
+    if (!looksLikeApiKey(key)) return denyInvalidApiKeyAttempt(req);
 
     // Fail closed: `verifyApiKey` catches internally today, but a malformed
     // input or a future plugin version must never fall through as

--- a/packages/web/src/lib/api-key-format.ts
+++ b/packages/web/src/lib/api-key-format.ts
@@ -1,0 +1,51 @@
+/**
+ * The shape of a Pinchy API key, in one place.
+ *
+ * This module exists so the prefix is a single constant rather than two
+ * strings that happen to agree: `auth.ts` hands it to the plugin as
+ * `defaultPrefix` (which is what actually mints keys), and `withApiKey` uses
+ * it to reject a candidate before paying for verification. Were those to
+ * drift, the filter would start rejecting valid keys — an outage across the
+ * whole API, caused by a check that was meant to be free.
+ */
+
+/**
+ * Every key Pinchy issues is `pinchy_<random>`.
+ *
+ * Guaranteed rather than conventional: `/api/settings/api-keys` is the only
+ * path that mints a key (the plugin's own `/api-key/*` endpoints are answered
+ * 404 for client requests, see the `hooks.before` guard in auth.ts), and it
+ * passes no `prefix`, so every key falls through to `defaultPrefix`.
+ *
+ * It is also a documented promise — the Agent Provisioning API reference says
+ * keys are always prefixed this way so they're recognizable in logs, shell
+ * history and secret scanners. Changing it invalidates every key in every
+ * deployment at once.
+ */
+export const API_KEY_PREFIX = "pinchy_";
+
+/**
+ * Whether `candidate` could be a Pinchy key at all.
+ *
+ * Deliberately a shape check and nothing more — it says a string is not one of
+ * ours, never that it is. Verification stays with `auth.api.verifyApiKey`.
+ *
+ * The point is what it saves: verification hashes the candidate and does a
+ * database lookup, and `/api/v1/*` is reachable by anyone. This turns the
+ * traffic that pays for none of that — scanners spraying other products'
+ * token formats — into a string comparison.
+ *
+ * It is a complement to `tryAcquireInvalidApiKeyIpSlot`
+ * (lib/api-key-rate-limiter.ts), not a substitute, and the division of labour
+ * is worth stating: that limiter bounds how many invalid attempts an address
+ * gets an ANSWER for, but it is consulted after `verifyApiKey` has already
+ * run, so it never bounded the work. This bounds the work and bounds nothing
+ * else — a caller who knows the prefix still reaches the lookup, and the
+ * per-IP limiter is what covers them.
+ *
+ * Leaks nothing: the prefix is published in the docs, so a timing difference
+ * between "wrong shape" and "wrong key" tells an attacker what they read.
+ */
+export function looksLikeApiKey(candidate: string): boolean {
+  return candidate.length > API_KEY_PREFIX.length && candidate.startsWith(API_KEY_PREFIX);
+}

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -8,6 +8,7 @@ import bcrypt from "bcryptjs";
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { appendAuditLog, redactEmail } from "@/lib/audit";
+import { API_KEY_PREFIX } from "@/lib/api-key-format";
 import { SIGN_IN_RATE_LIMIT_WINDOW_SECONDS } from "@/lib/auth-rate-limit";
 import { getCachedDomain } from "@/lib/domain";
 import { shouldUseSecureCookies } from "@/lib/secure-cookies";
@@ -238,7 +239,11 @@ export const auth = betterAuth({
       // decision, not two.
       enableSessionForAPIKeys: false,
       // One-time key format: `pinchy_<random>`.
-      defaultPrefix: "pinchy_",
+      // Shared with `looksLikeApiKey` (lib/api-key-format.ts), which rejects a
+      // candidate carrying anything else BEFORE paying for verification. One
+      // constant rather than two agreeing strings: a drift between them would
+      // reject every valid key at once.
+      defaultPrefix: API_KEY_PREFIX,
       // MUST stay longer than `defaultPrefix`. The plugin stores
       // `start = key.substring(0, charactersLength)` as the masked identifier,
       // and its default is 6 — one character SHORTER than `pinchy_`. Left
@@ -248,7 +253,7 @@ export const auth = betterAuth({
       // plaintext is shown once and never stored — so 7 for the prefix + 6 real
       // characters, matching the plugin's own intent for the field.
       // Locked in by auth-apikey.integration.test.ts, against a real key.
-      startingCharactersConfig: { charactersLength: "pinchy_".length + 6 },
+      startingCharactersConfig: { charactersLength: API_KEY_PREFIX.length + 6 },
       // Defaults to false. Pinchy stores exactly one thing here: the
       // `createdBy` provenance snapshot behind "whose key is this, and do we
       // rotate it now that they've left?" (lib/api-key-identity.ts). Never


### PR DESCRIPTION
Follow-up to #1086, which 8804fee7 closed. That change bounds how many invalid attempts an address gets an *answer* for. This one bounds the *work*.

## The gap

`withApiKey` verifies first and consults the limiter second:

```ts
if (!key) return denyInvalidApiKeyAttempt(req);
const res = await auth.api.verifyApiKey({ body: { key } }).catch(() => null);
if (!res?.valid || !res.key) return denyInvalidApiKeyAttempt(req);
```

`tryAcquireInvalidApiKeyIpSlot` runs inside `denyInvalidApiKeyAttempt` — one line *after* `verifyApiKey` has already hashed the candidate and hit the database. So the per-IP limit caps the 429s and the audit rows, not the round trips: an address with no budget left still costs a lookup per request, and always will.

On a public endpoint most of that traffic is credential scanners spraying other products' token formats — `sk-live-…`, `ghp_…`. None of those can be one of our keys, and saying so costs a string comparison.

## Why the prefix is safe to rely on

Every key Pinchy has issued starts with `pinchy_`. `/api/settings/api-keys` is the only creation path — the plugin's own `/api-key/*` endpoints are answered 404 by the `hooks.before` guard in `auth.ts` — and it passes no `prefix`, so every key falls through to `defaultPrefix`. The reference already documents it as a promise.

It's now **one** constant that `auth.ts` imports as `defaultPrefix`, rather than a second string that happens to agree. Drift there wouldn't degrade gracefully: it would reject every valid key in every deployment at once.

## The part worth reviewing

The check routes through `denyInvalidApiKeyAttempt`, **not** a bare 401. Skipping verification must not also skip the accounting — otherwise a wrongly shaped key becomes the one attempt that never trips the per-IP limiter and never writes an `auth.rate_limited` row, and spraying gets *cheaper* than it is today instead of more expensive.

The test that holds that line drives 21 malformed keys through the wrapper and expects the 21st to be `429` with the right `Retry-After`. The cheap assertion — `verifyApiKey` untouched — passes either way, which is exactly why it isn't the one to trust.

## Not in scope

The per-key budget stays hard-coded at 300/min. It's deliberately generous for the documented use case, nobody has hit it, and adding permanent config surface on a hunch would be guessing. If it ever does bite, the stricter invalid-key limit (20/min/IP) is the likelier culprit and a different knob.

## On the wire

Nothing changes: same 401, same 429, same audit rows, same `Retry-After`. Only the cost of saying no.

## Gates

`pnpm test` 11592 ✓ · `pnpm test:scripts` 1116 ✓ · `typecheck` ✓ · `lint` 0 errors · `format:check` ✓ · `pnpm build` ✓ · docs build + `check:anchors` + `check:rendered` + docs tests ✓