### PR TITLE
fix(docker): let the model download actually outlast a rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,13 @@ jobs:
         run: |
           set -euo pipefail
           cd "$RUNNER_TEMP"
-          curl -sSfL --retry 3 --retry-delay 2 --retry-all-errors \
+          # No --retry-delay: it disables curl's exponential backoff, which is
+          # what made the GGUF download give up after 25 s against an HF 429
+          # (Dockerfile.openclaw carries the long version, including what the
+          # flag does NOT do). Lower stakes here — a 2 MB asset from GitHub
+          # releases — but the same wrong flag. --retry-max-time caps when a
+          # retry may still start, not the total.
+          curl -sSfL --retry 5 --retry-all-errors --retry-max-time 120 \
             -o actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check --strict

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -92,8 +92,30 @@ RUN openclaw plugins install @openclaw/llama-cpp-provider \
 # for whatever HF returns under load. Integrity is still enforced by the
 # sha256sum -c below — a truncated or tampered download fails the build
 # regardless of how many retries it took.
+#
+# There is deliberately NO --retry-delay. It reads like a tuning knob and is a
+# kill switch: curl's manual says "By using --retry-delay you disable this
+# exponential backoff algorithm". `--retry 5 --retry-delay 5` therefore spent
+# its whole patience in 25 s, and on 2026-08-06 that lost the Pre-release build
+# on main to HF 429s — six requests fired INTO a rate limit rather than waiting
+# one out. Without the flag the wait doubles 1,2,4,8,… so the retry COUNT is
+# what buys patience: 8 retries sleep ~255 s where 5 would sleep ~31 s.
+#
+# Retry-After is NOT the lever here, tempting as it is to credit. curl honours
+# that header whether or not --retry-delay is set — it takes the larger of the
+# two, never the smaller (checked against curl 8.x, not inferred from the
+# manual). So the exact 5 s spacing above is itself the evidence that HF sent
+# no usable Retry-After at all, and restored backoff is the entire fix.
+#
+# --retry-max-time bounds when curl may still START another retry, not the
+# total wall clock: "if the timer has not reached the limit, the request is
+# made and while performing, it may take longer than this given time period".
+# That is the right bound for a rate limit, where attempts fail in
+# milliseconds and the sleeping is the whole cost. A transfer that stalls
+# mid-flight is a different failure needing different flags (-m /
+# --speed-limit); this bound does not pretend to cover it.
 RUN mkdir -p /opt/embedding-models \
-    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+    && curl -fsSL --retry 8 --retry-all-errors --retry-max-time 600 \
        -o /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf \
        https://huggingface.co/ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/resolve/66f974f8cd48cc3b9c41c516b95508e75b4bee64/embeddinggemma-300m-qat-Q8_0.gguf \
     && echo "6fa0c02a9c302be6f977521d399b4de3a46310a4f2621ee0063747881b673f67  /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf" | sha256sum -c -

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -120,12 +120,19 @@ RUN rm -rf packages/web/.next/cache
 # retry flags matter because this is a large, uncached blob whose transient HF
 # hiccup would otherwise redden an unrelated PR; the sha256sum -c enforces
 # integrity regardless of how many retries it took.
+#
+# No --retry-delay, for the reason spelled out over the same command in
+# Dockerfile.openclaw: a fixed delay disables curl's exponential backoff, which
+# is what turned an HF 429 into a red build on 2026-08-06. It does NOT disable
+# Retry-After compliance — curl honours that header either way — and
+# --retry-max-time bounds when a retry may still start, not the total wall
+# clock. Keep these flags in step with that file.
 # ---------------------------------------------------------------------------
 FROM mirror.gcr.io/library/node:22-slim AS embedding-model
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/embedding-models \
-    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+    && curl -fsSL --retry 8 --retry-all-errors --retry-max-time 600 \
        -o /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf \
        https://huggingface.co/ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/resolve/66f974f8cd48cc3b9c41c516b95508e75b4bee64/embeddinggemma-300m-qat-Q8_0.gguf \
     && echo "6fa0c02a9c302be6f977521d399b4de3a46310a4f2621ee0063747881b673f67  /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf" | sha256sum -c -

--- a/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
+++ b/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
@@ -31,6 +31,80 @@ const DOCKERFILE_OPENCLAW = readFileSync(resolve(REPO_ROOT, "Dockerfile.openclaw
 const DOCKERFILE_PINCHY = readFileSync(resolve(REPO_ROOT, "Dockerfile.pinchy"), "utf8");
 const VERIFY_SCRIPT = readFileSync(resolve(REPO_ROOT, "config/verify-memory-search.sh"), "utf8");
 
+/**
+ * Extracts the GGUF download command itself — `curl -fsSL … huggingface…gguf`.
+ *
+ * Anchoring on the first `curl` token would match `apt-get install … curl` and,
+ * worse, would let flag text in the *explanatory comment* above the command
+ * satisfy a flag assertion while the real command had lost it. The comment sits
+ * before `curl -fsSL`, so it is outside this span. The command is
+ * backslash-continued across lines, hence `[\s\S]` up to the HF URL.
+ *
+ * Throws rather than returning "" when it finds nothing: an empty string
+ * satisfies every NEGATIVE assertion below vacuously, so a Dockerfile this
+ * function can no longer read must be an error, not a pass.
+ */
+function downloadCommand(dockerfile: string): string {
+  const command = dockerfile.match(/curl -fsSL[\s\S]*?huggingface\.co\S+\.gguf/)?.[0];
+  if (!command) {
+    throw new Error(
+      "No `curl -fsSL … huggingface…gguf` download found — this guard cannot assert flags on a command it did not locate."
+    );
+  }
+  return command;
+}
+
+/**
+ * Asserts the download is willing to outlast a HuggingFace rate limit, not just
+ * a single hiccup.
+ *
+ * On 2026-08-06 the `Pre-release` image build went red on main against HF 429s.
+ * `--retry 5 --retry-all-errors --retry-delay 5` was in place and the guard
+ * below was green, because it asserted the flags were PRESENT rather than what
+ * they resolve to. curl's manual on the flag that did the damage:
+ *
+ *   "When curl is about to retry a transfer, it first waits one second and then
+ *    for all forthcoming retries it doubles the waiting time … By using
+ *    --retry-delay you disable this exponential backoff algorithm."
+ *
+ * So every attempt landed inside 25 s — six requests into a rate limit, which
+ * is closer to making it worse than to riding it out. The observed timeline was
+ * exactly that: 0.2s, 5.2s, 10.2s, 15.2s, 20.3s, 25.3s, all 429.
+ *
+ * What --retry-delay does NOT do, easy as it is to assume: it does not switch
+ * off curl's Retry-After compliance. curl takes the LARGER of the computed
+ * sleep and the header, so Retry-After is honoured either way — measured
+ * against curl 8.x with a 429-serving stub, not inferred. Which means the even
+ * 5 s spacing above is itself the evidence that HF sent no usable Retry-After,
+ * and restored exponential backoff is the entire fix.
+ *
+ * This is the same failure shape as the X-Frame-Options gate documented in
+ * AGENTS.md — assert the behaviour a command resolves to, not the flag a file
+ * asked for.
+ */
+function expectPatientBackoff(download: string): void {
+  // A fixed delay is the specific thing that broke it: it switches off the
+  // exponential backoff and leaves every retry evenly spaced.
+  expect(download).not.toMatch(/--retry-delay/);
+
+  // Without the fixed delay, backoff doubles 1,2,4,8,… so the retry COUNT is
+  // what buys patience: 8 retries sleep ~255s in total, 5 would sleep ~31s and
+  // land back where this started.
+  const retries = Number(download.match(/--retry\s+(\d+)/)?.[1]);
+  expect(retries).toBeGreaterThanOrEqual(8);
+
+  // …and the count alone is unbounded upward once doubling passes a minute, so
+  // bound how long curl may keep STARTING retries. That is what
+  // --retry-max-time caps — not the total wall clock, and not a transfer
+  // already in flight. This is the number to argue about if it ever needs
+  // changing; it is deliberately long enough to ride out a rate limit (8
+  // retries sleep ~255s, comfortably inside 300) and short enough that a
+  // genuinely gone upstream fails the same afternoon rather than occupying a
+  // runner.
+  const maxTime = Number(download.match(/--retry-max-time\s+(\d+)/)?.[1]);
+  expect(maxTime).toBeGreaterThanOrEqual(300);
+}
+
 /** Extracts the pinned HF `resolve/<40-hex-sha>/…gguf` revision from a Dockerfile's download URL. */
 function ggufRevision(dockerfile: string): string | undefined {
   return dockerfile.match(/huggingface\.co\/\S+\/resolve\/([0-9a-f]{40})\/\S+\.gguf/)?.[1];
@@ -78,17 +152,13 @@ describe("memory embedding pin drift guard", () => {
     // a passing build and a flaky-red one (PR #768 fell over twice this way on
     // 2026-07-16). --retry already covers the transient HTTP codes (incl. 504);
     // --retry-all-errors widens that to 4xx / non-HTTP errors as a safety net.
-    //
-    // Anchor on the actual download command — `curl -fsSL … huggingface…gguf` —
-    // NOT on the first `curl` token (that's `apt-get install … curl`). Anchoring
-    // loosely would let the flag text in the *explanatory comment* above satisfy
-    // these assertions and mask a real removal of the flags from the command. The
-    // comment sits before `curl -fsSL`, so it is outside this span. The curl is
-    // backslash-continued across lines, hence [\s\S] up to the HF URL.
-    const download =
-      DOCKERFILE_OPENCLAW.match(/curl -fsSL[\s\S]*?huggingface\.co\S+\.gguf/)?.[0] ?? "";
+    const download = downloadCommand(DOCKERFILE_OPENCLAW);
     expect(download).toMatch(/--retry\s+\d+/);
     expect(download).toMatch(/--retry-all-errors/);
+  });
+
+  it("waits long enough for a rate limit, with backoff left switched on", () => {
+    expectPatientBackoff(downloadCommand(DOCKERFILE_OPENCLAW));
   });
 
   it("the CI smoke test checks the same model path", () => {
@@ -135,10 +205,13 @@ describe("KB embedding pin drift guard", () => {
   });
 
   it("retries the GGUF download on transient HTTP failures", () => {
-    const download =
-      DOCKERFILE_PINCHY.match(/curl -fsSL[\s\S]*?huggingface\.co\S+\.gguf/)?.[0] ?? "";
+    const download = downloadCommand(DOCKERFILE_PINCHY);
     expect(download).toMatch(/--retry\s+\d+/);
     expect(download).toMatch(/--retry-all-errors/);
+  });
+
+  it("waits long enough for a rate limit, with backoff left switched on", () => {
+    expectPatientBackoff(downloadCommand(DOCKERFILE_PINCHY));
   });
 
   it("pins the SAME revision + checksum as the agent-memory model (both load the identical GGUF)", () => {


### PR DESCRIPTION
## What happened

`Pre-release` went red on `main` this morning (`558bc6f0d`) building the Pinchy image. Not a code failure — HuggingFace answered **429** to the pinned embeddinggemma GGUF download:

```
0.2s → 429   5.2s → 429   10.2s → 429   15.2s → 429   20.3s → 429   25.3s → 429
```

Six attempts, 25 seconds, exactly 5 s apart.

## Why the retry couldn't help

The command was `curl -fsSL --retry 5 --retry-all-errors --retry-delay 5`. From curl's manual:

> When curl is about to retry a transfer, it first waits one second and then for all forthcoming retries it doubles the waiting time … **By using `--retry-delay` you disable this exponential backoff algorithm.**

429 is already in curl's transient set, so `--retry-all-errors` was never what mattered here.

## The fix

`--retry 8 --retry-all-errors --retry-max-time 600` in both `Dockerfile.pinchy` and `Dockerfile.openclaw` (they must stay in lockstep — same GGUF, same pins).

- No fixed delay → backoff doubles 1,2,4,8,…
- 8 retries rather than 5, because with backoff the *count* is what buys patience: ~255 s of sleeping instead of ~31 s.
- `--retry-max-time 600` bounds it.

`sha256sum -c` is untouched: a truncated or tampered download fails the build loud however many retries it took.

## Two things these flags do NOT do

An earlier revision of this PR got both wrong by reading the manual instead of running curl. Corrected, with the measurement:

**`--retry-delay` does not switch off `Retry-After` compliance.** curl takes the **larger** of its computed sleep and the header. Measured on curl 8.7.1 against a stub serving `429` + `Retry-After: 4`, under `--retry-delay 1`:

```
HIT 1785993866.72   HIT 1785993870.72   HIT 1785993874.72
```

4.00 s apart — the header won. That makes the even 5 s spacing in the failure above *evidence in its own right*: HF sent no usable `Retry-After`, so restored exponential backoff is the entire fix rather than half of it.

**`--retry-max-time` does not bound total wall clock.** It bounds when curl may still *start* another retry — "if the timer has not reached the limit, the request is made and while performing, it may take longer than this given time period". That is the right bound for a rate limit, where attempts fail in milliseconds and the sleeping is the whole cost. A transfer that stalls mid-flight is a different failure wanting `-m` / `--speed-limit`, and this PR does not pretend to cover it.

## The guard was green the whole time

`memory-embedding-pin-drift.test.ts` asserted `--retry N` and `--retry-all-errors` were **present**. Both were. The combination gave up in 25 seconds. That is the shape AGENTS.md already names for X-Frame-Options: *assert what a concrete command resolves to, not what a file asked for.*

The extractor now **throws** instead of returning `""` when it cannot find the download. Every new assertion is negative or arithmetic on a regex capture, and `""` satisfies `not.toMatch` vacuously — a guard that stops finding its subject must fail, not pass.

**Both canary-verified, not read:** red against the old flags in both Dockerfiles; and renaming the command so the extractor misses it fails both suites with the thrown message.

## What this does NOT explain, and one thing it surfaced

**Why HF answered 429 is not established.** The request leaves a shared GitHub-runner address range and HF's anonymous limits are not visible from here. This PR makes the retry survive such an answer; it does not claim to prevent it.

An earlier draft blamed a merge-queue burst. **The timeline refutes that** and it has been removed: the download failed at `04:46:37`, the second `Pre-release` run started at `04:49:36`.

What the investigation did establish is worth acting on separately: **`pre-release.yml` carries no `cache-from` at all**, where `ci.yml`'s `build-images` reads `type=gha,scope=<img>-main`. Every push to `main` therefore fetches the ~300 MB blob cold, twice — once per image. The successful follow-up run bears this out: 13 min 18 s + 10 min 09 s = **24 minutes** of image build, against `ci.yml`'s own measured 6 min 27 warm / 20 min 06 cold. The workflow that asks HuggingFace most often is the one with no layer cache. That is a change to the release path, so it is **deliberately not in this PR**.

## Second commit, lower stakes, stated plainly

`ci.yml`'s actionlint fetch carried `--retry 3 --retry-delay 2` — the same wrong flag, ~6 s of patience, a 2 MB asset from GitHub releases. Fixed because it is wrong for the same documented reason, **not** because anything was observed failing there. Its comment stays short and points at `Dockerfile.openclaw` for the long version; two copies of that reasoning would drift.

It is **not** covered by a drift guard, and the commit message says so. A repo-wide "no `--retry-delay`" rule is what would catch the next copy; that is a bigger change than this one is worth.

## Gates

`pnpm test` (11 835 passed / 18 skipped) · `pnpm test:scripts` (1 240) · `pnpm -C packages/web typecheck` · `pnpm -C packages/web lint` (0 errors) · `prettier --check .` · `check-docs-required` (nothing to ask for) · `pnpm build`.

CI's `Build OpenClaw image` passing is the part that matters most here: the changed `RUN curl` layer is a cache miss, so it really re-downloaded the GGUF under the new flags.