### PR TITLE
test(approvals): let the probe name the reason it failed

### DIFF
--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -768,9 +768,7 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
       const decision = await page.request.post(`/api/approvals/${requestId}/decision`, {
         data: { decision: "approve" },
       });
-      expect(decision.status()).toBe(200);
-
-      // Assert the ROUTE'S OWN ANSWER first, and assert the whole object.
+      // Assert the ROUTE'S OWN ANSWER first, and compare it WHOLE.
       //
       // The route already knows why a decision did not reach the parked call —
       // it puts `resumeError` in this body, one sentence per branch
@@ -784,10 +782,16 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
       // which is only dumped on failure — so even the comparison against a
       // green run was worthless, because that run had captured nothing.
       //
-      // toMatchObject on the whole body is what surfaces it: an unexpected
-      // `resumeError` lands in the diff instead of hiding behind a boolean
-      // that merely says "not true".
-      expect(await decision.json()).toMatchObject({ ok: true, resumed: true });
+      // The matcher is the load-bearing part, and `toMatchObject` is the wrong
+      // one: it prints the RECEIVED object pruned to the expected keys, so an
+      // unexpected `resumeError` never reaches the diff and the failure still
+      // reads `resumed: false` and stops there — the same silence, one level
+      // down. `toEqual` prints the body as it came, which is the whole point.
+      // The status is asserted off the raw text because a non-200 body is
+      // `{ error }` and need not be JSON at all.
+      const decisionBody = await decision.text();
+      expect(decision.status(), decisionBody).toBe(200);
+      expect(JSON.parse(decisionBody)).toEqual({ ok: true, status: "approved", resumed: true });
 
       // The decision is recorded as approval.granted — and `resumed` says it
       // reached the parked call. Asserting only that the row exists would pass
@@ -798,12 +802,24 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
         predicate: (e) => e.resource === `approval:${requestId}`,
         deadlineMs: 15000,
       });
-      // Same reasoning: compare the fields together so a failure prints the
-      // recorded reason rather than just the word "failure".
+      // Same reasoning, same matcher. Named fields rather than the whole detail
+      // here, because that object also carries the request, agent, requester,
+      // approver, tool name and args digest — values this probe has no business
+      // pinning. The three below are the ones the route writes when a resume
+      // did not happen, and `toEqual` ignores a key whose value is undefined,
+      // so the happy path matches the two-field expectation while a red run
+      // prints the reason.
+      const grantedDetail = granted.detail as {
+        resumed?: boolean;
+        resumeReason?: string;
+        resumeDetail?: string;
+      };
       expect({
         outcome: granted.outcome,
-        ...(granted.detail as { resumed?: boolean; resumeReason?: string; resumeDetail?: string }),
-      }).toMatchObject({ outcome: "success", resumed: true });
+        resumed: grantedDetail.resumed,
+        resumeReason: grantedDetail.resumeReason,
+        resumeDetail: grantedDetail.resumeDetail,
+      }).toEqual({ outcome: "success", resumed: true });
 
       // The runtime reports back that it let the call through…
       await pollAuditForEvent(page, {

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -770,6 +770,25 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
       });
       expect(decision.status()).toBe(200);
 
+      // Assert the ROUTE'S OWN ANSWER first, and assert the whole object.
+      //
+      // The route already knows why a decision did not reach the parked call —
+      // it puts `resumeError` in this body, one sentence per branch
+      // (nothing-waiting / refused / unreachable). This probe used to throw
+      // that response away and assert only the audit row's `outcome`, so its
+      // one live failure read
+      //
+      //     Expected: "success"   Received: "failure"
+      //
+      // and named none of the three. Diagnosing it took the CI gateway log,
+      // which is only dumped on failure — so even the comparison against a
+      // green run was worthless, because that run had captured nothing.
+      //
+      // toMatchObject on the whole body is what surfaces it: an unexpected
+      // `resumeError` lands in the diff instead of hiding behind a boolean
+      // that merely says "not true".
+      expect(await decision.json()).toMatchObject({ ok: true, resumed: true });
+
       // The decision is recorded as approval.granted — and `resumed` says it
       // reached the parked call. Asserting only that the row exists would pass
       // just as happily over a run that stays parked until it times out, which
@@ -779,8 +798,12 @@ test.describe("Plugin behavior — pinchy-approvals", () => {
         predicate: (e) => e.resource === `approval:${requestId}`,
         deadlineMs: 15000,
       });
-      expect(granted.outcome).toBe("success");
-      expect((granted.detail as { resumed?: boolean }).resumed).toBe(true);
+      // Same reasoning: compare the fields together so a failure prints the
+      // recorded reason rather than just the word "failure".
+      expect({
+        outcome: granted.outcome,
+        ...(granted.detail as { resumed?: boolean; resumeReason?: string; resumeDetail?: string }),
+      }).toMatchObject({ outcome: "success", resumed: true });
 
       // The runtime reports back that it let the call through…
       await pollAuditForEvent(page, {


### PR DESCRIPTION
Test-only. Lifts the one part of #1168 that #1167 did not cover onto current main.

## Why

The approvals probe asserted the audit row's `outcome`, so its one live failure read

```
Expected: "success"
Received: "failure"
```

and named none of the three reasons a decision can miss a parked call.

Working out which one it was took the CI gateway log, a count of RPC lines, and a comparison against a green run. That comparison was worthless, and it took a while to notice why:

| run | captured `openclaw-1` lines |
| --- | --- |
| green (job 92445802641) | 6 |
| red (job 92649882069) | 387 |

The gateway log is only dumped on failure. Silence read as a measurement, and two fixes got aimed at hypotheses the evidence never actually supported.

None of that was necessary. The decision route already knows which branch it took and puts the matching sentence in `resumeError` — `nothing-waiting`, `refused`, or `unreachable`. The probe was throwing that response away.

## What changed

- **Assert the route's own answer first.** It is synchronous, closest to the cause, and carries the reason.
- **Compare objects with `toEqual`, not single fields**, so an unexpected `resumeError` / `resumeReason` lands in the diff instead of hiding behind a boolean that only says "not true".
- **Assert the status off the raw body text**, so a 403/409 prints `{ "error": "forbidden" }` instead of a bare `Expected 200 / Received 403` — the same defect, one line up.

### The matcher is the load-bearing part

`toMatchObject` does **not** do this, which is worth stating explicitly because the first cut of this PR used it. Its failure message prints the received object *pruned to the expected keys* (`getObjectSubset` in `@jest/expect-utils`), so the extra field never reaches the diff. Measured against Playwright's own `expect`, same input both ways:

```
toMatchObject({ ok: true, resumed: true })     toEqual({ ok: true, status: "approved", resumed: true })
  Object {                                       Object {
    "ok": true,                                    "ok": true,
-   "resumed": true,                          +    "resumeError": "The agent is no longer waiting for this decision…",
+   "resumed": false,                          -   "resumed": true,
  }                                            +   "resumed": false,
                                                   "status": "approved",
                                                 }
```

The audit-row assertion names its three fields rather than spreading the whole `detail`, which also carries the request, agent, requester, approver, tool name and args digest — values this probe has no business pinning. `toEqual` ignores a key whose value is `undefined`, so the happy path still matches a two-field expectation.

## Relationship to the other PRs

The defect those failures pointed at is **already fixed on main** by #1167 — `linkApproval` accepting a decided row, `awaitApprovalLink`, and session scoping, which together go further than #1168 did.

That makes #1168 superseded apart from this change, which is why this is a fresh branch off main rather than a rebase of it. I have not closed #1168 — that is yours to call; my recommendation is on the PR.

## Gates

`prettier --check`, `eslint`, and `tsc --noEmit -p packages/web/tsconfig.json` (green; also via the pre-push `next build`).

Note on the typecheck surface, since an earlier version of this description got it wrong: `e2e/**` is outside `tsconfig.typecheck.json`, but it is **inside** `packages/web/tsconfig.json`, which is what `next build` checks — so a type error in a Playwright spec really does fail the build. AGENTS.md §"The Pre-Push Build Runs On Relevance" says so directly.

No unit-test surface. The change only proves itself on a red run, which is the point of it.
