### PR TITLE
fix(api): an admin may not reach into another user's personal agent

### DIFF
--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -172,8 +172,9 @@ All agent-accessible files live under `/data/` in the container, mounted via Doc
 
 Pinchy restricts which agents a user can see:
 
-- **Admins** can access all agents (personal and shared)
-- **Users** can access shared agents and their own personal agent
+- **Admins** can access every shared agent, and their own personal agent
+- **Users** can access shared agents their visibility admits them to, and their own personal agent
+- A personal agent is private to its owner. No role reaches somebody else's — an admin's sidebar does not list it, and its ID answers "not found" on every endpoint, management surfaces included
 - Only admins can view and modify agent permissions
 
 For the full details, see [Agent Permissions](/concepts/agent-permissions/).

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -174,7 +174,7 @@ Pinchy restricts which agents a user can see:
 
 - **Admins** can access every shared agent, and their own personal agent
 - **Users** can access shared agents their visibility admits them to, and their own personal agent
-- A personal agent is private to its owner. No role reaches somebody else's — an admin's sidebar does not list it, and its ID answers "not found" on every endpoint, management surfaces included
+- A personal agent is private to its owner. No role reaches somebody else's — an admin's sidebar does not list it, and its ID answers "not found" on every `/api/agents/:id/` endpoint, management surfaces and automations included
 - Only admins can view and modify agent permissions
 
 For the full details, see [Agent Permissions](/concepts/agent-permissions/).

--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -208,7 +208,9 @@ Not every user can see every agent. Pinchy enforces access rules:
 
 - **Admins** can access every shared agent, of any visibility, plus their own personal agent
 - **Users** can access shared agents their visibility admits them to, plus their own personal agent
-- **Nobody** can see or access another user's personal agent — admins included. It is absent from the sidebar and its ID answers "not found" everywhere, including the admin-only management endpoints that reindex an agent's knowledge base, set its integration permissions, or connect a Telegram bot to it
+- **Nobody** can see or access another user's personal agent — admins included. It is absent from the sidebar, and its ID answers "not found" on every `/api/agents/:id/` endpoint, the admin-only management ones included: reindexing an agent's knowledge base, setting its integration permissions, connecting a Telegram bot to it
+
+That holds on every surface, [automations](/concepts/agent-settings/#automations-tab) included: an admin manages those on shared agents, not on a colleague's private Smithers. Admin power over agents is power over the agents your organization shares, not over the assistant each person talks to.
 
 Only admins can view and modify the Permissions tab. Regular users can chat with agents they have access to, but cannot change what tools those agents use.
 

--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -206,9 +206,9 @@ If any one layer fails, the others still prevent unauthorized access.
 
 Not every user can see every agent. Pinchy enforces access rules:
 
-- **Admins** can access all agents — personal and shared
-- **Users** can access shared agents (created by anyone) and their own personal agent
-- Users **cannot** see or access other users' personal agents
+- **Admins** can access every shared agent, of any visibility, plus their own personal agent
+- **Users** can access shared agents their visibility admits them to, plus their own personal agent
+- **Nobody** can see or access another user's personal agent — admins included. It is absent from the sidebar and its ID answers "not found" everywhere, including the admin-only management endpoints that reindex an agent's knowledge base, set its integration permissions, or connect a Telegram bot to it
 
 Only admins can view and modify the Permissions tab. Regular users can chat with agents they have access to, but cannot change what tools those agents use.
 

--- a/docs/src/content/docs/concepts/groups.mdx
+++ b/docs/src/content/docs/concepts/groups.mdx
@@ -25,7 +25,7 @@ Groups let admins organize users into teams and control which agents each team c
 2. Use the member picker to add or remove users.
 3. Save your changes.
 
-A user can belong to multiple groups. Admins always have access to all agents regardless of group membership.
+A user can belong to multiple groups. Admins always have access to every shared agent, regardless of group membership — groups never hide a shared agent from an admin. They do not reach another user's personal Smithers, which stays private to its owner; see [Agent access control](/concepts/agent-permissions/#agent-access-control).
 
 ## Agent visibility modes
 

--- a/docs/src/content/docs/concepts/user-roles.mdx
+++ b/docs/src/content/docs/concepts/user-roles.mdx
@@ -51,13 +51,13 @@ Members can chat with agents they have access to, manage their own profile and p
 
 Roles interact with agent visibility to determine which agents a user can see in the sidebar.
 
-- **Admins** see all agents — shared agents of any visibility, plus every user's personal agents.
+- **Admins** see every shared agent, of any visibility — plus their own personal Smithers, and no one else's.
 - **Members** see:
   - Their own personal Smithers agent
   - Shared agents with visibility set to **All users**
   - Shared agents with **Restricted** visibility, if they belong to an assigned group <Badge text="Enterprise" variant="note" />
 
-Members cannot see other users' personal agents or restricted agents they are not grouped into.
+Nobody sees another user's personal agent, and that includes admins. A personal Smithers is private to the person it belongs to: it is absent from an admin's sidebar, and its ID answers "not found" on every management endpoint — reindexing its knowledge base, changing its permissions, connecting a Telegram bot to it. Admin power over agents is power over the agents an organization shares, not over the assistant each person talks to. Members additionally cannot see restricted agents they are not grouped into.
 
 Only admins can change an agent's visibility setting or assign groups to it. For details on visibility modes, see [Agent Permissions](/concepts/agent-permissions/).
 

--- a/docs/src/content/docs/concepts/user-roles.mdx
+++ b/docs/src/content/docs/concepts/user-roles.mdx
@@ -57,7 +57,7 @@ Roles interact with agent visibility to determine which agents a user can see in
   - Shared agents with visibility set to **All users**
   - Shared agents with **Restricted** visibility, if they belong to an assigned group <Badge text="Enterprise" variant="note" />
 
-Nobody sees another user's personal agent, and that includes admins. A personal Smithers is private to the person it belongs to: it is absent from an admin's sidebar, and its ID answers "not found" on every management endpoint — reindexing its knowledge base, changing its permissions, connecting a Telegram bot to it. Admin power over agents is power over the agents an organization shares, not over the assistant each person talks to. Members additionally cannot see restricted agents they are not grouped into.
+Nobody sees another user's personal agent, and that includes admins. A personal Smithers is private to the person it belongs to: it is absent from an admin's sidebar, and its ID answers "not found" on the agent management endpoints — reindexing its knowledge base, changing its permissions, connecting a Telegram bot to it. Admin power over agents is power over the agents an organization shares, not over the assistant each person talks to — [automations](/concepts/agent-settings/#automations-tab) included. Members additionally cannot see restricted agents they are not grouped into.
 
 Only admins can change an agent's visibility setting or assign groups to it. For details on visibility modes, see [Agent Permissions](/concepts/agent-permissions/).
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -97,7 +97,7 @@ After creating the agent, you can customize it through the agent settings tabs. 
 - **Permissions** — Configure which tools and directories the agent can access
 - **Access** <Badge text="Enterprise" variant="note" /> — Set visibility to all users or restrict to specific groups
 
-**Admin-only, any agent:**
+**Admin-only, shared agents and your own Smithers:**
 
 - **Telegram** — Connect a Telegram bot to this agent
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -302,10 +302,14 @@ Email workflows now have their own **Automations** tab in an agent's settings, w
 
 Endpoints that gate on your access to an agent used to answer `403` when you asked about one you're not allowed to see. That told you the agent existed — which, for someone else's personal agent, is the one thing Pinchy withholds from everybody, admins included. They now answer `404`, with the same body an ID that was never issued gets.
 
-This closes the last of it on the Automations endpoints. Two consequences if you drive the API directly:
+Two consequences on the Automations endpoints if you drive the API directly:
 
 - `GET`/`POST /api/automations` and `GET /api/automations/connections` answer `404` for an agent you can't see, and keep `403` for one you can see but may not manage — a shared agent you chat with daily still says so plainly.
-- Admins reach automations on **shared** agents, not on a colleague's personal agent. Opening that agent's settings has failed the same way since the same change; these routes were the last ones that still answered. An admin who already holds a workflow's ID can still disable or delete it through `PATCH`/`DELETE /api/automations/:id` — a runaway automation stays stoppable.
+- Admins reach automations on **shared** agents, not on a colleague's personal agent. Opening that agent's settings has failed the same way since the same change. An admin who already holds a workflow's ID can still disable or delete it through `PATCH`/`DELETE /api/automations/:id` — a runaway automation stays stoppable.
+
+Four admin-only management endpoints were still answering, and they are the last of it: reindexing an agent's knowledge base, listing the documents its index cannot search, setting its integration permissions, and connecting a Telegram bot to it. Each looked the agent up by ID and proceeded, so an admin who had a colleague's agent ID could act on their personal assistant. All four answer `404` there now.
+
+Nothing in Pinchy's own screens reaches those agents, so day-to-day admin work is unchanged: shared agents, and your own Smithers during Telegram setup, work exactly as before. Two smaller answers changed along with it — `GET`/`DELETE /api/agents/:agentId/integrations` and `GET /api/agents/:agentId/channels/telegram` used to answer `200` for an agent ID that belongs to nothing at all, and now answer `404`. Only a script calling those endpoints directly would notice.
 
 Nothing to configure, and nothing changes in the UI.
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -134,7 +134,7 @@ default is an explicit action ([`PATCH /api/settings/providers/default`](#patch-
 
 ### `GET /api/agents`
 
-List agents visible to the current user. Admins see all agents. Non-admin users see shared agents and their own personal agents.
+List agents visible to the current user. Admins see every shared agent, of any visibility; non-admin users see shared agents their visibility setting admits them to. Everyone additionally sees their own personal Smithers, and nobody sees anyone else's — admins included.
 
 **Response:**
 
@@ -216,7 +216,9 @@ Get a single agent by ID.
 
 An agent you may not see answers `404` as well, with the same body — someone else's personal agent, or a restricted agent outside your groups, is deliberately indistinguishable from an ID that was never issued. This holds for admins too: nobody can list another user's personal agents, so nobody gets to confirm one exists.
 
-Every endpoint that gates on **your access to the agent** answers the same way, over the WebSocket chat bridge as well as over HTTP, and including the `agentId`-keyed [Automations endpoints](#automations). One group under this prefix does not, and it is worth knowing which: the admin-only management endpoints (`knowledge/*`, `integrations`, and connecting a Telegram bot) apply no visibility rule at all — they are restricted to admins and return `404` only when no agent has the ID.
+Every endpoint that gates on **your access to the agent** answers the same way, over the WebSocket chat bridge as well as over HTTP, and including the `agentId`-keyed [Automations endpoints](#automations). That now covers the admin-only management endpoints too — `knowledge/*`, `integrations`, and connecting a Telegram bot: being an admin is not a visibility rule, so those answer `404` for another user's personal agent as well. They are the surfaces that reindex an agent's documents, grant it an integration, or give it a Telegram bot, and none of that is reachable for an agent Pinchy will not show you.
+
+No endpoint under this prefix is exempt, and a test asserts it rather than this page claiming it: `agent-route-access-gate.test.ts` fails on a handler that does not run the gate, so a new one cannot quietly skip it.
 
 ### `PATCH /api/agents/:id`
 
@@ -477,7 +479,7 @@ The request returns as soon as the job is queued — indexing runs in the backgr
 
 - `401` — not authenticated
 - `403` — not an admin
-- `404` — agent not found
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
 - `409` — a reindex is already running. One index job runs at a time across the whole instance, so the run in your way may belong to a **different** agent. The response carries the running job's `jobId`, `status`, and `agent` — `GET` that agent's reindex endpoint to watch it, rather than retrying.
 - `503` — the bundled embedding model file is missing from the image (a broken build or mount, not a configuration step)
 
@@ -536,7 +538,7 @@ Every run writes two `knowledge.reindex` audit entries, correlated by `jobId`: t
 
 - `401` — not authenticated
 - `403` — not an admin
-- `404` — agent not found
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
 
 ### `POST /api/internal/knowledge/search`
 
@@ -551,6 +553,12 @@ Runs a hybrid (vector + full-text) search over the requesting agent's indexed, g
 The counter answers for the last run; this answers for everything currently in the agent's granted folders, so it is usually the larger of the two. That is the two numbers agreeing, not disagreeing: a file unchanged since an earlier run is `skipped` by the next one and never counted again.
 
 Scoped to the folders that agent is granted, exactly like search itself, so the list never names a document the agent isn't allowed to know about.
+
+**Errors:**
+
+- `401` — not authenticated
+- `403` — not an admin
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
 
 ## Automations
 
@@ -1158,6 +1166,12 @@ Get the Telegram bot configuration for an agent. **Admin only.**
 
 `hint` is the last 4 characters of the bot token for visual verification. `mainBotConfigured` indicates whether the global Smithers/main bot is set up — a prerequisite before any other agent can connect to Telegram.
 
+**Errors:**
+
+- `401` — not authenticated
+- `403` — not an admin
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
+
 ### `POST /api/agents/:agentId/channels/telegram`
 
 Connect an agent to a Telegram bot. **Admin only.** The main bot must be configured first (exception: the main bot itself).
@@ -1177,6 +1191,7 @@ Connect an agent to a Telegram bot. **Admin only.** The main bot must be configu
 **Errors:**
 
 - `400` — invalid or non-working bot token
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
 - `409` — `telegram_not_configured` (main bot missing), or the bot token is already used by another agent
 
 ### `DELETE /api/agents/:agentId/channels/telegram`
@@ -1284,6 +1299,8 @@ Test credentials against the external system without persisting changes. Used by
 ### `GET /api/agents/:agentId/integrations`
 
 Get an agent's integration permissions: which connections are enabled, access level (read-only, read-write, full, custom), and which data models are allowed.
+
+All three endpoints in this group are **admin only**, and all three answer `404` for an agent you may not see — including another user's personal agent, which no admin can see.
 
 ### `PUT /api/agents/:agentId/integrations`
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1298,13 +1298,17 @@ Test credentials against the external system without persisting changes. Used by
 
 ### `GET /api/agents/:agentId/integrations`
 
-Get an agent's integration permissions: which connections are enabled, access level (read-only, read-write, full, custom), and which data models are allowed.
+Get an agent's integration permissions: which connections are enabled, access level (read-only, read-write, full, custom), and which data models are allowed. **Admin only.**
 
-All three endpoints in this group are **admin only**, and all three answer `404` for an agent you may not see — including another user's personal agent, which no admin can see.
+**Errors:**
+
+- `401` — not authenticated
+- `403` — not an admin
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
 
 ### `PUT /api/agents/:agentId/integrations`
 
-Replace all permissions for this agent on a connection.
+Replace all permissions for this agent on a connection. **Admin only.**
 
 **Request body:**
 
@@ -1315,9 +1319,21 @@ Replace all permissions for this agent on a connection.
 
 This is a full replace, not a merge: the previous permission rows for this agent/connection pair are deleted and the submitted `permissions` array is inserted in their place. Pass an empty array to revoke every permission on that connection without clearing the connection selection itself.
 
+**Errors:**
+
+- `401` — not authenticated
+- `403` — not an admin
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either); or the connection does not exist
+
 ### `DELETE /api/agents/:agentId/integrations`
 
-Remove all integration permissions for this agent, across every connection. Used when a connection is cleared from the agent's Permissions tab.
+Remove all integration permissions for this agent, across every connection. Used when a connection is cleared from the agent's Permissions tab. **Admin only.**
+
+**Errors:**
+
+- `401` — not authenticated
+- `403` — not an admin
+- `404` — agent not found, or it is another user's personal agent (admins cannot reach those either)
 
 ### `GET /api/integrations/oauth/start?provider=<google|microsoft>`
 

--- a/packages/web/src/__tests__/api/agent-admin-routes-visibility.integration.test.ts
+++ b/packages/web/src/__tests__/api/agent-admin-routes-visibility.integration.test.ts
@@ -1,0 +1,386 @@
+// Real-DB integration test for the four ADMIN-ONLY route families under
+// /api/agents/[agentId]/ — knowledge/reindex, knowledge/unsearchable,
+// integrations, and connecting a Telegram bot.
+//
+// The verdict these pin: an admin may NOT reach into another user's personal
+// agent, not even on a management surface. `getVisibleAgents` withholds those
+// agents from admins, `PATCH /api/agents/:id` — the only route that can set the
+// `pinchy-files` grants the knowledge routes resolve their scope from — already
+// answers 404, and so does `DELETE /api/agents/:id`. These four looked the
+// agent up by id and proceeded, so an admin holding an id could reindex a
+// stranger's Smithers, read the documents its index cannot search, grant it
+// live access to an Odoo or email connection, and attach a Telegram bot to it.
+//
+// Each case issues BOTH requests — the personal agent of another user, and an
+// id nobody ever issued — and asserts the two answers are equal. That equality
+// is the contract; the 404 literal alongside it says which answer it is. Same
+// shape as uploads-post.integration.test.ts, for the same reason: the mocked
+// route tests stub `getAgentWithAccess`, so only a real DB proves the helper
+// actually withholds the row.
+//
+// What stays mocked, and why:
+//   - @/lib/auth (getSession) / next/headers — no real browser session exists
+//     in a test process; withAuth/requireAdmin read it via headers().
+//   - @/lib/enterprise, @/lib/groups — the personal-agent rule in
+//     assertAgentAccess is decided before license state or group membership is
+//     ever consulted, so leaving those real would only add table setup to a
+//     question they do not answer.
+//   - @/lib/knowledge/* , @/lib/telegram, @/lib/openclaw-config,
+//     @/lib/telegram-allow-store — the side effects each route would have had
+//     if the gate let it through. Mocked so that "nothing happened" is
+//     assertable rather than merely likely: a refusal that still enqueued a job
+//     or called Telegram would show up here.
+//
+// Everything else — the agents table, agent_connection_permissions, audit_log,
+// and the real getAgentWithAccess — runs against the real database.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  auth: { api: { getSession: (...args: unknown[]) => mockGetSession(...args) } },
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
+}));
+
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: vi.fn().mockResolvedValue([]),
+  getAgentGroupIds: vi.fn().mockResolvedValue([]),
+  getAllAgentGroupIds: vi.fn().mockResolvedValue(new Map<string, string[]>()),
+}));
+
+// `deferAuditLog` wraps Next's `after()`, which throws outside a request scope
+// — a route handler invoked directly from a test has none. Mocking it keeps the
+// positive control (a shared agent really does get reindexed) exercisable, and
+// makes "the refusal audited nothing" assertable rather than merely implied.
+const mockDeferAuditLog = vi.fn();
+vi.mock("@/lib/audit-deferred", () => ({
+  deferAuditLog: (...args: unknown[]) => mockDeferAuditLog(...args),
+  recordAuditFailure: vi.fn(),
+}));
+
+const mockEnqueueIndexJob = vi.fn();
+const mockGetLatestIndexJobForAgent = vi.fn();
+vi.mock("@/lib/knowledge/index-jobs", () => ({
+  enqueueIndexJob: (...args: unknown[]) => mockEnqueueIndexJob(...args),
+  getLatestIndexJobForAgent: (...args: unknown[]) => mockGetLatestIndexJobForAgent(...args),
+}));
+
+const mockListUnsearchableDocuments = vi.fn();
+vi.mock("@/lib/knowledge/unsearchable", () => ({
+  listUnsearchableDocuments: (...args: unknown[]) => mockListUnsearchableDocuments(...args),
+}));
+
+vi.mock("@/lib/knowledge/kb-embedder", () => ({
+  kbEmbedderAvailable: () => true,
+}));
+
+const mockValidateTelegramBotToken = vi.fn();
+vi.mock("@/lib/telegram", () => ({
+  validateTelegramBotToken: (...args: unknown[]) => mockValidateTelegramBotToken(...args),
+  hasMainTelegramBot: vi.fn().mockResolvedValue(true),
+  probeTelegramPollingConflict: vi.fn().mockResolvedValue({ conflict: false }),
+}));
+
+const mockUpdateTelegramChannelConfig = vi.fn();
+vi.mock("@/lib/openclaw-config", () => ({
+  updateTelegramChannelConfig: (...args: unknown[]) => mockUpdateTelegramChannelConfig(...args),
+  regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/telegram-allow-store", () => ({
+  clearAllowStoreForAccount: vi.fn(),
+  recalculateTelegramAllowStores: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ── Real DB imports (loaded AFTER mocks are declared) ─────────────────────
+
+import { db } from "@/db";
+import { users, agents, agentConnectionPermissions, auditLog } from "@/db/schema";
+import {
+  POST as REINDEX_POST,
+  GET as REINDEX_GET,
+} from "@/app/api/agents/[agentId]/knowledge/reindex/route";
+import { GET as UNSEARCHABLE_GET } from "@/app/api/agents/[agentId]/knowledge/unsearchable/route";
+import {
+  GET as INTEGRATIONS_GET,
+  PUT as INTEGRATIONS_PUT,
+  DELETE as INTEGRATIONS_DELETE,
+} from "@/app/api/agents/[agentId]/integrations/route";
+import {
+  GET as TELEGRAM_GET,
+  POST as TELEGRAM_POST,
+} from "@/app/api/agents/[agentId]/channels/telegram/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** An id that is a well-formed UUID and belongs to no agent. */
+const UNKNOWN_AGENT_ID = "00000000-0000-4000-8000-000000000000";
+
+async function seedUser(overrides?: Partial<typeof users.$inferInsert>) {
+  const [row] = await db
+    .insert(users)
+    .values({
+      name: "Test User",
+      email: `user-${crypto.randomUUID()}@example.com`,
+      emailVerified: true,
+      role: "member",
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+/**
+ * Somebody else's Smithers, with knowledge-base grants on it. Real personal
+ * agents are seeded without a `pluginConfig` and cannot be given one (PATCH is
+ * gated, and the Permissions tab renders only for `isAdmin && !isPersonal`), so
+ * granting paths here is deliberately MORE generous than production allows:
+ * it makes the knowledge routes do real work if the gate ever lets them
+ * through, instead of no-opping their way to a passing test.
+ */
+async function seedForeignPersonalAgent() {
+  const owner = await seedUser({ name: "Owner" });
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Smithers",
+      model: "anthropic/claude-haiku-4-5-20251001",
+      greetingMessage: "Hello!",
+      isPersonal: true,
+      visibility: "restricted",
+      ownerId: owner.id,
+      pluginConfig: { "pinchy-files": { allowed_paths: ["/data/hr"] } },
+    })
+    .returning();
+  return row;
+}
+
+function makeParams(agentId: string) {
+  return { params: Promise.resolve({ agentId }) };
+}
+
+function makeRequest(agentId: string, init?: ConstructorParameters<typeof NextRequest>[1]) {
+  return new NextRequest(`http://localhost/api/agents/${agentId}/x`, init);
+}
+
+function jsonBody(agentId: string, body: unknown) {
+  return makeRequest(agentId, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Run `call` for another user's personal agent and for an unknown id, and
+ * assert the two answers are byte-identical. Returns nothing: what a caller
+ * asserts afterwards is that no side effect happened.
+ */
+async function expectIndistinguishable(
+  foreignAgentId: string,
+  call: (agentId: string) => Promise<Response>
+) {
+  const denied = await call(foreignAgentId);
+  const unknown = await call(UNKNOWN_AGENT_ID);
+
+  // The literal pins WHICH answer it is; the equality is the actual contract
+  // and survives a later change of wording.
+  expect(denied.status).toBe(404);
+  expect(denied.status).toBe(unknown.status);
+  expect(await denied.json()).toEqual(await unknown.json());
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockValidateTelegramBotToken.mockResolvedValue({
+    valid: true,
+    botId: 123456,
+    botUsername: "test_bot",
+  });
+  mockEnqueueIndexJob.mockResolvedValue({ status: "queued", job: { id: "job-1" } });
+  mockGetLatestIndexJobForAgent.mockResolvedValue(null);
+  mockListUnsearchableDocuments.mockResolvedValue({ documents: [], total: 0 });
+
+  const admin = await seedUser({ name: "Admin", role: "admin" });
+  mockGetSession.mockResolvedValue({
+    user: { id: admin.id, email: admin.email, role: "admin" },
+  });
+});
+
+describe("admin-only agent management routes vs another user's personal agent (real DB)", () => {
+  it("POST knowledge/reindex answers alike and queues nothing", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) =>
+      REINDEX_POST(jsonBody(id, {}), makeParams(id))
+    );
+
+    expect(mockEnqueueIndexJob).not.toHaveBeenCalled();
+    // Not even the "nothing to index" no-op row, which would name the agent.
+    expect(mockDeferAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("GET knowledge/reindex answers alike and reads no job state", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) => REINDEX_GET(makeRequest(id), makeParams(id)));
+
+    expect(mockGetLatestIndexJobForAgent).not.toHaveBeenCalled();
+  });
+
+  it("GET knowledge/unsearchable answers alike and never queries the index", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) =>
+      UNSEARCHABLE_GET(makeRequest(id), makeParams(id))
+    );
+
+    expect(mockListUnsearchableDocuments).not.toHaveBeenCalled();
+  });
+
+  it("GET integrations answers alike", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) =>
+      INTEGRATIONS_GET(makeRequest(id), makeParams(id))
+    );
+  });
+
+  it("PUT integrations answers alike and grants no connection", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) =>
+      INTEGRATIONS_PUT(
+        jsonBody(id, {
+          connectionId: "conn-1",
+          permissions: [{ model: "res.partner", operation: "read" }],
+        }),
+        makeParams(id)
+      )
+    );
+
+    const rows = await db
+      .select()
+      .from(agentConnectionPermissions)
+      .where(eq(agentConnectionPermissions.agentId, foreign.id));
+    expect(rows).toEqual([]);
+  });
+
+  it("DELETE integrations answers alike and writes no audit row", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) =>
+      INTEGRATIONS_DELETE(makeRequest(id, { method: "DELETE" }), makeParams(id))
+    );
+
+    const rows = await db.select().from(auditLog);
+    expect(rows).toEqual([]);
+  });
+
+  it("GET channels/telegram answers alike", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) =>
+      TELEGRAM_GET(makeRequest(id), makeParams(id))
+    );
+  });
+
+  it("POST channels/telegram answers alike and never reaches Telegram", async () => {
+    const foreign = await seedForeignPersonalAgent();
+
+    await expectIndistinguishable(foreign.id, (id) =>
+      TELEGRAM_POST(jsonBody(id, { botToken: "123456:ABC-token" }), makeParams(id))
+    );
+
+    expect(mockValidateTelegramBotToken).not.toHaveBeenCalled();
+    expect(mockUpdateTelegramChannelConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe("the same routes still serve an agent the admin may see (real DB)", () => {
+  // The gate must not have turned "admin-only" into "owner-only": a shared
+  // agent is exactly what these surfaces exist to manage, and a change that
+  // closed them would pass every assertion above.
+  async function seedSharedAgent() {
+    const [row] = await db
+      .insert(agents)
+      .values({
+        name: "Support Agent",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        greetingMessage: "Hello!",
+        isPersonal: false,
+        visibility: "all",
+        ownerId: null,
+        pluginConfig: { "pinchy-files": { allowed_paths: ["/data/hr"] } },
+      })
+      .returning();
+    return row;
+  }
+
+  it("reindexes a shared agent's granted folders", async () => {
+    const shared = await seedSharedAgent();
+
+    const res = await REINDEX_POST(jsonBody(shared.id, {}), makeParams(shared.id));
+
+    expect(res.status).toBe(202);
+    expect(mockEnqueueIndexJob).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueIndexJob.mock.calls[0][0]).toMatchObject({
+      agentId: shared.id,
+      paths: ["/data/hr"],
+    });
+  });
+
+  it("lists a shared agent's integrations", async () => {
+    const shared = await seedSharedAgent();
+
+    const res = await INTEGRATIONS_GET(makeRequest(shared.id), makeParams(shared.id));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("reports Telegram state for a shared agent", async () => {
+    const shared = await seedSharedAgent();
+
+    const res = await TELEGRAM_GET(makeRequest(shared.id), makeParams(shared.id));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ configured: false });
+  });
+
+  it("serves the admin's OWN personal agent — the main-bot setup flow depends on it", async () => {
+    // telegram-link-settings.tsx sets the org's main bot up on the admin's own
+    // Smithers, found via `/api/agents`. The owner branch of the read gate is
+    // what keeps that flow working.
+    const [session] = [await mockGetSession()];
+    const [own] = await db
+      .insert(agents)
+      .values({
+        name: "Smithers",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        greetingMessage: "Hello!",
+        isPersonal: true,
+        visibility: "restricted",
+        ownerId: session.user.id,
+      })
+      .returning();
+
+    const res = await TELEGRAM_GET(makeRequest(own.id), makeParams(own.id));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ configured: false, mainBotConfigured: true });
+  });
+});

--- a/packages/web/src/__tests__/api/agent-admin-routes-visibility.integration.test.ts
+++ b/packages/web/src/__tests__/api/agent-admin-routes-visibility.integration.test.ts
@@ -365,7 +365,7 @@ describe("the same routes still serve an agent the admin may see (real DB)", () 
     // telegram-link-settings.tsx sets the org's main bot up on the admin's own
     // Smithers, found via `/api/agents`. The owner branch of the read gate is
     // what keeps that flow working.
-    const [session] = [await mockGetSession()];
+    const session = await mockGetSession();
     const [own] = await db
       .insert(agents)
       .values({

--- a/packages/web/src/__tests__/api/agent-integrations.test.ts
+++ b/packages/web/src/__tests__/api/agent-integrations.test.ts
@@ -65,6 +65,16 @@ vi.mock("@/db", () => ({
   },
 }));
 
+// The route no longer checks the agent's existence itself: it asks the shared
+// read gate, which additionally withholds another user's personal agent from an
+// admin. Mocking the helper is what lets this file assert the delegation; the
+// helper's own rule is pinned in lib/agent-access.test.ts, and the end-to-end
+// answer against a real DB in agent-admin-routes-visibility.integration.test.ts.
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
 vi.mock("@/lib/openclaw-config", () => ({
   regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
 }));
@@ -78,12 +88,15 @@ vi.mock("@/lib/audit-deferred", () => ({
 }));
 
 import { GET, PUT, DELETE } from "@/app/api/agents/[agentId]/integrations/route";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { agentConnectionPermissions, integrationConnections } from "@/db/schema";
 
 const AGENT_ID = "agent-1";
 const CONNECTION_ID = "conn-1";
+
+/** What the read gate hands back for an agent this caller may see. */
+const agentRow = { id: AGENT_ID, name: "Support Agent" };
 
 function makeParams(agentId: string) {
   return { params: Promise.resolve({ agentId }) };
@@ -92,9 +105,27 @@ function makeParams(agentId: string) {
 describe("GET /api/agents/[agentId]/integrations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetAgentWithAccess.mockResolvedValue(agentRow);
     mockSelectFrom.mockImplementation(() => ({
       where: mockSelectWhere.mockResolvedValue([]),
     }));
+  });
+
+  it("forwards the read gate's refusal and reads no permission row", async () => {
+    // An admin aiming at another user's personal agent. This route never
+    // checked existence at all, so it answered 200 with an empty list — which
+    // is the same answer a real agent with no integrations gives, and a
+    // different one from what a nonexistent id now gives.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
+
+    const req = new NextRequest(`http://localhost:7777/api/agents/${AGENT_ID}/integrations`);
+    const res = await GET(req, makeParams(AGENT_ID));
+
+    expect(res.status).toBe(404);
+    expect(mockGetAgentWithAccess).toHaveBeenCalledWith(AGENT_ID, "admin-1", "admin");
+    expect(mockSelectWhere).not.toHaveBeenCalled();
   });
 
   it("returns 401 for unauthenticated request", async () => {
@@ -237,6 +268,7 @@ describe("GET /api/agents/[agentId]/integrations", () => {
 describe("PUT /api/agents/[agentId]/integrations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetAgentWithAccess.mockResolvedValue(agentRow);
     mockSelectFrom.mockImplementation(() => ({
       where: mockSelectWhere,
     }));
@@ -320,7 +352,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("returns 200 for a valid 'read' operation on model 'email'", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     mockTxSelectWhere.mockResolvedValueOnce([]);
 
@@ -337,7 +368,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("does not restrict operation vocabulary for non-email models (e.g. Odoo)", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     mockTxSelectWhere.mockResolvedValueOnce([]);
 
@@ -354,7 +384,9 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("returns 404 when agent does not exist", async () => {
-    mockSelectWhere.mockResolvedValueOnce([]); // agent not found
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
 
     const req = new NextRequest(`http://localhost:7777/api/agents/ghost-agent/integrations`, {
       method: "PUT",
@@ -367,8 +399,30 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
     expect(body.error).toBe("Agent not found");
   });
 
+  it("forwards the read gate's refusal and writes no permission row", async () => {
+    // The sharpest of the four families: this is not index management, it is a
+    // permission WRITE. Granting another user's private Smithers live access to
+    // an Odoo or email connection would be invisible to its owner and to every
+    // list the admin can see. The gate runs before the transaction.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
+
+    const req = new NextRequest(`http://localhost:7777/api/agents/${AGENT_ID}/integrations`, {
+      method: "PUT",
+      body: JSON.stringify({
+        connectionId: CONNECTION_ID,
+        permissions: [{ model: "res.partner", operation: "read" }],
+      }),
+    });
+    const res = await PUT(req, makeParams(AGENT_ID));
+
+    expect(res.status).toBe(404);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockAppendAuditLog).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when connection does not exist", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([]); // connection not found
 
     const req = new NextRequest(`http://localhost:7777/api/agents/${AGENT_ID}/integrations`, {
@@ -382,7 +436,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
 
   it("deletes existing permissions and inserts new ones", async () => {
     // Connection exists (validation query runs outside transaction)
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     // Existing permissions for diff (inside transaction)
     mockTxSelectWhere.mockResolvedValueOnce([{ model: "res.partner", operation: "read" }]);
@@ -405,7 +458,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("does not call regenerateOpenClawConfig (delegated to agent PATCH)", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     mockTxSelectWhere.mockResolvedValueOnce([]);
 
@@ -423,7 +475,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("writes audit log with added/removed diff", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     // Existing permissions (inside transaction)
     mockTxSelectWhere.mockResolvedValueOnce([
@@ -460,7 +511,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
 
   it("wraps DELETE+INSERT in a database transaction", async () => {
     // Connection exists (validation query runs outside transaction)
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     mockTxSelectWhere.mockResolvedValueOnce([]);
 
@@ -483,7 +533,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("handles empty permissions (clear all)", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     mockTxSelectWhere.mockResolvedValueOnce([{ model: "res.partner", operation: "read" }]);
 
@@ -503,7 +552,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("does not turn a committed change into a 500 when the audit write fails", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     mockTxSelectWhere.mockResolvedValueOnce([]);
     mockAppendAuditLog.mockRejectedValueOnce(new Error("audit db unavailable"));
@@ -524,7 +572,6 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
   });
 
   it("does not leak the raw DB error text when the permission write fails", async () => {
-    mockSelectWhere.mockResolvedValueOnce([{ id: AGENT_ID }]); // agent exists
     mockSelectWhere.mockResolvedValueOnce([{ id: CONNECTION_ID }]); // connection exists
     mockTransaction.mockRejectedValueOnce(
       new Error(
@@ -551,7 +598,30 @@ describe("PUT /api/agents/[agentId]/integrations", () => {
 describe("DELETE /api/agents/[agentId]/integrations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetAgentWithAccess.mockResolvedValue(agentRow);
+    mockSelectFrom.mockImplementation(() => ({
+      where: mockSelectWhere.mockResolvedValue([]),
+    }));
     mockDeleteWhere.mockResolvedValue(undefined);
+  });
+
+  it("forwards the read gate's refusal and deletes nothing", async () => {
+    // This route never checked existence either: it answered 200 `{success:
+    // true}` and wrote a `config.changed` audit row claiming permissions were
+    // cleared, for an agent the caller may not see — and for ids that were
+    // never issued.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
+
+    const req = new NextRequest(`http://localhost:7777/api/agents/${AGENT_ID}/integrations`, {
+      method: "DELETE",
+    });
+    const res = await DELETE(req, makeParams(AGENT_ID));
+
+    expect(res.status).toBe(404);
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+    expect(mockAppendAuditLog).not.toHaveBeenCalled();
   });
 
   it("returns 401 for unauthenticated request", async () => {

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -112,6 +112,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireAdmin.mockResolvedValue(adminSession);
+    mockGetAgentWithAccess.mockResolvedValue(mockAgent);
   });
 
   it("returns configured: false when no token exists", async () => {
@@ -226,11 +227,12 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("returns mainBotConfigured: true for personal agent even when global main bot is missing", async () => {
+    // The personal agent this branch exists for is the ADMIN'S OWN Smithers —
+    // telegram-link-settings.tsx finds it in the admin's own `/api/agents`
+    // list, and the read gate lets an owner through. The exemption survives
+    // the gate; only somebody else's personal agent is turned away.
     mockHasMainTelegramBot.mockResolvedValueOnce(false);
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
-      id: "agent-1",
-      isPersonal: true,
-    } as any);
+    mockGetAgentWithAccess.mockResolvedValueOnce({ ...mockAgent, isPersonal: true });
     vi.mocked(getSetting).mockResolvedValueOnce(null);
 
     const response = await GET(new NextRequest("http://localhost"), {
@@ -241,13 +243,31 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     expect(response.status).toBe(200);
     expect(data).toEqual({ configured: false, mainBotConfigured: true });
   });
+
+  it("forwards the read gate's refusal and reads no setting for the agent", async () => {
+    // An admin aiming at another user's personal agent. This route used to
+    // answer 200 `{configured:false}` for an id nobody ever issued and 200
+    // WITH a token hint for a personal agent it had no business naming — an
+    // existence oracle over agents `getVisibleAgents` withholds from admins.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
+
+    const response = await GET(new NextRequest("http://localhost"), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error).toBe("Agent not found");
+    expect(getSetting).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/agents/[agentId]/channels/telegram", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireAdmin.mockResolvedValue(adminSession);
-    vi.mocked(db.query.agents.findFirst).mockResolvedValue(mockAgent as any);
+    mockGetAgentWithAccess.mockResolvedValue(mockAgent);
     mockValidateTelegramBotToken.mockResolvedValue({
       valid: true,
       botId: 123456,
@@ -353,7 +373,9 @@ describe("POST /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("returns 404 for non-existent agent", async () => {
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce(undefined as any);
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
 
     const response = await POST(makeRequest({ botToken: "123456:ABC-token" }), {
       params: mockParams,
@@ -362,6 +384,24 @@ describe("POST /api/agents/[agentId]/channels/telegram", () => {
 
     expect(response.status).toBe(404);
     expect(data.error).toBe("Agent not found");
+  });
+
+  it("forwards the read gate's refusal and connects nothing", async () => {
+    // Connecting a bot to another user's private Smithers is a write into an
+    // agent nobody can list. The gate answers before the token is validated,
+    // so the refusal costs no call to Telegram either.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
+
+    const response = await POST(makeRequest({ botToken: "123456:ABC-token" }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(404);
+    expect(mockValidateTelegramBotToken).not.toHaveBeenCalled();
+    expect(setSetting).not.toHaveBeenCalled();
+    expect(appendAuditLog).not.toHaveBeenCalled();
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -520,11 +560,10 @@ describe("POST /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("allows personal agent setup even when main bot is missing (first-time bootstrap)", async () => {
+    // The bootstrap case is the admin's OWN Smithers, which the read gate lets
+    // an owner through — the exemption survives the gate.
     mockHasMainTelegramBot.mockResolvedValueOnce(false);
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
-      ...mockAgent,
-      isPersonal: true,
-    } as any);
+    mockGetAgentWithAccess.mockResolvedValueOnce({ ...mockAgent, isPersonal: true });
 
     const response = await POST(makeRequest({ botToken: "123456:ABC-token" }), {
       params: mockParams,

--- a/packages/web/src/__tests__/api/knowledge-reindex.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-reindex.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
 import type { KbIndexJob } from "@/lib/knowledge/index-jobs";
 import type { IngestResult } from "@/lib/knowledge/types";
@@ -15,16 +15,15 @@ vi.mock("@/lib/auth", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
 }));
 
-const mockLimit = vi.fn();
-const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
-vi.mock("@/db", () => ({
-  db: { select: (...args: unknown[]) => mockSelect(...args) },
-}));
-
-vi.mock("@/db/schema", () => ({
-  activeAgents: { __table: "active_agents", id: "active_agents.id" },
+// The route no longer looks the agent up itself: it asks the shared read gate,
+// which is what withholds another user's personal agent from an admin. Mocking
+// the helper (rather than `@/db`) is what lets this file assert the delegation;
+// the helper's own rule is pinned in lib/agent-access.test.ts, and the
+// end-to-end answer against a real DB in
+// agent-admin-routes-visibility.integration.test.ts.
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
 }));
 
 const mockGetSetting = vi.fn();
@@ -104,7 +103,7 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue({ user: { id: "admin-1", role: "admin" } });
-    mockLimit.mockResolvedValue([agentRow]);
+    mockGetAgentWithAccess.mockResolvedValue(agentRow);
     mockGetSetting.mockResolvedValue("http://ollama.local:11434");
     mockKbEmbedderAvailable.mockReturnValue(true);
     mockEnqueueIndexJob.mockResolvedValue({ status: "queued", job: makeJob() });
@@ -126,10 +125,28 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
   });
 
   it("returns 404 when the agent does not exist (or is deleted) and never enqueues", async () => {
-    mockLimit.mockResolvedValueOnce([]);
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(404);
     expect(mockEnqueueIndexJob).not.toHaveBeenCalled();
+  });
+
+  it("asks the read gate with the caller's identity, before it reads the body", async () => {
+    // Being admin-only is not a visibility rule: another user's personal agent
+    // is withheld from admins too, and only the gate knows that. It runs
+    // first, so an agent this caller may not see costs no validation error
+    // that would distinguish it from one that does not exist.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
+
+    const res = await POST(makeRequest({ paths: 42 }), ctx as never);
+
+    expect(mockGetAgentWithAccess).toHaveBeenCalledWith("agent-1", "admin-1", "admin");
+    expect(res.status).toBe(404);
+    expect(mockDeferAuditLog).not.toHaveBeenCalled();
   });
 
   // The whole point of #714: a real corpus is hours of embedding, so the
@@ -205,7 +222,11 @@ describe("POST /api/agents/[agentId]/knowledge/reindex", () => {
   });
 
   it("returns 200 and never enqueues when the agent has no granted folders", async () => {
-    mockLimit.mockResolvedValueOnce([{ id: "agent-1", name: "Smithers", pluginConfig: null }]);
+    mockGetAgentWithAccess.mockResolvedValueOnce({
+      id: "agent-1",
+      name: "Smithers",
+      pluginConfig: null,
+    });
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ jobId: null, status: "noop", pathCount: 0 });
@@ -278,7 +299,7 @@ describe("GET /api/agents/[agentId]/knowledge/reindex", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue({ user: { id: "admin-1", role: "admin" } });
-    mockLimit.mockResolvedValue([agentRow]);
+    mockGetAgentWithAccess.mockResolvedValue(agentRow);
     GET = (await import("@/app/api/agents/[agentId]/knowledge/reindex/route")).GET;
   });
 
@@ -293,8 +314,24 @@ describe("GET /api/agents/[agentId]/knowledge/reindex", () => {
   });
 
   it("returns 404 when the agent does not exist", async () => {
-    mockLimit.mockResolvedValueOnce([]);
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
     expect((await GET(makeGetRequest(), ctx as never)).status).toBe(404);
+  });
+
+  it("asks the read gate with the caller's identity, and reports no job state on refusal", async () => {
+    // The status projection is the readable half of the same secret: it names
+    // the agent, its path count and its run history. Same gate as the write.
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
+
+    const res = await GET(makeGetRequest(), ctx as never);
+
+    expect(mockGetAgentWithAccess).toHaveBeenCalledWith("agent-1", "admin-1", "admin");
+    expect(res.status).toBe(404);
+    expect(mockGetLatestIndexJobForAgent).not.toHaveBeenCalled();
   });
 
   it("reports no job for an agent that has never been reindexed", async () => {

--- a/packages/web/src/__tests__/api/knowledge-unsearchable.test.ts
+++ b/packages/web/src/__tests__/api/knowledge-unsearchable.test.ts
@@ -7,7 +7,7 @@
  * lib/knowledge/unsearchable.integration.test.ts.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
 
@@ -22,16 +22,15 @@ vi.mock("@/lib/auth", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
 }));
 
-const mockLimit = vi.fn();
-const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
-vi.mock("@/db", () => ({
-  db: { select: (...args: unknown[]) => mockSelect(...args) },
-}));
-
-vi.mock("@/db/schema", () => ({
-  activeAgents: { __table: "active_agents", id: "active_agents.id" },
+// The route no longer looks the agent up itself: it asks the shared read gate,
+// which is what withholds another user's personal agent from an admin. Mocking
+// the helper (rather than `@/db`) is what lets this file assert the delegation;
+// the helper's own rule is pinned in lib/agent-access.test.ts, and the
+// end-to-end answer against a real DB in
+// agent-admin-routes-visibility.integration.test.ts.
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
 }));
 
 const mockListUnsearchableDocuments = vi.fn();
@@ -58,7 +57,7 @@ describe("GET /api/agents/[agentId]/knowledge/unsearchable", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue({ user: { id: "admin-1", role: "admin" } });
-    mockLimit.mockResolvedValue([agentRow]);
+    mockGetAgentWithAccess.mockResolvedValue(agentRow);
     mockListUnsearchableDocuments.mockResolvedValue({ documents: [], total: 0 });
     GET = (await import("@/app/api/agents/[agentId]/knowledge/unsearchable/route")).GET;
   });
@@ -82,12 +81,23 @@ describe("GET /api/agents/[agentId]/knowledge/unsearchable", () => {
   });
 
   it("returns 404 for an unknown agent and never queries", async () => {
-    mockLimit.mockResolvedValueOnce([]);
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Agent not found" }, { status: 404 })
+    );
 
     const res = await GET(makeRequest(), ctx as never);
 
     expect(res.status).toBe(404);
     expect(mockListUnsearchableDocuments).not.toHaveBeenCalled();
+  });
+
+  it("asks the read gate with the caller's identity, not just the agent id", async () => {
+    // Being admin-only is not a visibility rule. The gate is what withholds
+    // another user's personal agent, and it can only do that if the route
+    // hands it who is asking — the answer differs per caller, not per role.
+    await GET(makeRequest(), ctx as never);
+
+    expect(mockGetAgentWithAccess).toHaveBeenCalledWith("agent-1", "admin-1", "admin");
   });
 
   // The security boundary of this route: the scope comes from the agent's
@@ -104,7 +114,11 @@ describe("GET /api/agents/[agentId]/knowledge/unsearchable", () => {
   });
 
   it("scopes to nothing when the agent has no pinchy-files grants", async () => {
-    mockLimit.mockResolvedValueOnce([{ id: "agent-1", name: "Smithers", pluginConfig: null }]);
+    mockGetAgentWithAccess.mockResolvedValueOnce({
+      id: "agent-1",
+      name: "Smithers",
+      pluginConfig: null,
+    });
 
     const res = await GET(makeRequest(), ctx as never);
 

--- a/packages/web/src/__tests__/security/agent-route-access-gate.test.ts
+++ b/packages/web/src/__tests__/security/agent-route-access-gate.test.ts
@@ -34,9 +34,12 @@
 //     every path or that its refusal is returned. A handler that called it and
 //     ignored the result would pass. Review owns that; the route tests and
 //     `agent-admin-routes-visibility.integration.test.ts` cover the behaviour.
-//   - Its scope is this one prefix. `/api/automations` is keyed by `agentId`
-//     through a query parameter and is deliberately outside — that surface has
-//     its own scope gate (`canManageAgentWorkflows`) and its own open verdict.
+//   - Its scope is this one prefix, so it does not speak for `/api/automations`,
+//     which takes `agentId` as a query parameter. Those routes reach the same
+//     gate through `resolveWorkflowAgent` (#880) and layer a manage-scope 403 on
+//     top of it; `resolve-agent.test.ts` is what holds that end. Extending this
+//     walk to them would have to model that second gate, which is why they are
+//     covered where they live rather than here.
 import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";

--- a/packages/web/src/__tests__/security/agent-route-access-gate.test.ts
+++ b/packages/web/src/__tests__/security/agent-route-access-gate.test.ts
@@ -1,0 +1,203 @@
+// packages/web/src/__tests__/security/agent-route-access-gate.test.ts
+//
+// Every handler under `/api/agents/[agentId]/` gates on the caller's view of
+// the agent, via `getAgentWithAccess`.
+//
+// Why this is a guard and not a paragraph: the rule was a paragraph, and four
+// route families did not follow it. `knowledge/reindex`, `knowledge/unsearchable`,
+// `integrations` and the Telegram `GET`/`POST` each looked the agent up by id
+// and proceeded, so an admin holding a colleague's agent id could reindex their
+// Smithers, read the documents its index cannot search, grant it live access to
+// an Odoo or email connection, and attach a Telegram bot to it — while
+// `getVisibleAgents`, the chat page and `PATCH`/`DELETE /api/agents/:id` all
+// answered "not found" for the same agent. Being an admin is not a visibility
+// rule; see `getAgentWithAccess`'s docblock for the verdict.
+//
+// Closing those four made the prefix uniform. Nothing kept it that way, and the
+// docs now state the property outright ("its ID answers 'not found' on every
+// management endpoint" — concepts/user-roles.mdx, concepts/agent-permissions.mdx,
+// architecture.mdx). A claim in prose that nothing checks is the drift AGENTS.md
+// § "A Hand-Maintained List That Mirrors Code Will Be Wrong" catalogues: the one
+// list that stayed correct is the one with a guard. The next handler added under
+// this prefix inherits the rule, or names itself here.
+//
+// What it checks, precisely: for each exported HTTP handler, the AST of THAT
+// handler contains a call to `getAgentWithAccess`. Per handler, not per file —
+// `integrations/route.ts` has three, and a gate on two of them would satisfy any
+// file-level count. It walks real call expressions rather than matching text, so
+// a comment naming the helper cannot stand in for calling it (these routes
+// explain their gate in prose directly above it).
+//
+// Known limitations, so nobody reads a green run as more than it is:
+//
+//   - It proves the call is present in the handler, not that it is reached on
+//     every path or that its refusal is returned. A handler that called it and
+//     ignored the result would pass. Review owns that; the route tests and
+//     `agent-admin-routes-visibility.integration.test.ts` cover the behaviour.
+//   - Its scope is this one prefix. `/api/automations` is keyed by `agentId`
+//     through a query parameter and is deliberately outside — that surface has
+//     its own scope gate (`canManageAgentWorkflows`) and its own open verdict.
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import ts from "typescript";
+
+const AGENT_ID_DIR = resolve(__dirname, "../../app/api/agents/[agentId]");
+const APP_DIR = resolve(__dirname, "../../app");
+
+const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
+
+const ACCESS_GATE = "getAgentWithAccess";
+
+/**
+ * Handlers that legitimately do not gate on the caller's view of the agent,
+ * each with a written reason.
+ *
+ * Empty on purpose, and it is meant to stay that way: today all 16 handlers
+ * under this prefix gate. An entry is an assertion of fact ("this handler
+ * cannot use the gate, because …"), so it takes a reason rather than an issue
+ * number — same contract as `raw-fetch-exempt`. It is checked in both
+ * directions: an entry for a handler that is gated, or for one that no longer
+ * exists, fails like any other drift.
+ */
+const EXEMPT_HANDLERS: Record<string, string> = {};
+
+function walkRouteFiles(dir: string): string[] {
+  const result: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      result.push(...walkRouteFiles(fullPath));
+    } else if (entry === "route.ts" || entry === "route.tsx") {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+/** `app/api/agents/[agentId]/uploads/route.ts` → `/api/agents/[agentId]/uploads`. */
+function routeFileToPath(file: string): string {
+  return "/" + relative(APP_DIR, file).replace(/\/route\.tsx?$/, "");
+}
+
+/** True when this subtree calls `getAgentWithAccess(...)` — a call, not a mention. */
+function callsAccessGate(node: ts.Node): boolean {
+  let found = false;
+  const visit = (n: ts.Node) => {
+    if (found) return;
+    if (
+      ts.isCallExpression(n) &&
+      ts.isIdentifier(n.expression) &&
+      n.expression.text === ACCESS_GATE
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return found;
+}
+
+interface Handler {
+  /** e.g. `GET /api/agents/[agentId]/integrations`. */
+  id: string;
+  gated: boolean;
+}
+
+/**
+ * Every exported HTTP handler in one route file, in both spellings this tree
+ * uses: `export async function GET(…)` and `export const GET = withAdmin(…)`.
+ * The wrapper does not need unwrapping — the whole exported declaration is the
+ * subtree searched, so `withAdmin(async (…) => { … })` is covered by it.
+ */
+function extractHandlers(file: string): Handler[] {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const routePath = routeFileToPath(file);
+  const handlers: Handler[] = [];
+
+  const isExported = (node: ts.Node) =>
+    ts.canHaveModifiers(node) &&
+    ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ===
+      true;
+
+  for (const statement of source.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name && isExported(statement)) {
+      if (!HTTP_METHODS.has(statement.name.text)) continue;
+      handlers.push({
+        id: `${statement.name.text} ${routePath}`,
+        gated: callsAccessGate(statement),
+      });
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement) && isExported(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) continue;
+        if (!HTTP_METHODS.has(declaration.name.text)) continue;
+        handlers.push({
+          id: `${declaration.name.text} ${routePath}`,
+          gated: callsAccessGate(declaration),
+        });
+      }
+    }
+  }
+
+  return handlers;
+}
+
+const handlers = walkRouteFiles(AGENT_ID_DIR).flatMap(extractHandlers);
+
+describe("every /api/agents/[agentId]/ handler gates on the caller's view of the agent", () => {
+  // A walk that stops finding handlers reports "no offenders" and reads exactly
+  // like a clean pass. 16 handlers exist today; the floor fails long before a
+  // broken walk can be mistaken for compliance.
+  it("finds the route handlers it is supposed to check", () => {
+    expect(handlers.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it("gates every handler through getAgentWithAccess", () => {
+    const ungated = handlers
+      .filter((handler) => !handler.gated && !(handler.id in EXEMPT_HANDLERS))
+      .map((handler) => handler.id);
+
+    expect(
+      ungated,
+      `These handlers under /api/agents/[agentId]/ do not call ${ACCESS_GATE}, so they act on an ` +
+        `agent the caller may not be allowed to see — another user's personal agent is withheld ` +
+        `from admins too. Gate them:\n\n` +
+        `  const agentOrError = await ${ACCESS_GATE}(agentId, session.user.id!, session.user.role);\n` +
+        `  if (agentOrError instanceof NextResponse) return agentOrError;\n\n` +
+        `Run it BEFORE parsing the body: a validation error only a real id can reach is the same ` +
+        `oracle as a 403. If a handler genuinely cannot gate, add it to EXEMPT_HANDLERS with a ` +
+        `written reason.\n\nUngated:`
+    ).toEqual([]);
+  });
+
+  it("carries no exemption that has gone stale", () => {
+    const byId = new Map(handlers.map((handler) => [handler.id, handler]));
+
+    for (const [id, reason] of Object.entries(EXEMPT_HANDLERS)) {
+      expect(
+        reason.trim().length,
+        `EXEMPT_HANDLERS["${id}"] needs a written reason`
+      ).toBeGreaterThan(10);
+      const handler = byId.get(id);
+      expect(
+        handler,
+        `EXEMPT_HANDLERS names "${id}", which is not a handler under this prefix`
+      ).toBeDefined();
+      // A verdict must not outlive its evidence: once the handler gates, the
+      // exemption asserts something that is no longer true.
+      expect(
+        handler?.gated,
+        `EXEMPT_HANDLERS["${id}"] is exempt but now calls ${ACCESS_GATE}`
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -13,7 +13,7 @@ import {
   recalculateTelegramAllowStores,
 } from "@/lib/telegram-allow-store";
 import { db } from "@/db";
-import { agents, channelLinks, settings } from "@/db/schema";
+import { channelLinks, settings } from "@/db/schema";
 import { eq, like } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
 import { setBotTokenSchema } from "@/lib/schemas/telegram";
@@ -24,11 +24,20 @@ export async function GET(req: Request, { params }: { params: Promise<{ agentId:
   if (admin instanceof NextResponse) return admin;
   const { agentId } = await params;
 
-  const [agent, botToken, globalMainBot] = await Promise.all([
-    db.query.agents.findFirst({
-      where: eq(agents.id, agentId),
-      columns: { isPersonal: true },
-    }),
+  // Read gate before anything else, and it must be awaited on its own rather
+  // than folded into the Promise.all below: a refusal has to cost no lookup of
+  // this agent's token. Being an admin is not a visibility rule — see
+  // getAgentWithAccess's docblock. The role check above is not an oracle: it
+  // refuses every id alike.
+  //
+  // The personal agent that matters here is the admin's OWN Smithers, which the
+  // gate lets an owner through; telegram-link-settings.tsx finds it in the
+  // admin's own `/api/agents` list. Only somebody else's is turned away.
+  const agentOrError = await getAgentWithAccess(agentId, admin.user.id, admin.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+  const agent = agentOrError;
+
+  const [botToken, globalMainBot] = await Promise.all([
     getSetting(`telegram_bot_token:${agentId}`),
     hasMainTelegramBot(),
   ]);
@@ -36,7 +45,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ agentId:
   // Personal agents (Smithers) are themselves the main bot — the prerequisite
   // is trivially satisfied from their perspective, otherwise first-time setup
   // would hit an unresolvable chicken-and-egg.
-  const mainBotConfigured = agent?.isPersonal ? true : globalMainBot;
+  const mainBotConfigured = agent.isPersonal ? true : globalMainBot;
 
   if (!botToken) {
     return NextResponse.json({ configured: false, mainBotConfigured });
@@ -81,16 +90,18 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ age
   const admin = await requireAdmin();
   if (admin instanceof NextResponse) return admin;
   const { agentId } = await params;
+
+  // Read gate first, before the body is even parsed: connecting a bot to
+  // another user's private Smithers is a write into an agent nobody can list,
+  // and a validation error only a real id can reach would disclose which ids
+  // are real. Same rule as the DELETE below.
+  const agentOrError = await getAgentWithAccess(agentId, admin.user.id, admin.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+  const agent = agentOrError;
+
   const parsed = await parseRequestBody(setBotTokenSchema, req);
   if ("error" in parsed) return parsed.error;
   const { botToken } = parsed.data;
-
-  const agent = await db.query.agents.findFirst({
-    where: eq(agents.id, agentId),
-  });
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
 
   // Guard: main Telegram bot must exist before additional agents can connect.
   // Users can only link their Telegram account via the main bot — without it,

--- a/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { eq, and, inArray } from "drizzle-orm";
 import { withAdmin } from "@/lib/api-auth";
+import { getAgentWithAccess } from "@/lib/agent-access";
 import { db } from "@/db";
-import { agentConnectionPermissions, integrationConnections, agents } from "@/db/schema";
+import { agentConnectionPermissions, integrationConnections } from "@/db/schema";
 import { appendAuditLog, type AuditLogEntry } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { parseRequestBody } from "@/lib/api-validation";
@@ -14,9 +15,22 @@ type RouteContext = { params: Promise<{ agentId: string }> };
  * GET /api/agents/[agentId]/integrations
  *
  * Returns current integration permissions for this agent, grouped by connection.
+ *
+ * Admin-only AND gated on the admin's own view of the agent: another user's
+ * personal agent answers 404, the same answer an id nobody ever issued gets.
+ * Being an admin is not a visibility rule — see getAgentWithAccess's docblock
+ * for the verdict, and `PATCH`/`DELETE /api/agents/:id` for the two routes that
+ * already answered this way.
+ *
+ * Until the gate landed this route checked nothing at all, so it answered `200
+ * []` for every id — indistinguishable from a real agent that simply has no
+ * integrations.
  */
-export const GET = withAdmin<RouteContext>(async (_req, { params }) => {
+export const GET = withAdmin<RouteContext>(async (_req, { params }, session) => {
   const { agentId } = await params;
+
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
 
   // Join permissions with connections WITHOUT a projection-less
   // `.innerJoin(integrationConnections, …)`. That returns every column of both
@@ -90,9 +104,22 @@ export const GET = withAdmin<RouteContext>(async (_req, { params }) => {
  * PUT /api/agents/[agentId]/integrations
  *
  * Replace all permissions for this agent on a given connection.
+ *
+ * The sharpest of this file's three handlers, and the reason the read gate
+ * belongs on all of them: this is a permission WRITE, not index management.
+ * Granting another user's private Smithers live access to an Odoo or email
+ * connection would be invisible to its owner and absent from every list the
+ * granting admin can see.
  */
 export const PUT = withAdmin<RouteContext>(async (request, { params }, session) => {
   const { agentId } = await params;
+
+  // Also the agent's existence check, which this route used to run against
+  // `agents` — the gate reads `active_agents`, so a soft-deleted agent now
+  // answers 404 instead of accepting permission rows. The FK violation that
+  // check was written for (a stale UI submitting a deleted id) stays covered.
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
 
   const parsed = await parseRequestBody(setAgentIntegrationsSchema, request);
   if ("error" in parsed) return parsed.error;
@@ -100,14 +127,6 @@ export const PUT = withAdmin<RouteContext>(async (request, { params }, session) 
 
   let existingPerms: { model: string; operation: string }[];
   try {
-    // Validate the agent exists. The path param is unconstrained; a stale UI
-    // can submit a deleted agentId, which would otherwise reach a raw FK
-    // violation on insert and surface as a 500 with the DB error text.
-    const agentRows = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, agentId));
-    if (agentRows.length === 0) {
-      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-    }
-
     // Validate connection exists
     const connRows = await db
       .select()
@@ -213,9 +232,16 @@ export const PUT = withAdmin<RouteContext>(async (request, { params }, session) 
  * DELETE /api/agents/[agentId]/integrations
  *
  * Remove ALL integration permissions for this agent (used when connection is cleared).
+ *
+ * Gated like its siblings. It, too, checked nothing before: an unknown id was
+ * answered `200 {success:true}` and given a `config.changed` audit row claiming
+ * permissions had been cleared.
  */
 export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) => {
   const { agentId } = await params;
+
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
 
   // Get existing permissions for audit log
   const existingPerms = await db

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/reindex/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
 
 import { withAdmin } from "@/lib/api-auth";
+import { getAgentWithAccess } from "@/lib/agent-access";
 import { parseRequestBody } from "@/lib/api-validation";
 import { knowledgeReindexSchema } from "@/lib/schemas/knowledge-base";
-import { db } from "@/db";
-import { activeAgents, type AgentPluginConfig } from "@/db/schema";
+import { type AgentPluginConfig } from "@/db/schema";
 import { enqueueIndexJob, getLatestIndexJobForAgent } from "@/lib/knowledge/index-jobs";
 import { reindexAuditEntry } from "@/lib/knowledge/reindex-audit";
 import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
@@ -14,12 +13,6 @@ import { deferAuditLog } from "@/lib/audit-deferred";
 import { safeProviderError, type EntityRef } from "@/lib/audit";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
-
-/** The agent, or null if it does not exist / is deleted. */
-async function findAgent(agentId: string) {
-  const [agent] = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId)).limit(1);
-  return agent ?? null;
-}
 
 /**
  * The agent's granted knowledge-base folders, optionally narrowed to a
@@ -43,10 +36,18 @@ function resolveTargetPaths(agent: { pluginConfig: unknown }, requested?: string
  * (src/server/kb-index-worker.ts) and this route hands back a job id to poll
  * via GET on the same path (#714).
  *
- * Access boundary: admin-only (`withAdmin`) — index management is an admin
- * action. The folders reindexed are resolved from the SAME source the search
- * route scopes retrieval by: the agent's admin-configured `pinchy-files`
- * `allowed_paths`.
+ * Access boundary: admin-only (`withAdmin`) AND gated on the admin's own view
+ * of the agent (`getAgentWithAccess`) — being an admin is not a visibility
+ * rule. Another user's personal agent answers 404 here exactly as it does on
+ * `PATCH`/`DELETE /api/agents/:id`; see the verdict in getAgentWithAccess's
+ * docblock. The role check runs first and is not an oracle: a non-admin is
+ * refused for every id alike, real or invented.
+ *
+ * The folders reindexed are resolved from the SAME source the search route
+ * scopes retrieval by: the agent's admin-configured `pinchy-files`
+ * `allowed_paths`. That is also why "index management is instance-wide" does
+ * not survive contact with this route — its scope is one agent's grants, and
+ * `PATCH` is the only route that can set them.
  *
  * Both the resolved paths and the agent's name are snapshotted onto the job:
  * the worker must index what was authorized at the moment of the request, and
@@ -56,13 +57,15 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
   const { agentId } = await params;
   const actorId = session.user.id!;
 
+  // Read gate before body validation: an agent this admin may not see must not
+  // be distinguishable from one that does not exist, and a 400 that only a real
+  // id can reach would be exactly that distinction.
+  const agentOrError = await getAgentWithAccess(agentId, actorId, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+  const agent = agentOrError;
+
   const parsed = await parseRequestBody(knowledgeReindexSchema, request);
   if ("error" in parsed) return parsed.error;
-
-  const agent = await findAgent(agentId);
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
 
   const agentRef: EntityRef = { id: agent.id, name: agent.name };
   const targetPaths = resolveTargetPaths(agent, parsed.data.paths);
@@ -197,18 +200,18 @@ export const POST = withAdmin<RouteContext>(async (request, { params }, session)
  * snapshot is the run's input, which the admin already owns in the permissions
  * UI and which can disagree with the grants they are looking at now.
  *
- * Admin-only, like the reindex it reports on.
+ * Admin-only and access-gated, like the reindex it reports on: this is the
+ * readable half of the same secret — it names the agent's run history and how
+ * many folders were behind it.
  */
 // Read-only status projection, no state change — GET is outside
 // require-audit-log's scope (it only checks POST/PUT/PATCH/DELETE), so no
 // audit call is needed here.
-export const GET = withAdmin<RouteContext>(async (_request, { params }) => {
+export const GET = withAdmin<RouteContext>(async (_request, { params }, session) => {
   const { agentId } = await params;
 
-  const agent = await findAgent(agentId);
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
 
   const job = await getLatestIndexJobForAgent(agentId);
   if (!job) return NextResponse.json({ job: null });

--- a/packages/web/src/app/api/agents/[agentId]/knowledge/unsearchable/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/knowledge/unsearchable/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
 
 import { withAdmin } from "@/lib/api-auth";
-import { db } from "@/db";
-import { activeAgents, type AgentPluginConfig } from "@/db/schema";
+import { getAgentWithAccess } from "@/lib/agent-access";
+import { type AgentPluginConfig } from "@/db/schema";
 import { DEFAULT_ORG_ID } from "@/lib/knowledge/constants";
 import { listUnsearchableDocuments } from "@/lib/knowledge/unsearchable";
 
@@ -29,16 +28,18 @@ type RouteContext = { params: Promise<{ agentId: string }> };
  * path parameter here would turn a diagnostics panel into a way to enumerate
  * documents the agent was never granted.
  *
- * Admin-only, like the reindex it explains.
+ * Admin-only and access-gated, like the reindex it explains: the scope comes
+ * from the agent's grants, so the caller has to be allowed to see the agent
+ * first. Another user's personal agent answers 404 — same answer as an id
+ * nobody ever issued, see getAgentWithAccess's docblock.
  */
 // audit-exempt: read-only projection of already-stored index state, no state change.
-export const GET = withAdmin<RouteContext>(async (_request, { params }) => {
+export const GET = withAdmin<RouteContext>(async (_request, { params }, session) => {
   const { agentId } = await params;
 
-  const [agent] = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId)).limit(1);
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+  const agent = agentOrError;
 
   const allowedPaths =
     (agent.pluginConfig as AgentPluginConfig | null)?.["pinchy-files"]?.allowed_paths ?? [];

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -151,22 +151,45 @@ export function requireAgentWriteAccess(
  * than through this helper must run the read gate FIRST for the same reason —
  * `DELETE /api/agents/[agentId]/channels/telegram` is the worked example.
  *
- * Two things this does NOT close, said plainly so the next reader does not
+ * **Being an admin is not a visibility rule**, and the admin-only management
+ * surfaces under `/api/agents/:id/` go through this helper for that reason
+ * (`knowledge/reindex`, `knowledge/unsearchable`, `integrations`, and
+ * connecting a Telegram bot). They used to look the agent up by id and
+ * proceed, so an admin holding one could reindex a stranger's Smithers, read
+ * the documents its index cannot search, grant it live access to an Odoo or
+ * email connection, and attach a Telegram bot to it. The argument that index
+ * management is instance-wide does not rescue that: those routes resolve their
+ * scope from ONE agent's `pinchy-files` grants, and `PATCH /api/agents/:id` —
+ * the only route that can set them — already answers 404 for the same agent.
+ * A surface that can act on a grant it cannot see or set is an inconsistency,
+ * not a capability. `POST /integrations` is the plainest case: a permission
+ * write into a private agent, invisible to its owner and to every list the
+ * granting admin can see.
+ *
+ * Their role check runs BEFORE this gate, and that ordering is safe where the
+ * telegram DELETE's was not: `withAdmin`/`requireAdmin` refuse every id alike,
+ * real or invented, so the answer carries nothing about the agent.
+ *
+ * One thing this does NOT close, said plainly so the next reader does not
  * mistake "byte-identical" for "indistinguishable":
  *
  * - **Timing.** The denial path runs a license lookup and, for a restricted
  *   agent, two group queries that the `!agent` path never reaches. Equalising
  *   that costs a query on every miss and buys little against a UUID keyspace.
- * - **Routes that do not use this helper.** The admin-only
- *   `/api/agents/:id/knowledge/*` and `/integrations` endpoints apply no
- *   visibility rule at all — a separate verdict, not an oversight of this one;
- *   `reference/api.mdx` describes what each endpoint really does rather than
- *   claiming the prefix as a whole.
  *
- * The Automations routes were the third item here and are now closed (#880).
- * `resolveWorkflowAgent` shows the layering this docblock asks for: read gate
- * first, so an agent the caller cannot see is a 404, and only then the
- * manage-scope 403 for one they can.
+ * The list used to carry two more. The Automations routes were one and are now
+ * closed (#880) — `resolveWorkflowAgent` shows the layering this docblock asks
+ * for: read gate first, so an agent the caller cannot see is a 404, and only
+ * then the manage-scope 403 for one they can. The admin-only
+ * `/api/agents/:id/knowledge/*`, `/integrations` and Telegram-connect endpoints
+ * were the other, and are the paragraph above.
+ *
+ * What is left is deliberate and narrow: `PATCH`/`DELETE /api/automations/[id]`
+ * are keyed by WORKFLOW id and gate on `canManageAgentWorkflows` alone, so an
+ * admin already holding such an id can stop a runaway automation on an agent
+ * they cannot see. They cannot list or create one — that path is `agentId`-keyed
+ * and runs this gate. See `email-workflows/authz.ts` for why, and do not add a
+ * caller that consults that predicate without a visibility gate in front of it.
  */
 export async function getAgentWithAccess(agentId: string, userId: string, userRole: string) {
   const rows = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId));

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -170,6 +170,13 @@ export function requireAgentWriteAccess(
  * telegram DELETE's was not: `withAdmin`/`requireAdmin` refuse every id alike,
  * real or invented, so the answer carries nothing about the agent.
  *
+ * That the prefix has no gap left is asserted, not asserted-in-prose:
+ * `__tests__/security/agent-route-access-gate.test.ts` walks every exported
+ * handler under `app/api/agents/[agentId]/` and fails on one that does not call
+ * this function. The four families above were a paragraph nothing checked, and
+ * the docs now state the property outright — so the next handler added under the
+ * prefix inherits the rule instead of quietly re-opening it.
+ *
  * One thing this does NOT close, said plainly so the next reader does not
  * mistake "byte-identical" for "indistinguishable":
  *


### PR DESCRIPTION
Follow-up to #1148, which closed the 403-vs-404 oracle. This answers the bigger question that PR left open in the `getAgentWithAccess` docblock: **may an admin reach into another user's personal agent at all, on management surfaces?**

## The verdict: no

Four admin-only route families under `/api/agents/[agentId]/` looked the agent up by id and proceeded — `knowledge/reindex`, `knowledge/unsearchable`, `integrations`, and the Telegram `GET`/`POST`. An admin holding a colleague's agent id could reindex their Smithers, read the documents its index cannot search, grant it live access to an Odoo or email connection, and attach a Telegram bot to it.

Four things decided it:

1. **The write surface that creates these grants is already closed to admins.** `PATCH /api/agents/:id` is the only route that can set `pluginConfig["pinchy-files"].allowed_paths` — the very allow-list the knowledge routes resolve their scope from — and it answers 404 for another user's personal agent. An admin was acting on grants they could neither see nor set.

2. **"Index management is genuinely instance-wide" does not survive the code.** Both knowledge routes are agent-scoped by construction: `resolveTargetPaths` reads the agent's grants, `listUnsearchableDocuments` denies by default on an empty list. `createSmithersAgent` creates personal agents with no `pluginConfig`, and they cannot be given one (PATCH is gated; the Permissions tab renders only for `isAdmin && !isPersonal`). So a reindex through a stranger's id is a no-op that discloses the agent's existence and buys the admin nothing. There is no org-wide reindex route to mistake it for.

3. **No UI path reaches those agents.** Every call site sources its `agentId` from `getVisibleAgents` or from the chat settings page, which itself 404s. The main-bot chicken-and-egg in the Telegram `GET` is the admin's *own* Smithers, which the owner branch of the gate lets through.

4. **`PUT /integrations` is the sharpest case in the other direction** — not index management, but a permission write into a private agent, invisible to its owner and absent from every list the granting admin can see.

## What changed

All four now gate through `getAgentWithAccess`, so another user's personal agent answers 404 byte-identically to an id nobody ever issued — consistent with `PATCH`/`DELETE /api/agents/:id`, `getVisibleAgents`, and the chat page. The gate runs before body validation, so a refusal cannot be told apart from a miss by a validation error only a real id can reach. The role check still runs first, and that ordering is safe where the Telegram `DELETE`'s was not: `withAdmin`/`requireAdmin` refuse every id alike.

Two side effects worth naming:

- `GET`/`DELETE /api/agents/:agentId/integrations` and `GET .../channels/telegram` never checked existence at all. They answered `200` — an empty list, or `{"success": true}` plus a `config.changed` audit row claiming permissions were cleared — for ids that belonged to nothing. Now `404`.
- `PUT /integrations` checked `agents`; the gate reads `active_agents`, so a soft-deleted agent stops accepting permission rows.

## Verification

A real-DB integration test issues **both** requests per route — the foreign personal agent and an unknown id — and asserts the answers are equal, following the pattern from `uploads-post.integration.test.ts`. It ships with four positive controls (shared agents, and the admin's own Smithers during Telegram setup) so a change that turned "admin-only" into "owner-only" could not pass.

**Verified by canary, not by reading:** with the four gates reverted, all eight refusal assertions fail and the four positive controls stay green.

- `pnpm test` — 11744 passed, 18 skipped
- `pnpm -C packages/web test:db` — 70 files, 528 tests passed (throwaway pgvector container)
- `pnpm test:scripts` — 1184 passed
- `pnpm -C packages/web typecheck`, `pnpm -C packages/web lint`, `pnpm format:check` — clean
- docs build + `check:anchors` / `check:rendered` / `check:llms` — clean

## Docs

The `api.mdx` paragraph that named these endpoints as the exception now names only `/api/automations`. The `getAgentWithAccess` docblock carries the verdict and its reasoning.

The review pass then found the same false sentence on three concept pages, wrong since v0.5.2 and never noticed because no guard reads claims: `concepts/agent-permissions.mdx`, `concepts/user-roles.mdx` and `architecture.mdx` all said admins can access every user's personal agent. `getting-started.mdx` listed the Telegram tab as "Admin-only, any agent". Upgrade note added to the open section.

---

## Review pass

Two findings, both of which every check was green on.

**The rule had no guard.** It held in four route families because four files were edited; the next handler added under the prefix would reopen the hole silently. `agent-route-access-gate.test.ts` now walks every exported handler under `/api/agents/[agentId]/` and fails on one whose AST contains no `getAgentWithAccess` call — per handler, not per file (`integrations/route.ts` has three), on real call expressions rather than text (these routes explain their gate in prose right above it), with a corpus floor. Canary-verified in all four directions: gate stripped from one of three siblings, gate replaced by a comment naming the helper, exemption for a gated handler, exemption for a handler that does not exist. 16 of 16 handlers gate today.

**The docs replaced three false absolutes with three new ones.** "Its ID answers 'not found' everywhere" / "on every management endpoint" was contradicted by automations, where an admin could still reach a colleague's private agent. #880 landed on main during the review and closed exactly that, so after the rebase the pages state the rule with no exception left to name. `concepts/groups.mdx` also still carried the original false claim verbatim — the first sweep missed it.

Smaller: `/api/automations` was filed as a group "under this prefix" (it is not — query parameter, different gate); the three agent-integration endpoints shared one `404` sentence under the `GET` heading, so `PUT`/`DELETE` anchors never showed it, and each has its own Errors list now; the upgrade note's heading promised "on every surface".

Re-verified after the fixes: `pnpm test` 11747 passed / 18 skipped, `test:db` 528 passed (70 files), `test:scripts` 1184 passed, typecheck/lint/`format:check` clean, docs build + `check:anchors` / `check:rendered` / `check:llms` clean.


## Rebased onto #880

`main` closed the Automations reach while this branch was open, which changed what several of these sentences should say. Three reconciliations, none of them mechanical:

- The `getAgentWithAccess` docblock listed three things it did not close. Two are now closed and the third is a wording change, so the list is one item (timing) plus a note on what genuinely remains: `PATCH`/`DELETE /api/automations/[id]` are keyed by **workflow** id, so an admin already holding one can stop a runaway automation on an agent they cannot see — they can neither list nor create.
- The upgrade note is folded into main's "An agent you may not see now answers 'not found'" rather than added beside it. That note claimed the Automations routes "were the last ones that still answered"; these four endpoints disprove it, and it now names the actual last ones.
- The three concept pages drop the automations exception this branch had just added to them.

Re-verified on the rebase: `pnpm test` 11844 passed / 18 skipped, `test:db` 540 passed (70 files), `test:scripts` 1240 passed, typecheck / lint (0 errors) / `format:check` clean, docs build + `check:anchors` / `check:rendered` / `check:llms` / `docs test` clean.
