### PR TITLE
docs(kb): say what the index reads, and stop citing issues nobody is tracking

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -82,7 +82,7 @@ Each invited user gets their own personal **Smithers** agent, created automatica
 
 You can create agents from templates. Creating an agent is simple: pick a template, give it a name, add an optional tagline, and click Create. Each agent gets a unique auto-generated avatar.
 
-For example, a **Knowledge Base** agent can read text files, Markdown, and **PDF documents** (including scanned PDFs with vision-capable models) from directories you select — but has no access to anything else by default.
+For example, a **Knowledge Base** agent can read text files, Markdown, and **PDF documents** (including scanned PDFs with vision-capable models) from directories you select — but has no access to anything else by default. Searching is narrower than reading: the index takes text-based PDFs only, so a document can be readable on request and still not come back as a search hit. See [Supported file types](/guides/mount-data-directories/#supported-file-types).
 
 After creating the agent, you can customize it through the agent settings tabs. Which tabs you see depends on your role and the agent type:
 

--- a/docs/src/content/docs/glossary/rbac-for-ai-agents.mdx
+++ b/docs/src/content/docs/glossary/rbac-for-ai-agents.mdx
@@ -67,7 +67,7 @@ Most teams start with basic RBAC and grow into granular as the deployment mature
 
 ## In Pinchy
 
-Pinchy provides admin and member roles, plus [groups](/concepts/groups/) that scope which users can see and use which agents, separately from each agent's tool allow-list. Granular RBAC — [custom roles, #527](https://github.com/heypinchy/pinchy/issues/527), and [SSO/SAML, #526](https://github.com/heypinchy/pinchy/issues/526) — is on the roadmap.
+Pinchy provides admin and member roles, plus [groups](/concepts/groups/) that scope which users can see and use which agents, separately from each agent's tool allow-list. Granular RBAC is not there yet: [custom roles](https://github.com/heypinchy/pinchy/issues/527) are on the roadmap, and enterprise SSO/SAML is not available today.
 
 ## Related terms
 

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -62,7 +62,7 @@ curl -X POST -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/
 
 This reads the agent's granted folders, extracts text from each PDF, splits it into overlapping chunks, embeds every chunk with a bundled local model (`embeddinggemma`), and stores the result in Pinchy's own Postgres database (using `pgvector`) so it can be searched later.
 
-Indexing is idempotent — unchanged files are skipped on the next run, changed files are re-indexed, and files removed from disk are dropped from the index. **Re-run reindex whenever documents change** — new files, edits, or deletions. There's no automatic file-watcher yet; a scheduled sweep is tracked in [#714](https://github.com/heypinchy/pinchy/issues/714).
+Indexing is idempotent — unchanged files are skipped on the next run, changed files are re-indexed, and files removed from disk are dropped from the index. **Re-run reindex whenever documents change** — new files, edits, or deletions. Pinchy does not watch the directory and does not sweep it on a schedule: a reindex happens because somebody asked for one.
 
 The request comes back immediately with a job to watch:
 
@@ -186,10 +186,10 @@ We cap how many passages any one document can contribute to a single answer, so 
 
 ## Scope in this release
 
-Phase 1 of the knowledge base is deliberately narrow:
+What the knowledge base does is deliberately narrow:
 
-- Only **text-based PDFs** are indexed and searchable via `knowledge_search`. Scanned/image-only PDFs and Office documents (`.docx`, etc.) are on the roadmap, not indexed today.
-- Indexing is a manual admin action (step 6). It runs in the background and reports its progress in the app, but you still have to ask for it — there is no file-watcher and no scheduled sweep yet ([#714](https://github.com/heypinchy/pinchy/issues/714)).
+- Only **text-based PDFs** are indexed and searchable via `knowledge_search`. Scanned or image-only PDFs, Office documents, plain text and Markdown are not. Pointed at one directly, the agent's file tools read more than the index does — Word documents, scanned PDFs, plain text — so a document can be readable on request and still not come back as a search hit. [Supported file types](/guides/mount-data-directories/#supported-file-types) has the full split.
+- Indexing is a manual admin action (step 6). It runs in the background and reports its progress in the app, but you still have to ask for it: nothing watches the directory and nothing sweeps it on a schedule.
 
 ### Documents that can't be searched
 
@@ -199,7 +199,7 @@ So the **Index** section in the agent's Permissions tab lists the documents this
 
 The list covers everything in those folders, while the `unsearchable` count above it covers only the documents the last run actually touched — a file that hasn't changed since the run before is `skipped`, not counted again. So the list is usually the larger of the two, and that's them agreeing, not disagreeing.
 
-Today these are almost always scans, and reading text from scans is on the roadmap ([#941](https://github.com/heypinchy/pinchy/issues/941)). When it lands, the list empties itself. Until then it tells you which questions your agent can't answer yet, before somebody asks one of them.
+These are almost always scans, which the index cannot read. The list is how you find out which questions your agent can't answer, before somebody asks one of them — and an agent can still be pointed at a scanned document directly, which reads it with the model's vision capabilities.
 
 If the list is empty after a run that finished, that's the whole message: every document in those folders came back with searchable text. After a run that failed we don't say it — the run stopped early, so there's nothing solid to say it about.
 

--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -161,7 +161,7 @@ Nothing is re-indexed or re-uploaded by this — the mounts point at the same ho
 
 Two different paths read the files under `/data/`, and they support different formats. The distinction matters when you plan a corpus, so it's worth knowing before you mount one.
 
-**Knowledge Base search** (`knowledge_search`) indexes **text-based PDFs**, plain text and Markdown. Scanned PDFs and Office documents are not indexed today — see [Create a Knowledge Base Agent — Scope in this release](/guides/create-knowledge-base-agent/#scope-in-this-release).
+**Knowledge Base search** (`knowledge_search`) indexes **text-based PDFs**, and nothing else. Scanned PDFs, Office documents, plain text and Markdown files under `/data/` are not indexed — see [Create a Knowledge Base Agent — Scope in this release](/guides/create-knowledge-base-agent/#scope-in-this-release).
 
 **Reading a file directly** (the agent's file tools) additionally handles **Word documents** (`.docx`) and **scanned PDFs**, which are analyzed using the configured model's vision capabilities.
 

--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -163,9 +163,9 @@ Two different paths read the files under `/data/`, and they support different fo
 
 **Knowledge Base search** (`knowledge_search`) indexes **text-based PDFs**, and nothing else. Scanned PDFs, Office documents, plain text and Markdown files under `/data/` are not indexed — see [Create a Knowledge Base Agent — Scope in this release](/guides/create-knowledge-base-agent/#scope-in-this-release).
 
-**Reading a file directly** (the agent's file tools) additionally handles **Word documents** (`.docx`) and **scanned PDFs**, which are analyzed using the configured model's vision capabilities.
+**Reading a file directly** (the agent's file tools) handles more: PDFs of either kind, **Word documents** (`.docx`), plain text and Markdown. Scanned PDFs are analyzed using the configured model's vision capabilities.
 
-So a scanned certificate under `/data/` can be opened and read on request, but it won't come back as a search hit — the agent has to be pointed at it. If a large part of your corpus is scans, the reindex report tells you so: it counts them under `unsearchable` rather than `indexed`.
+So a scanned certificate under `/data/` can be opened and read on request, but it won't come back as a search hit — the agent has to be pointed at it. If a large part of your corpus is scans, the reindex report tells you so: it counts them under `unsearchable` rather than `indexed`. A file whose type the index doesn't take at all — a `.md` runbook, a `.docx` — never enters the run, so no count mentions it: mount a corpus of those and the report comes back the way it would for an empty folder.
 
 ## Knowledge Base vs. workspace files
 

--- a/scripts/lib/docs-consistency.mjs
+++ b/scripts/lib/docs-consistency.mjs
@@ -48,13 +48,21 @@ export const FORWARD_LOOKING_PHRASES = [
   "will ship",
   // "a scheduled sweep is tracked in #714" sat in the KB guide until the
   // weekly cron reported the two claims either side of it and not that one:
-  // "tracked in" asserts the work has a live home, which is the same promise
-  // the phrases above make, spelled as a statement of fact. Measured across
-  // the whole docs tree before adding — the only other occurrences are a real
-  // forward-looking claim (already caught by "not yet supported" beside it)
-  // and "Changes across all tabs are tracked independently", which the
-  // required `is ` does not match.
-  "is tracked in",
+  // asserting that the work has a live home is the same promise the phrases
+  // above make, spelled as a statement of fact.
+  //
+  // The preposition is deliberately NOT part of the phrase. "A dedicated,
+  // irreversible erasure action ... is tracked separately (#697)" in the
+  // audit-trail concept is the identical promise, and a first cut reading
+  // `is tracked in` left it invisible to the weekly cron — the one shape the
+  // grep that found the KB sentence could not see.
+  //
+  // Measured across the whole docs tree: every other line containing
+  // "tracked" is about the present, and none of them matches the required
+  // `is ` — "Changes across all tabs are tracked independently", "How costs
+  // are tracked", "Tool execution time isn't tracked here",
+  // "already-tracked addresses keep their own budget".
+  "is tracked",
 ];
 
 /** How far from the phrase an issue reference still counts as attached. */

--- a/scripts/lib/docs-consistency.mjs
+++ b/scripts/lib/docs-consistency.mjs
@@ -46,6 +46,15 @@ export const FORWARD_LOOKING_PHRASES = [
   "are planned",
   "is planned",
   "will ship",
+  // "a scheduled sweep is tracked in #714" sat in the KB guide until the
+  // weekly cron reported the two claims either side of it and not that one:
+  // "tracked in" asserts the work has a live home, which is the same promise
+  // the phrases above make, spelled as a statement of fact. Measured across
+  // the whole docs tree before adding — the only other occurrences are a real
+  // forward-looking claim (already caught by "not yet supported" beside it)
+  // and "Changes across all tabs are tracked independently", which the
+  // required `is ` does not match.
+  "is tracked in",
 ];
 
 /** How far from the phrase an issue reference still counts as attached. */

--- a/scripts/lib/docs-consistency.test.mjs
+++ b/scripts/lib/docs-consistency.test.mjs
@@ -150,6 +150,35 @@ test("findUntrackedForwardClaims does not flag ordinary prose about the present"
   );
 });
 
+test("findUntrackedForwardClaims reads 'is tracked in' as the promise it is", () => {
+  // The shape that slipped past the weekly cron: the KB guide said "a
+  // scheduled sweep is tracked in [#714]" while the two claims either side of
+  // it were reported. It asserts the work has a live home, which is exactly
+  // what the other phrases promise.
+  const problems = findUntrackedForwardClaims([
+    {
+      path: "a.mdx",
+      source: "A scheduled sweep is tracked in a backlog item.",
+    },
+  ]);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /a\.mdx:1/);
+});
+
+test("findUntrackedForwardClaims leaves 'tracked' used about the present alone", () => {
+  // Measured across the docs tree before the phrase was added: this is the
+  // sentence that decided it had to be `is tracked in` and not `tracked`.
+  assert.deepEqual(
+    findUntrackedForwardClaims([
+      {
+        path: "a.mdx",
+        source: "Changes across all tabs are tracked independently.",
+      },
+    ]),
+    [],
+  );
+});
+
 test("extractForwardClaims reports the issues a promise cites", () => {
   const claims = extractForwardClaims([
     {

--- a/scripts/lib/docs-consistency.test.mjs
+++ b/scripts/lib/docs-consistency.test.mjs
@@ -150,7 +150,7 @@ test("findUntrackedForwardClaims does not flag ordinary prose about the present"
   );
 });
 
-test("findUntrackedForwardClaims reads 'is tracked in' as the promise it is", () => {
+test("findUntrackedForwardClaims reads 'is tracked' as the promise it is", () => {
   // The shape that slipped past the weekly cron: the KB guide said "a
   // scheduled sweep is tracked in [#714]" while the two claims either side of
   // it were reported. It asserts the work has a live home, which is exactly
@@ -165,14 +165,35 @@ test("findUntrackedForwardClaims reads 'is tracked in' as the promise it is", ()
   assert.match(problems[0], /a\.mdx:1/);
 });
 
+test("findUntrackedForwardClaims does not let the preposition decide", () => {
+  // The audit-trail concept promises crypto-erasure with "is tracked
+  // separately (#697)" — the same promise, a different preposition. A phrase
+  // of `is tracked in` would leave it invisible to the weekly cron, which is
+  // the one shape the grep that found the KB sentence could not see.
+  const problems = findUntrackedForwardClaims([
+    {
+      path: "a.mdx",
+      source: "A dedicated erasure action is tracked separately.",
+    },
+  ]);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /a\.mdx:1/);
+});
+
 test("findUntrackedForwardClaims leaves 'tracked' used about the present alone", () => {
-  // Measured across the docs tree before the phrase was added: this is the
-  // sentence that decided it had to be `is tracked in` and not `tracked`.
+  // Measured across the docs tree before the phrase was added: these are the
+  // sentences that decided it had to be `is tracked` and not `tracked`.
   assert.deepEqual(
     findUntrackedForwardClaims([
       {
         path: "a.mdx",
         source: "Changes across all tabs are tracked independently.",
+      },
+      { path: "b.mdx", source: "## How costs are tracked" },
+      { path: "c.mdx", source: "Tool execution time isn't tracked here." },
+      {
+        path: "d.mdx",
+        source: "Already-tracked addresses keep their own budget.",
       },
     ]),
     [],


### PR DESCRIPTION
The weekly `docs-freshness` cron has been **red since 2026-08-03** ([run 30803820162](https://github.com/heypinchy/pinchy/actions/runs/30803820162)). Clearing its two findings turned up four more that no check can see.

## What the cron reported

Two dead citations, dead for opposite reasons:

| Doc | Cited | Why it's stale |
| --- | --- | --- |
| `create-knowledge-base-agent.mdx:192` | #714 | Closed as **shipped** — the async worker and status UI are in the tree — but it was cited for "no file-watcher and no scheduled sweep yet", which was never its scope. |
| `create-knowledge-base-agent.mdx:202` | #941 | Closed in the 2026-08-01 backlog sweep, explicitly **not** as delivered. The guide promised a roadmap nobody tracks. |

Both sentences now state the limitation as the fact it is.

## What it could not report

**A half-stale multi-issue claim.** `rbac-for-ai-agents.mdx` promises granular RBAC citing #527 (open) and #526 (closed in the same sweep). `findResolvedForwardClaims` deliberately stays quiet while one cited issue is open — that rule is right and I did not change it — but half the sentence was promising enterprise SSO/SAML on the strength of a closed issue.

**A claim that was simply false.** `mount-data-directories.mdx` told readers the knowledge base indexes "text-based PDFs, plain text and Markdown". It does not, and never has: `DEFAULT_ALLOWED_EXTENSIONS` has been `[".pdf"]` since the ingest pipeline landed (`0850ded7`) and the index worker passes no override. Someone mounting a corpus of `.md` runbooks would have got an empty index and no explanation.

That one was measured, not assumed, because the tree makes it look otherwise — `office-convert.ts`, `xlsx-extract.ts` and the converted-PDF artifact store all sit under `lib/knowledge/`, and `docker-compose.yml` provisions a volume for their output. None of it is reachable from a reindex: `IngestDeps` carries `extractPdf` alone, the converter has no production caller, and the eval graders say so out loud (`attribution-graders.ts`: *"xlsx-extract is not wired into the ingest"*). The workspace-file route reads that artifact store, so an Office citation would render — nothing writes one.

## The guard gap

The cron reported the claims either side of `create-knowledge-base-agent.mdx:65` and not that line, because **"a scheduled sweep _is tracked in_ [#714]"** spells the same promise as a statement of fact. `is tracked in` joins `FORWARD_LOOKING_PHRASES`.

Measured against the whole docs tree before adding: the only other occurrences are a genuine claim already caught by `not yet supported` beside it, and *"Changes across all tabs are tracked independently"*, which the required `is ` does not match. Two unit tests pin both directions.

## Deliberately not touched

The closed-issue citations in `upgrading.mdx` (#199, #338, #352, #411, #483) and `ollama-setup.mdx` (#280). Those are historical — "this shipped, here is the issue" — and the upgrade sections are immutable besides. A blanket "docs must not cite a closed issue" rule would flag all six, which is how a guard earns its way into being switched off.

## Verification

Both cron halves run locally against the live GitHub API:

- `check-docs-freshness` → `✓ 8 tracked claim(s), none whose issues have all closed.`
- `check-main-version-pins` → `✓ all pins track v0.9.1 within a minor.` (green since #1044)

Plus `pnpm test:scripts` 1239 passed / 0 failed, `pnpm format:check` clean, and `cd docs && pnpm build && pnpm check:anchors && pnpm check:rendered` — 74 pages, no broken internal links, every table rendered.

`review-docs` was run over the branch; the two findings above under "what it could not report" are its output.