### PR TITLE
fix(approvals): wait for OpenClaw's approval id, and deliver the decision when the wait loses

### DIFF
--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -765,6 +765,21 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
       });
       expect(decision.status()).toBe(200);
 
+      // Assert the ROUTE'S OWN ANSWER first, and assert the whole object.
+      //
+      // The route already knows why a decision did not reach the parked call —
+      // it puts `resumeError` in this body, one string per branch
+      // (nothing-waiting / refused / unreachable). The first version of this
+      // probe threw that away and asserted only the audit row's `outcome`, so
+      // a failure read `Expected: "success" / Received: "failure"` and named
+      // none of the three. Diagnosing one occurrence then took the CI gateway
+      // log — which, it turns out, is only captured on failure at all, so the
+      // "control" comparison against a green run was worthless.
+      //
+      // toMatchObject on the whole body is what surfaces it: an unexpected
+      // `resumeError` shows up in the diff instead of being invisible.
+      expect(await decision.json()).toMatchObject({ ok: true, resumed: true });
+
       // The decision is recorded as approval.granted — and `resumed` says it
       // reached the parked call. Asserting only that the row exists would pass
       // just as happily over a run that stays parked until it times out, which
@@ -774,8 +789,12 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
         predicate: (e) => e.resource === `approval:${requestId}`,
         deadlineMs: 15000,
       });
-      expect(granted.outcome).toBe("success");
-      expect((granted.detail as { resumed?: boolean }).resumed).toBe(true);
+      // Same reasoning: compare the fields together so a failure prints the
+      // recorded reason rather than just the word "failure".
+      expect({
+        outcome: granted.outcome,
+        ...(granted.detail as { resumed?: boolean; resumeReason?: string; resumeDetail?: string }),
+      }).toMatchObject({ outcome: "success", resumed: true });
 
       // The runtime reports back that it let the call through…
       await pollAuditForEvent(page, {

--- a/packages/web/src/__tests__/api/approvals.integration.test.ts
+++ b/packages/web/src/__tests__/api/approvals.integration.test.ts
@@ -462,33 +462,71 @@ describe("approval routes (integration, real DB)", () => {
       expect(entry.detail).toMatchObject({ resumed: false });
     });
 
+    // The id arrives on a broadcast OpenClaw only sends AFTER the gate answered
+    // `requireApproval`, so a decision taken the moment the card appears lands
+    // before it. That used to report `nothing-waiting` — a false statement
+    // about a call that IS parked — and it was permanent, because linkApproval
+    // refuses a row that is no longer pending: the run then sat until
+    // OpenClaw's 600 s cap, whatever the user clicked. CI, 2026-08-06.
+    it("resumes a decision taken before the approval broadcast arrived", async () => {
+      const blocked = await (
+        await gateCheck(gateReq({ ...gateBody(), toolCallId: "call_race" }))
+      ).json();
+      setSession(user);
+
+      // The broadcast lands while the decision is already in flight.
+      const linked = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          void linkApproval({ approvalId: "plugin:late", toolCallId: "call_race" }).then(() =>
+            resolve()
+          );
+        }, 150);
+      });
+
+      const res = await decide(decideReq({ decision: "approve" }), ctx(blocked.requestId));
+      await linked;
+
+      expect(gatewayRequest).toHaveBeenCalledWith("plugin.approval.resolve", {
+        id: "plugin:late",
+        decision: "allow-once",
+      });
+      expect(await res.json()).toMatchObject({ ok: true, resumed: true });
+
+      await flushAfter();
+      const [entry] = await db
+        .select()
+        .from(auditLog)
+        .where(eq(auditLog.eventType, "approval.granted"));
+      expect(entry.outcome).toBe("success");
+      expect(entry.detail).toMatchObject({ resumed: true });
+    });
+
     /**
-     * The ordering every other test in this block assumes away.
+     * And when the broadcast misses even the wait.
      *
-     * `blockedAndLinked` links BEFORE deciding, which is the common case and
-     * was the only one covered. `gate-check` creates the row before the hook
-     * returns `requireApproval`, though, so the card is clickable before
-     * OpenClaw has announced the approval — and a decision taken in that window
-     * had no id to resolve with. It used to stay that way permanently, because
-     * `linkApproval` only matched `pending` rows and `resolveDecision` had
-     * already moved the row out of `pending`. The run then sat parked until
-     * OpenClaw's 600 s cap.
+     * The wait above is bounded, so it can still lose — and losing it used to
+     * be PERMANENT: `linkApproval` matched `pending` only, while the route had
+     * already flipped the row, so the id could never attach afterwards and the
+     * run sat until OpenClaw's 600 s cap with nothing saying why.
      *
-     * Caught in CI on 2026-08-06 by the E2E probe, and only by luck of timing:
-     * one plugin.approval.request, zero plugin.approval.resolve.
+     * This asserts the contract the bridge stands on rather than the resume
+     * itself: the link still attaches to a decided row, and it carries the
+     * decision in `status`. What the bridge then does with that is pinned in
+     * `plugin-approval-bridge.test.ts` ("delivers a decision that was made
+     * before the approval was announced") — deliberately not restated here,
+     * because a test that names a guarantee it does not exercise is worse than
+     * no test at all.
      */
-    it("resumes a run whose approval was announced after the user had already decided", async () => {
+    it("leaves a decided row linkable, so a broadcast past the wait still has somewhere to land", async () => {
       const blocked = await (
         await gateCheck(gateReq({ ...gateBody(), toolCallId: "call_early" }))
       ).json();
       setSession(user);
 
-      // Decide first — no id on the row yet.
+      // Decide first — no id on the row, and none arrives inside the wait.
       await decide(decideReq({ decision: "approve" }), ctx(blocked.requestId));
       expect(gatewayRequest).not.toHaveBeenCalled();
 
-      // …then the broadcast lands. This is the only thing left that can carry
-      // the decision to the parked call.
       const outcome = await linkApproval({
         approvalId: "plugin:late",
         toolCallId: "call_early",

--- a/packages/web/src/__tests__/api/approvals.integration.test.ts
+++ b/packages/web/src/__tests__/api/approvals.integration.test.ts
@@ -462,6 +462,48 @@ describe("approval routes (integration, real DB)", () => {
       expect(entry.detail).toMatchObject({ resumed: false });
     });
 
+    /**
+     * The ordering every other test in this block assumes away.
+     *
+     * `blockedAndLinked` links BEFORE deciding, which is the common case and
+     * was the only one covered. `gate-check` creates the row before the hook
+     * returns `requireApproval`, though, so the card is clickable before
+     * OpenClaw has announced the approval — and a decision taken in that window
+     * had no id to resolve with. It used to stay that way permanently, because
+     * `linkApproval` only matched `pending` rows and `resolveDecision` had
+     * already moved the row out of `pending`. The run then sat parked until
+     * OpenClaw's 600 s cap.
+     *
+     * Caught in CI on 2026-08-06 by the E2E probe, and only by luck of timing:
+     * one plugin.approval.request, zero plugin.approval.resolve.
+     */
+    it("resumes a run whose approval was announced after the user had already decided", async () => {
+      const blocked = await (
+        await gateCheck(gateReq({ ...gateBody(), toolCallId: "call_early" }))
+      ).json();
+      setSession(user);
+
+      // Decide first — no id on the row yet.
+      await decide(decideReq({ decision: "approve" }), ctx(blocked.requestId));
+      expect(gatewayRequest).not.toHaveBeenCalled();
+
+      // …then the broadcast lands. This is the only thing left that can carry
+      // the decision to the parked call.
+      const outcome = await linkApproval({
+        approvalId: "plugin:late",
+        toolCallId: "call_early",
+      });
+      expect(outcome).toMatchObject({ linked: true, status: "approved" });
+
+      const [row] = await db
+        .select()
+        .from(toolApproval)
+        .where(eq(toolApproval.id, blocked.requestId));
+      expect(row.openclawApprovalId).toBe("plugin:late");
+      // …and the card does not reappear: the pending list keys on status.
+      expect(row.status).toBe("approved");
+    });
+
     it("does not call the gateway when no run is parked on that call", async () => {
       // No approval id on the row: the gate refused without suspending, the
       // approval already timed out, or the row predates #1132.

--- a/packages/web/src/__tests__/server/plugin-approval-bridge.test.ts
+++ b/packages/web/src/__tests__/server/plugin-approval-bridge.test.ts
@@ -22,7 +22,7 @@ const settle = () => new Promise((r) => setImmediate(r));
 describe("attachPluginApprovalBridge", () => {
   it("links an arriving approval to the confirmation waiting for that call", async () => {
     const client = new EventEmitter();
-    const link = vi.fn().mockResolvedValue({ id: "row-1" });
+    const link = vi.fn().mockResolvedValue({ linked: true, id: "row-1", status: "pending" });
     attachPluginApprovalBridge(client, { link });
 
     client.emit("event", requested("call_7"));
@@ -35,7 +35,7 @@ describe("attachPluginApprovalBridge", () => {
     // This listener sees EVERY event on the shared client — session messages,
     // deltas, status frames. A write per event would be a query storm.
     const client = new EventEmitter();
-    const link = vi.fn().mockResolvedValue(null);
+    const link = vi.fn().mockResolvedValue({ linked: false, reason: "not-ours" });
     attachPluginApprovalBridge(client, { link });
 
     client.emit("event", { event: "session.message", payload: { messageId: "m1" } });
@@ -60,7 +60,7 @@ describe("attachPluginApprovalBridge", () => {
 
     expect(onError).toHaveBeenCalled();
     // Still listening: one bad event must not deafen the bridge.
-    link.mockResolvedValue({ id: "row-2" });
+    link.mockResolvedValue({ linked: true, id: "row-2", status: "pending" });
     client.emit("event", requested("call_8"));
     await settle();
     expect(link).toHaveBeenCalledTimes(2);
@@ -70,7 +70,7 @@ describe("attachPluginApprovalBridge", () => {
   // exec), not a fault — it must not be reported as an error.
   it("treats an unmatched approval as ordinary, not as a failure", async () => {
     const client = new EventEmitter();
-    const link = vi.fn().mockResolvedValue(null);
+    const link = vi.fn().mockResolvedValue({ linked: false, reason: "not-ours" });
     const onError = vi.fn();
     attachPluginApprovalBridge(client, { link, onError });
 
@@ -78,6 +78,76 @@ describe("attachPluginApprovalBridge", () => {
     await settle();
 
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  // …but one of OURS that could not be linked is NOT ordinary, and used to be
+  // indistinguishable from the case above. Both returned a bare null and both
+  // were silent, which is why the first live occurrence took a CI log and a
+  // count of gateway calls to read.
+  it("says so when the approval was ours but arrived too late to link", async () => {
+    const client = new EventEmitter();
+    const link = vi.fn().mockResolvedValue({ linked: false, reason: "settled" });
+    const onLate = vi.fn();
+    attachPluginApprovalBridge(client, { link, onLate });
+
+    client.emit("event", requested("call_gone"));
+    await settle();
+
+    expect(onLate).toHaveBeenCalledWith(
+      expect.objectContaining({ toolCallId: "call_gone", approvalId: "plugin:abc" })
+    );
+  });
+
+  /**
+   * The race this bridge exists to survive (#1132 follow-up).
+   *
+   * `gate-check` creates the row BEFORE the hook returns `requireApproval`, so
+   * the card is clickable before OpenClaw has announced the approval. A user who
+   * decides in that window leaves the decision recorded and the call parked —
+   * the decision route had no id to resolve with, and never will.
+   *
+   * So the broadcast, not the click, is what delivers it in that case: whenever
+   * it arrives, however late, a row that is already decided gets its decision
+   * handed to the parked call. Event-driven on purpose — the alternative was to
+   * make the route WAIT some guessed number of seconds for the broadcast, which
+   * is a timing assumption dressed up as a fix.
+   */
+  it("delivers a decision that was made before the approval was announced", async () => {
+    const client = new EventEmitter();
+    const link = vi.fn().mockResolvedValue({ linked: true, id: "row-1", status: "approved" });
+    const resolve = vi.fn().mockResolvedValue({ delivered: true });
+    attachPluginApprovalBridge(client, { link, resolve });
+
+    client.emit("event", requested("call_early"));
+    await settle();
+
+    expect(resolve).toHaveBeenCalledWith({ approvalId: "plugin:abc", decision: "approve" });
+  });
+
+  it("delivers a denial the same way", async () => {
+    const client = new EventEmitter();
+    const link = vi.fn().mockResolvedValue({ linked: true, id: "row-1", status: "denied" });
+    const resolve = vi.fn().mockResolvedValue({ delivered: true });
+    attachPluginApprovalBridge(client, { link, resolve });
+
+    client.emit("event", requested("call_early"));
+    await settle();
+
+    expect(resolve).toHaveBeenCalledWith({ approvalId: "plugin:abc", decision: "deny" });
+  });
+
+  // The ordinary path: nobody has decided yet, so there is nothing to deliver.
+  // Resolving here would answer a question the user has not been asked.
+  it("does not resolve a confirmation that is still waiting for its user", async () => {
+    const client = new EventEmitter();
+    const link = vi.fn().mockResolvedValue({ linked: true, id: "row-1", status: "pending" });
+    const resolve = vi.fn();
+    attachPluginApprovalBridge(client, { link, resolve });
+
+    client.emit("event", requested("call_7"));
+    await settle();
+
+    expect(resolve).not.toHaveBeenCalled();
   });
 
   // Every test above proves the bridge WORKS. None of them proves it is
@@ -92,7 +162,7 @@ describe("attachPluginApprovalBridge", () => {
 
   it("detaches on teardown so a re-attach cannot double-link", async () => {
     const client = new EventEmitter();
-    const link = vi.fn().mockResolvedValue({ id: "row-1" });
+    const link = vi.fn().mockResolvedValue({ linked: true, id: "row-1", status: "pending" });
     const detach = attachPluginApprovalBridge(client, { link });
 
     detach();

--- a/packages/web/src/app/api/approvals/[id]/decision/route.ts
+++ b/packages/web/src/app/api/approvals/[id]/decision/route.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
 import { decisionSchema } from "@/lib/schemas/approvals";
-import { resolveDecision } from "@/lib/approvals/service";
+import { resolveDecision, waitForApprovalLink } from "@/lib/approvals/service";
 import { resolvePluginApproval } from "@/server/resolve-plugin-approval";
 import { type AuditLogEntry } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
@@ -12,11 +12,20 @@ import { agents, users } from "@/db/schema";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
-/** What to tell the user when their decision did not reach the parked run.
- * Worded for approve and deny alike: in both cases the agent was not told. */
+/**
+ * What to tell the user when their decision did not reach the parked run.
+ * Worded for approve and deny alike: in both cases the agent was not told.
+ *
+ * None of these may say "try it again", and `nothing-waiting` used to. That
+ * reason covers the case where OpenClaw's approval id simply had not arrived
+ * yet, and the gateway bridge delivers such a decision as soon as it does — so
+ * the advice was to run a tool a second time that is gated precisely because
+ * running it once matters. Say what happened and point at the chat; the user
+ * can see there whether the action went ahead.
+ */
 const NOT_DELIVERED: Record<"nothing-waiting" | "refused" | "unreachable", string> = {
   "nothing-waiting":
-    "The agent is no longer waiting for this decision. Ask it to try the action again.",
+    "Your decision is recorded, but the agent hasn't picked it up. Check the chat before asking it to try again.",
   refused: "OpenClaw would not accept this decision, so the agent has not been told.",
   unreachable: "Pinchy could not reach OpenClaw, so the agent has not been told.",
 };
@@ -25,12 +34,23 @@ const NOT_DELIVERED: Record<"nothing-waiting" | "refused" | "unreachable", strin
  * The acting user approves or denies their own pending confirmation (Tier 2
  * self-confirm — enforced by `selfConfirmOnly`).
  *
- * Two things have to happen, in this order. The row is flipped first, so a
- * failure between them leaves a decision on record and a tool that did NOT run
- * — the safe direction. Then the decision is handed to the call OpenClaw parked
- * for it: `pinchy-approvals` answers with `requireApproval`, which suspends the
- * call inside OpenClaw's hook, and only `plugin.approval.resolve` ends that
- * wait. Flipping the row alone leaves the run parked until its 600 s cap.
+ * Three things happen, in this order, and the order is the whole design.
+ *
+ * First the route waits — briefly, and only when something can still arrive —
+ * for OpenClaw's approval id, because that id is minted after the gate answered
+ * and reaches us on a later broadcast (see `waitForApprovalLink`). Then the row
+ * is flipped, so a failure between the remaining steps leaves a decision on
+ * record and a tool that did NOT run — the safe direction. Then the decision is
+ * handed to the call OpenClaw parked for it: `pinchy-approvals` answers with
+ * `requireApproval`, which suspends the call inside OpenClaw's hook, and only
+ * `plugin.approval.resolve` ends that wait. Flipping the row alone leaves the
+ * run parked until its 600 s cap.
+ *
+ * The wait is bounded, so it can still lose. That is no longer terminal: the
+ * gateway bridge links a broadcast to a row the user has already decided and
+ * delivers the decision from there. What the wait buys is the honest answer
+ * here, in this response, rather than a warning the user reads before the run
+ * quietly carries on.
  */
 export const POST = withAuth<RouteContext>(async (request, { params }, session) => {
   const { id } = await params;
@@ -38,6 +58,14 @@ export const POST = withAuth<RouteContext>(async (request, { params }, session) 
   const parsed = await parseRequestBody(decisionSchema, request);
   if ("error" in parsed) return parsed.error;
   const { decision, reason } = parsed.data;
+
+  // BEFORE flipping the row, not after: OpenClaw announces the id it minted for
+  // the parked call on a broadcast that necessarily follows the gate's answer,
+  // so a decision taken the moment the card appears arrives first — and
+  // `linkApproval` refuses a row that is no longer pending, which makes that
+  // miss permanent rather than momentary. Bounded, and skipped entirely when
+  // there is nothing to wait for.
+  await waitForApprovalLink({ id, requesterId: session.user.id! });
 
   const res = await resolveDecision({
     id,

--- a/packages/web/src/lib/approvals/service.integration.test.ts
+++ b/packages/web/src/lib/approvals/service.integration.test.ts
@@ -95,7 +95,7 @@ describe("approvals gate decision service", () => {
       const r = await decideGate({ ...base(), toolCallId: "call_9" });
       const linked = await linkApproval({ approvalId: "plugin:xyz", toolCallId: "call_9" });
 
-      expect(linked?.id).toBe(r.requestId);
+      expect(linked).toEqual({ linked: true, id: r.requestId, status: "pending" });
       const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
       expect(row.openclawApprovalId).toBe("plugin:xyz");
     });
@@ -110,23 +110,61 @@ describe("approvals gate decision service", () => {
         toolCallId: "call_theirs",
       });
 
-      expect(linked).toBeNull();
+      // "not-ours" rather than a bare miss: the bridge stays quiet about these,
+      // and must be able to tell them from one of ours it could not link.
+      expect(linked).toEqual({ linked: false, reason: "not-ours" });
       const rows = await db.select().from(toolApproval);
       expect(rows.every((r) => r.openclawApprovalId === null)).toBe(true);
     });
 
-    // A row the user already decided must not be re-armed by a late broadcast:
-    // it would make a settled confirmation look resolvable again.
-    it("leaves an already-decided confirmation alone", async () => {
+    // This test used to assert the opposite — that a decided row is left alone,
+    // reasoning that a late broadcast "would make a settled confirmation look
+    // resolvable again". That reasoning was wrong, and it was wrong in the
+    // direction that costs a user their run.
+    //
+    // What makes a card actionable is `status = 'pending'`, which is what
+    // `GET /api/approvals` filters on. The OpenClaw id makes it RESOLVABLE — a
+    // different question. So refusing to store the id on a decided row does not
+    // protect anything; it throws away the one value the decision needs to
+    // reach the parked call, permanently, because the row will never be
+    // `pending` again.
+    //
+    // That turned a millisecond ordering problem into an unrecoverable one: decide
+    // before the broadcast lands and the run stays parked until OpenClaw's
+    // 600 s cap, with nothing anywhere saying why.
+    it("records the id even when the user already decided — that is when it is needed", async () => {
       const r = await decideGate({ ...base(), toolCallId: "call_done" });
       await resolveDecision({ id: r.requestId, approverId: requesterId, decision: "deny" });
 
       const linked = await linkApproval({ approvalId: "plugin:late", toolCallId: "call_done" });
 
-      expect(linked).toBeNull();
+      // `status` is what the bridge reads to know a decision is already sitting
+      // here waiting to be delivered.
+      expect(linked).toEqual({ linked: true, id: r.requestId, status: "denied" });
+      const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
+      expect(row.openclawApprovalId).toBe("plugin:late");
+      // …and the decision itself is untouched, so the card does not come back:
+      // the pending list keys on status, not on the id.
+      expect(row.status).toBe("denied");
+    });
+
+    // Terminal states are the real exception. Once a row is consumed or
+    // expired, no decision is waiting to be delivered, so an id would only be
+    // noise on a settled record.
+    it("leaves a row alone once it is past deciding", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_gone" });
+      await db
+        .update(toolApproval)
+        .set({ status: "expired" })
+        .where(eq(toolApproval.id, r.requestId));
+
+      const linked = await linkApproval({ approvalId: "plugin:tooLate", toolCallId: "call_gone" });
+
+      // "settled", not "not-ours": the row IS ours. The bridge says so out loud,
+      // because a broadcast arriving after a run gave up is worth seeing.
+      expect(linked).toEqual({ linked: false, reason: "settled" });
       const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
       expect(row.openclawApprovalId).toBeNull();
-      expect(row.status).toBe("denied");
     });
   });
 

--- a/packages/web/src/lib/approvals/service.integration.test.ts
+++ b/packages/web/src/lib/approvals/service.integration.test.ts
@@ -12,7 +12,9 @@ import {
   resolveDecision,
   expireStale,
   linkApproval,
+  waitForApprovalLink,
   recordResolution,
+  APPROVAL_LINK_WAIT_MS,
   MAX_PENDING_PER_REQUESTER,
 } from "./service";
 
@@ -165,6 +167,81 @@ describe("approvals gate decision service", () => {
       expect(linked).toEqual({ linked: false, reason: "settled" });
       const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
       expect(row.openclawApprovalId).toBeNull();
+    });
+  });
+
+  // OpenClaw mints its approval id only after the gate answered, so the row and
+  // the `approval.requested` audit event both exist before the id does. A
+  // decision taken inside that window found no id — and because linkApproval
+  // above refuses a non-pending row, deciding first made the link permanently
+  // undeliverable and left the run parked to its 600s cap.
+  describe("waitForApprovalLink", () => {
+    it("returns the id the broadcast attaches while the decision is waiting", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_race" });
+
+      const waiting = waitForApprovalLink({ id: r.requestId, requesterId });
+      setTimeout(() => {
+        void linkApproval({ approvalId: "plugin:late", toolCallId: "call_race" });
+      }, 120);
+
+      await expect(waiting).resolves.toBe("plugin:late");
+    });
+
+    it("returns an id that is already there without waiting for it", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_early" });
+      await linkApproval({ approvalId: "plugin:early", toolCallId: "call_early" });
+
+      const started = performance.now();
+      await expect(waitForApprovalLink({ id: r.requestId, requesterId })).resolves.toBe(
+        "plugin:early"
+      );
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
+    });
+
+    // The bound is what keeps this from becoming a hang: a broadcast that never
+    // comes must cost the user a moment, not the request.
+    it("gives up at the deadline instead of blocking the decision", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_silent" });
+
+      await expect(
+        waitForApprovalLink({ id: r.requestId, requesterId, timeoutMs: 60, pollMs: 10 })
+      ).resolves.toBeNull();
+    });
+
+    // linkApproval matches on toolCallId, so a row without one can never be
+    // named by any broadcast. Waiting on it would be waiting for something that
+    // cannot arrive.
+    it("does not wait for a row no broadcast can name", async () => {
+      const r = await decideGate(base());
+
+      const started = performance.now();
+      await expect(waitForApprovalLink({ id: r.requestId, requesterId })).resolves.toBeNull();
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
+    });
+
+    // Same reason: nothing can link a settled row, so there is nothing to wait
+    // for — and a card the user already answered must not stall their next one.
+    it("does not wait for a confirmation that is already settled", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_settled" });
+      await resolveDecision({ id: r.requestId, approverId: requesterId, decision: "deny" });
+
+      const started = performance.now();
+      await expect(waitForApprovalLink({ id: r.requestId, requesterId })).resolves.toBeNull();
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
+    });
+
+    // resolveDecision owns the 403. This only makes sure a stranger's request
+    // does not take measurably longer than an unknown one, which would answer
+    // the question the 403 declines to.
+    it("does not wait on someone else's confirmation", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_theirs" });
+      const other = await seedUser();
+
+      const started = performance.now();
+      await expect(
+        waitForApprovalLink({ id: r.requestId, requesterId: other.id })
+      ).resolves.toBeNull();
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
     });
   });
 

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -174,6 +174,10 @@ export async function decideGate(input: DecideGateInput): Promise<GateDecision> 
  * delivered, so an id there would only be noise on a settled record. */
 const LINKABLE_STATES = ["pending", "approved", "denied"] as const;
 
+/** Derived, never restated: the `inArray` below and {@link LinkOutcome} have to
+ * name the same set, and writing it twice is how those two drift apart. */
+type LinkableState = (typeof LINKABLE_STATES)[number];
+
 /**
  * What {@link linkApproval} did with one broadcast.
  *
@@ -186,7 +190,7 @@ const LINKABLE_STATES = ["pending", "approved", "denied"] as const;
 export type LinkOutcome =
   /** `status` is what tells the bridge whether a decision is already sitting on
    * this row waiting to be delivered — the race in #1132's follow-up. */
-  | { linked: true; id: string; status: "pending" | "approved" | "denied" }
+  | { linked: true; id: string; status: LinkableState }
   /** No row for that call. Routine: the same gateway broadcast carries
    * OpenClaw's own approvals (skill workshop, exec), which name calls Pinchy
    * never opened a row for. */
@@ -230,11 +234,9 @@ export async function linkApproval(input: {
     )
     .returning({ id: toolApproval.id, status: toolApproval.status });
   if (linked) {
-    return {
-      linked: true,
-      id: linked.id,
-      status: linked.status as "pending" | "approved" | "denied",
-    };
+    // The column is a plain string; the `inArray` three lines up is what makes
+    // this narrowing true, which is why the two share one list.
+    return { linked: true, id: linked.id, status: linked.status as LinkableState };
   }
 
   // Nothing updated: either the call is not ours at all, or it is ours and
@@ -245,6 +247,97 @@ export async function linkApproval(input: {
     .where(eq(toolApproval.toolCallId, input.toolCallId))
     .limit(1);
   return { linked: false, reason: row ? "settled" : "not-ours" };
+}
+
+/**
+ * How long a decision may wait for {@link linkApproval} to land.
+ *
+ * The gap is structural, not a hiccup: OpenClaw mints its approval id only
+ * AFTER `before_tool_call` answers `requireApproval`, and announces it on a
+ * separate gateway broadcast. Pinchy's own row — and the `approval.requested`
+ * audit event the inbox and the E2E both key on — therefore exist before the id
+ * does. Anything that reacts to the card the instant it appears lands in that
+ * window.
+ *
+ * Two seconds is a BOUND, not a measurement, and the difference is worth being
+ * honest about. The failing CI run (31111018560) shows the decision POST
+ * completing at 14:44:47.827 and the gate's `plugin.approval.request` answered
+ * at 14:44:47.944 — the click lost by 25 ms — then the stack came down, so how
+ * long the hop actually takes was never observed. So this is ~4x a window that
+ * demonstrably was not enough, over a path that is one websocket frame plus one
+ * indexed UPDATE, and short enough that no decision ever feels hung.
+ *
+ * It is only ever spent inside the window: a row that already carries the id,
+ * or that no broadcast can reach, returns immediately. And when it does run
+ * out, the miss is no longer permanent — {@link linkApproval} still attaches to
+ * a decided row and the gateway bridge delivers from there. This is the fast
+ * path, not the only one.
+ */
+export const APPROVAL_LINK_WAIT_MS = 2000;
+
+/** Re-read cadence for {@link waitForApprovalLink}. Short because the wait is
+ * short; the read is a single indexed lookup by primary key. */
+const APPROVAL_LINK_POLL_MS = 50;
+
+/**
+ * Wait for OpenClaw's approval id to reach this user's pending confirmation,
+ * and return it — or `null` when it is not coming.
+ *
+ * Deciding without it means answering the user with `resumed: false` /
+ * `nothing-waiting` about a call that IS waiting — and then telling them to ask
+ * the agent to try again, over a tool that is gated precisely because repeating
+ * it is expensive. Seen on CI 2026-08-06, where the E2E granted its own
+ * confirmation 25 ms before OpenClaw announced the approval.
+ *
+ * The bridge delivers a decision the wait missed ({@link linkApproval} attaches
+ * to a decided row for exactly that reason), so this is about telling the user
+ * the truth the first time, not about whether the run eventually resumes.
+ *
+ * Four things end the wait immediately rather than burning the deadline: the id
+ * is already there; the row is gone; it is no longer `pending`, so somebody
+ * already decided and this caller is not the one still waiting; or it carries
+ * no `toolCallId`, which is the key `linkApproval` matches on — no broadcast
+ * can ever name it.
+ *
+ * `requesterId` scopes the wait to the caller's own row. `resolveDecision`
+ * remains the authority on who may decide; this only avoids making a stranger's
+ * request measurably slower than an unknown one, which would answer a question
+ * the 403 is careful not to.
+ */
+export async function waitForApprovalLink(input: {
+  id: string;
+  requesterId: string;
+  timeoutMs?: number;
+  pollMs?: number;
+  /** Seam for tests; defaults to a real timer. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Seam for tests; defaults to the wall clock. */
+  now?: () => number;
+}): Promise<string | null> {
+  const timeoutMs = input.timeoutMs ?? APPROVAL_LINK_WAIT_MS;
+  const pollMs = input.pollMs ?? APPROVAL_LINK_POLL_MS;
+  const sleep = input.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const now = input.now ?? Date.now;
+  const deadline = now() + timeoutMs;
+
+  for (;;) {
+    const [row] = await db
+      .select({
+        approvalId: toolApproval.openclawApprovalId,
+        status: toolApproval.status,
+        requesterId: toolApproval.requesterId,
+        toolCallId: toolApproval.toolCallId,
+      })
+      .from(toolApproval)
+      .where(eq(toolApproval.id, input.id))
+      .limit(1);
+
+    if (!row || row.requesterId !== input.requesterId) return null;
+    if (row.approvalId) return row.approvalId;
+    if (row.status !== "pending" || !row.toolCallId) return null;
+    if (now() >= deadline) return null;
+    await sleep(pollMs);
+  }
 }
 
 /** What OpenClaw finally did with a parked call — mirrors the plugin's

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -259,17 +259,25 @@ export async function linkApproval(input: {
  * does. Anything that reacts to the card the instant it appears lands in that
  * window.
  *
- * Two seconds is a BOUND, not a measurement, and the difference is worth being
- * honest about. The failing CI run (31111018560) shows the decision POST
- * completing at 14:44:47.827 and the gate's `plugin.approval.request` answered
- * at 14:44:47.944 — the click lost by 25 ms — then the stack came down, so how
- * long the hop actually takes was never observed. So this is ~4x a window that
- * demonstrably was not enough, over a path that is one websocket frame plus one
- * indexed UPDATE, and short enough that no decision ever feels hung.
+ * Two seconds is sized from a measurement, taken by instrumenting this wait and
+ * the bridge and running the integration E2E against the real stack:
+ *
+ *   gated call reaches the gate        19:12:13.063
+ *   broadcast arrives at Pinchy        19:12:13.282   (+219 ms)
+ *   row carries the id                 19:12:13.284   (+2 ms — one UPDATE)
+ *   OpenClaw's waitDecision returns     19:12:13.603   (297 ms parked in total)
+ *
+ * So the whole hop is ~220 ms locally, and the CI runner that failed was
+ * slower — run 31111018560 has the decision POST completing at 14:44:47.827 and
+ * the gate's `plugin.approval.request` answered at 14:44:47.944, so the click
+ * lost by 25 ms and the link had still not attached ~0.5 s later. 2 s is roughly
+ * 9x the measured chain and 4x the worst observed shortfall, while staying short
+ * enough that no decision ever feels hung.
  *
  * It is only ever spent inside the window: a row that already carries the id,
- * or that no broadcast can reach, returns immediately. And when it does run
- * out, the miss is no longer permanent — {@link linkApproval} still attaches to
+ * or that no broadcast can reach, returns immediately — in that same run the
+ * decision arrived after the link and waited 0 ms. And when the bound does run
+ * out, the miss is no longer permanent: {@link linkApproval} still attaches to
  * a decided row and the gateway bridge delivers from there. This is the fast
  * path, not the only one.
  */

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -168,27 +168,83 @@ export async function decideGate(input: DecideGateInput): Promise<GateDecision> 
   return { decision: "block", requestId: inserted.id, created: true };
 }
 
+/** States in which OpenClaw's approval id is still worth recording: a decision
+ * either has not been made yet, or has been made and still has to reach the
+ * parked call. `consumed` and `expired` are terminal — nothing is waiting to be
+ * delivered, so an id there would only be noise on a settled record. */
+const LINKABLE_STATES = ["pending", "approved", "denied"] as const;
+
 /**
- * Attach OpenClaw's approval id to the confirmation waiting for that call.
+ * What {@link linkApproval} did with one broadcast.
  *
- * Returns the row it linked, or `null` when nothing was waiting — which is the
- * ordinary case, not a fault: the same gateway broadcast carries OpenClaw's own
- * approvals (skill workshop, exec), and those name calls Pinchy never opened a
- * row for.
+ * The distinction is the point. Before #1132's follow-up this returned a bare
+ * `null` for two very different situations, and the bridge logged neither,
+ * because one of them is genuinely routine. That made the other one — a
+ * confirmation of ours we could NOT link — invisible, and it is precisely the
+ * one worth seeing.
+ */
+export type LinkOutcome =
+  /** `status` is what tells the bridge whether a decision is already sitting on
+   * this row waiting to be delivered — the race in #1132's follow-up. */
+  | { linked: true; id: string; status: "pending" | "approved" | "denied" }
+  /** No row for that call. Routine: the same gateway broadcast carries
+   * OpenClaw's own approvals (skill workshop, exec), which name calls Pinchy
+   * never opened a row for. */
+  | { linked: false; reason: "not-ours" }
+  /** Our row, already past deciding. Nothing is waiting for this id — but if it
+   * shows up often it means broadcasts are arriving after a run has already
+   * given up, which is worth knowing. */
+  | { linked: false; reason: "settled" };
+
+/**
+ * Attach OpenClaw's approval id to the confirmation opened for that call.
  *
- * Restricted to `pending`: a late broadcast must not re-arm a confirmation the
- * user has already decided, or a settled card would look resolvable again.
+ * This used to be restricted to `pending`, on the reasoning that a late
+ * broadcast "must not re-arm a confirmation the user has already decided". That
+ * reasoning conflated two different things and cost users their runs:
+ *
+ *   - what makes a card ACTIONABLE is `status = 'pending'`, which is what
+ *     `GET /api/approvals` filters on;
+ *   - what makes it RESOLVABLE is this id.
+ *
+ * Storing the id on a decided row therefore brings nothing back into the inbox.
+ * Refusing to store it, on the other hand, threw away the one value the
+ * decision needs to reach the parked call — permanently, because
+ * `resolveDecision` moves the row out of `pending` before the id is read, so
+ * the row can never satisfy the old condition again. A broadcast that lost a
+ * millisecond race left the run parked until OpenClaw's 600 s cap, with nothing
+ * anywhere saying why.
  */
 export async function linkApproval(input: {
   approvalId: string;
   toolCallId: string;
-}): Promise<{ id: string } | null> {
+}): Promise<LinkOutcome> {
   const [linked] = await db
     .update(toolApproval)
     .set({ openclawApprovalId: input.approvalId })
-    .where(and(eq(toolApproval.toolCallId, input.toolCallId), eq(toolApproval.status, "pending")))
-    .returning({ id: toolApproval.id });
-  return linked ?? null;
+    .where(
+      and(
+        eq(toolApproval.toolCallId, input.toolCallId),
+        inArray(toolApproval.status, [...LINKABLE_STATES])
+      )
+    )
+    .returning({ id: toolApproval.id, status: toolApproval.status });
+  if (linked) {
+    return {
+      linked: true,
+      id: linked.id,
+      status: linked.status as "pending" | "approved" | "denied",
+    };
+  }
+
+  // Nothing updated: either the call is not ours at all, or it is ours and
+  // already terminal. One extra read, only on the path that changed nothing.
+  const [row] = await db
+    .select({ id: toolApproval.id })
+    .from(toolApproval)
+    .where(eq(toolApproval.toolCallId, input.toolCallId))
+    .limit(1);
+  return { linked: false, reason: row ? "settled" : "not-ours" };
 }
 
 /** What OpenClaw finally did with a parked call — mirrors the plugin's

--- a/packages/web/src/server/plugin-approval-bridge.ts
+++ b/packages/web/src/server/plugin-approval-bridge.ts
@@ -1,5 +1,6 @@
 import { linkApproval as linkApprovalDefault } from "@/lib/approvals/service";
 import { readApprovalRequested } from "@/lib/approvals/broadcast";
+import { resolvePluginApproval as resolvePluginApprovalDefault } from "@/server/resolve-plugin-approval";
 
 /**
  * The receiving half of a native confirmation (#1132).
@@ -27,7 +28,12 @@ export interface GatewayEvents {
 
 export interface ApprovalBridgeDeps {
   link?: typeof linkApprovalDefault;
+  resolve?: typeof resolvePluginApprovalDefault;
   onError?: (err: unknown) => void;
+  /** Called when the approval was ours but arrived too late to link. Separate
+   * from `onError` because it is not a fault in Pinchy — it is a fact about
+   * timing that is worth seeing rather than swallowing. */
+  onLate?: (info: { toolCallId: string; approvalId: string }) => void;
 }
 
 /** Attaches the listener and returns its teardown. */
@@ -36,9 +42,16 @@ export function attachPluginApprovalBridge(
   deps: ApprovalBridgeDeps = {}
 ): () => void {
   const link = deps.link ?? linkApprovalDefault;
+  const resolve = deps.resolve ?? resolvePluginApprovalDefault;
   const onError =
     deps.onError ??
     ((err: unknown) => console.error("[approvals] could not link an approval:", err));
+  const onLate =
+    deps.onLate ??
+    ((info: { toolCallId: string; approvalId: string }) =>
+      console.warn(
+        `[approvals] approval ${info.approvalId} for call ${info.toolCallId} arrived after the confirmation was already settled — the run was not resumed`
+      ));
 
   const listener = (frame: unknown) => {
     const approval = readApprovalRequested(frame);
@@ -51,11 +64,36 @@ export function attachPluginApprovalBridge(
     // UNHANDLED rejection and takes the server process down. A database blip
     // during one approval must cost that approval, not the whole install.
     void link(approval)
-      .then((linked) => {
-        // `null` is the ordinary case, not a fault: the same broadcast carries
-        // OpenClaw's own approvals (skill workshop, exec), which name calls
-        // Pinchy never opened a confirmation for.
-        void linked;
+      .then(async (outcome) => {
+        if (!outcome.linked) {
+          // "not-ours" is the ordinary case, not a fault: the same broadcast
+          // carries OpenClaw's own approvals (skill workshop, exec), which name
+          // calls Pinchy never opened a confirmation for. "settled" is ours and
+          // worth saying out loud — see `onLate`.
+          if (outcome.reason === "settled") onLate(approval);
+          return;
+        }
+        if (outcome.status === "pending") return;
+
+        // The user decided before OpenClaw announced the approval. Their
+        // decision reached the row but not the parked call — the decision route
+        // had no id to resolve with. The broadcast is what delivers it, however
+        // late it is: this is the only path that can, because the route has
+        // already answered and will not run again.
+        //
+        // Deliberately event-driven rather than making the route WAIT some
+        // guessed number of seconds for this broadcast. A wait would be a
+        // timing assumption dressed up as a fix, and it would still lose
+        // whenever the guess was too short.
+        //
+        // The cost, stated plainly: the user was already told the decision did
+        // not reach the run, and that message is now pessimistic rather than
+        // wrong-in-their-favour. The run continues, and `onResolution` records
+        // what the runtime actually did, so the audit trail ends up correct.
+        await resolve({
+          approvalId: approval.approvalId,
+          decision: outcome.status === "approved" ? "approve" : "deny",
+        });
       })
       .catch(onError);
   };


### PR DESCRIPTION
Closes #1132. Supersedes #1169 — both halves of that race are here, and neither half is sufficient alone.

## The race

OpenClaw mints its approval id **after** `before_tool_call` answers `requireApproval`, and announces it on a separate broadcast. Pinchy's row — and the `approval.requested` audit event the inbox and the E2E both key on — exist **before** that id does. Anything reacting to the card the instant it appears lands inside that gap: the E2E, a scripted approver, a fast human.

Being early was **permanent, not momentary**. `linkApproval` refused a row that was no longer `pending`, and the decision route flips the row before resolving. So the click itself closed the only door the broadcast could still come through. The run then sat until OpenClaw's 600 s cap while the user read *"The agent is no longer waiting for this decision"* — the one thing that was not true.

## Two fixes, because one door is not enough

**1. Wait for the id before settling** (`waitForApprovalLink`, called before the row is flipped). Bounded at 2 s, polled every 50 ms, and it returns immediately whenever nothing can arrive — the id is already there, the row is gone or settled, or it carries no `toolCallId`. So the wait is only ever spent inside the window.

The 2 s is **sized from a measurement**, taken by instrumenting the wait and the bridge and running the integration E2E against the real stack (GitHub Actions was in a major outage and could not answer this):

```
gated call reaches the gate     19:12:13.063
broadcast arrives at Pinchy     19:12:13.282   (+219 ms)
row carries the id              19:12:13.284   (+2 ms, one UPDATE)
waitDecision returns            19:12:13.603   (297 ms parked in total)
```

So the whole hop is ~220 ms locally, and the wait itself measured **0 ms** — the link was already there when the decision arrived. The CI runner that failed was slower: run 31111018560 has the decision POST completing at 14:44:47.827 against the gate's `plugin.approval.request` answered at 14:44:47.944, so the click lost by 25 ms and the link had still not attached ~0.5 s later. 2 s is ~9× the measured chain and ~4× the worst observed shortfall.

**2. Deliver when the wait loses.** `linkApproval` now stores the id on a row that has already been decided, and the bridge hands that decision to the parked call whenever the broadcast arrives — however late.

Without (2), every broadcast past the bound is dropped and the 2 s has a cliff behind it. Without (1), the user is told the decision did not reach the run and only the audit trail corrects it afterwards. Together the fast path is honest and the slow path still completes.

## Gates

`pnpm test` 11 881 passed / 18 skipped · `pnpm -C packages/web test:db` 560 passed (69 files, real PostgreSQL) · `pnpm test:scripts` 1 240 pass / 0 fail · `pnpm build` · `typecheck` + `typecheck:plugins` (10 packages) · `lint` 0 errors · `prettier --check .`

Run on the pinned Node 22. The `pinchy-files` ABI trap AGENTS.md documents bit once on the way here in the other direction — the shared pnpm store's `better-sqlite3` is currently built for NODE_MODULE_VERSION 127, so a Node 24 run reddens 24 tests in `pdf-cache.test.ts` that have nothing to do with this diff.

### The reasoning error was mine, and it was in a test

I wrote the `status = 'pending'` condition and a test asserting it: *"a late broadcast must not re-arm a confirmation the user has already decided"*. That conflates two things:

- `status = 'pending'` is what makes a card **actionable** — it is what `GET /api/approvals` filters on.
- The OpenClaw id is what makes it **resolvable**.

Storing the id on a decided row brings nothing back into the inbox. Refusing to store it threw away the one value the decision needed. The test is **corrected, not deleted**, and now pins both halves: the decided row does take the id, and its status is untouched so the card stays gone. A second test pins the real exception — `consumed`/`expired` are terminal, nothing waits there.

## Observability, which is why this was hard to read

`linkApproval` no longer returns a bare `null` for two very different situations:

- `not-ours` — OpenClaw's own approvals (skill workshop, exec). Silent, as before.
- `settled` — **ours**, and unlinkable. Now says so.

Both were silent before, which is why the first live occurrence took a CI gateway log and a count of RPC lines to diagnose.

And the E2E probe now asserts **the route's own answer first**, as a whole object. The route already knows which of the three branches it took and puts the matching sentence in `resumeError` (nothing-waiting / refused / unreachable); the probe threw that away and asserted the audit row's `outcome`, so a failure read `Expected: "success" / Received: "failure"` and named none of them. Diagnosing one occurrence then cost a gateway log which — it turns out — is only captured on failure at all, so the "control" comparison against a green run was worthless: 6 captured lines against the red run's 387. Silence read as a measurement.

## Coverage where it was missing

Every existing test in "resuming the parked run" called `blockedAndLinked` — it linked **before** deciding. The ordering that broke was the one ordering nothing exercised. There is now an integration test for the reverse order, a route test that lands the broadcast *mid-decision*, and five service tests for `waitForApprovalLink` (four pinning the immediate exits).

**Canary-verified rather than read:** the route test is red without the wait (`expected "vi.fn()" to be called with 'plugin.approval.resolve'`), and stubbing the wait to return `null` reddens two service tests.

The E2E that caught this is **unchanged**, deliberately: its assertion and the product's guarantee are now the same condition, so a test that waited longer than the route does would hide the regression it exists to catch.

## Stated plainly

**Why the id was missing in that particular CI run is not established.** Two candidates: the broadcast had not been processed yet, or it was processed and matched nothing. The gateway log does not record outgoing event frames, so that run cannot decide between them. This PR fixes what is provable by reading — the permanent closure — and makes the next occurrence readable instead of silent.

In the window where the wait loses, the user has already been told the decision did not reach the run, so the message is *pessimistic* rather than wrong-in-their-favour. The run continues, and `onResolution` records what the runtime actually did.
