### PR TITLE
docs(memory): the per-agent toggle shipped; the other two get a tracking issue

### DIFF
--- a/docs/src/content/docs/explanation/agent-memory.mdx
+++ b/docs/src/content/docs/explanation/agent-memory.mdx
@@ -50,6 +50,9 @@ You don't need to explain the memory model to your team — Pinchy handles it in
 
 ## What's coming next
 
-- **Per-agent memory toggle** — ability to disable memory for specific agents.
-- **Memory inspection** — tools for admins to see what agents have memorized.
-- **Memory deletion** — right to erasure for compliance requirements.
+Two gaps remain, both tracked in [#1137](https://github.com/heypinchy/pinchy/issues/1137):
+
+- **Memory inspection** — a way for admins to see what a shared agent has stored, without shell access to the host.
+- **Memory erasure** — an auditable path for a right-to-erasure request, and an honest answer for shared agents, where one file mixes every member's contributions.
+
+The per-agent toggle that used to head this list has shipped: memory is now its own permission, granted or withheld per agent — see [Memory is a permission](#memory-is-a-permission).

--- a/docs/src/content/docs/explanation/agent-memory.mdx
+++ b/docs/src/content/docs/explanation/agent-memory.mdx
@@ -50,9 +50,9 @@ You don't need to explain the memory model to your team — Pinchy handles it in
 
 ## What's coming next
 
-Two gaps remain, both tracked in [#1137](https://github.com/heypinchy/pinchy/issues/1137):
+Two gaps are on the roadmap, both tracked in [#1137](https://github.com/heypinchy/pinchy/issues/1137):
 
 - **Memory inspection** — a way for admins to see what a shared agent has stored, without shell access to the host.
-- **Memory erasure** — an auditable path for a right-to-erasure request, and an honest answer for shared agents, where one file mixes every member's contributions.
+- **Memory erasure** — an auditable path for a right-to-erasure request, and an honest answer for shared agents, whose memory mixes every member's contributions in one place.
 
-The per-agent toggle that used to head this list has shipped: memory is now its own permission, granted or withheld per agent — see [Memory is a permission](#memory-is-a-permission).
+Turning memory off for a single agent isn't one of them — that's a permission you grant or withhold today. See [Memory is a permission](#memory-is-a-permission).


### PR DESCRIPTION
## What does this PR do?

`explanation/agent-memory.mdx` still headed its "What's coming next" list with a **per-agent memory toggle**. That shipped in #1136 — memory is its own permission now — and the same page describes it sixty lines earlier under "Memory is a permission".

A doc promising something the repo already has is precisely what the `review-docs` reading pass exists to catch, and no CI guard sees it: `docs-consistency` fires on phrases like "planned" and "on the roadmap", and a bare `## What's coming next` heading slips past. #1137 noted the gap in its own text; this is the fix.

The remaining two now cite [#1137](https://github.com/heypinchy/pinchy/issues/1137), which is what makes a forward-looking claim auditable at all — the same contract as an untracked test skip.

Both are also stated more honestly than they were. "Tools for admins to see what agents have memorized" says nothing about why it matters; the real gap is that the only route today is SSH to the host. And erasure has to answer for shared agents, where one `MEMORY.md` mixes every member's contributions — a per-user cut is not something we can currently make, and the doc should not imply otherwise.

## Type of change

- [x] 📝 Documentation

## Reviewer notes

Docs-only, one file. Gates run: `pnpm test:scripts` (1237), docs build, `check:anchors` (74 pages), `check:rendered` (74 pages). The new in-page anchor `#memory-is-a-permission` is checked by `check:anchors` against the built site, not just asserted here.

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've updated the documentation
- [x] All existing tests pass