### PR TITLE
fix(api): close the agent existence oracle on the Automations routes

### DIFF
--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -158,7 +158,7 @@ For the full flow including BotFather setup and account linking, see [Set Up Tel
 
 The Automations tab is where an agent's **email workflows** live — standing rules that let the agent act on incoming mail on its own, without anyone opening a chat. A workflow pairs a deterministic **trigger** (which mail it fires on) with an **instruction** (what the agent does with each matching message). Pinchy checks the connected mailboxes on a schedule and runs the instruction once per new matching mail, tracking exactly which messages it has already handled so nothing is processed twice — and it never relies on the read/unread state you see in your own inbox.
 
-You'll see this tab on your personal Smithers and, as an admin, on shared agents that can read email. It's gated the same way the underlying API is: you can manage automations on a personal agent you own; admins can manage them on any agent, shared or personal.
+You'll see this tab on your personal Smithers and, as an admin, on shared agents that can read email. It's gated the same way the underlying API is: you can manage automations on a personal agent you own, and admins can manage them on any shared agent. A colleague's personal agent is nobody else's to manage — personal agents stay private to their owner, admins included.
 
 ### Create an automation
 

--- a/docs/src/content/docs/guides/email-automations.mdx
+++ b/docs/src/content/docs/guides/email-automations.mdx
@@ -87,7 +87,7 @@ Open **Audit Trail** in the sidebar after the first matching mail arrives and co
 The same rule as the underlying API:
 
 - **Members** can manage automations on a personal agent they own.
-- **Admins** can manage them on any agent.
+- **Admins** can manage them on any **shared** agent. A colleague's personal agent is not included: personal agents stay private to their owner, admins included.
 
 In practice automations live on shared agents, because that is where mailboxes can be connected — a personal Smithers has no integrations of its own. See [Integrations](/concepts/integrations/#integrations-are-admin-managed-and-attach-to-shared-agents).
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -299,7 +299,7 @@ Endpoints that gate on your access to an agent used to answer `403` when you ask
 This closes the last of it on the Automations endpoints. Two consequences if you drive the API directly:
 
 - `GET`/`POST /api/automations` and `GET /api/automations/connections` answer `404` for an agent you can't see, and keep `403` for one you can see but may not manage — a shared agent you chat with daily still says so plainly.
-- Admins reach automations on **shared** agents, not on a colleague's personal agent. The agent's settings page has answered `404` there since the same change; these routes were the last ones that didn't. An admin who already holds a workflow's ID can still disable or delete it through `PATCH`/`DELETE /api/automations/:id` — a runaway automation stays stoppable.
+- Admins reach automations on **shared** agents, not on a colleague's personal agent. Opening that agent's settings has failed the same way since the same change; these routes were the last ones that still answered. An admin who already holds a workflow's ID can still disable or delete it through `PATCH`/`DELETE /api/automations/:id` — a runaway automation stays stoppable.
 
 Nothing to configure, and nothing changes in the UI.
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -290,7 +290,18 @@ An agent with **Write files** permission can now turn tabular data it already ho
 
 #### Automations move into the agent
 
-Email workflows now have their own **Automations** tab in an agent's settings, where you can review, create, enable, disable and delete them. It is visible to admins on any agent, and to the owner of a personal agent. Existing workflows are listed as-is; nothing changes on upgrade until you edit one.
+Email workflows now have their own **Automations** tab in an agent's settings, where you can review, create, enable, disable and delete them. It is visible to admins on any shared agent, and to the owner of a personal agent. Existing workflows are listed as-is; nothing changes on upgrade until you edit one.
+
+#### An agent you may not see now answers "not found"
+
+Endpoints that gate on your access to an agent used to answer `403` when you asked about one you're not allowed to see. That told you the agent existed — which, for someone else's personal agent, is the one thing Pinchy withholds from everybody, admins included. They now answer `404`, with the same body an ID that was never issued gets.
+
+This closes the last of it on the Automations endpoints. Two consequences if you drive the API directly:
+
+- `GET`/`POST /api/automations` and `GET /api/automations/connections` answer `404` for an agent you can't see, and keep `403` for one you can see but may not manage — a shared agent you chat with daily still says so plainly.
+- Admins reach automations on **shared** agents, not on a colleague's personal agent. The agent's settings page has answered `404` there since the same change; these routes were the last ones that didn't. An admin who already holds a workflow's ID can still disable or delete it through `PATCH`/`DELETE /api/automations/:id` — a runaway automation stays stoppable.
+
+Nothing to configure, and nothing changes in the UI.
 
 #### Changing your password now signs you out on every other device
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -554,11 +554,13 @@ Scoped to the folders that agent is granted, exactly like search itself, so the 
 
 ## Automations
 
-Standing email workflows an agent runs on its own — see [the Automations tab](/concepts/agent-settings/#automations-tab). You can manage automations on a personal agent you own; admins can manage them on any agent.
+Standing email workflows an agent runs on its own — see [the Automations tab](/concepts/agent-settings/#automations-tab). You can manage automations on a personal agent you own; admins can manage them on any agent they can see, which is every shared agent. Someone else's **personal** agent is not one of them: personal agents stay private to their owner, admins included, and that rule wins here as it does everywhere else in Pinchy.
 
 The endpoints keyed by **`agentId`** ask two questions in order, and answer differently depending on which one you fail. Can you **see** the agent at all? If not — someone else's personal agent, or a restricted one outside your groups — you get a plain `404`, identical to an ID that was never issued, because any other answer would confirm the agent exists. If you can see it but may not **manage** its automations — the everyday case of a shared agent you chat with daily — you get `403`, which tells you nothing you did not already know and points you at an admin instead of at a typo.
 
 `PATCH` and `DELETE` are keyed by **workflow** id instead, and there a scope refusal is `404` too. The middle case has no equivalent: a workflow you may not manage is one you can never list either, since `GET /api/automations` is gated by the same rule. So `403` there would be the only way to learn that a workflow id is real.
+
+Being keyed by workflow id also gives these two a reach the `agentId` endpoints deliberately lack: an admin who already holds a workflow's id — from the [audit trail](/concepts/audit-trail/), which is where a runaway automation surfaces — can disable or delete it even on someone's personal agent. Standing autonomous authority has to stay stoppable. It grants no way to **find** such a workflow, only to act on one already known.
 
 ### `GET /api/automations?agentId=<agentId>`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -216,7 +216,7 @@ Get a single agent by ID.
 
 An agent you may not see answers `404` as well, with the same body — someone else's personal agent, or a restricted agent outside your groups, is deliberately indistinguishable from an ID that was never issued. This holds for admins too: nobody can list another user's personal agents, so nobody gets to confirm one exists.
 
-Every endpoint below that gates on **your access to the agent** answers the same way, over the WebSocket chat bridge as well as over HTTP. Two groups under this prefix do not, and it is worth knowing which: the admin-only management endpoints (`knowledge/*`, `integrations`, and connecting a Telegram bot) apply no visibility rule at all — they are restricted to admins and return `404` only when no agent has the ID. And `GET`/`POST /api/automations`, which is keyed by `agentId`, still answers `403` for an agent you may not manage.
+Every endpoint that gates on **your access to the agent** answers the same way, over the WebSocket chat bridge as well as over HTTP, and including the `agentId`-keyed [Automations endpoints](#automations). One group under this prefix does not, and it is worth knowing which: the admin-only management endpoints (`knowledge/*`, `integrations`, and connecting a Telegram bot) apply no visibility rule at all — they are restricted to admins and return `404` only when no agent has the ID.
 
 ### `PATCH /api/agents/:id`
 
@@ -556,7 +556,7 @@ Scoped to the folders that agent is granted, exactly like search itself, so the 
 
 Standing email workflows an agent runs on its own — see [the Automations tab](/concepts/agent-settings/#automations-tab). You can manage automations on a personal agent you own; admins can manage them on any agent.
 
-Every endpoint here answers `403` when what you asked for is outside your scope, and that deliberately differs from how a chat page answers. Opening an agent you may not see gives you a plain "not found", because a refusal there would tell you the agent exists. Automations refuse a scope you lack on an agent you can normally see and use, so they say so instead of pretending it is missing.
+Every endpoint here asks two questions in order, and answers differently depending on which one you fail. Can you **see** the agent at all? If not — someone else's personal agent, or a restricted one outside your groups — you get a plain `404`, identical to an ID that was never issued, because any other answer would confirm the agent exists. If you can see it but may not **manage** its automations — the everyday case of a shared agent you chat with daily — you get `403`, which tells you nothing you did not already know and points you at an admin instead of at a typo.
 
 ### `GET /api/automations?agentId=<agentId>`
 
@@ -566,8 +566,8 @@ List the agent's email workflows.
 
 - `400` — `agentId` is missing from the query string
 - `401` — not authenticated
-- `403` — the agent exists, but its automations are outside your scope: a shared agent is admin-only, and a personal agent's automations belong to its owner
-- `404` — no agent has that id
+- `403` — you can see the agent, but its automations are outside your scope: a shared agent is admin-only, and a personal agent's automations belong to its owner
+- `404` — no agent has that id, **or** you may not see the one that does
 
 ### `POST /api/automations`
 
@@ -592,8 +592,8 @@ Create a workflow. It is always created **disabled** and `pending`, whatever the
 
 - `400` — the body fails validation, or a requested connection is one the agent has no email **read** access to. The response names those connection ids; an id that doesn't exist lands here too, since it has no permission row either
 - `401` — not authenticated
-- `403` — you may not create a workflow on this agent (same scope rule as the list)
-- `404` — no agent has that id
+- `403` — you can see the agent but may not create a workflow on it (same scope rule as the list)
+- `404` — no agent has that id, **or** you may not see the one that does
 
 ### `PATCH /api/automations/:id`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -632,8 +632,8 @@ The email connections this agent can watch — what the create form offers in it
 
 - `400` — `agentId` is missing from the query string
 - `401` — not authenticated
-- `403` — the agent exists, but its automations are outside your scope
-- `404` — no agent has that id
+- `403` — you can see the agent, but its automations are outside your scope
+- `404` — no agent has that id, **or** you may not see the one that does
 
 ## Templates
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -556,7 +556,9 @@ Scoped to the folders that agent is granted, exactly like search itself, so the 
 
 Standing email workflows an agent runs on its own — see [the Automations tab](/concepts/agent-settings/#automations-tab). You can manage automations on a personal agent you own; admins can manage them on any agent.
 
-Every endpoint here asks two questions in order, and answers differently depending on which one you fail. Can you **see** the agent at all? If not — someone else's personal agent, or a restricted one outside your groups — you get a plain `404`, identical to an ID that was never issued, because any other answer would confirm the agent exists. If you can see it but may not **manage** its automations — the everyday case of a shared agent you chat with daily — you get `403`, which tells you nothing you did not already know and points you at an admin instead of at a typo.
+The endpoints keyed by **`agentId`** ask two questions in order, and answer differently depending on which one you fail. Can you **see** the agent at all? If not — someone else's personal agent, or a restricted one outside your groups — you get a plain `404`, identical to an ID that was never issued, because any other answer would confirm the agent exists. If you can see it but may not **manage** its automations — the everyday case of a shared agent you chat with daily — you get `403`, which tells you nothing you did not already know and points you at an admin instead of at a typo.
+
+`PATCH` and `DELETE` are keyed by **workflow** id instead, and there a scope refusal is `404` too. The middle case has no equivalent: a workflow you may not manage is one you can never list either, since `GET /api/automations` is gated by the same rule. So `403` there would be the only way to learn that a workflow id is real.
 
 ### `GET /api/automations?agentId=<agentId>`
 
@@ -609,8 +611,7 @@ Toggling to the state it already has is a no-op: still `200`, no audit entry —
 
 - `400` — the body has no boolean `enabled`
 - `401` — not authenticated
-- `403` — the workflow's agent is outside your scope
-- `404` — no workflow has that id. This endpoint addresses a workflow, not an agent, so a malformed id lands here as well: it definitionally matches nothing
+- `404` — no workflow has that id, **or** its agent is outside your scope. This endpoint addresses a workflow, not an agent, so a malformed id lands here as well: it definitionally matches nothing
 
 ### `DELETE /api/automations/:id`
 
@@ -621,8 +622,7 @@ Delete a workflow for good.
 **Errors:**
 
 - `401` — not authenticated
-- `403` — the workflow's agent is outside your scope
-- `404` — no workflow has that id (as with `PATCH`, a malformed id matches nothing)
+- `404` — no workflow has that id, **or** its agent is outside your scope (as with `PATCH`, a malformed id matches nothing)
 
 ### `GET /api/automations/connections?agentId=<agentId>`
 

--- a/packages/web/src/__tests__/api/automations-connections.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-connections.integration.test.ts
@@ -201,6 +201,9 @@ describe("GET /api/automations/connections", () => {
     const denied = await GET(req(agent.id), routeContext());
     const missing = await GET(req("no-such-agent"), routeContext());
 
+    // Pinned explicitly, not only compared: two equal statuses prove the oracle
+    // closed only once we know WHICH status they agree on.
+    expect(denied.status).toBe(404);
     expect(denied.status).toBe(missing.status);
     expect(await denied.json()).toEqual(await missing.json());
   });

--- a/packages/web/src/__tests__/api/automations-connections.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-connections.integration.test.ts
@@ -13,8 +13,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { db } from "@/db";
 import { agents, users, agentConnectionPermissions, integrationConnections } from "@/db/schema";
 import { makeNextRequest, routeContext } from "@/test-helpers/route";
+import type { AgentVisibility } from "@/db/enums";
 
-const { getSessionMock } = vi.hoisted(() => ({ getSessionMock: vi.fn() }));
+const { getSessionMock, licenseStateMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  licenseStateMock: vi.fn(),
+}));
 
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
@@ -22,6 +26,16 @@ vi.mock("next/headers", () => ({
 vi.mock("@/lib/auth", () => ({
   getSession: getSessionMock,
   auth: { api: { getSession: getSessionMock } },
+}));
+
+// Only the license STATE is replaced. The visibility half of the access gate is
+// live only on a LICENSED instance — a community instance maps "restricted" to
+// "all" (agent-access.effectiveVisibility) — so a suite that inherited the state
+// could not tell a visibility denial from a scope denial, and would stay green
+// whichever one the route produced.
+vi.mock("@/lib/enterprise", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/enterprise")>()),
+  getLicenseState: licenseStateMock,
 }));
 
 const { GET } = await import("@/app/api/automations/connections/route");
@@ -40,7 +54,15 @@ function asAdmin(id: string) {
 async function seedUser(id: string, role: "member" | "admin" = "member") {
   await db.insert(users).values({ id, name: id, email: `${id}@test.com`, role });
 }
-async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) {
+// `visibility` is spelled out by every case whose answer depends on it, rather
+// than inherited from the column default — the default IS "restricted", and a
+// test whose meaning turns on that is a test that reads as the opposite of what
+// it pins.
+async function seedAgent(opts: {
+  isPersonal: boolean;
+  ownerId: string | null;
+  visibility?: AgentVisibility;
+}) {
   const [row] = await db
     .insert(agents)
     .values({
@@ -49,6 +71,7 @@ async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) 
       greetingMessage: "Hi",
       isPersonal: opts.isPersonal,
       ownerId: opts.ownerId,
+      ...(opts.visibility ? { visibility: opts.visibility } : {}),
     })
     .returning();
   return row;
@@ -74,6 +97,7 @@ function req(agentId?: string) {
 describe("GET /api/automations/connections", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    licenseStateMock.mockResolvedValue("paid");
     await seedUser(OWNER);
     await seedUser(OTHER);
     await seedUser(ADMIN, "admin");
@@ -142,22 +166,43 @@ describe("GET /api/automations/connections", () => {
     ]);
   });
 
-  it("forbids a member from listing a shared agent's connections", async () => {
+  it("forbids a member from listing the connections of a shared agent they CAN see", async () => {
+    // visibility "all" on purpose: the member can see this agent, so the 403
+    // pins the SCOPE rule and nothing else.
     asMember(OWNER);
-    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "all" });
     const res = await GET(req(agent.id), routeContext());
     expect(res.status).toBe(403);
     // Read-side default wording from the shared gate (#1087).
     expect(await res.json()).toEqual({ error: "You do not have access to this agent" });
   });
 
-  it("forbids a member from listing another user's personal agent's connections", async () => {
-    // Coverage for the ownerId leg of canManageAgentWorkflows: personal, but
-    // owned by someone else — a member must not see its mailboxes.
+  it("answers 404 for another user's personal agent — never confirms it exists", async () => {
+    // Personal, owned by someone else: hidden from every caller, admins
+    // included, so a 403 would disclose the one thing nothing else in the
+    // product does — that this id is a real agent (#880).
     asMember(OTHER);
     const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
     const res = await GET(req(agent.id), routeContext());
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
+  });
+
+  it("answers 404 for a restricted shared agent outside the member's groups", async () => {
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "restricted" });
+    const res = await GET(req(agent.id), routeContext());
+    expect(res.status).toBe(404);
+  });
+
+  it("answers an agent it may not see byte-identically to one that does not exist", async () => {
+    asMember(OTHER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+
+    const denied = await GET(req(agent.id), routeContext());
+    const missing = await GET(req("no-such-agent"), routeContext());
+
+    expect(denied.status).toBe(missing.status);
+    expect(await denied.json()).toEqual(await missing.json());
   });
 
   it("lets an admin list a shared agent's connections", async () => {

--- a/packages/web/src/__tests__/api/automations-create.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-create.integration.test.ts
@@ -15,6 +15,12 @@
 //   - @/lib/audit-deferred.deferAuditLog — a thin next/after wrapper whose
 //     callback does not run under a direct handler call; we assert the payload
 //     it was handed instead of round-tripping through `after()`.
+//   - @/lib/enterprise.getLicenseState — the visibility half of the access gate
+//     is only LIVE on a licensed instance: a community instance maps
+//     "restricted" to "all" (agent-access.effectiveVisibility), so a suite that
+//     left this unmocked could not tell a visibility denial from a scope denial
+//     and would stay green whichever one the route produced. "paid" is the state
+//     a paying customer runs in, and the one where these answers matter.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 
@@ -28,10 +34,12 @@ import {
   integrationConnections,
 } from "@/db/schema";
 import { makeNextRequest, routeContext } from "@/test-helpers/route";
+import type { AgentVisibility } from "@/db/enums";
 
-const { getSessionMock, deferAuditLogMock } = vi.hoisted(() => ({
+const { getSessionMock, deferAuditLogMock, licenseStateMock } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   deferAuditLogMock: vi.fn(),
+  licenseStateMock: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({
@@ -45,6 +53,13 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/audit-deferred", () => ({
   deferAuditLog: (...args: unknown[]) => deferAuditLogMock(...args),
+}));
+
+// Only the license STATE is replaced; the rest of the module stays real so
+// nothing else in the route's graph silently loses behavior.
+vi.mock("@/lib/enterprise", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/enterprise")>()),
+  getLicenseState: licenseStateMock,
 }));
 
 // Imported after the mocks are registered.
@@ -65,7 +80,15 @@ async function seedUser(id: string, role: "member" | "admin" = "member") {
   await db.insert(users).values({ id, name: id, email: `${id}@test.com`, role });
 }
 
-async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) {
+// `visibility` is spelled out by every case whose answer depends on it, rather
+// than inherited from the column default — the default IS "restricted", and a
+// test whose meaning turns on that is a test that reads as the opposite of what
+// it pins.
+async function seedAgent(opts: {
+  isPersonal: boolean;
+  ownerId: string | null;
+  visibility?: AgentVisibility;
+}) {
   const [row] = await db
     .insert(agents)
     .values({
@@ -74,6 +97,7 @@ async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) 
       greetingMessage: "Hi",
       isPersonal: opts.isPersonal,
       ownerId: opts.ownerId,
+      ...(opts.visibility ? { visibility: opts.visibility } : {}),
     })
     .returning();
   return row;
@@ -117,6 +141,7 @@ async function loadWorkflows(agentId: string) {
 describe("POST /api/automations — create email workflow", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    licenseStateMock.mockResolvedValue("paid");
     // agents.owner_id and email_workflows.created_by both FK to user.id, so the
     // actors must exist before any agent/workflow references them.
     await seedUser(OWNER);
@@ -177,9 +202,12 @@ describe("POST /api/automations — create email workflow", () => {
     });
   });
 
-  it("forbids a member from creating a workflow on a shared agent (admin-only scope)", async () => {
+  it("forbids a member from creating a workflow on a shared agent they CAN see (admin-only scope)", async () => {
+    // visibility "all" on purpose: the member can see this agent, so the 403
+    // pins the SCOPE rule and nothing else. Left restricted, the very same 403
+    // would also be produced by a route that had no scope gate at all.
     asMember(OWNER);
-    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "all" });
     await seedConnection("conn-shared");
     await grantEmailPermission(agent.id, "conn-shared");
 
@@ -196,15 +224,47 @@ describe("POST /api/automations — create email workflow", () => {
     expect(deferAuditLogMock).not.toHaveBeenCalled();
   });
 
-  it("forbids a member from creating a workflow on someone else's personal agent", async () => {
+  it("answers 404 for someone else's personal agent — never confirms it exists", async () => {
+    // Nobody can enumerate another user's personal agents — getVisibleAgents
+    // withholds them from every caller, admins included — so a 403 here would
+    // disclose the one thing the rest of the product refuses to: that this id is
+    // a real agent.
     asMember(OTHER);
     const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
     await seedConnection("conn-x");
     await grantEmailPermission(agent.id, "conn-x");
 
     const res = await POST(postBody(validBody(agent.id, "conn-x")), routeContext());
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
     expect(await loadWorkflows(agent.id)).toHaveLength(0);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("answers 404 for a restricted shared agent outside the member's groups", async () => {
+    // The other half of "cannot see". Only live on a LICENSED instance: a
+    // community instance maps "restricted" to "all", which is why this suite
+    // pins the license state rather than inheriting it.
+    asMember(OWNER);
+    const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "restricted" });
+    await seedConnection("conn-restricted");
+    await grantEmailPermission(agent.id, "conn-restricted");
+
+    const res = await POST(postBody(validBody(agent.id, "conn-restricted")), routeContext());
+    expect(res.status).toBe(404);
+    expect(await loadWorkflows(agent.id)).toHaveLength(0);
+  });
+
+  it("answers an agent it may not see byte-identically to one that does not exist", async () => {
+    // The oracle is closed by the two answers being the SAME, not by both merely
+    // being 404 — a divergent body re-opens what an equal status closed.
+    asMember(OTHER);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+
+    const denied = await POST(postBody(validBody(agent.id, "conn-any")), routeContext());
+    const missing = await POST(postBody(validBody("no-such-agent", "conn-any")), routeContext());
+
+    expect(denied.status).toBe(missing.status);
+    expect(await denied.json()).toEqual(await missing.json());
   });
 
   it("lets an admin create a workflow on a shared agent", async () => {

--- a/packages/web/src/__tests__/api/automations-create.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-create.integration.test.ts
@@ -252,6 +252,30 @@ describe("POST /api/automations — create email workflow", () => {
     const res = await POST(postBody(validBody(agent.id, "conn-restricted")), routeContext());
     expect(res.status).toBe(404);
     expect(await loadWorkflows(agent.id)).toHaveLength(0);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("answers 404 to an ADMIN for someone else's personal agent", async () => {
+    // The admin-visible consequence of running the read gate first, and it is a
+    // deliberate narrowing rather than a side effect (#880): `assertAgentAccess`
+    // holds personal agents private to their owner *including admins* — its own
+    // comment says the admin fast-path must not bypass it — while
+    // `canManageAgentWorkflows` returns true for any admin on any agent. The
+    // Automations API was the one place those two rules met, and it used to
+    // resolve them the other way, granting admins a reach into a colleague's
+    // private agent that no other agent-scoped surface gives them.
+    //
+    // The emergency capability survives one route down: an admin holding a
+    // WORKFLOW id can still stop it (automations-manage.integration.test.ts).
+    asAdmin(ADMIN);
+    const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+    await seedConnection("conn-admin-personal");
+    await grantEmailPermission(agent.id, "conn-admin-personal");
+
+    const res = await POST(postBody(validBody(agent.id, "conn-admin-personal")), routeContext());
+    expect(res.status).toBe(404);
+    expect(await loadWorkflows(agent.id)).toHaveLength(0);
+    expect(deferAuditLogMock).not.toHaveBeenCalled();
   });
 
   it("answers an agent it may not see byte-identically to one that does not exist", async () => {
@@ -263,6 +287,11 @@ describe("POST /api/automations — create email workflow", () => {
     const denied = await POST(postBody(validBody(agent.id, "conn-any")), routeContext());
     const missing = await POST(postBody(validBody("no-such-agent", "conn-any")), routeContext());
 
+    // Pinned explicitly, not just compared: "conn-any" is deliberately unseeded,
+    // so a route that checked connections BEFORE the agent would answer 400 to
+    // both and satisfy the comparison while asserting nothing about the oracle.
+    // Symmetric blindness reads exactly like agreement.
+    expect(denied.status).toBe(404);
     expect(denied.status).toBe(missing.status);
     expect(await denied.json()).toEqual(await missing.json());
   });

--- a/packages/web/src/__tests__/api/automations-manage.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-manage.integration.test.ts
@@ -276,9 +276,16 @@ describe("Automations management API", () => {
       expect(deferAuditLogMock).not.toHaveBeenCalled();
     });
 
-    it("forbids a member from toggling a shared agent's workflow", async () => {
+    it("answers 404 for a shared agent's workflow — even when the agent is visible", async () => {
+      // The verdict for this route differs from the agent-keyed ones, and the
+      // visible agent is what makes the difference visible: there, a 403 is
+      // honest because the caller has already been told the agent exists. Here
+      // the resource is the WORKFLOW, and nobody who fails this scope gate can
+      // enumerate workflows at all — GET /api/automations is gated by the very
+      // same predicate. So any distinguishable answer discloses that this
+      // workflow id is real (#880).
       asMember(OWNER);
-      const agent = await seedAgent({ isPersonal: false, ownerId: null });
+      const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "all" });
       const wf = await seedWorkflow(agent.id, { enabled: false });
 
       const res = await PATCH(
@@ -288,8 +295,35 @@ describe("Automations management API", () => {
         }),
         routeContext({ id: wf.id })
       );
-      expect(res.status).toBe(403);
+      expect(res.status).toBe(404);
       expect((await loadWorkflow(wf.id)).enabled).toBe(false);
+    });
+
+    it("answers a workflow it may not manage exactly as one that does not exist", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "all" });
+      const wf = await seedWorkflow(agent.id, { enabled: false });
+
+      const denied = await PATCH(
+        req(`http://localhost/api/automations/${wf.id}`, {
+          method: "PATCH",
+          body: { enabled: true },
+        }),
+        routeContext({ id: wf.id })
+      );
+      // A real uuid that matches no row — not a malformed id, which the route
+      // short-circuits on shape alone and would prove nothing here.
+      const ghost = "00000000-0000-4000-8000-000000000000";
+      const missing = await PATCH(
+        req(`http://localhost/api/automations/${ghost}`, {
+          method: "PATCH",
+          body: { enabled: true },
+        }),
+        routeContext({ id: ghost })
+      );
+
+      expect(denied.status).toBe(missing.status);
+      expect(await denied.json()).toEqual(await missing.json());
     });
 
     it("returns 404 for an unknown workflow", async () => {
@@ -335,16 +369,31 @@ describe("Automations management API", () => {
       expect(entry.detail.name).toBe("Reject me");
     });
 
-    it("forbids a member from deleting a shared agent's workflow", async () => {
+    it("answers 404 for a shared agent's workflow — even when the agent is visible", async () => {
       asMember(OWNER);
-      const agent = await seedAgent({ isPersonal: false, ownerId: null });
+      const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "all" });
       const wf = await seedWorkflow(agent.id);
 
       const res = await DELETE(
         req(`http://localhost/api/automations/${wf.id}`, { method: "DELETE" }),
         routeContext({ id: wf.id })
       );
-      expect(res.status).toBe(403);
+      expect(res.status).toBe(404);
+      // The refusal is a refusal, not just a quieter status.
+      expect(await loadWorkflow(wf.id)).toBeDefined();
+      expect(deferAuditLogMock).not.toHaveBeenCalled();
+    });
+
+    it("answers 404 for a workflow on someone else's personal agent", async () => {
+      asMember(OTHER);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      const wf = await seedWorkflow(agent.id);
+
+      const res = await DELETE(
+        req(`http://localhost/api/automations/${wf.id}`, { method: "DELETE" }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(404);
       expect(await loadWorkflow(wf.id)).toBeDefined();
     });
 

--- a/packages/web/src/__tests__/api/automations-manage.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-manage.integration.test.ts
@@ -20,10 +20,12 @@ import {
   integrationConnections,
 } from "@/db/schema";
 import { makeNextRequest, routeContext } from "@/test-helpers/route";
+import type { AgentVisibility } from "@/db/enums";
 
-const { getSessionMock, deferAuditLogMock } = vi.hoisted(() => ({
+const { getSessionMock, deferAuditLogMock, licenseStateMock } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   deferAuditLogMock: vi.fn(),
+  licenseStateMock: vi.fn(),
 }));
 
 vi.mock("next/headers", () => ({
@@ -35,6 +37,16 @@ vi.mock("@/lib/auth", () => ({
 }));
 vi.mock("@/lib/audit-deferred", () => ({
   deferAuditLog: (...args: unknown[]) => deferAuditLogMock(...args),
+}));
+
+// Only the license STATE is replaced. The visibility half of the access gate is
+// live only on a LICENSED instance — a community instance maps "restricted" to
+// "all" (agent-access.effectiveVisibility) — so a suite that inherited the state
+// could not tell a visibility denial from a scope denial, and would stay green
+// whichever one the route produced. This suite was in exactly that position.
+vi.mock("@/lib/enterprise", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/enterprise")>()),
+  getLicenseState: licenseStateMock,
 }));
 
 const { GET } = await import("@/app/api/automations/route");
@@ -54,7 +66,15 @@ function asAdmin(id: string) {
 async function seedUser(id: string, role: "member" | "admin" = "member") {
   await db.insert(users).values({ id, name: id, email: `${id}@test.com`, role });
 }
-async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) {
+// `visibility` is spelled out by every case whose answer depends on it, rather
+// than inherited from the column default — the default IS "restricted", and a
+// test whose meaning turns on that is a test that reads as the opposite of what
+// it pins.
+async function seedAgent(opts: {
+  isPersonal: boolean;
+  ownerId: string | null;
+  visibility?: AgentVisibility;
+}) {
   const [row] = await db
     .insert(agents)
     .values({
@@ -63,6 +83,7 @@ async function seedAgent(opts: { isPersonal: boolean; ownerId: string | null }) 
       greetingMessage: "Hi",
       isPersonal: opts.isPersonal,
       ownerId: opts.ownerId,
+      ...(opts.visibility ? { visibility: opts.visibility } : {}),
     })
     .returning();
   return row;
@@ -111,6 +132,7 @@ async function loadWorkflow(id: string) {
 describe("Automations management API", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    licenseStateMock.mockResolvedValue("paid");
     await seedUser(OWNER);
     await seedUser(OTHER);
     await seedUser(ADMIN, "admin");
@@ -140,9 +162,13 @@ describe("Automations management API", () => {
       });
     });
 
-    it("forbids a member from listing a shared agent's workflows", async () => {
+    it("forbids a member from listing the workflows of a shared agent they CAN see", async () => {
+      // visibility "all" on purpose: the member can see this agent, so the 403
+      // pins the SCOPE rule and nothing else. Left restricted, the very same 403
+      // would also be produced by a route that had no scope gate at all — which
+      // is the shape this suite was in before the license state was pinned.
       asMember(OWNER);
-      const agent = await seedAgent({ isPersonal: false, ownerId: null });
+      const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "all" });
       const res = await GET(
         req(`http://localhost/api/automations?agentId=${agent.id}`),
         routeContext()
@@ -151,6 +177,46 @@ describe("Automations management API", () => {
       // The read-side wording, which the shared gate supplies as its default
       // (#1087) — the create route deliberately overrides it.
       expect(await res.json()).toEqual({ error: "You do not have access to this agent" });
+    });
+
+    it("answers 404 for someone else's personal agent — never confirms it exists", async () => {
+      // Nobody can enumerate another user's personal agents (getVisibleAgents
+      // withholds them from admins too), so a 403 would disclose the one thing
+      // the rest of the product refuses to (#880).
+      asMember(OTHER);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      const res = await GET(
+        req(`http://localhost/api/automations?agentId=${agent.id}`),
+        routeContext()
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("answers 404 for a restricted shared agent outside the member's groups", async () => {
+      asMember(OWNER);
+      const agent = await seedAgent({ isPersonal: false, ownerId: null, visibility: "restricted" });
+      const res = await GET(
+        req(`http://localhost/api/automations?agentId=${agent.id}`),
+        routeContext()
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("answers an agent it may not see byte-identically to one that does not exist", async () => {
+      asMember(OTHER);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+
+      const denied = await GET(
+        req(`http://localhost/api/automations?agentId=${agent.id}`),
+        routeContext()
+      );
+      const missing = await GET(
+        req(`http://localhost/api/automations?agentId=ghost`),
+        routeContext()
+      );
+
+      expect(denied.status).toBe(missing.status);
+      expect(await denied.json()).toEqual(await missing.json());
     });
 
     it("requires an agentId query parameter", async () => {

--- a/packages/web/src/__tests__/api/automations-manage.integration.test.ts
+++ b/packages/web/src/__tests__/api/automations-manage.integration.test.ts
@@ -215,8 +215,27 @@ describe("Automations management API", () => {
         routeContext()
       );
 
+      // Pinned explicitly, not only compared: two equal statuses prove the
+      // oracle closed only once we know WHICH status they agree on.
+      expect(denied.status).toBe(404);
       expect(denied.status).toBe(missing.status);
       expect(await denied.json()).toEqual(await missing.json());
+    });
+
+    it("answers 404 to an ADMIN for someone else's personal agent", async () => {
+      // A deliberate narrowing, not a side effect (#880). `assertAgentAccess`
+      // holds personal agents private to their owner *including admins*, while
+      // `canManageAgentWorkflows` admits any admin anywhere; the Automations API
+      // was where the two met, and it used to resolve them the other way.
+      // Running the read gate first settles it the way every other agent-scoped
+      // surface already does.
+      asAdmin(ADMIN);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      const res = await GET(
+        req(`http://localhost/api/automations?agentId=${agent.id}`),
+        routeContext()
+      );
+      expect(res.status).toBe(404);
     });
 
     it("requires an agentId query parameter", async () => {
@@ -395,6 +414,31 @@ describe("Automations management API", () => {
       );
       expect(res.status).toBe(404);
       expect(await loadWorkflow(wf.id)).toBeDefined();
+      expect(deferAuditLogMock).not.toHaveBeenCalled();
+    });
+
+    it("still lets an admin stop a workflow on someone else's personal agent", async () => {
+      // The other half of the #880 narrowing, and the reason it is a narrowing
+      // rather than a revocation: the agentId-keyed routes now answer 404 to an
+      // admin for a colleague's private agent, but a workflow is standing
+      // autonomous authority, and one that misbehaves must stay stoppable by
+      // someone. This route is keyed by WORKFLOW id and gates on
+      // `canManageAgentWorkflows` alone, so an admin who already holds the id —
+      // from the audit trail, which is where they would learn of a runaway
+      // workflow — can still delete it.
+      //
+      // That asymmetry is deliberate: it grants no way to FIND the workflow, so
+      // it adds no enumeration, only the ability to act on one already known.
+      asAdmin(ADMIN);
+      const agent = await seedAgent({ isPersonal: true, ownerId: OWNER });
+      const wf = await seedWorkflow(agent.id);
+
+      const res = await DELETE(
+        req(`http://localhost/api/automations/${wf.id}`, { method: "DELETE" }),
+        routeContext({ id: wf.id })
+      );
+      expect(res.status).toBe(200);
+      expect(await loadWorkflow(wf.id)).toBeUndefined();
     });
 
     it("lets an admin delete a shared agent's workflow", async () => {

--- a/packages/web/src/__tests__/lib/email-workflows/resolve-agent.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/resolve-agent.test.ts
@@ -2,20 +2,35 @@
  * Unit tests for the shared Automations agent-scope gate.
  *
  * `canManageAgentWorkflows` (authz.test.ts) is the rule; this is the HTTP
- * preamble wrapped around it — load, 404, gate, 403 — which three routes used
- * to carry as their own copy (#1087).
+ * preamble wrapped around it — read gate, then scope gate, then 403 — which
+ * three routes used to carry as their own copy (#1087).
  *
  * The 403 wording gets its own cases on purpose. Collapsing the copies turned
  * user-visible copy into a defaulted parameter, so the drift this refactor
  * newly makes possible is a caller that omits the third argument and silently
  * downgrades "you may not create a workflow" to "you have no access". The
  * route-level counterpart lives in automations-create.integration.test.ts.
+ *
+ * `getAgentWithAccess` is mocked so the two layers can be driven apart; its own
+ * behaviour (what it answers for a hidden agent) is pinned in
+ * agent-access.test.ts, and the two composed for real in the three
+ * automations-*.integration.test.ts suites. `assertAgentAccess` stays REAL —
+ * the visibility facts these cases rest on must not become fiction.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
 
+const { getAgentWithAccessMock } = vi.hoisted(() => ({ getAgentWithAccessMock: vi.fn() }));
+
+// Mocked so no test here opens a real connection at import time — agent-access
+// imports @/db, and importOriginal below pulls the real module in.
 vi.mock("@/db", () => ({ db: { select: vi.fn() } }));
 
-import { db } from "@/db";
+vi.mock("@/lib/agent-access", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/agent-access")>()),
+  getAgentWithAccess: getAgentWithAccessMock,
+}));
+
 import { assertAgentAccess } from "@/lib/agent-access";
 import {
   resolveWorkflowAgent,
@@ -33,12 +48,14 @@ const personalAgent = {
 };
 const sharedAgent = { id: "agent-2", name: "Team bot", isPersonal: false, ownerId: null };
 
-/** Stub the `select().from().where()` chain with the row the lookup finds. */
-function mockLookup(row: unknown | undefined) {
-  const where = vi.fn().mockResolvedValue(row === undefined ? [] : [row]);
-  const from = vi.fn().mockReturnValue({ where });
-  vi.mocked(db.select).mockReturnValue({ from } as never);
-  return { from, where };
+/** The read gate admits this agent — the actor can see it. */
+function gateAdmits(agent: unknown) {
+  getAgentWithAccessMock.mockResolvedValue(agent);
+}
+
+/** The read gate refuses, and this is the response it refuses with. */
+function gateRefusesWith(response: NextResponse) {
+  getAgentWithAccessMock.mockResolvedValue(response);
 }
 
 async function bodyOf(response: Response) {
@@ -51,27 +68,40 @@ beforeEach(() => {
 
 describe("resolveWorkflowAgent", () => {
   it("returns the agent when the actor owns it", async () => {
-    mockLookup(personalAgent);
+    gateAdmits(personalAgent);
     const result = await resolveWorkflowAgent("agent-1", { id: OWNER, role: "user" });
     expect(result).toEqual({ agent: personalAgent });
   });
 
   it("returns the agent for an admin on a shared agent", async () => {
-    mockLookup(sharedAgent);
+    gateAdmits(sharedAgent);
     const result = await resolveWorkflowAgent("agent-2", { id: OTHER, role: "admin" });
     expect(result).toEqual({ agent: sharedAgent });
   });
 
-  it("answers 404 when no agent matches", async () => {
-    mockLookup(undefined);
-    const result = await resolveWorkflowAgent("ghost", { id: OWNER, role: "user" });
+  it("runs the read gate before the scope gate", async () => {
+    // Order is the whole fix: the scope gate cannot answer first, because its
+    // answer (403) is what discloses an agent the read gate would have hidden.
+    gateAdmits(sharedAgent);
+    await resolveWorkflowAgent("agent-2", { id: OWNER, role: "user" });
+    expect(getAgentWithAccessMock).toHaveBeenCalledWith("agent-2", OWNER, "user");
+  });
+
+  it("passes the read gate's refusal through untouched", async () => {
+    // Identity, not a re-derivation: whatever the read gate answers for an agent
+    // the caller may not see — today a 404 indistinguishable from a missing one
+    // — is what the caller gets. A resolver that rebuilt the response here could
+    // reopen the oracle while agent-access stayed correct.
+    const refusal = NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    gateRefusesWith(refusal);
+
+    const result = await resolveWorkflowAgent("agent-1", { id: OTHER, role: "user" });
     if (!("error" in result)) throw new Error("expected an error response");
-    expect(result.error.status).toBe(404);
-    expect(await bodyOf(result.error)).toEqual({ error: "Agent not found" });
+    expect(result.error).toBe(refusal);
   });
 
   it("answers 403 with the read-side default wording", async () => {
-    mockLookup(sharedAgent);
+    gateAdmits(sharedAgent);
     const result = await resolveWorkflowAgent("agent-2", { id: OWNER, role: "user" });
     if (!("error" in result)) throw new Error("expected an error response");
     expect(result.error.status).toBe(403);
@@ -81,7 +111,7 @@ describe("resolveWorkflowAgent", () => {
   });
 
   it("answers 403 with the caller's wording when one is given", async () => {
-    mockLookup(sharedAgent);
+    gateAdmits(sharedAgent);
     const result = await resolveWorkflowAgent(
       "agent-2",
       { id: OWNER, role: "user" },
@@ -92,57 +122,70 @@ describe("resolveWorkflowAgent", () => {
       error: "You do not have permission to create a workflow on this agent",
     });
   });
-
-  it("refuses someone else's personal agent", async () => {
-    mockLookup(personalAgent);
-    const result = await resolveWorkflowAgent("agent-1", { id: OTHER, role: "user" });
-    if (!("error" in result)) throw new Error("expected an error response");
-    expect(result.error.status).toBe(403);
-  });
 });
 
 /**
- * This gate answers 403 where `loadChatPageAgent` answers 404 for a refusal,
- * which reads as a contradiction now that both live one directory apart. It is
- * deliberate, and the reasoning is on `resolveWorkflowAgent` — but reasoning in
- * a comment is not a check, so pin the two legs it rests on. Both assert the
- * SAME (agent, actor) pair against BOTH gates: what would silently rot here is
- * not the status code, it is the visibility fact the argument is built on.
+ * Which refusal an actor gets depends on WHICH gate turned them away, and both
+ * legs assert the SAME (agent, actor) pair against the real `assertAgentAccess`
+ * first. What would silently rot here is not the status code — it is the
+ * visibility fact each argument is built on.
+ *
+ * These cases drive the mocked read gate from that real verdict, so they cannot
+ * quietly start asserting a fiction: an agent `assertAgentAccess` admits is fed
+ * to the resolver as admitted, and one it throws on as refused.
  */
-describe("the deliberate 403-not-404 split", () => {
+describe("which gate refuses decides which answer", () => {
   const visibleSharedAgent = { ...sharedAgent, visibility: "all" };
+  const hiddenRefusal = () => NextResponse.json({ error: "Agent not found" }, { status: 404 });
 
   it("answers 403 for an agent the visibility gate lets the actor see", async () => {
-    // The honest leg. A 404 here would deny an agent this member has in their
-    // sidebar and chats with — `assertAgentAccess` throws on denial, so this
-    // not throwing IS the claim that they can see it.
+    // The honest 403, and the reason the fix is a layering rather than a blanket
+    // 404: this is a shared agent the member has in their sidebar and chats with
+    // daily. "Agent not found" about an agent on their screen is simply false.
+    // `assertAgentAccess` throws on denial, so this not throwing IS the claim
+    // that they can see it.
     expect(() =>
       assertAgentAccess(visibleSharedAgent, OWNER, "user", [], [], "paid")
     ).not.toThrow();
 
-    mockLookup(visibleSharedAgent);
+    gateAdmits(visibleSharedAgent);
     const result = await resolveWorkflowAgent("agent-2", { id: OWNER, role: "user" });
     if (!("error" in result)) throw new Error("expected an error response");
     expect(result.error.status).toBe(403);
   });
 
-  it("answers 403 for an agent the visibility gate hides — the knowingly-open leg", async () => {
-    // Someone else's personal agent: refused by both gates, so 403-vs-404 here
-    // really does confirm existence. Left open on the reasoning in the
-    // docblock, and asserted rather than assumed so that "this leg is the
-    // hidden one" cannot quietly stop being true.
+  it("answers 404 for an agent the visibility gate hides", async () => {
+    // Someone else's personal agent: hidden from every caller, admins included,
+    // so a 403 would confirm an existence nothing else in the product discloses.
+    // The scope gate must never get to speak about it.
     expect(() => assertAgentAccess(personalAgent, OTHER, "user", [], [], "paid")).toThrow();
 
-    mockLookup(personalAgent);
+    gateRefusesWith(hiddenRefusal());
     const result = await resolveWorkflowAgent("agent-1", { id: OTHER, role: "user" });
     if (!("error" in result)) throw new Error("expected an error response");
-    expect(result.error.status).toBe(403);
+    expect(result.error.status).toBe(404);
+    expect(await bodyOf(result.error)).toEqual({ error: "Agent not found" });
+  });
+
+  it("answers a hidden agent exactly as it answers a missing one", async () => {
+    // Both refusals come from the same gate, so they are the same response by
+    // construction — pinned anyway, because that identity IS the property.
+    gateRefusesWith(hiddenRefusal());
+    const hidden = await resolveWorkflowAgent("agent-1", { id: OTHER, role: "user" });
+    gateRefusesWith(hiddenRefusal());
+    const missing = await resolveWorkflowAgent("ghost", { id: OTHER, role: "user" });
+
+    if (!("error" in hidden) || !("error" in missing)) {
+      throw new Error("expected error responses");
+    }
+    expect(hidden.error.status).toBe(missing.error.status);
+    expect(await bodyOf(hidden.error)).toEqual(await bodyOf(missing.error));
   });
 });
 
 describe("resolveWorkflowAgentFromQuery", () => {
-  it("answers 400 before touching the database when agentId is missing", async () => {
-    mockLookup(personalAgent);
+  it("answers 400 before reaching the access gate when agentId is missing", async () => {
+    gateAdmits(personalAgent);
     const result = await resolveWorkflowAgentFromQuery(
       new Request("http://localhost/api/automations"),
       { id: OWNER, role: "user" }
@@ -150,11 +193,11 @@ describe("resolveWorkflowAgentFromQuery", () => {
     if (!("error" in result)) throw new Error("expected an error response");
     expect(result.error.status).toBe(400);
     expect(await bodyOf(result.error)).toEqual({ error: "agentId is required" });
-    expect(db.select).not.toHaveBeenCalled();
+    expect(getAgentWithAccessMock).not.toHaveBeenCalled();
   });
 
   it("resolves the agentId out of the query string", async () => {
-    mockLookup(personalAgent);
+    gateAdmits(personalAgent);
     const result = await resolveWorkflowAgentFromQuery(
       new Request("http://localhost/api/automations?agentId=agent-1"),
       { id: OWNER, role: "user" }
@@ -163,7 +206,7 @@ describe("resolveWorkflowAgentFromQuery", () => {
   });
 
   it("forwards a caller's 403 wording", async () => {
-    mockLookup(sharedAgent);
+    gateAdmits(sharedAgent);
     const result = await resolveWorkflowAgentFromQuery(
       new Request("http://localhost/api/automations?agentId=agent-2"),
       { id: OWNER, role: "user" },

--- a/packages/web/src/app/api/automations/[id]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/route.ts
@@ -19,6 +19,30 @@ type RouteContext = { params: Promise<{ id: string }> };
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
+ * The one answer both routes give for a workflow the caller may not have: the
+ * same 404 an id that matches nothing gets.
+ *
+ * **This route's verdict differs from the agent-keyed Automations routes, and
+ * deliberately so** (#880). There, `resolveWorkflowAgent` keeps a 403 for an
+ * agent the caller can SEE but may not manage — a shared agent in their sidebar,
+ * where "not found" would be false and would send them checking the id instead
+ * of asking an admin. Here the resource is the WORKFLOW, and that middle state
+ * does not exist: `GET /api/automations` is gated by the very same
+ * `canManageAgentWorkflows`, so nobody who fails this gate can enumerate
+ * workflows at all. Read and manage coincide, which puts every refusal squarely
+ * in the oracle case of the criterion on `getAgentWithAccess` — a distinguishable
+ * error is fine when the caller can already enumerate the resource, and an oracle
+ * when they cannot.
+ *
+ * It costs nothing: a caller who gets this never sees the workflow in any list
+ * either, so there is no state in which 403 would have told them something they
+ * could act on.
+ */
+function workflowNotFound() {
+  return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+}
+
+/**
  * Load a workflow together with the ownership fields of its agent — everything
  * the scope gate and the audit snapshot need, in one round trip. Returns
  * undefined when the id is malformed or matches nothing.
@@ -45,7 +69,8 @@ async function loadWorkflowWithAgent(id: string) {
  * PATCH /api/automations/[id] — flip a workflow's `enabled` state. This is the
  * human-gated activation step "propose, don't self-activate" reserves for a
  * person: a created workflow sits disabled until a reviewer turns it on here.
- * Scope gate matches create (own personal agent → member; shared → admin).
+ * Scope RULE matches create (own personal agent → member; shared → admin); the
+ * refusal does not — see `workflowNotFound`.
  *
  * `status` is deliberately untouched — it is a health signal the dispatcher
  * writes (pending→active/error), not a field this route owns; the loader gates
@@ -59,14 +84,9 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   const { enabled } = parsed.data;
 
   const workflow = await loadWorkflowWithAgent(id);
-  if (!workflow) {
-    return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
-  }
+  if (!workflow) return workflowNotFound();
   if (!canManageAgentWorkflows(workflow, { id: session.user.id!, role: session.user.role })) {
-    return NextResponse.json(
-      { error: "You do not have permission to change this workflow" },
-      { status: 403 }
-    );
+    return workflowNotFound();
   }
 
   // No-op toggle: nothing changed, so nothing to record. Return 200 (idempotent)
@@ -94,20 +114,16 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
 
 /**
  * DELETE /api/automations/[id] — reject/remove a workflow. The FK cascade drops
- * its connection rows and ledger entries with it. Scope gate matches create.
+ * its connection rows and ledger entries with it. Scope RULE matches create; the
+ * refusal does not — see `workflowNotFound`.
  */
 export const DELETE = withAuth<RouteContext>(async (_request, { params }, session) => {
   const { id } = await params;
 
   const workflow = await loadWorkflowWithAgent(id);
-  if (!workflow) {
-    return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
-  }
+  if (!workflow) return workflowNotFound();
   if (!canManageAgentWorkflows(workflow, { id: session.user.id!, role: session.user.role })) {
-    return NextResponse.json(
-      { error: "You do not have permission to delete this workflow" },
-      { status: 403 }
-    );
+    return workflowNotFound();
   }
 
   await db.delete(emailWorkflows).where(eq(emailWorkflows.id, id));

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -157,12 +157,16 @@ export function requireAgentWriteAccess(
  * - **Timing.** The denial path runs a license lookup and, for a restricted
  *   agent, two group queries that the `!agent` path never reaches. Equalising
  *   that costs a query on every miss and buys little against a UUID keyspace.
- * - **Routes that do not use this helper.** `GET`/`POST /api/automations` still
- *   answer 403 for an agent the caller may not manage, and the admin-only
+ * - **Routes that do not use this helper.** The admin-only
  *   `/api/agents/:id/knowledge/*` and `/integrations` endpoints apply no
- *   visibility rule at all. Both are separate verdicts, not oversights of this
- *   one; `reference/api.mdx` describes what each endpoint really does rather
- *   than claiming the prefix as a whole.
+ *   visibility rule at all — a separate verdict, not an oversight of this one;
+ *   `reference/api.mdx` describes what each endpoint really does rather than
+ *   claiming the prefix as a whole.
+ *
+ * The Automations routes were the third item here and are now closed (#880).
+ * `resolveWorkflowAgent` shows the layering this docblock asks for: read gate
+ * first, so an agent the caller cannot see is a 404, and only then the
+ * manage-scope 403 for one they can.
  */
 export async function getAgentWithAccess(agentId: string, userId: string, userRole: string) {
   const rows = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId));

--- a/packages/web/src/lib/chats/load-chat-agent.ts
+++ b/packages/web/src/lib/chats/load-chat-agent.ts
@@ -42,10 +42,10 @@ export async function loadChatAgentName(agentId: string): Promise<string | undef
  * than a 403 on purpose: a member who cannot see an agent should not learn that
  * it exists.
  *
- * The Automations gate (`resolveWorkflowAgent`) answers 403 for its refusals,
- * which looks like the opposite call. It gates *manage scope*, not visibility,
- * so its ordinary refusal is an agent the member demonstrably can see — the
- * reasoning, and the one leg left knowingly open, are on that function.
+ * The Automations gate (`resolveWorkflowAgent`) makes the same call, from the
+ * other side: it runs the visibility gate first and answers 404 exactly where
+ * this one does, then reserves 403 for its *manage-scope* refusal — an agent the
+ * member demonstrably can see. The reasoning is on that function.
  *
  * Group ids are fetched only when they can change the answer (a non-admin
  * hitting a restricted agent), which is what keeps the common case at one

--- a/packages/web/src/lib/email-workflows/authz.ts
+++ b/packages/web/src/lib/email-workflows/authz.ts
@@ -8,6 +8,18 @@
  * autonomous authority scoped to one agent, so "may I touch this agent" is the
  * whole question — connection-level checks (create) sit on top of this, not
  * instead of it.
+ *
+ * **This is a scope rule, not the whole answer, and the difference now matters**
+ * (#880). The `agentId`-keyed routes run the VISIBILITY gate in front of it
+ * (`resolveWorkflowAgent` → `getAgentWithAccess`), and that gate holds personal
+ * agents private to their owner *including admins*. So the "someone else's
+ * personal agent is admin-only" leg above is reachable only through
+ * `PATCH`/`DELETE /api/automations/[id]`, which is keyed by workflow id and
+ * gates on this predicate alone — an admin who already holds a workflow id can
+ * still stop a runaway automation, but cannot list or create one on a
+ * colleague's private agent. Adding a caller that consults this function
+ * WITHOUT a visibility gate re-grants that reach; do it deliberately or not at
+ * all.
  */
 export interface WorkflowAgentScope {
   isPersonal: boolean;

--- a/packages/web/src/lib/email-workflows/resolve-agent.ts
+++ b/packages/web/src/lib/email-workflows/resolve-agent.ts
@@ -69,9 +69,10 @@ export type WorkflowAgentResult = { agent: WorkflowAgent } | { error: NextRespon
  *   resolve them in favour of the scope rule, granting admins a reach into a
  *   colleague's private agent that no other agent-scoped surface gives them.
  *   Nothing in the product could exercise it: the Automations tab lives on
- *   `/chat/[agentId]/settings`, which loads through `GET /api/agents/[agentId]`
- *   — gated by this same read gate since #1148 — so that page already answers
- *   404 for exactly this case. This was the last route under it still saying
+ *   `/chat/[agentId]/settings`, which loads its agent through
+ *   `GET /api/agents/[agentId]` — gated by this same read gate since #1148 — so
+ *   that fetch already answers 404 for exactly this case and the tab renders
+ *   with no agent at all. This was the last route under that page still saying
  *   otherwise, reachable only by hand against an id obtained out of band.
  *   Running the read gate first settles it the way the rest of the product
  *   already had. The emergency capability

--- a/packages/web/src/lib/email-workflows/resolve-agent.ts
+++ b/packages/web/src/lib/email-workflows/resolve-agent.ts
@@ -55,9 +55,29 @@ export type WorkflowAgentResult = { agent: WorkflowAgent } | { error: NextRespon
  * here would let this file re-open the oracle while `agent-access` stayed
  * correct — the response, not merely the status, is the thing being shared.
  *
- * One consequence worth naming: the read gate reads `active_agents`, so a
- * soft-deleted agent now answers 404 instead of accepting workflow calls. That
- * is the right answer and was not previously true.
+ * Two consequences worth naming, because both are narrowings this layering
+ * causes rather than merely permits:
+ *
+ * - The read gate reads `active_agents`, so a soft-deleted agent now answers
+ *   404 instead of accepting workflow calls. That is the right answer and was
+ *   not previously true.
+ * - **An admin no longer reaches someone else's personal agent here.**
+ *   `canManageAgentWorkflows` returns true for any admin on any agent, while
+ *   `assertAgentAccess` holds personal agents private to their owner *including
+ *   admins* — its own comment insists the admin fast-path must not bypass that.
+ *   The Automations API was the one place those two rules met, and it used to
+ *   resolve them in favour of the scope rule, granting admins a reach into a
+ *   colleague's private agent that no other agent-scoped surface gives them.
+ *   Nothing in the product could exercise it: the Automations tab lives on
+ *   `/chat/[agentId]/settings`, which loads through `GET /api/agents/[agentId]`
+ *   — gated by this same read gate since #1148 — so that page already answers
+ *   404 for exactly this case. This was the last route under it still saying
+ *   otherwise, reachable only by hand against an id obtained out of band.
+ *   Running the read gate first settles it the way the rest of the product
+ *   already had. The emergency capability
+ *   survives one route down: `PATCH`/`DELETE /api/automations/[id]` is keyed by
+ *   workflow id and still lets an admin stop a runaway automation they already
+ *   hold the id for — acting on a known workflow, with no way to find one.
  *
  * The legs are pinned in resolve-agent.test.ts against `assertAgentAccess`
  * itself, so the visibility facts this rests on cannot rot unnoticed.

--- a/packages/web/src/lib/email-workflows/resolve-agent.ts
+++ b/packages/web/src/lib/email-workflows/resolve-agent.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
 
-import { db } from "@/db";
-import { agents } from "@/db/schema";
+import { getAgentWithAccess } from "@/lib/agent-access";
 import { canManageAgentWorkflows } from "./authz";
 
 /**
@@ -20,8 +18,8 @@ export type WorkflowAgentResult = { agent: WorkflowAgent } | { error: NextRespon
 
 /**
  * Resolve an agentId to an agent the actor may manage workflows on — the
- * load → 404 → scope-gate → 403 preamble that every agent-scoped Automations
- * route opens with (list, create, connection picker).
+ * read-gate → scope-gate preamble that every agent-scoped Automations route
+ * opens with (list, create, connection picker).
  *
  * Single-sourced deliberately: `canManageAgentWorkflows` was already shared,
  * but the lookup and the two HTTP answers around it were copied per route
@@ -34,31 +32,34 @@ export type WorkflowAgentResult = { agent: WorkflowAgent } | { error: NextRespon
  * differs per route ("access to this agent" when reading, "permission to create a
  * workflow" when writing). Sharing the gate must not silently rewrite either.
  *
- * **A refusal answers 403, and that deliberately differs from `loadChatPageAgent`,
- * which answers 404** ("a member who cannot see an agent should not learn that it
- * exists"). The two are not the same question. That one is a *visibility* gate
- * (`assertAgentAccess`): whoever fails it cannot reach the agent anywhere, so the
- * only thing a 403 would tell them is that it exists. This is a *manage-scope*
- * gate (`canManageAgentWorkflows`), and its ordinary refusal is a shared agent the
- * member sees in their sidebar and chats with daily. "Agent not found" about an
- * agent on their screen is simply false, and it sends them checking the id instead
- * of asking an admin.
+ * **Two gates, in this order: can you SEE this agent, and only then may you
+ * manage its workflows.** The order is the whole point, and it is what closes
+ * the existence oracle these routes used to carry (#880).
  *
- * The other leg — someone else's personal agent, or a restricted one outside the
- * actor's groups — is refused by both gates, so there 403-vs-404 really does
- * confirm existence. It stays 403 knowingly, for two reasons:
+ * The read gate is `getAgentWithAccess`, which answers 404 — byte-identical to
+ * an agent that does not exist — for an agent the caller may not see. Its
+ * docblock carries the criterion: a distinguishable error is fine when the
+ * caller can already enumerate the resource, and an oracle when they cannot.
+ * Nobody can enumerate someone else's personal agent (`getVisibleAgents`
+ * withholds them from every caller, admins included), so answering 403 here
+ * disclosed exactly what the rest of the product refuses to. Any logged-in
+ * member could hand these two routes an id and learn whether it was real.
  *
- * - There is nothing to enumerate. `agents.id` is `crypto.randomUUID()`, so the
- *   answer only ever speaks about an id the caller already holds; it reveals none
- *   they don't. Holding a foreign agent's id is itself the leak worth chasing, and
- *   this function is not where that happened.
- * - 404 here would close nothing. `getAgentWithAccess` answers 403 for exactly
- *   that invisible agent on every `/api/agents/[agentId]/*` route a plain member
- *   can reach, so an Automations-only 404 would trade a worse error message for a
- *   property the instance does not actually have. Closing the oracle means
- *   changing `getAgentWithAccess` (and the ~10 routes built on it), not this.
+ * The scope gate stays 403, and that is preserved rather than swept away: its
+ * ORDINARY refusal is a shared agent the member sees in their sidebar and chats
+ * with daily. "Agent not found" about an agent on their screen is simply false,
+ * and it sends them checking the id instead of asking an admin. Having passed
+ * the read gate, they already know it exists, so 403 discloses nothing.
  *
- * Both legs are pinned in resolve-agent.test.ts against `assertAgentAccess`
+ * The refusal from the read gate is passed through **untouched**. Rebuilding it
+ * here would let this file re-open the oracle while `agent-access` stayed
+ * correct — the response, not merely the status, is the thing being shared.
+ *
+ * One consequence worth naming: the read gate reads `active_agents`, so a
+ * soft-deleted agent now answers 404 instead of accepting workflow calls. That
+ * is the right answer and was not previously true.
+ *
+ * The legs are pinned in resolve-agent.test.ts against `assertAgentAccess`
  * itself, so the visibility facts this rests on cannot rot unnoticed.
  */
 export async function resolveWorkflowAgent(
@@ -66,23 +67,13 @@ export async function resolveWorkflowAgent(
   actor: { id: string; role: string | null | undefined },
   forbiddenMessage = "You do not have access to this agent"
 ): Promise<WorkflowAgentResult> {
-  const [agent] = await db
-    .select({
-      id: agents.id,
-      name: agents.name,
-      isPersonal: agents.isPersonal,
-      ownerId: agents.ownerId,
-    })
-    .from(agents)
-    .where(eq(agents.id, agentId));
+  const gated = await getAgentWithAccess(agentId, actor.id, actor.role ?? "");
+  if (gated instanceof NextResponse) return { error: gated };
 
-  if (!agent) {
-    return { error: NextResponse.json({ error: "Agent not found" }, { status: 404 }) };
-  }
-  if (!canManageAgentWorkflows(agent, actor)) {
+  if (!canManageAgentWorkflows(gated, actor)) {
     return { error: NextResponse.json({ error: forbiddenMessage }, { status: 403 }) };
   }
-  return { agent };
+  return { agent: gated };
 }
 
 /**


### PR DESCRIPTION
Closes #880.

## What was open

`GET`/`POST /api/automations` and `GET /api/automations/connections` looked the agent up themselves and answered `403` whenever `canManageAgentWorkflows` said no. Any logged-in member could hand these routes an id and learn whether it was a real agent — **including someone else's personal agent**, which `getVisibleAgents` withholds from every caller, admins included.

That is the same oracle #1148 closed for the ~12 routes gating through `getAgentWithAccess`, for the WebSocket bridge, and for `DELETE /api/agents/[agentId]/channels/telegram`. The criterion is on that helper's docblock: a distinguishable error is fine when the caller **can already enumerate** the resource, and an oracle when they cannot.

## The fix: layer the gates, don't collapse them

`resolveWorkflowAgent` now runs the **read gate first**:

- an agent the caller cannot see → `404`, byte-identical to one that does not exist;
- an agent they **can** see but may not manage → the deliberate `403` survives. That is the everyday case — a shared agent in their sidebar — where "not found" would simply be false and would send them checking the id instead of asking an admin.

The gate's refusal is passed through **untouched** rather than rebuilt, so this file cannot re-open what `agent-access` closed.

Fixing the shared resolver rather than the two named call sites also covers the **connection picker**, which carried the identical hole. One consequence worth naming: the read gate reads `active_agents`, so a soft-deleted agent now answers `404` instead of accepting workflow calls.

## The second verdict, decided rather than swept in

`PATCH`/`DELETE /api/automations/[id]` are keyed by **workflow** id, so they disclose a different resource. **They now answer `404` for a scope refusal**, and the reasoning is deliberately not the same as above:

for an agent there is a real middle state (visible but unmanageable), which is why the `403` survives there. For a workflow that state does not exist — `GET /api/automations` is gated by the very same `canManageAgentWorkflows`, so read and manage coincide. Nobody who fails this gate can list the workflow anywhere, which put every refusal squarely in the oracle case. It costs nothing to close: such a caller never sees the workflow in any list, and the UI branches on the message rather than the status.

Scope kept minimal — only the refusal changes. The join still reads `agents` rather than `active_agents`, so a workflow on a soft-deleted agent stays manageable by an admin: a lifecycle question, not a disclosure one.

## A third consequence the first pass left silent

Running the read gate first also settled a rule conflict nobody had made explicit, and a self-review caught that it did so without a word anywhere.

`canManageAgentWorkflows` returns true for **any** admin on **any** agent — its docblock says "someone else's personal agent is admin-only" in as many words. `assertAgentAccess` holds personal agents private to their owner *including admins*, with a comment insisting the admin fast-path must not bypass it. The Automations API was the one place both applied. It used to resolve them in favour of the scope rule; it now resolves them the other way.

**That is the right answer, and the product had already given it.** The Automations tab lives on `/chat/[agentId]/settings`, which loads through `GET /api/agents/[agentId]` — gated by the same read gate since #1148 — so that page has answered `404` for this case all along. These routes were the last ones under it still saying otherwise, reachable only by hand against an id obtained out of band.

What was missing was the record, so it now exists in all three places a reader might look:

- **Tests.** An admin gets `404` for a colleague's personal agent on create and on list. Verified by canary against the pre-fix resolver — both fail there, so they pin a change rather than restate the status quo.
- **The surviving capability, pinned too.** `PATCH`/`DELETE /api/automations/:id` is keyed by workflow id and still lets an admin stop a runaway automation they already hold the id for. It grants no way to *find* one. Untested, that asymmetry reads as an oversight.
- **Docs.** Three pages promised the opposite, one of them spelling it out as "any agent, shared or personal". Corrected, plus an upgrade note — which also covers the `403` → `404` switch itself, something #1148 shipped without one.

Three tests were also hardened: each compared a denial against a miss without pinning *which* status they agree on, and the create case feeds a deliberately unseeded connection id — so a route that checked connections before the agent would answer `400` to both, satisfy the comparison, and assert nothing. Symmetric blindness reads exactly like agreement.

## Why the tests needed redesigning, not a status flip

The three integration suites could not have caught this **and could not have pinned the fix either**. They inherited the license state, and a community instance maps visibility `restricted` → `all`, so a visibility denial and a scope denial produced the same `403` whichever one the route meant — green either way.

They now pin the state at `paid` and spell out `visibility` per case. That is what makes the new cases mean anything:

- the two shared-agent scope cases seed `visibility: "all"`, so their `403` pins the **scope** rule and could not be satisfied by a route with no scope gate at all;
- new: someone else's personal agent → `404`;
- new: a restricted shared agent outside the member's groups → `404`;
- new: the denial and the miss compared **byte-for-byte**, since equal statuses with divergent bodies would re-open the oracle;
- the workflow-id cases assert the verdict where it is hardest — the agent **is** visible and the workflow's existence is withheld anyway.

The unit suite drives the two layers apart (`getAgentWithAccess` mocked, `assertAgentAccess` real) and pins that the read gate's refusal is forwarded by **identity**.

## Docs

`reference/api.mdx`: the paragraph under `GET /api/agents/:id` stated the old exception as fact and now folds the Automations endpoints into the general rule; the section intro explains both verdicts; every affected error table updated. The `getAgentWithAccess` docblock no longer lists this as an open verdict, and `load-chat-agent`'s cross-reference is corrected.

The `review-docs` pass caught one thing the coverage guards structurally cannot — the connection picker's error table (48866b3), identifiers all present and the sentence wrong.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm -C packages/web test:db` | 69 files, 528 tests — green |
| automations suites | 45 tests (was 33) |
| `pnpm test` | green except 24 pre-existing `pinchy-files` failures |
| `pnpm test:scripts` | 1237 — green |
| `pnpm -C packages/web typecheck` / `lint` | clean (0 errors) |
| `pnpm build` | green |
| docs build + `check:anchors` / `check:rendered` / `check:llms` | green |

The `pinchy-files` failures are a local environment defect, not this change: `better_sqlite3.node` is compiled against `NODE_MODULE_VERSION 137` (Node 24) while the repo pins Node 22, and the module loader's error arrives as a product assertion. **Reproduced on the base commit** to confirm it is pre-existing.
