### PR TITLE
fix(eval): the KB abstention detector recognised 0 of 8 real abstentions

### DIFF
--- a/packages/web/eval/kb/kb-eval-models.spec.ts
+++ b/packages/web/eval/kb/kb-eval-models.spec.ts
@@ -83,6 +83,7 @@ import { gradeKbRun } from "../../src/lib/eval/kb/answer-graders";
 import type { KbRunTrajectory, KbRunResult } from "../../src/lib/eval/kb/answer-graders";
 import {
   DEFAULT_KB_JUDGE_MODEL,
+  LlmAbstentionJudge,
   LlmNliClient,
   LlmRelevanceJudge,
   createOllamaCloudChatFn,
@@ -299,6 +300,11 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
     const chat = createOllamaCloudChatFn({ apiKey: ollamaKey, model: judgeModel });
     const nli = new LlmNliClient(chat);
     const relevance = new LlmRelevanceJudge(chat);
+    // Third judge role, same chat fn. NOT the NLI client with a cleverly
+    // worded hypothesis: that was tried, and entailment turned out to be the
+    // wrong relation for "did this answer decline?" on every judge model
+    // tested. See `buildAbstentionPrompt`.
+    const abstention = new LlmAbstentionJudge(chat);
 
     const withRetry = async (fn: () => Promise<void>, what: string): Promise<void> => {
       const attempts = 4;
@@ -423,7 +429,7 @@ test.describe("KB Eval Harness Layer 3: groundedness sweep (real Ollama Cloud)",
         // dispatch above does — but by this point the answer is already in
         // hand and re-dispatching to recover it would be pure waste.
         const result = await withTransportRetry(
-          () => gradeKbRun(trajectory, gold, { nli, relevance }),
+          () => gradeKbRun(trajectory, gold, { nli, relevance, abstention }),
           { what: `judge ${model}/${goldId}` }
         );
         const stampedResult: KbRunResult = { ...result, scenario: goldId };

--- a/packages/web/src/lib/eval/kb/__tests__/answer-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/answer-graders.test.ts
@@ -4,6 +4,7 @@ import { gradeAnswerRelevance, gradeCitationCorrectness, gradeKbRun } from "../a
 import type { AnswerRelevanceOptions, KbRunTrajectory, RelevanceJudge } from "../answer-graders";
 import type { RetrievedSource } from "../attribution-graders";
 import { stubNliClient } from "./stub-nli-client";
+import type { AbstentionJudge } from "../groundedness-grader";
 import type { GoldQA, KbGraderResult } from "../types";
 
 function src(n: number, sourcePath: string, page: number | null = 1): RetrievedSource {
@@ -20,6 +21,13 @@ function highScoreNli() {
   return stubNliClient(() => ({ label: "entailment" as const, score: 0.95 }));
 }
 
+/** An AbstentionJudge returning a fixed verdict — 0 = answered, 1 = declined. */
+function fixedAbstentionJudge(score: number): AbstentionJudge {
+  return { declines: async () => score };
+}
+const ANSWERED = fixedAbstentionJudge(0);
+const DECLINED = fixedAbstentionJudge(1);
+
 describe("gradeAnswerRelevance", () => {
   it("passes an on-topic answer (judge scores high)", async () => {
     const judge = fixedRelevanceJudge(0.9);
@@ -27,7 +35,8 @@ describe("gradeAnswerRelevance", () => {
     const result = await gradeAnswerRelevance(
       "The retention policy requires seven years [1].",
       "How long must records be retained?",
-      judge
+      judge,
+      false
     );
 
     expect(result).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
@@ -39,7 +48,8 @@ describe("gradeAnswerRelevance", () => {
     const result = await gradeAnswerRelevance(
       "Our office is open Monday through Friday [1].",
       "How long must records be retained?",
-      judge
+      judge,
+      false
     );
 
     expect(result.passed).toBe(false);
@@ -60,7 +70,8 @@ describe("gradeAnswerRelevance", () => {
     const result = await gradeAnswerRelevance(
       "I couldn't find this in the knowledge base.",
       "How long must records be retained?",
-      judge
+      judge,
+      true
     );
 
     expect(result).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
@@ -71,7 +82,13 @@ describe("gradeAnswerRelevance", () => {
     const judge = fixedRelevanceJudge(0.55);
     const opts: AnswerRelevanceOptions = { tau: 0.6 };
 
-    const result = await gradeAnswerRelevance("Some answer [1].", "Some query?", judge, opts);
+    const result = await gradeAnswerRelevance(
+      "Some answer [1].",
+      "Some query?",
+      judge,
+      false,
+      opts
+    );
 
     expect(result.passed).toBe(false);
     expect(result.tags).toEqual(["off-topic-grounded"]);
@@ -93,7 +110,8 @@ describe("gradeAnswerRelevance", () => {
 
 - [1] /data/handbook/policy.md — p. 12`,
       "How long must records be retained?",
-      judge
+      judge,
+      false
     );
 
     expect(seenAnswer).not.toMatch(/Sources/);
@@ -169,6 +187,7 @@ describe("gradeKbRun", () => {
     const result = await gradeKbRun(traj, baseGold, {
       nli: highScoreNli(),
       relevance: fixedRelevanceJudge(0.9),
+      abstention: ANSWERED,
     });
 
     expect(result).toEqual({
@@ -191,6 +210,7 @@ describe("gradeKbRun", () => {
     const result = await gradeKbRun(traj, baseGold, {
       nli: highScoreNli(),
       relevance: fixedRelevanceJudge(0.1),
+      abstention: ANSWERED,
     });
 
     expect(result.model).toBe("other-model");
@@ -218,6 +238,7 @@ describe("gradeKbRun", () => {
     const result = await gradeKbRun(traj, baseGold, {
       nli,
       relevance: fixedRelevanceJudge(0.9),
+      abstention: ANSWERED,
     });
 
     expect(result.passed).toBe(false);
@@ -245,7 +266,11 @@ describe("gradeKbRun", () => {
       },
     };
 
-    const result = await gradeKbRun(traj, gold, { nli: highScoreNli(), relevance });
+    const result = await gradeKbRun(traj, gold, {
+      nli: highScoreNli(),
+      relevance,
+      abstention: DECLINED,
+    });
 
     expect(result).toEqual({
       model: "test-model",
@@ -265,6 +290,7 @@ describe("gradeKbRun", () => {
     const result = await gradeKbRun(traj, gold, {
       nli: highScoreNli(),
       relevance: fixedRelevanceJudge(0.9),
+      abstention: ANSWERED,
     });
 
     expect(result.passed).toBe(false);

--- a/packages/web/src/lib/eval/kb/__tests__/groundedness-grader.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/groundedness-grader.test.ts
@@ -67,14 +67,24 @@ describe("isAbstention", () => {
 
   const Q = "What is Northwind's parental leave policy?";
 
+  // The five strings below are the phrases the DELETED phrase-list detector
+  // matched literally. They are kept as inputs, but the assertion is now the
+  // opposite of what it was: each must follow whatever the judge says, in BOTH
+  // directions. A test that only asserted `judgeSaysYes ⇒ true` would pass for
+  // any string at all, while its name went on implying that English abstention
+  // phrasing is what the detector recognises — which is precisely the mechanism
+  // this file's subject no longer has. Flipping the judge is what makes these
+  // five inputs mean something: it fails the moment anyone reintroduces a
+  // phrase shortcut ahead of the judge.
   it.each([
     "I couldn't find this in the knowledge base.",
     "I could not find that information anywhere.",
     "The corpus doesn't contain an answer to this.",
     "The corpus does not contain any mention of this.",
     "This is not in the knowledge base.",
-  ])("detects abstention: %s", async (answer) => {
+  ])("follows the judge, with no shortcut for the old phrase list: %s", async (answer) => {
     expect(await isAbstention(Q, answer, judgeSaysYes())).toBe(true);
+    expect(await isAbstention(Q, answer, judgeSaysNo())).toBe(false);
   });
 
   it("does not flag a normal answering sentence as abstention", async () => {
@@ -156,8 +166,10 @@ describe("isAbstention", () => {
   // A stub judge cannot prove a real judge reads these correctly; that was
   // measured separately against the live judge (all 8 abstentions 0.95–1.00,
   // all 40 answering runs 0.00 — see `buildAbstentionPrompt`). What these two
-  // pin is that the detector no longer rules them out BEFORE the judge sees
-  // them.
+  // pin is that the detector reaches the judge with them intact and returns
+  // the judge's verdict — so both directions are asserted. `judgeSaysYes ⇒
+  // true` fails if the `[N]` veto comes back; `judgeSaysNo ⇒ false` fails if a
+  // phrase shortcut does. One direction alone would pass for any input.
   // ---------------------------------------------------------------------
 
   it("recognises an abstention that cites its evidence (sweep: qwen3.5, gqa-abstention-1)", async () => {
@@ -168,15 +180,16 @@ describe("isAbstention", () => {
     ].join("\n");
 
     expect(await isAbstention(Q, answer, judgeSaysYes())).toBe(true);
+    expect(await isAbstention(Q, answer, judgeSaysNo())).toBe(false);
   });
 
   it("recognises an abstention written in German (sweep: glm-5.2, gqa-abstention-2)", async () => {
+    const deQuery = "Wie lautet Northwinds Richtlinie zur Elternzeit?";
     const answer =
       "Ich konnte in den indizierten Dokumenten leider **keine eigentliche Richtlinie zur Elternzeit** (parental leave) finden.";
 
-    expect(
-      await isAbstention("Wie lautet Northwinds Richtlinie zur Elternzeit?", answer, judgeSaysYes())
-    ).toBe(true);
+    expect(await isAbstention(deQuery, answer, judgeSaysYes())).toBe(true);
+    expect(await isAbstention(deQuery, answer, judgeSaysNo())).toBe(false);
   });
 });
 

--- a/packages/web/src/lib/eval/kb/__tests__/groundedness-grader.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/groundedness-grader.test.ts
@@ -7,6 +7,7 @@ import {
   splitSentences,
 } from "../groundedness-grader";
 import { stubNliClient } from "./stub-nli-client";
+import type { AbstentionJudge } from "../groundedness-grader";
 import type { GoldQA, KbGraderResult } from "../types";
 
 function highScoreClient() {
@@ -45,36 +46,137 @@ describe("splitSentences", () => {
   });
 });
 
+/** An AbstentionJudge stub returning a fixed score, recording what it was shown. */
+function stubAbstentionJudge(score: number) {
+  const calls: { query: string; answer: string }[] = [];
+  const judge: AbstentionJudge & { calls: typeof calls } = {
+    calls,
+    async declines(query, answer) {
+      calls.push({ query, answer });
+      return score;
+    },
+  };
+  return judge;
+}
+
 describe("isAbstention", () => {
+  /** Judge that reads every answer as a refusal — isolates STRUCTURE from judge quality. */
+  const judgeSaysYes = () => stubAbstentionJudge(0.95);
+  /** Judge that reads every answer as an answer — proves the threshold is real, not a rubber stamp. */
+  const judgeSaysNo = () => stubAbstentionJudge(0.05);
+
+  const Q = "What is Northwind's parental leave policy?";
+
   it.each([
     "I couldn't find this in the knowledge base.",
     "I could not find that information anywhere.",
     "The corpus doesn't contain an answer to this.",
     "The corpus does not contain any mention of this.",
     "This is not in the knowledge base.",
-  ])("detects abstention phrase: %s", (answer) => {
-    expect(isAbstention(answer)).toBe(true);
+  ])("detects abstention: %s", async (answer) => {
+    expect(await isAbstention(Q, answer, judgeSaysYes())).toBe(true);
   });
 
-  it("does not flag a normal answering sentence as abstention", () => {
-    expect(isAbstention("The retention policy requires seven years [1].")).toBe(false);
-  });
-
-  it("does NOT flag a grounded, cited answer that merely uses an abstention phrase mid-sentence", () => {
-    // Substring-match footgun: this answer literally contains "does not
-    // contain" yet is a real, cited answer. An abstention cites nothing, so
-    // the presence of an inline [N] citation is the discriminator — misreading
-    // this as a refusal would spuriously trip false-abstention AND skip the
-    // relevance judge, corrupting the (tracked) Layer-3 scorecard.
+  it("does not flag a normal answering sentence as abstention", async () => {
     expect(
-      isAbstention(
-        "The handbook does not contain a dedicated clause, but section 4 states records are kept for ten years [1]."
+      await isAbstention(Q, "The retention policy requires seven years [1].", judgeSaysNo())
+    ).toBe(false);
+  });
+
+  it("does NOT flag a grounded, cited answer that merely uses an abstention phrase mid-sentence", async () => {
+    // Substring-match footgun: this answer literally contains "does not
+    // contain" yet is a real, cited answer — it ANSWERS the question and
+    // happens to negate along the way. Misreading it as a refusal would
+    // spuriously trip false-abstention AND skip the relevance judge,
+    // corrupting the (tracked) Layer-3 scorecard.
+    //
+    // What separates it from a real abstention is not whether it carries a
+    // citation (the veto this detector used to apply, see below) but whether
+    // it states the requested fact. That is a question about meaning, so it is
+    // the judge's; this pins the wiring, and `buildAbstentionPrompt` is where
+    // the judge is told the distinction.
+    expect(
+      await isAbstention(
+        "How long are records kept?",
+        "The handbook does not contain a dedicated clause, but section 4 states records are kept for ten years [1].",
+        judgeSaysNo()
       )
     ).toBe(false);
   });
 
-  it("still detects a genuine abstention (abstention phrase, no citations)", () => {
-    expect(isAbstention("The knowledge base does not contain an answer to this.")).toBe(true);
+  it("still detects a genuine abstention (no citations at all)", async () => {
+    expect(
+      await isAbstention(
+        Q,
+        "The knowledge base does not contain an answer to this.",
+        judgeSaysYes()
+      )
+    ).toBe(true);
+  });
+
+  it("shows the judge the question, and the answer BODY with the Sources list stripped", async () => {
+    const judge = judgeSaysYes();
+
+    await isAbstention(
+      Q,
+      "I could not find the policy text [1].\n\n**Sources:**\n\n- [1] absent-topic-pointer.md",
+      judge
+    );
+
+    expect(judge.calls).toHaveLength(1);
+    // The question is load-bearing, not decoration: asking about the answer
+    // alone did not separate abstentions from answers on ANY judge model
+    // tried (see `buildAbstentionPrompt`).
+    expect(judge.calls[0].query).toBe(Q);
+    // Not the Sources list: a citation line quoting a document title is not
+    // the answer's claim, and feeding it to the judge grades the wrong text.
+    expect(judge.calls[0].answer).toBe("I could not find the policy text [1].");
+  });
+
+  it("uses the abstention tau, not the groundedness one", async () => {
+    // 0.55 sits above DEFAULT_ABSTENTION_TAU (0.5) and below DEFAULT_TAU
+    // (0.6). Reading the wrong default here would flip this verdict.
+    expect(await isAbstention(Q, "Some answer.", stubAbstentionJudge(0.55))).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------
+  // Regressions from the 2026-08-05 sweep. Both answers below are verbatim
+  // model output from that run; both were charged `missed-abstention` (and
+  // `off-topic-grounded` downstream) by the previous detector, which
+  //
+  //   1. vetoed any answer carrying an inline [N] marker, on the stated
+  //      premise that "an abstention cites NOTHING" — but all four models
+  //      cited the index document as EVIDENCE that only a section title
+  //      exists, which is the better behaviour, and
+  //   2. matched a literal, English-only phrase list, which no German
+  //      abstention can satisfy — making the DE abstention item structurally
+  //      unpassable in a harness that has a cross-lingual axis and a skill
+  //      file instructing the agent to answer in the user's language.
+  //
+  // A stub judge cannot prove a real judge reads these correctly; that was
+  // measured separately against the live judge (all 8 abstentions 0.95–1.00,
+  // all 40 answering runs 0.00 — see `buildAbstentionPrompt`). What these two
+  // pin is that the detector no longer rules them out BEFORE the judge sees
+  // them.
+  // ---------------------------------------------------------------------
+
+  it("recognises an abstention that cites its evidence (sweep: qwen3.5, gqa-abstention-1)", async () => {
+    const answer = [
+      "I couldn't find the actual text of Northwind's parental leave policy in the indexed documents.",
+      "",
+      "The search results show that parental leave is listed as one of the HR policy sections maintained by the People Operations team [1], but the detailed policy text itself doesn't appear in the search results.",
+    ].join("\n");
+
+    expect(await isAbstention(Q, answer, judgeSaysYes())).toBe(true);
+  });
+
+  it("recognises an abstention written in German (sweep: glm-5.2, gqa-abstention-2)", async () => {
+    const answer =
+      "Ich konnte in den indizierten Dokumenten leider **keine eigentliche Richtlinie zur Elternzeit** (parental leave) finden.";
+
+    expect(
+      await isAbstention("Wie lautet Northwinds Richtlinie zur Elternzeit?", answer, judgeSaysYes())
+    ).toBe(true);
   });
 });
 
@@ -179,7 +281,8 @@ describe("gradeGroundednessForGold", () => {
       "I couldn't find this in the knowledge base.",
       [],
       gold,
-      nli
+      nli,
+      true
     );
 
     expect(result).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
@@ -194,7 +297,8 @@ describe("gradeGroundednessForGold", () => {
       "Records must be retained for seven years [1].",
       ["Records must be retained for seven years per policy."],
       gold,
-      nli
+      nli,
+      false
     );
 
     expect(result.passed).toBe(false);
@@ -209,7 +313,8 @@ describe("gradeGroundednessForGold", () => {
       "I couldn't find this in the knowledge base.",
       ["Records must be retained for seven years per policy."],
       gold,
-      nli
+      nli,
+      true
     );
 
     expect(result.passed).toBe(false);
@@ -224,7 +329,8 @@ describe("gradeGroundednessForGold", () => {
       "Records must be retained for seven years [1].",
       ["Records must be retained for seven years per policy."],
       gold,
-      nli
+      nli,
+      false
     );
 
     expect(result).toEqual<KbGraderResult>({ passed: true, tags: [], notes: [] });
@@ -237,7 +343,8 @@ describe("gradeGroundednessForGold", () => {
       "The sky is purple [1].",
       ["Records must be retained for seven years per policy."],
       baseGold,
-      nli
+      nli,
+      false
     );
 
     expect(result.passed).toBe(false);

--- a/packages/web/src/lib/eval/kb/__tests__/groundedness-pipeline.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/groundedness-pipeline.test.ts
@@ -22,6 +22,10 @@ import type { RetrievedSource } from "../attribution-graders";
 import { stubNliClient } from "./stub-nli-client";
 import type { GoldQA, KbFailureTag } from "../types";
 
+/** An AbstentionJudge returning a fixed verdict — 0 = answered, 1 = declined. */
+const ANSWERED = { declines: async () => 0 };
+const DECLINED = { declines: async () => 1 };
+
 function src(n: number, sourcePath: string, page: number | null = 1): RetrievedSource {
   return { n, sourcePath, page };
 }
@@ -58,6 +62,12 @@ describe("groundedness pipeline self-test: gradeKbRun -> buildScorecard, end to 
   };
   // Scripted NLI: the one cited sentence is highly entailed by the cited
   // passage — a deterministic "grounded" verdict, not a real model judgment.
+  //
+  // `gradeKbRun` puts TWO questions to this same client — "is this sentence
+  // supported?" and "does this answer decline to answer?" — so each fixture's
+  // client answers them separately, keyed off the hypothesis. A client that
+  // returned one flat score would answer both with it and read every answer
+  // here as a refusal.
   const groundedNli = stubNliClient([0.95]);
 
   // --- Fixture 2: an answer with one ungrounded sentence. ---
@@ -84,7 +94,7 @@ describe("groundedness pipeline self-test: gradeKbRun -> buildScorecard, end to 
   };
   // Scripted NLI: this sentence scores LOW against its cited passage — a
   // deterministic "not entailed" verdict (the passage says navy blue, the
-  // answer claims purple/gold).
+  // answer claims purple/gold). It is still an ANSWER, not a refusal.
   const ungroundedNli = stubNliClient([0.1]);
 
   // --- Fixture 3: a correct abstention (gold says the corpus can't answer). ---
@@ -106,20 +116,28 @@ describe("groundedness pipeline self-test: gradeKbRun -> buildScorecard, end to 
     latencyMs: 60,
     tokens: { prompt: 20, completion: 10 },
   };
-  // NLI is never consulted for a correctly-abstained answer (gradeGroundednessForGold's
-  // expectAbstention short-circuit) — any client would do; reuse groundedNli.
+  // The judge IS consulted here, once: `gradeKbRun` asks it whether this
+  // answer declines to answer, and hands the verdict to both graders that
+  // branch on it. Only the per-sentence entailment check is skipped
+  // (gradeGroundednessForGold's expectAbstention short-circuit).
 
   it("grades all three fixtures to their known KbRunResult, then buildScorecard<KbFailureTag> aggregates them correctly", async () => {
     const relevance = fixedRelevanceJudge(0.9);
 
-    const grounded = await gradeKbRun(groundedTraj, groundedGold, { nli: groundedNli, relevance });
+    const grounded = await gradeKbRun(groundedTraj, groundedGold, {
+      nli: groundedNli,
+      relevance,
+      abstention: ANSWERED,
+    });
     const ungrounded = await gradeKbRun(ungroundedTraj, ungroundedGold, {
       nli: ungroundedNli,
       relevance,
+      abstention: ANSWERED,
     });
     const abstained = await gradeKbRun(abstentionTraj, abstentionGold, {
       nli: groundedNli,
       relevance,
+      abstention: DECLINED,
     });
 
     // Per-run KbRunResult assertions — the exact, scripted verdicts.

--- a/packages/web/src/lib/eval/kb/__tests__/groundedness-pipeline.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/groundedness-pipeline.test.ts
@@ -63,11 +63,12 @@ describe("groundedness pipeline self-test: gradeKbRun -> buildScorecard, end to 
   // Scripted NLI: the one cited sentence is highly entailed by the cited
   // passage — a deterministic "grounded" verdict, not a real model judgment.
   //
-  // `gradeKbRun` puts TWO questions to this same client — "is this sentence
-  // supported?" and "does this answer decline to answer?" — so each fixture's
-  // client answers them separately, keyed off the hypothesis. A client that
-  // returned one flat score would answer both with it and read every answer
-  // here as a refusal.
+  // This client answers ONE question: "is this sentence supported by the cited
+  // passages?" Abstention is a separate question put to a separate role, so it
+  // is scripted separately per fixture (the `abstention:` dep below) rather
+  // than by wording a hypothesis for this client. That separation is the whole
+  // point of the change this file guards — entailment turned out to be the
+  // wrong relation for "did this answer decline?" (see `buildAbstentionPrompt`).
   const groundedNli = stubNliClient([0.95]);
 
   // --- Fixture 2: an answer with one ungrounded sentence. ---

--- a/packages/web/src/lib/eval/kb/__tests__/llm-nli.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/llm-nli.test.ts
@@ -9,10 +9,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ABSTENTION_PARSE_FALLBACK,
+  LlmAbstentionJudge,
   LlmNliClient,
   LlmRelevanceJudge,
   NLI_PARSE_FALLBACK,
   RELEVANCE_PARSE_FALLBACK,
+  parseAbstentionResponse,
   parseNliResponse,
   parseRelevanceResponse,
 } from "../llm-nli";
@@ -163,5 +166,52 @@ describe("LlmRelevanceJudge", () => {
     expect(score).toBe(0.7);
     expect(calls[0]).toContain("How often are laptops replaced?");
     expect(calls[0]).toContain("Every 3 years.");
+  });
+});
+
+describe("parseAbstentionResponse", () => {
+  it("parses a clean JSON score", () => {
+    expect(parseAbstentionResponse('{"score": 1}')).toBe(1);
+  });
+
+  it("falls back to 'did not decline' (not a throw) on a malformed reply", () => {
+    expect(parseAbstentionResponse("the model rambled")).toBe(ABSTENTION_PARSE_FALLBACK);
+  });
+
+  it("clamps an out-of-range score into [0, 1]", () => {
+    expect(parseAbstentionResponse('{"score": 4}')).toBe(1);
+  });
+});
+
+describe("LlmAbstentionJudge", () => {
+  it("shows the judge BOTH the question and the answer", async () => {
+    const calls: string[] = [];
+    const chat: LlmChatFn = async (prompt) => {
+      calls.push(prompt);
+      return '{"score": 1}';
+    };
+    const judge = new LlmAbstentionJudge(chat);
+
+    const score = await judge.declines(
+      "What is Northwind's parental leave policy?",
+      "I couldn't find the policy text in the indexed documents [1]."
+    );
+
+    expect(score).toBe(1);
+    // The question is the load-bearing half. Measured against the 48 archived
+    // answers of the 2026-08-05 sweep, asking the judge about the answer ALONE
+    // — as an NLI hypothesis, with no question in the prompt — did not
+    // separate the two classes at all, on any of three judge models. With the
+    // question present, the same 48 answers separate 0.95–1.00 (abstentions)
+    // against 0.00 (every one of the 40 answering runs).
+    expect(calls[0]).toContain("What is Northwind's parental leave policy?");
+    expect(calls[0]).toContain("I couldn't find the policy text");
+  });
+
+  it("scores an answer that states the requested fact as not declining", async () => {
+    const chat: LlmChatFn = async () => '{"score": 0}';
+    const judge = new LlmAbstentionJudge(chat);
+
+    expect(await judge.declines("How often are laptops replaced?", "Every 3 years [1].")).toBe(0);
   });
 });

--- a/packages/web/src/lib/eval/kb/answer-graders.ts
+++ b/packages/web/src/lib/eval/kb/answer-graders.ts
@@ -19,6 +19,7 @@ import {
 } from "./attribution-graders";
 import type { RetrievedSource } from "./attribution-graders";
 import { gradeGroundednessForGold, isAbstention } from "./groundedness-grader";
+import type { AbstentionJudge } from "./groundedness-grader";
 import type { GroundednessOptions } from "./groundedness-grader";
 import type { NliClient } from "./nli";
 import type { GoldQA, KbFailureTag, KbGraderResult, RunResult, RunTokenUsage } from "./types";
@@ -61,14 +62,21 @@ export const DEFAULT_RELEVANCE_TAU = 0.5;
  * so this passes outright without ever calling the judge. Whether the
  * abstention itself was the CORRECT behavior is `gradeGroundednessForGold`'s
  * job (`missed-abstention` / `false-abstention`), not this grader's.
+ *
+ * `abstained` is resolved once by `gradeKbRun` and passed in — see the note on
+ * `gradeGroundednessForGold`. This short-circuit is why the 2026-08-05 sweep
+ * reported `off-topic-grounded` on 7 of its 8 abstention runs: the detector
+ * did not recognise them, so each honest refusal was scored against the
+ * question it declined to answer and duly fell below τ.
  */
 export async function gradeAnswerRelevance(
   answer: string,
   query: string,
   judge: RelevanceJudge,
+  abstained: boolean,
   opts: AnswerRelevanceOptions = {}
 ): Promise<KbGraderResult> {
-  if (isAbstention(answer)) {
+  if (abstained) {
     return { passed: true, tags: [], notes: [] };
   }
 
@@ -152,14 +160,21 @@ export type KbRunResult = RunResult<KbFailureTag>;
  * `gradeAnswerRelevance` (does the answer address the query), and
  * `gradeCitationCorrectness` (fabricated-citation detection against the
  * run's real retrieved set). All four run unconditionally and are merged via
- * `composeKbGraderResults` — no manual abstention branching is needed here:
- * a correct abstention (`gold.expectAbstention` true, answer abstains)
- * naturally yields an empty Sources list, so `gradeAttribution` and
- * `gradeCitationCorrectness` pass trivially (nothing to check), and
- * `gradeAnswerRelevance` passes without ever calling the judge (its own
- * `isAbstention` short-circuit). Only `gradeGroundednessForGold` does
- * anything gold-aware; the other three simply have nothing to flag when the
- * answer is a correct, citation-free abstention.
+ * `composeKbGraderResults`.
+ *
+ * Abstention is resolved ONCE here and handed to the two graders that branch
+ * on it, so they cannot disagree about the same answer (see the note on
+ * `gradeGroundednessForGold`).
+ *
+ * The attribution axes deliberately keep grading an abstention. An earlier
+ * version of this comment asserted they had nothing to check, "since a
+ * correct abstention naturally yields an empty Sources list" — the
+ * 2026-08-05 sweep answered that empirically: every abstention in it cited
+ * the index document as proof of absence, and gpt-oss wrote a Sources list
+ * for one in a format that does not render. Abstaining changes whether
+ * declining to answer is a defect; it does not license a broken citation
+ * list. So `gradeAttribution` and `gradeCitationCorrectness` run either way,
+ * and an abstention that cites well simply passes them.
  */
 export async function gradeKbRun(
   traj: KbRunTrajectory,
@@ -167,22 +182,26 @@ export async function gradeKbRun(
   deps: {
     nli: NliClient;
     relevance: RelevanceJudge;
+    abstention: AbstentionJudge;
     groundedness?: GroundednessOptions;
     relevanceOpts?: AnswerRelevanceOptions;
   }
 ): Promise<KbRunResult> {
   const attribution = gradeAttribution({ answer: traj.answer, retrieved: traj.retrieved });
+  const abstained = await isAbstention(gold.query, traj.answer, deps.abstention);
   const groundedness = await gradeGroundednessForGold(
     traj.answer,
     traj.citedPassageTexts,
     gold,
     deps.nli,
+    abstained,
     deps.groundedness
   );
   const relevance = await gradeAnswerRelevance(
     traj.answer,
     gold.query,
     deps.relevance,
+    abstained,
     deps.relevanceOpts
   );
   const citationCorrectness = gradeCitationCorrectness(traj.answer, traj.retrieved);

--- a/packages/web/src/lib/eval/kb/groundedness-grader.ts
+++ b/packages/web/src/lib/eval/kb/groundedness-grader.ts
@@ -55,50 +55,68 @@ export function splitSentences(text: string): string[] {
 }
 
 /**
- * Small, documented phrase list matching the abstention language the KB
- * agent template teaches (`agent-templates/data/knowledge-base.ts`) for "the
- * corpus genuinely does not contain the answer." Matched case-insensitively
- * against the WHOLE answer (not just the body) since an abstention answer
- * typically has no Sources list to strip in the first place. Deliberately
- * kept small and literal rather than an NLI/LLM-judged abstention detector —
- * the template's phrasing is narrow and stable, and a false negative here
- * (an abstention not recognized as one) is preferable to a false positive
- * (ordinary prose that happens to include "not" and "contain" nearby getting
- * misread as a refusal).
+ * Judges whether an answer declines to answer its question. A separate role
+ * from `NliClient` and `RelevanceJudge` because it is a separate question, and
+ * — the expensive lesson — because it is NOT an entailment question. See
+ * `buildAbstentionPrompt` in `llm-nli.ts` for what the prompt must contain and
+ * what happened to three judge models when it did not.
  */
-const ABSTENTION_PHRASES = [
-  /couldn['’]t find/i,
-  /could not find/i,
-  /don['’]t contain/i,
-  /doesn['’]t contain/i,
-  /do not contain/i,
-  /does not contain/i,
-  /not in the knowledge base/i,
-];
-
-/** Any inline `[N]` citation marker. Its PRESENCE means the answer cited a source. */
-const INLINE_CITATION_MARKER = /\[\d+\]/;
+export interface AbstentionJudge {
+  /** 1 = clearly declines to answer `query`, 0 = clearly answers it. */
+  declines(query: string, answer: string): Promise<number>;
+}
 
 /**
- * True if `answer` is a template-taught abstention ("I couldn't find this in
- * the knowledge base").
- *
- * An abstention cites NOTHING — the template teaches a bare refusal with no
- * Sources. So the presence of any inline `[N]` citation is the discriminator:
- * an answer that USES an abstention phrase but still cites a source ("The
- * handbook does not contain a dedicated clause, but section 4 states … [1].")
- * is a real, grounded answer, not a refusal. Without this guard the substring
- * phrases below (`does not contain`, `do not contain` — ordinary prose, not
- * just refusals) would misread such an answer as an abstention, spuriously
- * tripping `false-abstention` in `gradeGroundednessForGold` and skipping the
- * relevance judge in `gradeAnswerRelevance` — both of which corrupt the
- * (tracked) Layer-3 scorecard. Requiring zero citations keeps the intended
- * bias toward false-negatives (a missed abstention is safer than a
- * misclassified real answer).
+ * Threshold for `isAbstention`. Against the 48 archived answers of the
+ * 2026-08-05 sweep the two classes land at 0.95–1.00 (all 8 abstentions) and
+ * 0.00 (all 40 answering runs) — no run falls between. 0.5 sits in the middle
+ * of that gap; any value in (0, 0.95] would classify those 48 identically, so
+ * this number is not load-bearing and should not be tuned to move a result.
  */
-export function isAbstention(answer: string): boolean {
-  if (INLINE_CITATION_MARKER.test(answer)) return false;
-  return ABSTENTION_PHRASES.some((phrase) => phrase.test(answer));
+export const DEFAULT_ABSTENTION_TAU = 0.5;
+
+/**
+ * True if `answer` declines to answer `query` because the corpus does not
+ * support it.
+ *
+ * This asks a JUDGE, not a phrase list, and that is a correction rather than a
+ * refinement. The previous detector matched seven literal English phrases and
+ * vetoed any answer carrying an inline `[N]` marker, on the stated premise
+ * that "an abstention cites NOTHING". Replayed against the 2026-08-05 sweep,
+ * it recognised **0 of 8** genuine abstentions:
+ *
+ * - All four models cited the index document as EVIDENCE that only a section
+ *   title exists ("the index lists parental leave but contains no policy text
+ *   [1]"). Citing the proof of absence is the better behaviour, and the veto
+ *   charged every one of them `missed-abstention` for it.
+ * - Dropping the veto still left 5 of 8 unrecognised, including ALL FOUR
+ *   German answers — an English phrase list cannot match a German refusal, so
+ *   the DE abstention item was structurally unpassable in a harness that has
+ *   a cross-lingual axis and ships a skill file telling the agent to answer in
+ *   the user's language.
+ *
+ * The counter-case the old veto existed to protect is still handled, and
+ * without guessing at shapes: "The handbook does not contain a dedicated
+ * clause, but section 4 states records are kept for ten years [1]" states the
+ * requested fact, and the judge scores it 0.
+ *
+ * Graded on the answer BODY (`answerBody`): a Sources line quoting a document
+ * title is not the answer's claim, and feeding it to the judge grades the
+ * wrong text. One judge call, no k-averaging — unlike the entailment scores
+ * this is a wide binary decision (0.95 vs 0.00, nothing between), so averaging
+ * repeats would cost three calls per run to move nothing.
+ */
+export async function isAbstention(
+  query: string,
+  answer: string,
+  judge: AbstentionJudge,
+  opts: { tau?: number } = {}
+): Promise<boolean> {
+  const tau = opts.tau ?? DEFAULT_ABSTENTION_TAU;
+  // `.trim()`: `answerBody` leaves the blank lines that separated the body
+  // from the stripped Sources list.
+  const score = await judge.declines(query, answerBody(answer).trim());
+  return score >= tau;
 }
 
 export interface GroundednessOptions {
@@ -176,16 +194,24 @@ export async function gradeGroundedness(
  * - `goldQA.expectAbstention` falsy (the corpus CAN answer): abstaining is a
  *   `false-abstention` failure. Otherwise, falls through to the normal
  *   per-sentence `gradeGroundedness` check.
+ *
+ * `abstained` is passed IN rather than computed here, and is required rather
+ * than defaulted. Two graders branch on it (this one and
+ * `gradeAnswerRelevance`), and when each decided for itself they could
+ * disagree about the same answer — the same "one question, two answers" shape
+ * that `cited-path-match.ts` was extracted to close on the citation axis.
+ * `gradeKbRun` resolves it once, via `isAbstention`, and hands both the same
+ * verdict. Required, so adding a third caller is a compile error rather than
+ * a silent third opinion.
  */
 export async function gradeGroundednessForGold(
   answer: string,
   citedPassages: string[],
   goldQA: GoldQA,
   nli: NliClient,
+  abstained: boolean,
   opts: GroundednessOptions = {}
 ): Promise<KbGraderResult> {
-  const abstained = isAbstention(answer);
-
   if (goldQA.expectAbstention) {
     if (abstained) return { passed: true, tags: [], notes: [] };
     return {

--- a/packages/web/src/lib/eval/kb/llm-nli.ts
+++ b/packages/web/src/lib/eval/kb/llm-nli.ts
@@ -25,6 +25,7 @@
 
 import type { NliClient, NliLabel, NliVerdict } from "./nli";
 import type { RelevanceJudge } from "./answer-graders";
+import type { AbstentionJudge } from "./groundedness-grader";
 
 /** A model call: send one prompt, get back the model's raw text reply. Dependency-injected — see module doc comment. */
 export type LlmChatFn = (prompt: string) => Promise<string>;
@@ -44,6 +45,28 @@ export const NLI_PARSE_FALLBACK: NliVerdict = { label: "neutral", score: 0 };
 
 /** Same conservative-failure reasoning as `NLI_PARSE_FALLBACK`, for `parseRelevanceResponse`. */
 export const RELEVANCE_PARSE_FALLBACK = 0;
+
+/**
+ * Fallback for `parseAbstentionResponse`: "this answer did not decline."
+ *
+ * Unlike the two above, this one is NOT unambiguously conservative, and it is
+ * worth saying so rather than implying a safety it does not have. Either
+ * fallback asserts something: 0 makes an unparseable reply read as a model
+ * that answered (so a gold-abstention item is charged `missed-abstention`),
+ * and 1 makes it read as a refusal (so an answerable item is charged
+ * `false-abstention`). There is no neutral value, because the grader's
+ * question is binary.
+ *
+ * 0 is chosen because it keeps the tag pointing at the more common case and
+ * matches the other two fallbacks' direction, and because the parse failure
+ * is logged either way. The honest fix is for an unparseable judge reply to
+ * be an INVALID TRIAL (`run-infra-error`) rather than a verdict — the sweep
+ * already has that concept for transport failures. Not built here: across the
+ * 48 archived answers this judge produced zero unparseable replies, so the
+ * path is untested in practice and a speculative implementation of it would
+ * be worse than a documented limitation.
+ */
+export const ABSTENTION_PARSE_FALLBACK = 0;
 
 const VALID_NLI_LABELS: readonly NliLabel[] = ["entailment", "neutral", "contradiction"];
 
@@ -137,12 +160,28 @@ export function parseNliResponse(raw: string): NliVerdict {
  * no entailment label, only a degree of "does this address the question."
  */
 export function parseRelevanceResponse(raw: string): number {
+  return parseScoreReply(raw, "relevance", RELEVANCE_PARSE_FALLBACK);
+}
+
+/**
+ * Same `{"score": <0..1>}` contract, for the abstention judge role. Kept as
+ * its own export (rather than reusing `parseRelevanceResponse`) so the warn
+ * lines name the role that actually failed — a judge reply that cannot be
+ * parsed is diagnosed from the log, and "relevance judge reply" printed for
+ * an abstention call sends the reader to the wrong prompt.
+ */
+export function parseAbstentionResponse(raw: string): number {
+  return parseScoreReply(raw, "abstention", ABSTENTION_PARSE_FALLBACK);
+}
+
+/** Shared body of the two `{"score": …}` parsers — same robustness, different role label and fallback. */
+function parseScoreReply(raw: string, role: string, fallback: number): number {
   const jsonText = extractJsonObjectText(raw);
   if (jsonText === null) {
     console.warn(
-      `[llm-nli] no JSON object found in relevance judge reply, falling back to ${RELEVANCE_PARSE_FALLBACK}: ${raw.slice(0, 200)}`
+      `[llm-nli] no JSON object found in ${role} judge reply, falling back to ${fallback}: ${raw.slice(0, 200)}`
     );
-    return RELEVANCE_PARSE_FALLBACK;
+    return fallback;
   }
 
   let parsed: unknown;
@@ -150,24 +189,24 @@ export function parseRelevanceResponse(raw: string): number {
     parsed = JSON.parse(jsonText);
   } catch (err) {
     console.warn(
-      `[llm-nli] relevance judge reply is not valid JSON, falling back to ${RELEVANCE_PARSE_FALLBACK}: ${String(err)}`
+      `[llm-nli] ${role} judge reply is not valid JSON, falling back to ${fallback}: ${String(err)}`
     );
-    return RELEVANCE_PARSE_FALLBACK;
+    return fallback;
   }
 
   if (typeof parsed !== "object" || parsed === null) {
     console.warn(
-      `[llm-nli] relevance judge reply parsed to a non-object, falling back to ${RELEVANCE_PARSE_FALLBACK}`
+      `[llm-nli] ${role} judge reply parsed to a non-object, falling back to ${fallback}`
     );
-    return RELEVANCE_PARSE_FALLBACK;
+    return fallback;
   }
 
   const score = (parsed as Record<string, unknown>).score;
   if (typeof score !== "number" || !Number.isFinite(score)) {
     console.warn(
-      `[llm-nli] relevance judge reply has an invalid score ${JSON.stringify(score)}, falling back to ${RELEVANCE_PARSE_FALLBACK}`
+      `[llm-nli] ${role} judge reply has an invalid score ${JSON.stringify(score)}, falling back to ${fallback}`
     );
-    return RELEVANCE_PARSE_FALLBACK;
+    return fallback;
   }
 
   return clamp01(score);
@@ -231,6 +270,53 @@ export class LlmRelevanceJudge implements RelevanceJudge {
   async score(query: string, answer: string): Promise<number> {
     const raw = await this.chat(buildRelevancePrompt(query, answer));
     return parseRelevanceResponse(raw);
+  }
+}
+
+/**
+ * Prompt contract for the abstention judge role — see `parseAbstentionResponse`.
+ *
+ * This is a CLASSIFICATION prompt with the question in it, and both of those
+ * properties were arrived at by measurement rather than taste. The detector
+ * this replaces asked the NLI judge to entail a claim about the answer text
+ * ("this text declines to answer the question") with no question in the
+ * prompt. Against the 48 archived answers of the 2026-08-05 sweep that failed
+ * on every judge tried — `gpt-oss:20b` scored a complete, unambiguous answer
+ * 0.95 on it twelve times running, and `gpt-oss:120b` and `kimi-k2.6` put
+ * abstentions and answers alike in one narrow band. Entailment is the wrong
+ * relation for the question, and the question is not answerable without the
+ * question.
+ *
+ * The two paragraphs about what does and does not count are the boundary the
+ * old phrase-list detector got wrong in both directions: an abstention that
+ * cites its evidence still declines, and an answer that supplies the
+ * requested fact does not decline merely because it also negates something
+ * along the way.
+ */
+export function buildAbstentionPrompt(query: string, answer: string): string {
+  return `You are grading whether an ANSWER declines to answer a QUESTION.
+
+An answer DECLINES when it reports that the documents do not contain what was asked. It still counts as declining when it cites documents as evidence of that absence, and when it offers related context it did find.
+
+An answer does NOT decline when it states the fact that was asked for — even if it also mentions that some other detail is missing, and even if it turns out to be wrong.
+
+Respond with ONLY a JSON object, no other text, in exactly this shape:
+{"score": <number between 0 and 1, where 1 = clearly declines to answer and 0 = clearly answers the question>}
+
+QUESTION:
+${query}
+
+ANSWER:
+${answer}`;
+}
+
+/** `AbstentionJudge` implementation backed by an injected LLM chat function — see `LlmNliClient`. */
+export class LlmAbstentionJudge implements AbstentionJudge {
+  constructor(private readonly chat: LlmChatFn) {}
+
+  async declines(query: string, answer: string): Promise<number> {
+    const raw = await this.chat(buildAbstentionPrompt(query, answer));
+    return parseAbstentionResponse(raw);
   }
 }
 

--- a/packages/web/src/lib/eval/kb/llm-nli.ts
+++ b/packages/web/src/lib/eval/kb/llm-nli.ts
@@ -174,8 +174,16 @@ export function parseAbstentionResponse(raw: string): number {
   return parseScoreReply(raw, "abstention", ABSTENTION_PARSE_FALLBACK);
 }
 
-/** Shared body of the two `{"score": …}` parsers — same robustness, different role label and fallback. */
-function parseScoreReply(raw: string, role: string, fallback: number): number {
+/**
+ * Shared body of the two `{"score": …}` parsers — same robustness, different
+ * role label and fallback.
+ *
+ * `role` is a union, not a `string`: naming the failing role is the ONLY reason
+ * the two parsers are separate exports, so a free-form label would let the next
+ * role in with a typo and quietly send the reader to the wrong prompt — the
+ * exact failure the split exists to prevent.
+ */
+function parseScoreReply(raw: string, role: "relevance" | "abstention", fallback: number): number {
   const jsonText = extractJsonObjectText(raw);
   if (jsonText === null) {
     console.warn(


### PR DESCRIPTION
## What was wrong

The 2026-08-05 KB groundedness sweep charged `missed-abstention` on both abstention items for all four models — an 8/8 failure. In this harness a failure that uniform has meant the grader every time, so I read the eight answers before believing the tags. All eight abstain correctly, in the words `knowledge-search/SKILL.md` asks for:

> "the detailed policy text itself isn't included in the indexed materials" — kimi
> "Ich konnte in den indizierten Dokumenten leider **keine eigentliche Richtlinie zur Elternzeit** finden" — glm
> "I couldn't find the actual text of Northwind's parental leave policy" — qwen
> "does not include a specific text for the parental-leave policy in the documents that are currently indexed" — gpt-oss

Two defects in `isAbstention`, both confirmed by replaying the archived answers through the production function:

1. **It vetoed any answer carrying an inline `[N]` marker**, on the stated premise that *"an abstention cites NOTHING"*. All four models cited the index document as **evidence** that only a section title exists. Citing the proof of absence is the better behaviour, and it was charged as a defect.
2. **Dropping the veto still left 5 of 8 unrecognised**, including **all four German answers** — the phrase list is literal and English-only. The DE abstention item was structurally unpassable in a harness that has a `cross-lingual` axis and ships a skill file instructing the agent to answer in the user's language.

The counter-check the old comment worried about is empty: of the 40 answerable runs, **zero** would be misread as abstentions without the veto.

`off-topic-grounded` on 7 of those 8 runs is the same defect downstream — `gradeAnswerRelevance` short-circuits on abstention, so each unrecognised refusal was scored against the question it had declined to answer.

## Why it is a judge now, and why not the NLI judge

"Does this text state the requested fact, or report its absence?" is a question about meaning. My first attempt asked the existing NLI judge to entail a claim *about the answer text*. **That does not work, on any judge model tried** — measured against the same 48 archived answers:

| hypothesis | abstentions | answering runs |
| --- | --- | --- |
| "The answer states that the requested information could not be found in the documents." | 0.95–0.99 | up to **0.99** |
| "The requested information is not available in the indexed documents." | 0.95–0.96 | up to **0.95** |
| "This text declines to answer the question." | 0.92–0.99 | **11 of 40 at ≥ 0.95** |

An answer reading *"The daily meal per diem was **$45** [1]"* scored 0.98 on the first. `gpt-oss:20b` scored a complete, unambiguous answer 0.95 on the third **twelve times running** — so this is not judge noise, and a control hypothesis ("This text is a recipe for onion soup") correctly scores 0.05, so it is not a yes-sayer either. `gpt-oss:120b` and `kimi-k2.6` put both classes in one narrow band instead.

Entailment is the wrong relation for the question, and the question cannot be judged without the question in the prompt.

`LlmAbstentionJudge` is a third judge role — same shape as `LlmRelevanceJudge` — with a classification prompt carrying **both** the question and the answer. On the same 48 answers it separates completely:

- all 8 abstentions: **0.95–1.00**
- all 40 answering runs: **0.00**

No run falls between, which is why `DEFAULT_ABSTENTION_TAU` is not load-bearing.

## Structure

`gradeKbRun` resolves abstention **once** and hands the verdict to both graders that branch on it, as a **required** parameter. Two graders deciding for themselves could disagree about the same answer — the same "one question, two answers" shape `cited-path-match.ts` was extracted to close on the citation axis. A third caller is now a compile error rather than a third opinion.

Also corrects `gradeKbRun`'s doc comment, which claimed the attribution axes have nothing to grade on an abstention *"since a correct abstention naturally yields an empty Sources list"*. The sweep answered that empirically: every abstention in it cited, and one wrote a Sources list that does not render. Abstaining changes whether declining to answer is a defect; it does not license a broken citation list. Those axes keep grading.

## Verification

- 164 unit tests in `src/lib/eval/kb/__tests__` (6 new, none removed); full suite **11800 passed**.
- Two regression tests carry **verbatim sweep output** — the evidence-citing English abstention and the German one.
- A stub judge cannot prove a live judge reads those correctly; that was measured separately, against the real judge, and the numbers are in `buildAbstentionPrompt`'s doc comment.
- Typecheck + prettier + eslint clean (eslint reports only pre-existing warnings in untouched files).

## Consequence for #1156

15 of that dataset's 72 tags come from this defect. Its README and CHANGELOG present the sweep as the first one that measures the models rather than the harness, and that claim does not hold. Re-grading the archived trajectories through the corrected pipeline is the next step — it needs no stack and no re-dispatch, since grading runs host-side and the answers are on disk.