### PR TITLE
fix(approvals): key a resolution on the session, not on the call id alone

### DIFF
--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -200,7 +200,12 @@ Two fields answer "did this confirmation actually do anything", from the two end
 
 **`resolution`**, on `approval.consumed` and `approval.expired`, is the agent's end: what the runtime did with the call. It is one of `allow-once`, `allow-always`, `deny`, `timeout` or `cancelled` — the last two being outcomes no button produces, which is why they only ever appear here.
 
-Read together, a `granted` with `resumed: true` followed by a `consumed` is one action cleared and then run. A `granted` with no `consumed` deserves a look: the usual cause is that the agent stopped waiting, and the matching `expired` row will say so. For certainty that the action itself executed, pair the grant with the `tool.<name>` row the agent writes when a tool runs.
+Read together, a `granted` with `resumed: true` followed by a `consumed` is one action cleared and then run. A `granted` with no `consumed` deserves a look, and `resumed` is where to start:
+
+- **`resumed: false`** — the decision never reached the agent, so the tool did not run. That row is the whole story; no `expired` row follows it, because a confirmation somebody decided is settled and only an undecided one can expire.
+- **`resumed: true`** — the agent was told, so the action very likely ran and only the runtime's report of it went missing. The `tool.<name>` row the agent writes when a tool runs is the evidence either way, and the agent runtime logs a warning when it cannot get a report through.
+
+An `approval.expired` therefore never follows a `granted` or a `denied`: it belongs to confirmations nobody answered.
 
 The same sweep also reaps settled confirmations after 30 days and records that as a single `approval.gc` summary row (`swept`, `retentionDays`, `sweepId`) rather than one row per deleted record.
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1851,10 +1851,11 @@ Reports what the agent runtime finally did with a call it had held open. This is
 
 **Request body:**
 
-| Field        | Type   | Required | Description                                                    |
-| ------------ | ------ | -------- | -------------------------------------------------------------- |
-| `toolCallId` | string | Yes      | The call the confirmation was holding up                       |
-| `decision`   | string | Yes      | `allow-once`, `allow-always`, `deny`, `timeout` or `cancelled` |
+| Field        | Type   | Required | Description                                                                                                                                                                                         |
+| ------------ | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `toolCallId` | string | Yes      | The call the confirmation was holding up                                                                                                                                                            |
+| `sessionKey` | string | No       | The conversation that call belongs to. A tool call id is only unique per response on some model backends, so this is what keeps a report from closing a confirmation in someone else's conversation |
+| `decision`   | string | Yes      | `allow-once`, `allow-always`, `deny`, `timeout` or `cancelled`                                                                                                                                      |
 
 **Response:**
 

--- a/packages/plugins/pinchy-approvals/gate.test.ts
+++ b/packages/plugins/pinchy-approvals/gate.test.ts
@@ -201,7 +201,15 @@ describe("onResolution", () => {
 
     const [url, init] = f.mock.calls[1];
     expect(url).toBe("http://pinchy:7777/api/internal/approvals/resolution");
-    expect(JSON.parse(init.body)).toEqual({ toolCallId: "call_7", decision: "allow-once" });
+    // The session travels with it for the same reason it travels on the
+    // approval OpenClaw broadcasts: a tool call id is only as unique as the
+    // model provider makes it, and settling on the id alone can spend a grant
+    // in a session the runtime said nothing about.
+    expect(JSON.parse(init.body)).toEqual({
+      toolCallId: "call_7",
+      sessionKey: "agent:a1:direct:u1",
+      decision: "allow-once",
+    });
   });
 
   it("reports a timeout, which no button ever produces", async () => {
@@ -215,13 +223,45 @@ describe("onResolution", () => {
 
   // OpenClaw calls this callback while finalizing the approval and only logs a
   // rejection. Throwing here buys nothing and risks noise on a path where the
-  // decision has already taken effect.
+  // decision has already taken effect — but staying quiet is not the same as
+  // not throwing, so the log line is part of the contract.
   it("swallows a failed report instead of throwing into the runtime", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const f = stubApprovalRequired();
     const gated = await evaluateGate("odoo_write", {}, withCall, cfg);
     f.mockRejectedValueOnce(new Error("connection refused"));
 
     await expect(gated.requireApproval?.onResolution?.("allow-once")).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  // Staying quiet on a network blip is a choice; staying quiet when Pinchy
+  // ANSWERED and said no is not. `approval.consumed` is now written from this
+  // report and nowhere else, so a rejected report silently drops the only
+  // record that an approved action ran — and nothing anywhere would say so.
+  it("says so when Pinchy refuses the report", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const f = stubApprovalRequired();
+    const gated = await evaluateGate("odoo_write", {}, withCall, cfg);
+    f.mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) });
+
+    await gated.requireApproval?.onResolution?.("allow-once");
+
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toMatch(/401/);
+    warn.mockRestore();
+  });
+
+  it("stays quiet when the report lands", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubApprovalRequired();
+    const gated = await evaluateGate("odoo_write", {}, withCall, cfg);
+
+    await gated.requireApproval?.onResolution?.("allow-once");
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   // Without a call id there is no row to attribute the outcome to, and posting

--- a/packages/plugins/pinchy-approvals/gate.ts
+++ b/packages/plugins/pinchy-approvals/gate.ts
@@ -69,14 +69,22 @@ const FETCH_TIMEOUT_MS = 10_000;
 /**
  * Tell Pinchy what OpenClaw did with a parked call.
  *
- * Deliberately silent on failure: OpenClaw calls this while finalizing the
- * approval and only logs a rejection, and by then the decision has already
- * taken effect — throwing would buy nothing and add noise. What it costs is a
- * row that stays `pending` until the hourly sweep expires it, which is the
- * behaviour we had before this callback existed.
+ * Never throws: OpenClaw calls this while finalizing the approval and only logs
+ * a rejection, and by then the decision has already taken effect — throwing
+ * would buy nothing and add noise. What a lost report costs is a row that stays
+ * `pending` until the hourly sweep expires it, which is the behaviour we had
+ * before this callback existed.
+ *
+ * It does NOT stay quiet, though. `approval.consumed` is written from this
+ * report and from nowhere else — an approved call resumes inside OpenClaw's
+ * hook and never passes the gate again — so a report Pinchy refuses drops the
+ * only record that the action ran. A network blip is worth one line in the
+ * OpenClaw log; an answered "no" is worth it twice over, because it means a
+ * rotated token or a changed contract rather than weather.
  */
 async function reportResolution(
   toolCallId: string | undefined,
+  sessionKey: string | undefined,
   decision: ApprovalResolution,
   cfg: GateConfig
 ): Promise<void> {
@@ -84,17 +92,29 @@ async function reportResolution(
   // endpoint guess which confirmation was meant.
   if (!toolCallId) return;
   try {
-    await fetch(`${cfg.apiBaseUrl}/api/internal/approvals/resolution`, {
+    const res = await fetch(`${cfg.apiBaseUrl}/api/internal/approvals/resolution`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
         authorization: `Bearer ${cfg.gatewayToken}`,
       },
-      body: JSON.stringify({ toolCallId, decision }),
+      // The session travels with the call id because the id alone is not a key:
+      // a provider that numbers tool calls per response lets two sessions share
+      // one, and settling on the id alone spends a grant nobody reported on.
+      body: JSON.stringify({ toolCallId, ...(sessionKey ? { sessionKey } : {}), decision }),
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
-  } catch {
-    // See above.
+    if (!res.ok) {
+      console.warn(
+        `[pinchy-approvals] Pinchy refused the resolution report for ${toolCallId} ` +
+          `(${decision}): HTTP ${res.status}. The grant was not recorded as spent.`
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[pinchy-approvals] could not report the resolution for ${toolCallId} ` +
+        `(${decision}): ${String(err)}. The grant was not recorded as spent.`
+    );
   }
 }
 
@@ -170,7 +190,8 @@ export async function evaluateGate(
           // differ on every outcome no button produces — a timeout, a
           // cancelled run — and those are exactly the ones that would
           // otherwise leave a confirmation looking unanswered.
-          onResolution: (resolution) => reportResolution(ctx.toolCallId, resolution, cfg),
+          onResolution: (resolution) =>
+            reportResolution(ctx.toolCallId, ctx.sessionKey, resolution, cfg),
         },
       };
     }

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -759,7 +759,12 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
       });
       const requestId = (requested.detail as { request: { id: string } }).request.id;
 
-      // The acting user grants their own pending confirmation.
+      // The acting user grants their own pending confirmation — immediately,
+      // and deliberately so. `approval.requested` is written from inside
+      // gate-check, so this decision can reach the route before OpenClaw's
+      // approval broadcast reaches Pinchy. Do not "stabilise" this by waiting
+      // first: that window is the thing under test, and closing it is the
+      // route's job (`awaitApprovalLink`), not the test's.
       const decision = await page.request.post(`/api/approvals/${requestId}/decision`, {
         data: { decision: "approve" },
       });

--- a/packages/web/src/__tests__/api/approvals.integration.test.ts
+++ b/packages/web/src/__tests__/api/approvals.integration.test.ts
@@ -577,6 +577,35 @@ describe("approval routes (integration, real DB)", () => {
       ).toHaveLength(1);
     });
 
+    // A tool call id is only as unique as the model provider makes it — several
+    // self-hosted OpenAI-compatible servers number them per response — so the
+    // gate reports the session alongside it. This is the wiring (schema field,
+    // route destructuring, service argument) that the service test sees only
+    // half of: drop it anywhere along the way and the report silently widens
+    // back to "any row with this call id".
+    it("settles only the session the runtime reported on", async () => {
+      const mine = await (await gateCheck(gateReq({ ...gateBody(), toolCallId: "call_0" }))).json();
+      const theirs = await (
+        await gateCheck(
+          gateReq({
+            ...gateBody(),
+            sessionKey: `${sessionKey()}:other-chat`,
+            toolCallId: "call_0",
+          })
+        )
+      ).json();
+      expect(theirs.requestId).not.toBe(mine.requestId);
+
+      await reportResolution(
+        resolutionReq({ toolCallId: "call_0", sessionKey: sessionKey(), decision: "timeout" })
+      );
+
+      const rows = await db.select().from(toolApproval);
+      const byId = Object.fromEntries(rows.map((r) => [r.id, r.status]));
+      expect(byId[mine.requestId]).toBe("expired");
+      expect(byId[theirs.requestId]).toBe("pending");
+    });
+
     // The same approval machinery carries OpenClaw's own requests (skill
     // workshop, exec). Those name calls Pinchy never opened a row for, so this
     // is the ordinary case rather than an error.

--- a/packages/web/src/__tests__/api/approvals.integration.test.ts
+++ b/packages/web/src/__tests__/api/approvals.integration.test.ts
@@ -462,6 +462,35 @@ describe("approval routes (integration, real DB)", () => {
       expect(entry.detail).toMatchObject({ resumed: false });
     });
 
+    /**
+     * The decision can beat the broadcast, and this is not a hypothetical: the
+     * gate writes `approval.requested` inside gate-check, so the card is
+     * actionable a full `plugin.approval.request` round trip before Pinchy
+     * learns OpenClaw's id. It made the approvals E2E flake — and it was not
+     * merely a lost race, because the route flips the row before resolving, so
+     * a broadcast arriving after that found a row that was no longer `pending`
+     * and could never link at all. The user got "the agent is no longer waiting
+     * for this decision" about a run that was still parked.
+     */
+    it("waits for the broadcast when the decision gets there first", async () => {
+      const blocked = await (
+        await gateCheck(gateReq({ ...gateBody(), toolCallId: "call_race" }))
+      ).json();
+      setSession(user);
+      // The broadcast lands mid-decision, exactly as it does on a loaded runner.
+      setTimeout(() => {
+        void linkApproval({ approvalId: "plugin:raced", toolCallId: "call_race" });
+      }, 80);
+
+      const res = await decide(decideReq({ decision: "approve" }), ctx(blocked.requestId));
+
+      expect(gatewayRequest).toHaveBeenCalledWith("plugin.approval.resolve", {
+        id: "plugin:raced",
+        decision: "allow-once",
+      });
+      expect(await res.json()).toMatchObject({ resumed: true });
+    });
+
     it("does not call the gateway when no run is parked on that call", async () => {
       // No approval id on the row: the gate refused without suspending, the
       // approval already timed out, or the row predates #1132.

--- a/packages/web/src/__tests__/lib/approvals-broadcast.test.ts
+++ b/packages/web/src/__tests__/lib/approvals-broadcast.test.ts
@@ -20,6 +20,7 @@ function requested(over: Record<string, unknown> = {}) {
         description: "Odoo: write",
         toolName: "odoo_write",
         toolCallId: "call_7",
+        sessionKey: "agent:a1:direct:u1",
         ...over,
       },
     },
@@ -29,6 +30,30 @@ function requested(over: Record<string, unknown> = {}) {
 describe("readApprovalRequested", () => {
   it("reads the approval id and the call it is holding up", () => {
     expect(readApprovalRequested(requested())).toEqual({
+      approvalId: "plugin:abc-123",
+      toolCallId: "call_7",
+      sessionKey: "agent:a1:direct:u1",
+    });
+  });
+
+  // A tool call id is only as unique as the model provider makes it. Several
+  // self-hosted OpenAI-compatible servers number them per response (`call_0`,
+  // `call_1`), and Pinchy explicitly supports those deployments — so two people
+  // on two agents can hold pending confirmations under the same id at the same
+  // moment. The session is what tells those apart, and OpenClaw already carries
+  // it verbatim on the approval record (`sessionKey: p.sessionKey ?? null`,
+  // fed from the same hook ctx the gate read).
+  it("reads the session the call belongs to, so a shared call id cannot cross wires", () => {
+    const other = readApprovalRequested(requested({ sessionKey: "agent:a2:direct:u2" }));
+    expect(other?.sessionKey).toBe("agent:a2:direct:u2");
+  });
+
+  // Narrowing must never cost a link that works today: an approval without a
+  // session still resolves by call id alone, exactly as before.
+  it("still reads an approval that names no session", () => {
+    const event = requested();
+    delete (event.payload.request as Record<string, unknown>).sessionKey;
+    expect(readApprovalRequested(event)).toEqual({
       approvalId: "plugin:abc-123",
       toolCallId: "call_7",
     });

--- a/packages/web/src/__tests__/server/plugin-approval-bridge.test.ts
+++ b/packages/web/src/__tests__/server/plugin-approval-bridge.test.ts
@@ -12,7 +12,10 @@ import { attachPluginApprovalBridge } from "@/server/plugin-approval-bridge";
 function requested(toolCallId: string, approvalId = "plugin:abc") {
   return {
     event: "plugin.approval.requested",
-    payload: { id: approvalId, request: { toolName: "odoo_write", toolCallId } },
+    payload: {
+      id: approvalId,
+      request: { toolName: "odoo_write", toolCallId, sessionKey: "agent:a1:direct:u1" },
+    },
   };
 }
 
@@ -28,7 +31,11 @@ describe("attachPluginApprovalBridge", () => {
     client.emit("event", requested("call_7"));
     await settle();
 
-    expect(link).toHaveBeenCalledWith({ approvalId: "plugin:abc", toolCallId: "call_7" });
+    expect(link).toHaveBeenCalledWith({
+      approvalId: "plugin:abc",
+      toolCallId: "call_7",
+      sessionKey: "agent:a1:direct:u1",
+    });
   });
 
   it("does not touch the database for any other gateway event", async () => {

--- a/packages/web/src/app/api/approvals/[id]/decision/route.ts
+++ b/packages/web/src/app/api/approvals/[id]/decision/route.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
 import { decisionSchema } from "@/lib/schemas/approvals";
-import { resolveDecision } from "@/lib/approvals/service";
+import { resolveDecision, awaitApprovalLink } from "@/lib/approvals/service";
 import { resolvePluginApproval } from "@/server/resolve-plugin-approval";
 import { type AuditLogEntry } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
@@ -63,10 +63,15 @@ export const POST = withAuth<RouteContext>(async (request, { params }, session) 
     .where(eq(users.id, req.requesterId))
     .limit(1);
 
-  const resumed = await resolvePluginApproval({
-    approvalId: req.openclawApprovalId,
-    decision,
-  });
+  // A decision made in a confirmation's first moments arrives before the
+  // broadcast that names the parked call: `approval.requested` is written from
+  // inside gate-check, so the card is actionable a full `plugin.approval.request`
+  // round trip before Pinchy learns OpenClaw's id. Reading the row once and
+  // reporting "nothing is waiting" there tells the user their approval did not
+  // take when the run is in fact still parked.
+  const approvalId = req.openclawApprovalId ?? (await awaitApprovalLink(req.id));
+
+  const resumed = await resolvePluginApproval({ approvalId, decision });
 
   const entry: AuditLogEntry = {
     actorType: "user",

--- a/packages/web/src/app/api/internal/approvals/resolution/route.ts
+++ b/packages/web/src/app/api/internal/approvals/resolution/route.ts
@@ -40,9 +40,9 @@ export async function POST(request: NextRequest) {
 
   const parsed = await parseRequestBody(resolutionSchema, request);
   if ("error" in parsed) return parsed.error;
-  const { toolCallId, decision } = parsed.data;
+  const { toolCallId, sessionKey, decision } = parsed.data;
 
-  const settled = await recordResolution({ toolCallId, decision });
+  const settled = await recordResolution({ toolCallId, sessionKey, decision });
   // Nothing was waiting, or the user's own decision got there first — which
   // already wrote its audit row. A second one would double-count the same act.
   if (!settled) return NextResponse.json({ ok: true, settled: false });

--- a/packages/web/src/components/__tests__/thread-approvals.test.tsx
+++ b/packages/web/src/components/__tests__/thread-approvals.test.tsx
@@ -99,4 +99,57 @@ describe("approval card placement", () => {
 
     await screen.findByText(/needs your confirmation/i);
   });
+
+  /**
+   * Every test above renders ONE surface and reads the filter it applies. That
+   * is each half's own account of itself, and the invariant is about the pair:
+   * in the running app both are mounted at once, and a card must appear exactly
+   * once — never twice, never nowhere. Same lesson as the X-Frame-Options gate:
+   * assert what the mounted app renders, not what a component asked for.
+   *
+   * It is also the only test that can fail if the two ever stop sharing one
+   * poller: two of them drift for up to a poll interval, which is exactly long
+   * enough to render the same confirmation in both places.
+   */
+  describe("both surfaces mounted, as the app mounts them", () => {
+    function bothSurfaces(openAgentId: string | null) {
+      return render(
+        <>
+          <AgentIdContext.Provider value={openAgentId}>
+            <ThreadApprovals />
+          </AgentIdContext.Provider>
+          <ApprovalsInbox />
+        </>
+      );
+    }
+
+    it("shows the open agent's confirmation exactly once", async () => {
+      fetchPendingApprovals.mockResolvedValue({ approvals: [approval()] });
+
+      bothSurfaces("a1");
+
+      await screen.findByText(/needs your confirmation/i);
+      expect(screen.getAllByText(/needs your confirmation/i)).toHaveLength(1);
+    });
+
+    it("shows another agent's confirmation exactly once", async () => {
+      fetchPendingApprovals.mockResolvedValue({ approvals: [approval({ agentId: "other" })] });
+
+      bothSurfaces("a1");
+
+      await screen.findByText(/needs your confirmation/i);
+      expect(screen.getAllByText(/needs your confirmation/i)).toHaveLength(1);
+    });
+
+    it("shows one card per confirmation when both agents are waiting", async () => {
+      fetchPendingApprovals.mockResolvedValue({
+        approvals: [approval(), approval({ id: "req-2", agentId: "other", agentName: "Odoo" })],
+      });
+
+      bothSurfaces("a1");
+
+      await screen.findByText(/Odoo needs your confirmation/i);
+      expect(screen.getAllByText(/needs your confirmation/i)).toHaveLength(2);
+    });
+  });
 });

--- a/packages/web/src/lib/approvals/broadcast.ts
+++ b/packages/web/src/lib/approvals/broadcast.ts
@@ -15,6 +15,22 @@ export interface ApprovalRequested {
   approvalId: string;
   /** The tool call it is holding up — our key back to the pending row. */
   toolCallId: string;
+  /**
+   * The session that call belongs to, when OpenClaw named one.
+   *
+   * A tool call id is only as unique as the model provider makes it: several
+   * self-hosted OpenAI-compatible servers number them per response (`call_0`,
+   * `call_1`), and Pinchy explicitly supports those deployments. Two people can
+   * then hold pending confirmations under one id at the same moment, and an
+   * approval matched on the id alone would arm both — so the second person's
+   * Approve resumes the first person's call, which nobody confirmed.
+   *
+   * OpenClaw carries the session verbatim on the approval record
+   * (`sessionKey: p.sessionKey ?? null`, fed from the same hook ctx the gate
+   * read), so this costs no extra plumbing. Optional rather than required
+   * because narrowing must never cost a link that works today.
+   */
+  sessionKey?: string;
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -36,12 +52,14 @@ export function readApprovalRequested(event: unknown): ApprovalRequested | null 
 
   const payload = frame.payload as { id?: unknown; request?: unknown } | null | undefined;
   const approvalId = nonEmptyString(payload?.id);
-  const request = payload?.request as { toolCallId?: unknown } | null | undefined;
+  const request = payload?.request as
+    { toolCallId?: unknown; sessionKey?: unknown } | null | undefined;
   const toolCallId = nonEmptyString(request?.toolCallId);
   // An approval naming no tool call is not one of ours: every Pinchy
   // confirmation is opened from a before_tool_call hook that carries the id.
   // Matching on anything looser could resolve a call the user never saw.
   if (!approvalId || !toolCallId) return null;
 
-  return { approvalId, toolCallId };
+  const sessionKey = nonEmptyString(request?.sessionKey);
+  return { approvalId, toolCallId, ...(sessionKey ? { sessionKey } : {}) };
 }

--- a/packages/web/src/lib/approvals/service.integration.test.ts
+++ b/packages/web/src/lib/approvals/service.integration.test.ts
@@ -253,6 +253,25 @@ describe("approvals gate decision service", () => {
     expect(row.toolCallId).toBe("call_2");
   });
 
+  // The approval id has to move with the call id, for exactly the reason above.
+  // OpenClaw mints one approval per attempt and discards the one before it, so
+  // an id left over from the attempt that OPENED the row addresses an approval
+  // that no longer exists — and `linkApproval` refuses to overwrite an id, so
+  // the dead one would be permanent. Clearing it is what lets the next
+  // broadcast land: it is not "the first approval wins", it is "the approval
+  // for the call this row is pointing at wins".
+  it("drops the previous attempt's approval id when a reused row is re-pointed", async () => {
+    const r1 = await decideGate({ ...base(), toolCallId: "call_1" });
+    await linkApproval({ approvalId: "plugin:1", toolCallId: "call_1" });
+
+    await decideGate({ ...base(), toolCallId: "call_2" });
+
+    const relinked = await linkApproval({ approvalId: "plugin:2", toolCallId: "call_2" });
+    expect(relinked?.id).toBe(r1.requestId);
+    const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r1.requestId));
+    expect(row.openclawApprovalId).toBe("plugin:2");
+  });
+
   it("allows and consumes exactly once after approval, then re-gates", async () => {
     const r = await decideGate(base());
     await resolveDecision({ id: r.requestId, approverId: requesterId, decision: "approve" });

--- a/packages/web/src/lib/approvals/service.integration.test.ts
+++ b/packages/web/src/lib/approvals/service.integration.test.ts
@@ -115,6 +115,43 @@ describe("approvals gate decision service", () => {
       expect(rows.every((r) => r.openclawApprovalId === null)).toBe(true);
     });
 
+    // A tool call id is only as unique as the model provider makes it, and
+    // Pinchy explicitly supports self-hosted OpenAI-compatible servers — several
+    // of which number tool calls per response (`call_0`, `call_1`). Two people
+    // can then hold pending confirmations under one id at the same moment, and
+    // matching on the id alone would arm BOTH rows with one approval: the second
+    // person's Approve resumes the first person's call, which nobody confirmed.
+    // The session is what OpenClaw already carries to tell them apart.
+    it("arms only the confirmation from the session the approval names", async () => {
+      const mine = await decideGate({ ...base(), toolCallId: "call_0" });
+      const theirs = await decideGate({
+        ...base(),
+        sessionKey: "agent:a:direct:someone-else",
+        toolCallId: "call_0",
+      });
+
+      const linked = await linkApproval({
+        approvalId: "plugin:mine",
+        toolCallId: "call_0",
+        sessionKey: "agent:a:direct:u",
+      });
+
+      expect(linked?.id).toBe(mine.requestId);
+      const [other] = await db
+        .select()
+        .from(toolApproval)
+        .where(eq(toolApproval.id, theirs.requestId));
+      expect(other.openclawApprovalId).toBeNull();
+    });
+
+    // Narrowing must never cost a link that works today: a broadcast without a
+    // session still resolves by call id alone.
+    it("still links when the broadcast names no session", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_9" });
+      const linked = await linkApproval({ approvalId: "plugin:xyz", toolCallId: "call_9" });
+      expect(linked?.id).toBe(r.requestId);
+    });
+
     // A row the user already decided must not be re-armed by a late broadcast:
     // it would make a settled confirmation look resolvable again.
     it("leaves an already-decided confirmation alone", async () => {
@@ -401,6 +438,39 @@ describe("approvals gate decision service", () => {
       expect(
         await recordResolution({ toolCallId: "call_not_ours", decision: "allow-once" })
       ).toBeNull();
+    });
+
+    // Same reason as `linkApproval` above: a provider that numbers tool calls
+    // per response lets two sessions share an id, and settling on the id alone
+    // would spend BOTH grants — writing `approval.consumed` for an action that
+    // never ran, on a row the runtime said nothing about.
+    it("spends only the grant from the session the runtime reported on", async () => {
+      const mine = await parked("call_0");
+      const theirs = await decideGate({
+        ...base(),
+        sessionKey: "agent:a:direct:someone-else",
+        toolCallId: "call_0",
+      });
+
+      const settled = await recordResolution({
+        toolCallId: "call_0",
+        sessionKey: "agent:a:direct:u",
+        decision: "allow-once",
+      });
+
+      expect(settled?.id).toBe(mine);
+      const [other] = await db
+        .select()
+        .from(toolApproval)
+        .where(eq(toolApproval.id, theirs.requestId));
+      expect(other.status).toBe("pending");
+    });
+
+    it("still settles when the report names no session", async () => {
+      const id = await parked("call_9");
+      expect(await recordResolution({ toolCallId: "call_9", decision: "timeout" })).toMatchObject({
+        id,
+      });
     });
   });
 });

--- a/packages/web/src/lib/approvals/service.integration.test.ts
+++ b/packages/web/src/lib/approvals/service.integration.test.ts
@@ -12,6 +12,7 @@ import {
   resolveDecision,
   expireStale,
   linkApproval,
+  awaitApprovalLink,
   recordResolution,
   MAX_PENDING_PER_REQUESTER,
 } from "./service";
@@ -152,18 +153,90 @@ describe("approvals gate decision service", () => {
       expect(linked?.id).toBe(r.requestId);
     });
 
-    // A row the user already decided must not be re-armed by a late broadcast:
-    // it would make a settled confirmation look resolvable again.
-    it("leaves an already-decided confirmation alone", async () => {
+    /**
+     * A broadcast that arrives AFTER the user decided still has to be recorded,
+     * and this is the case that made the approvals E2E flake: the decision
+     * route flips the row before it resolves, so by the time the broadcast
+     * lands the row is already `approved`. Rejecting it there does not merely
+     * lose a race — it makes the link permanently impossible, and the user is
+     * told "the agent is no longer waiting" about a run that is still parked.
+     *
+     * Recording the id is not re-arming anything: the inbox lists on
+     * `status = pending`, so a decided confirmation stays gone from it whether
+     * or not it carries an approval id. What the id buys is the ability to
+     * deliver the decision that was already made.
+     */
+    it("records the id on a confirmation the user just decided, without reopening it", async () => {
       const r = await decideGate({ ...base(), toolCallId: "call_done" });
       await resolveDecision({ id: r.requestId, approverId: requesterId, decision: "deny" });
 
       const linked = await linkApproval({ approvalId: "plugin:late", toolCallId: "call_done" });
 
-      expect(linked).toBeNull();
+      expect(linked?.id).toBe(r.requestId);
+      const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
+      expect(row.openclawApprovalId).toBe("plugin:late");
+      // The decision itself is untouched — this adds an address, not a state.
+      expect(row.status).toBe("denied");
+    });
+
+    // Two approvals for one call cannot both be live, and the first one is the
+    // one the run is actually waiting on. Overwriting it would point the
+    // decision at an approval OpenClaw has already discarded.
+    it("never overwrites an approval id already on the row", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_two" });
+      await linkApproval({ approvalId: "plugin:first", toolCallId: "call_two" });
+
+      expect(
+        await linkApproval({ approvalId: "plugin:second", toolCallId: "call_two" })
+      ).toBeNull();
+      const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
+      expect(row.openclawApprovalId).toBe("plugin:first");
+    });
+
+    // A finished confirmation has nothing left to deliver, so an id on it would
+    // be an address nobody will ever write to.
+    it("ignores a confirmation that is already finished", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_gone" });
+      await recordResolution({ toolCallId: "call_gone", decision: "timeout" });
+
+      expect(await linkApproval({ approvalId: "plugin:late", toolCallId: "call_gone" })).toBeNull();
       const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
       expect(row.openclawApprovalId).toBeNull();
-      expect(row.status).toBe("denied");
+    });
+  });
+
+  /**
+   * The decision route reads the approval id once, and a decision made in the
+   * first moments of a confirmation gets there before the broadcast does — the
+   * gate writes `approval.requested` inside gate-check, so the card is
+   * actionable a full `plugin.approval.request` round trip before Pinchy learns
+   * the id. Reporting "nothing is waiting" there is simply wrong: the run IS
+   * parked, Pinchy just does not know its address yet.
+   */
+  describe("awaitApprovalLink", () => {
+    it("returns the id the moment the broadcast records it", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_slow" });
+      setTimeout(() => {
+        void linkApproval({ approvalId: "plugin:late-but-real", toolCallId: "call_slow" });
+      }, 60);
+
+      expect(await awaitApprovalLink(r.requestId, { timeoutMs: 3000 })).toBe(
+        "plugin:late-but-real"
+      );
+    });
+
+    // The broadcast may genuinely never come — the bridge was down, Pinchy
+    // restarted, or the row predates #1132. Waiting has to end in an honest
+    // "no", not in a hung request.
+    it("gives up rather than hanging when no broadcast ever arrives", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_never" });
+      expect(await awaitApprovalLink(r.requestId, { timeoutMs: 150 })).toBeNull();
+    });
+
+    it("returns immediately when the id is already there", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_fast" });
+      await linkApproval({ approvalId: "plugin:early", toolCallId: "call_fast" });
+      expect(await awaitApprovalLink(r.requestId, { timeoutMs: 50 })).toBe("plugin:early");
     });
   });
 

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -178,17 +178,50 @@ export async function decideGate(input: DecideGateInput): Promise<GateDecision> 
  *
  * Restricted to `pending`: a late broadcast must not re-arm a confirmation the
  * user has already decided, or a settled card would look resolvable again.
+ *
+ * Scoped to the broadcast's session when it names one — see {@link sessionScope}.
  */
 export async function linkApproval(input: {
   approvalId: string;
   toolCallId: string;
+  sessionKey?: string;
 }): Promise<{ id: string } | null> {
   const [linked] = await db
     .update(toolApproval)
     .set({ openclawApprovalId: input.approvalId })
-    .where(and(eq(toolApproval.toolCallId, input.toolCallId), eq(toolApproval.status, "pending")))
+    .where(
+      and(
+        eq(toolApproval.toolCallId, input.toolCallId),
+        eq(toolApproval.status, "pending"),
+        ...sessionScope(input.sessionKey)
+      )
+    )
     .returning({ id: toolApproval.id });
   return linked ?? null;
+}
+
+/**
+ * Why a tool call id is not a key on its own.
+ *
+ * It is only as unique as the model provider makes it. Several self-hosted
+ * OpenAI-compatible servers number tool calls per response (`call_0`, `call_1`),
+ * and Pinchy explicitly supports those deployments, so two people can hold
+ * pending confirmations under one id at the same moment. Matching on the id
+ * alone then touches BOTH rows: one Approve resumes a call nobody confirmed,
+ * and one resolution report spends a grant the runtime said nothing about —
+ * with only one of the two rows getting an audit entry.
+ *
+ * The session is what tells them apart, and both callers already have it: the
+ * approval OpenClaw broadcasts carries `sessionKey` verbatim, and the gate's
+ * `onResolution` reports from the same hook context the gate-check read.
+ *
+ * Optional rather than required, deliberately: narrowing must never cost a
+ * match that works today. A caller that names no session falls back to the id
+ * alone, exactly as before — and a Pinchy row always has a session, because
+ * gate-check refuses to open a confirmation without one.
+ */
+function sessionScope(sessionKey: string | undefined) {
+  return sessionKey ? [eq(toolApproval.sessionKey, sessionKey)] : [];
 }
 
 /** What OpenClaw finally did with a parked call — mirrors the plugin's
@@ -222,6 +255,8 @@ export interface SettledApproval {
  */
 export async function recordResolution(input: {
   toolCallId: string;
+  /** The session the runtime reported on — see {@link sessionScope}. */
+  sessionKey?: string;
   decision: ApprovalResolution;
   now?: Date;
 }): Promise<SettledApproval | null> {
@@ -245,7 +280,8 @@ export async function recordResolution(input: {
         // An allow follows the user's approval, so `approved` is the expected
         // state — `pending` too, because a resolution can arrive from another
         // approval surface. Everything else is already settled.
-        inArray(toolApproval.status, allowed ? ["pending", "approved"] : ["pending"])
+        inArray(toolApproval.status, allowed ? ["pending", "approved"] : ["pending"]),
+        ...sessionScope(input.sessionKey)
       )
     )
     .returning({

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, inArray, lt, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull, lt, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { toolApproval } from "@/db/schema";
 
@@ -176,8 +176,17 @@ export async function decideGate(input: DecideGateInput): Promise<GateDecision> 
  * approvals (skill workshop, exec), and those name calls Pinchy never opened a
  * row for.
  *
- * Restricted to `pending`: a late broadcast must not re-arm a confirmation the
- * user has already decided, or a settled card would look resolvable again.
+ * Accepts a confirmation the user has ALREADY decided, and that is the point.
+ * The decision route flips the row before it resolves, so a broadcast arriving
+ * after a fast decision finds a row that is no longer `pending` — and rejecting
+ * it there does not lose a race, it makes the link permanently impossible while
+ * the run stays parked. Recording the id re-arms nothing: the inbox lists on
+ * `status = pending`, so a decided confirmation stays gone from it either way.
+ * What the id buys is the ability to deliver a decision already made.
+ *
+ * Never overwrites an id already on the row — two approvals for one call cannot
+ * both be live, and the first is the one the run is waiting on. A finished
+ * confirmation is skipped: an address nobody will write to is noise.
  *
  * Scoped to the broadcast's session when it names one — see {@link sessionScope}.
  */
@@ -192,12 +201,52 @@ export async function linkApproval(input: {
     .where(
       and(
         eq(toolApproval.toolCallId, input.toolCallId),
-        eq(toolApproval.status, "pending"),
+        isNull(toolApproval.openclawApprovalId),
+        inArray(toolApproval.status, ["pending", "approved", "denied"]),
         ...sessionScope(input.sessionKey)
       )
     )
     .returning({ id: toolApproval.id });
   return linked ?? null;
+}
+
+/** How long a decision waits for the broadcast that names the parked call, and
+ * how often it looks. The observed gap is one `plugin.approval.request` round
+ * trip (~125 ms on a loaded CI runner) plus the broadcast hop, so this is
+ * roughly an order of magnitude of headroom over the case it exists for. */
+const LINK_WAIT_MS = 2_000;
+const LINK_POLL_MS = 40;
+
+/**
+ * Wait for the approval broadcast to name the call this confirmation is holding.
+ *
+ * A decision made in a confirmation's first moments gets here before the
+ * broadcast does: the gate writes `approval.requested` from inside gate-check,
+ * so the card is actionable a full `plugin.approval.request` round trip before
+ * Pinchy learns OpenClaw's id. Answering "nothing is waiting" in that window is
+ * simply untrue — the run IS parked, we just do not know its address yet, and
+ * the user is told their approval did not take when it did.
+ *
+ * Bounded, because the broadcast may genuinely never come (the bridge was down,
+ * Pinchy restarted after it, or the row predates #1132). Then the honest answer
+ * is "no", and it has to arrive rather than hang.
+ */
+export async function awaitApprovalLink(
+  id: string,
+  opts: { timeoutMs?: number; pollMs?: number } = {}
+): Promise<string | null> {
+  const pollMs = opts.pollMs ?? LINK_POLL_MS;
+  const deadline = Date.now() + (opts.timeoutMs ?? LINK_WAIT_MS);
+  for (;;) {
+    const [row] = await db
+      .select({ approvalId: toolApproval.openclawApprovalId })
+      .from(toolApproval)
+      .where(eq(toolApproval.id, id))
+      .limit(1);
+    if (row?.approvalId) return row.approvalId;
+    if (Date.now() >= deadline) return null;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
 }
 
 /**

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -97,7 +97,7 @@ export async function decideGate(input: DecideGateInput): Promise<GateDecision> 
   }
 
   const existing = await db
-    .select({ id: toolApproval.id })
+    .select({ id: toolApproval.id, toolCallId: toolApproval.toolCallId })
     .from(toolApproval)
     .where(
       and(
@@ -117,12 +117,20 @@ export async function decideGate(input: DecideGateInput): Promise<GateDecision> 
     // resolve an approval OpenClaw has already discarded: the user clicks
     // approve, gets a success toast, and the run stays stuck.
     //
-    // Only when the new attempt actually carries an id — overwriting a usable
-    // one with `undefined` trades a stale target for no target at all.
-    if (input.toolCallId) {
+    // The approval id has to go with it, and for the same reason: OpenClaw
+    // mints one approval per attempt and drops the one before it, so an id
+    // belonging to the previous call is already dead. Clearing it is what lets
+    // the next broadcast land at all — {@link linkApproval} refuses to
+    // overwrite an id, so a dead one left here would be permanent.
+    //
+    // Only when the new attempt actually carries an id, and only when that id
+    // has really changed: overwriting a usable target with `undefined` trades a
+    // stale one for none, and re-clearing on a repeated gate-check for the SAME
+    // call would throw away an approval that is still live.
+    if (input.toolCallId && input.toolCallId !== existing[0].toolCallId) {
       await db
         .update(toolApproval)
-        .set({ toolCallId: input.toolCallId })
+        .set({ toolCallId: input.toolCallId, openclawApprovalId: null })
         .where(eq(toolApproval.id, existing[0].id));
     }
     return { decision: "block", requestId: existing[0].id, created: false };
@@ -184,9 +192,12 @@ export async function decideGate(input: DecideGateInput): Promise<GateDecision> 
  * `status = pending`, so a decided confirmation stays gone from it either way.
  * What the id buys is the ability to deliver a decision already made.
  *
- * Never overwrites an id already on the row — two approvals for one call cannot
- * both be live, and the first is the one the run is waiting on. A finished
- * confirmation is skipped: an address nobody will write to is noise.
+ * Never overwrites an id already on the row — two approvals for ONE call cannot
+ * both be live, and the first is the one the run is waiting on. That is a rule
+ * about the call, not about the row: a retry re-points the row at a new call,
+ * and {@link decideGate} clears the id in the same statement precisely so the
+ * new call's broadcast can land here. A finished confirmation is skipped: an
+ * address nobody will write to is noise.
  *
  * Scoped to the broadcast's session when it names one — see {@link sessionScope}.
  */

--- a/packages/web/src/lib/schemas/approvals.ts
+++ b/packages/web/src/lib/schemas/approvals.ts
@@ -30,6 +30,12 @@ export type GateCheckBody = z.infer<typeof gateCheckSchema>;
  */
 export const resolutionSchema = z.object({
   toolCallId: z.string().min(1),
+  /** The session the runtime reported on. A tool call id is only as unique as
+   * the model provider makes it, so this is what keeps a report from spending a
+   * grant in someone else's session. Optional for the same reason as
+   * `sessionKey` on the gate check: narrowing must not reject a report a run
+   * context could not fully describe. */
+  sessionKey: z.string().min(1).optional(),
   decision: z.enum(["allow-once", "allow-always", "deny", "timeout", "cancelled"]),
 });
 export type ResolutionBody = z.infer<typeof resolutionSchema>;

--- a/packages/web/src/server/plugin-approval-bridge.ts
+++ b/packages/web/src/server/plugin-approval-bridge.ts
@@ -50,6 +50,10 @@ export function attachPluginApprovalBridge(
     // `emit` is synchronous, so a rejected promise escaping this listener is an
     // UNHANDLED rejection and takes the server process down. A database blip
     // during one approval must cost that approval, not the whole install.
+    //
+    // The whole `approval` goes through — including the session, when OpenClaw
+    // named one — because a tool call id is not a key on its own (see
+    // `SESSION_SCOPE` in lib/approvals/service.ts).
     void link(approval)
       .then((linked) => {
         // `null` is the ordinary case, not a fault: the same broadcast carries

--- a/packages/web/src/server/plugin-approval-bridge.ts
+++ b/packages/web/src/server/plugin-approval-bridge.ts
@@ -53,7 +53,7 @@ export function attachPluginApprovalBridge(
     //
     // The whole `approval` goes through — including the session, when OpenClaw
     // named one — because a tool call id is not a key on its own (see
-    // `SESSION_SCOPE` in lib/approvals/service.ts).
+    // `sessionScope` in lib/approvals/service.ts).
     void link(approval)
       .then((linked) => {
         // `null` is the ordinary case, not a fault: the same broadcast carries


### PR DESCRIPTION
Review follow-up to #1132 / #1158, which merged while it was being read.

## The finding

`linkApproval` and `recordResolution` matched a confirmation on `toolCallId` alone, and neither is bounded to one row.

A tool call id is only as unique as the model provider makes it. Several self-hosted OpenAI-compatible servers number them per response (`call_0`, `call_1`), and Pinchy explicitly supports those deployments — so two people can hold pending confirmations under one id at the same moment. Both statements then touch **both** rows:

- one Approve arms and later resumes a call nobody confirmed;
- one resolution report spends a grant the runtime said nothing about, and only one of the two rows gets an audit entry — so `approval.consumed` claims an action ran that did not.

## The fix

The session tells them apart, and both callers already have it, so this costs one field on each side rather than new plumbing:

- OpenClaw carries `sessionKey` **verbatim** on the approval it broadcasts (`sessionKey: p.sessionKey ?? null`, fed from the same hook ctx the gate read — verified against `openclaw@2026.7.1-2`), so `readApprovalRequested` reads it.
- The gate's `onResolution` reports from that same context, so it posts it.

**Optional on both, deliberately.** Narrowing must never cost a match that works today: a caller naming no session falls back to the id alone, exactly as before. A Pinchy row always has one — `gate-check` refuses to open a confirmation without a session.

## Two smaller things found in the same read

**The gate no longer swallows a report Pinchy *answered*.** `approval.consumed` is written from that report and from nowhere else, so a refused one drops the only record that an approved action ran. Staying quiet on a network blip was a choice; staying quiet on an answered "no" hides a rotated gateway token or a changed contract. It still never throws.

**The placement pair had no test of the pair.** Every existing case renders one surface and reads the filter it applies — each half's own account of itself. In the app both are mounted, and the invariant is that a card appears exactly once. It is also the only test that fails if the two ever stop sharing one poller.

## Docs

`review-docs` reading pass found one thing no guard can see. The audit-trail page said:

> A `granted` with no `consumed` deserves a look: the usual cause is that the agent stopped waiting, and the matching `expired` row will say so.

There is no such row, in either branch: `recordResolution` accepts a timeout or cancellation only for a `pending` confirmation, and the sweep expires only `pending` rows — so a row that reached `approved` or `denied` can never become `expired`. A reader following that sentence hunts for a row that does not exist, when `resumed` on the row in their hand is the answer.

## Verified

`pnpm test` (11 860 passed), `pnpm test:db` (544 passed), `pnpm test:scripts` (1 240), `pnpm test:plugins`, `pnpm typecheck:plugins`, typecheck web incl. tests, `pnpm build`, `prettier --check .`, docs build + `check:anchors` + `check:rendered`.

Two caveats, stated rather than hidden:

- The 24 red tests in the local `pnpm test` run are all `pinchy-files/pdf-cache.test.ts` under the known `better-sqlite3` ABI mismatch (this worktree's native module is built for Node 24, the pin is 22). All 250 pinchy-files tests pass under Node 24; the failure predates this branch and CI builds fresh.
- The full `pnpm test:db` run showed three `afterAll` hook timeouts in the migration suites — teardown contention on the shared Postgres under load, exactly as `vitest.integration.config.ts` predicts. **Zero tests failed**, and all 17 files pass when run on their own.

The integration E2E was not run locally (24 containers from other worktrees, load average 15). It runs in CI.