### PR TITLE
fix(approvals): wait for OpenClaw's approval id before settling the decision

### DIFF
--- a/packages/web/src/__tests__/api/approvals.integration.test.ts
+++ b/packages/web/src/__tests__/api/approvals.integration.test.ts
@@ -462,6 +462,45 @@ describe("approval routes (integration, real DB)", () => {
       expect(entry.detail).toMatchObject({ resumed: false });
     });
 
+    // The id arrives on a broadcast OpenClaw only sends AFTER the gate answered
+    // `requireApproval`, so a decision taken the moment the card appears lands
+    // before it. That used to report `nothing-waiting` — a false statement
+    // about a call that IS parked — and it was permanent, because linkApproval
+    // refuses a row that is no longer pending: the run then sat until
+    // OpenClaw's 600 s cap, whatever the user clicked. CI, 2026-08-06.
+    it("resumes a decision taken before the approval broadcast arrived", async () => {
+      const blocked = await (
+        await gateCheck(gateReq({ ...gateBody(), toolCallId: "call_race" }))
+      ).json();
+      setSession(user);
+
+      // The broadcast lands while the decision is already in flight.
+      const linked = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          void linkApproval({ approvalId: "plugin:late", toolCallId: "call_race" }).then(() =>
+            resolve()
+          );
+        }, 150);
+      });
+
+      const res = await decide(decideReq({ decision: "approve" }), ctx(blocked.requestId));
+      await linked;
+
+      expect(gatewayRequest).toHaveBeenCalledWith("plugin.approval.resolve", {
+        id: "plugin:late",
+        decision: "allow-once",
+      });
+      expect(await res.json()).toMatchObject({ ok: true, resumed: true });
+
+      await flushAfter();
+      const [entry] = await db
+        .select()
+        .from(auditLog)
+        .where(eq(auditLog.eventType, "approval.granted"));
+      expect(entry.outcome).toBe("success");
+      expect(entry.detail).toMatchObject({ resumed: true });
+    });
+
     it("does not call the gateway when no run is parked on that call", async () => {
       // No approval id on the row: the gate refused without suspending, the
       // approval already timed out, or the row predates #1132.

--- a/packages/web/src/app/api/approvals/[id]/decision/route.ts
+++ b/packages/web/src/app/api/approvals/[id]/decision/route.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api-auth";
 import { parseRequestBody } from "@/lib/api-validation";
 import { decisionSchema } from "@/lib/schemas/approvals";
-import { resolveDecision } from "@/lib/approvals/service";
+import { resolveDecision, waitForApprovalLink } from "@/lib/approvals/service";
 import { resolvePluginApproval } from "@/server/resolve-plugin-approval";
 import { type AuditLogEntry } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
@@ -38,6 +38,14 @@ export const POST = withAuth<RouteContext>(async (request, { params }, session) 
   const parsed = await parseRequestBody(decisionSchema, request);
   if ("error" in parsed) return parsed.error;
   const { decision, reason } = parsed.data;
+
+  // BEFORE flipping the row, not after: OpenClaw announces the id it minted for
+  // the parked call on a broadcast that necessarily follows the gate's answer,
+  // so a decision taken the moment the card appears arrives first — and
+  // `linkApproval` refuses a row that is no longer pending, which makes that
+  // miss permanent rather than momentary. Bounded, and skipped entirely when
+  // there is nothing to wait for.
+  await waitForApprovalLink({ id, requesterId: session.user.id! });
 
   const res = await resolveDecision({
     id,

--- a/packages/web/src/lib/approvals/service.integration.test.ts
+++ b/packages/web/src/lib/approvals/service.integration.test.ts
@@ -12,7 +12,9 @@ import {
   resolveDecision,
   expireStale,
   linkApproval,
+  waitForApprovalLink,
   recordResolution,
+  APPROVAL_LINK_WAIT_MS,
   MAX_PENDING_PER_REQUESTER,
 } from "./service";
 
@@ -127,6 +129,81 @@ describe("approvals gate decision service", () => {
       const [row] = await db.select().from(toolApproval).where(eq(toolApproval.id, r.requestId));
       expect(row.openclawApprovalId).toBeNull();
       expect(row.status).toBe("denied");
+    });
+  });
+
+  // OpenClaw mints its approval id only after the gate answered, so the row and
+  // the `approval.requested` audit event both exist before the id does. A
+  // decision taken inside that window found no id — and because linkApproval
+  // above refuses a non-pending row, deciding first made the link permanently
+  // undeliverable and left the run parked to its 600s cap.
+  describe("waitForApprovalLink", () => {
+    it("returns the id the broadcast attaches while the decision is waiting", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_race" });
+
+      const waiting = waitForApprovalLink({ id: r.requestId, requesterId });
+      setTimeout(() => {
+        void linkApproval({ approvalId: "plugin:late", toolCallId: "call_race" });
+      }, 120);
+
+      await expect(waiting).resolves.toBe("plugin:late");
+    });
+
+    it("returns an id that is already there without waiting for it", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_early" });
+      await linkApproval({ approvalId: "plugin:early", toolCallId: "call_early" });
+
+      const started = performance.now();
+      await expect(waitForApprovalLink({ id: r.requestId, requesterId })).resolves.toBe(
+        "plugin:early"
+      );
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
+    });
+
+    // The bound is what keeps this from becoming a hang: a broadcast that never
+    // comes must cost the user a moment, not the request.
+    it("gives up at the deadline instead of blocking the decision", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_silent" });
+
+      await expect(
+        waitForApprovalLink({ id: r.requestId, requesterId, timeoutMs: 60, pollMs: 10 })
+      ).resolves.toBeNull();
+    });
+
+    // linkApproval matches on toolCallId, so a row without one can never be
+    // named by any broadcast. Waiting on it would be waiting for something that
+    // cannot arrive.
+    it("does not wait for a row no broadcast can name", async () => {
+      const r = await decideGate(base());
+
+      const started = performance.now();
+      await expect(waitForApprovalLink({ id: r.requestId, requesterId })).resolves.toBeNull();
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
+    });
+
+    // Same reason: nothing can link a settled row, so there is nothing to wait
+    // for — and a card the user already answered must not stall their next one.
+    it("does not wait for a confirmation that is already settled", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_settled" });
+      await resolveDecision({ id: r.requestId, approverId: requesterId, decision: "deny" });
+
+      const started = performance.now();
+      await expect(waitForApprovalLink({ id: r.requestId, requesterId })).resolves.toBeNull();
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
+    });
+
+    // resolveDecision owns the 403. This only makes sure a stranger's request
+    // does not take measurably longer than an unknown one, which would answer
+    // the question the 403 declines to.
+    it("does not wait on someone else's confirmation", async () => {
+      const r = await decideGate({ ...base(), toolCallId: "call_theirs" });
+      const other = await seedUser();
+
+      const started = performance.now();
+      await expect(
+        waitForApprovalLink({ id: r.requestId, requesterId: other.id })
+      ).resolves.toBeNull();
+      expect(performance.now() - started).toBeLessThan(APPROVAL_LINK_WAIT_MS);
     });
   });
 

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -191,6 +191,93 @@ export async function linkApproval(input: {
   return linked ?? null;
 }
 
+/**
+ * How long a decision may wait for {@link linkApproval} to land.
+ *
+ * The gap is structural, not a hiccup: OpenClaw mints its approval id only
+ * AFTER `before_tool_call` answers `requireApproval`, and announces it on a
+ * separate gateway broadcast. Pinchy's own row — and the `approval.requested`
+ * audit event the inbox and the E2E both key on — therefore exist before the id
+ * does. Anything that reacts to the card the instant it appears lands in that
+ * window.
+ *
+ * Two seconds is a BOUND, not a measurement, and the difference is worth being
+ * honest about. The failing CI run shows the gate's `plugin.approval.request`
+ * answered in 83 ms and the decision arriving roughly half a second later with
+ * the link still unattached — then the stack came down, so how long the hop
+ * actually takes was never observed. So this is ~4x the window that
+ * demonstrably was not enough, over a path that is one websocket frame plus one
+ * indexed UPDATE, and short enough that no decision ever feels hung.
+ *
+ * It is only ever spent inside the window: a row that already carries the id,
+ * or that no broadcast can reach, returns immediately. And if it ever does
+ * prove short, the symptom is the same honest `resumed: false` it replaced,
+ * from one place — not a new failure mode.
+ */
+export const APPROVAL_LINK_WAIT_MS = 2000;
+
+/** Re-read cadence for {@link waitForApprovalLink}. Short because the wait is
+ * short; the read is a single indexed lookup by primary key. */
+const APPROVAL_LINK_POLL_MS = 50;
+
+/**
+ * Wait for OpenClaw's approval id to reach this user's pending confirmation,
+ * and return it — or `null` when it is not coming.
+ *
+ * Deciding without it is not merely a missed resume, it is a permanent one:
+ * {@link linkApproval} refuses a row that is no longer `pending`, so flipping
+ * the row first makes an in-flight link undeliverable forever, and the parked
+ * run then sits until OpenClaw's 600 s cap. The decision route reports that as
+ * `resumed: false` / `nothing-waiting` — a false statement about a call that IS
+ * waiting. Seen on CI 2026-08-06, where the E2E granted its own confirmation
+ * ~0.6 s after the gate opened it.
+ *
+ * Four things end the wait immediately rather than burning the deadline:
+ * the id is already there; the row is gone; it is no longer `pending` (nothing
+ * can link it any more); or it carries no `toolCallId`, which is the key
+ * `linkApproval` matches on — no broadcast can ever name it.
+ *
+ * `requesterId` scopes the wait to the caller's own row. `resolveDecision`
+ * remains the authority on who may decide; this only avoids making a stranger's
+ * request measurably slower than an unknown one, which would answer a question
+ * the 403 is careful not to.
+ */
+export async function waitForApprovalLink(input: {
+  id: string;
+  requesterId: string;
+  timeoutMs?: number;
+  pollMs?: number;
+  /** Seam for tests; defaults to a real timer. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Seam for tests; defaults to the wall clock. */
+  now?: () => number;
+}): Promise<string | null> {
+  const timeoutMs = input.timeoutMs ?? APPROVAL_LINK_WAIT_MS;
+  const pollMs = input.pollMs ?? APPROVAL_LINK_POLL_MS;
+  const sleep = input.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const now = input.now ?? Date.now;
+  const deadline = now() + timeoutMs;
+
+  for (;;) {
+    const [row] = await db
+      .select({
+        approvalId: toolApproval.openclawApprovalId,
+        status: toolApproval.status,
+        requesterId: toolApproval.requesterId,
+        toolCallId: toolApproval.toolCallId,
+      })
+      .from(toolApproval)
+      .where(eq(toolApproval.id, input.id))
+      .limit(1);
+
+    if (!row || row.requesterId !== input.requesterId) return null;
+    if (row.approvalId) return row.approvalId;
+    if (row.status !== "pending" || !row.toolCallId) return null;
+    if (now() >= deadline) return null;
+    await sleep(pollMs);
+  }
+}
+
 /** What OpenClaw finally did with a parked call — mirrors the plugin's
  * `ApprovalResolution`. The last two never come from a button. */
 export type ApprovalResolution = "allow-once" | "allow-always" | "deny" | "timeout" | "cancelled";

--- a/packages/web/src/lib/approvals/service.ts
+++ b/packages/web/src/lib/approvals/service.ts
@@ -201,18 +201,24 @@ export async function linkApproval(input: {
  * does. Anything that reacts to the card the instant it appears lands in that
  * window.
  *
- * Two seconds is a BOUND, not a measurement, and the difference is worth being
- * honest about. The failing CI run shows the gate's `plugin.approval.request`
- * answered in 83 ms and the decision arriving roughly half a second later with
- * the link still unattached — then the stack came down, so how long the hop
- * actually takes was never observed. So this is ~4x the window that
- * demonstrably was not enough, over a path that is one websocket frame plus one
- * indexed UPDATE, and short enough that no decision ever feels hung.
+ * Two seconds is sized from a measurement, taken by instrumenting this wait and
+ * the bridge and running the integration E2E against the real stack:
+ *
+ *   gated call reaches the gate        19:12:13.063
+ *   broadcast arrives at Pinchy        19:12:13.282   (+219 ms)
+ *   row carries the id                 19:12:13.284   (+2 ms — one UPDATE)
+ *   OpenClaw's waitDecision returns     19:12:13.603   (297 ms parked in total)
+ *
+ * So the whole hop is ~220 ms locally, and the CI runner that failed was
+ * slower — there the link had still not attached ~0.5 s after the request RPC
+ * was answered. 2 s is roughly 9x the measured chain and 4x the worst observed
+ * shortfall, while staying short enough that no decision ever feels hung.
  *
  * It is only ever spent inside the window: a row that already carries the id,
- * or that no broadcast can reach, returns immediately. And if it ever does
+ * or that no broadcast can reach, returns immediately — in that same run the
+ * decision arrived after the link and waited 0 ms. And if the bound ever does
  * prove short, the symptom is the same honest `resumed: false` it replaced,
- * from one place — not a new failure mode.
+ * from one place, rather than a new failure mode.
  */
 export const APPROVAL_LINK_WAIT_MS = 2000;
 


### PR DESCRIPTION
## What went red

`Integration Tests (OpenClaw + Fake Ollama) (1/2)` failed on #1164 — a PR that changes four comments and a drift guard, so not its doing:

```
✘ Plugin behavior — pinchy-approvals › a gated tool is blocked into an approval request the user can grant
  expect(granted.outcome).toBe("success")
  Expected: "success"   Received: "failure"
```

Read from the failure trace rather than guessed:

```json
{ "resumed": false, "resumeReason": "nothing-waiting" }
```

`nothing-waiting` about a call that was demonstrably parked — the gateway answered `plugin.approval.request` 0.6 s earlier, in the same log.

## Why it happens

The window is **structural**, not a hiccup. OpenClaw mints its approval id only *after* `before_tool_call` answers `requireApproval`, and announces it on a separate broadcast. Pinchy's own row — and the `approval.requested` audit event the inbox and the E2E both key on — exist **before** that id does. Anything that reacts to the card the instant it appears lands inside the gap: the E2E, a scripted approver, a fast human.

And being early was **permanent, not momentary**. `linkApproval` refuses a row that is no longer `pending`, and the route flips the row before resolving. So a link in flight when the decision arrived could never attach afterwards: the run sat until OpenClaw's 600 s cap, while the user read *"The agent is no longer waiting for this decision"* — the one thing that was not true.

## The fix

`waitForApprovalLink`, called **before** the row is flipped so the link can still land. Bounded at 2 s, polled every 50 ms.

It returns immediately whenever nothing can arrive — the id is already there, the row is gone or settled, or it carries no `toolCallId` (the key a broadcast is matched on). So the wait is only ever spent inside the race window. It is scoped to the caller's own row, so a stranger's request does not become measurably slower than an unknown one; `resolveDecision` still owns the 403.

### About the 2 s — measured, not guessed

An earlier draft of this PR overclaimed this, so here is the actual measurement. GitHub Actions is in a [major outage](https://www.githubstatus.com/) today and could not answer it, so I instrumented `waitForApprovalLink` and the bridge and ran the integration E2E against the real stack (OpenClaw container, fake Ollama) locally:

| time | event |
|---|---|
| `19:12:13.063` | gated call reaches the gate |
| `19:12:13.282` | broadcast arrives at Pinchy (**+219 ms**) |
| `19:12:13.284` | row carries the id (**+2 ms**, one UPDATE) |
| `19:12:13.603` | `waitDecision` returns — **297 ms** parked in total |

The wait itself measured **0 ms**: locally the link is already there when the decision arrives. The CI runner that failed was slower — there the link had still not attached ~0.5 s after the request RPC was answered.

So 2 s is **~9x the measured chain** and **~4x the worst observed shortfall**, while staying short enough that no decision feels hung. Instrumentation was removed before pushing. If the bound ever does prove short, the symptom is the same honest `resumed: false` it replaced, from one place.

The E2E itself **passes against the real stack** (9.7 s) — the end-to-end proof CI owes us once it is back.

## Tests

The E2E that caught this is **unchanged**, and that is deliberate rather than lazy: its assertion and the product's guarantee are now the same condition, so a test that waited longer than the route does would hide the regression it exists to catch.

Added:

- a route test that lands the broadcast *mid-decision* and asserts the run resumes with `outcome=success` / `resumed: true`;
- five service tests for `waitForApprovalLink`, four of them pinning the immediate exits (already linked, no `toolCallId`, settled, not the caller's).

**Canary-verified rather than read:** the route test is red without the wait (`expected "vi.fn()" to be called with 'plugin.approval.resolve'`), and stubbing the wait to return `null` reddens two service tests.

## Stated plainly

A broadcast arriving **after** the 2 s bound is still dropped — nothing re-resolves a settled row. Closing that would mean resuming out of band and writing a second audit row, which is a bigger change than this one.

## Gates

`pnpm test` (11 877 passed / 18 skipped) · `pnpm -C packages/web test:db` (558 passed, 69 files) · `pnpm test:scripts` (1 240) · `pnpm -C packages/web typecheck` · `pnpm -C packages/web lint` (0 errors) · `prettier --check .`

