### PR TITLE
fix(deps): pdfjs-dist 6.2.108 closes the PDF XSS advisory

### DIFF
--- a/packages/plugins/pinchy-files/generate-file.test.ts
+++ b/packages/plugins/pinchy-files/generate-file.test.ts
@@ -7,15 +7,16 @@ import { generateFile } from "./generate-file";
  * by an unbounded wrap (the regression #1/#2 guard against). No font data or
  * canvas factory is needed just to read structural page count. */
 async function countPdfPages(buffer: Buffer): Promise<number> {
-  const doc = await getDocument({
+  const loadingTask = getDocument({
     data: new Uint8Array(buffer),
     isEvalSupported: false,
     disableAutoFetch: true,
     disableFontFace: true,
     useSystemFonts: false,
-  } as Record<string, unknown>).promise;
+  } as Record<string, unknown>);
+  const doc = await loadingTask.promise;
   const numPages = doc.numPages;
-  await doc.destroy();
+  await loadingTask.destroy();
   return numPages;
 }
 

--- a/packages/plugins/pinchy-files/package.json
+++ b/packages/plugins/pinchy-files/package.json
@@ -12,7 +12,7 @@
     "better-sqlite3": "^12.11.1",
     "exceljs": "^4.4.0",
     "mammoth": "^1.12.0",
-    "pdfjs-dist": "^5.7.284",
+    "pdfjs-dist": "^6.2.108",
     "pdfkit": "^0.19.1",
     "turndown": "^7.2.0",
     "turndown-plugin-gfm": "^1.0.2"

--- a/packages/plugins/pinchy-files/pdf-extract.ts
+++ b/packages/plugins/pinchy-files/pdf-extract.ts
@@ -298,7 +298,8 @@ export async function extractPdfText(
   const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
   const data = new Uint8Array(buffer);
 
-  const doc = await getDocument({
+  // pdfjs 6 removed PDFDocumentProxy.destroy(); the loading task owns teardown.
+  const loadingTask = getDocument({
     data,
     isEvalSupported: false,
     disableAutoFetch: true,
@@ -306,7 +307,8 @@ export async function extractPdfText(
     useSystemFonts: false,
     standardFontDataUrl: STANDARD_FONT_DATA_URL,
     CanvasFactory: NodeCanvasFactory,
-  } as Record<string, unknown>).promise;
+  } as Record<string, unknown>);
+  const doc = await loadingTask.promise;
 
   const totalPages = doc.numPages;
   const pagesToProcess = Math.min(totalPages, maxPages);
@@ -370,6 +372,6 @@ export async function extractPdfText(
     await yieldToEventLoop();
   }
 
-  await doc.destroy();
+  await loadingTask.destroy();
   return { pages, totalPages, truncated: totalPages > maxPages };
 }

--- a/packages/plugins/pinchy-files/pdf-render.test.ts
+++ b/packages/plugins/pinchy-files/pdf-render.test.ts
@@ -11,13 +11,14 @@ describe("renderPageToImage", () => {
   it("renders a PDF page to a PNG buffer", async () => {
     const buffer = readFileSync(join(FIXTURES, "text-only.pdf"));
     const data = new Uint8Array(buffer);
-    const doc = await getDocument({
+    const loadingTask = getDocument({
       data,
       isEvalSupported: false,
       disableAutoFetch: true,
       disableFontFace: true,
       useSystemFonts: false,
-    } as Record<string, unknown>).promise;
+    } as Record<string, unknown>);
+    const doc = await loadingTask.promise;
 
     const page = await doc.getPage(1);
     const pngBuffer = await renderPageToImage(page);
@@ -32,6 +33,6 @@ describe("renderPageToImage", () => {
     expect(pngBuffer.length).toBeLessThan(5_000_000);
 
     page.cleanup();
-    await doc.destroy();
+    await loadingTask.destroy();
   });
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -67,7 +67,7 @@
     "nodemailer": "^9.0.3",
     "odoo-node": "0.3.0",
     "openclaw-node": "0.14.0",
-    "pdfjs-dist": "^5.7.284",
+    "pdfjs-dist": "^6.2.108",
     "pdfkit": "^0.19.1",
     "postgres": "^3.4.9",
     "prismjs": "^1.30.0",

--- a/packages/web/src/lib/knowledge/pdf-extract.ts
+++ b/packages/web/src/lib/knowledge/pdf-extract.ts
@@ -36,13 +36,15 @@ export async function extractPdfPages(absPath: string): Promise<ExtractedPdfPage
   // type but is a documented runtime option (disables eval-based font
   // compilation, which Node has no use for); same cast pinchy-files' own
   // pdf-extract.ts uses for its (larger) options object.
-  const doc = await getDocument({
+  // pdfjs 6 removed PDFDocumentProxy.destroy(); the loading task owns teardown.
+  const loadingTask = getDocument({
     data,
     isEvalSupported: false,
     disableAutoFetch: true,
     disableFontFace: true,
     useSystemFonts: false,
-  } as Record<string, unknown>).promise;
+  } as Record<string, unknown>);
+  const doc = await loadingTask.promise;
 
   const pages: ExtractedPdfPage[] = [];
   try {
@@ -74,7 +76,7 @@ export async function extractPdfPages(absPath: string): Promise<ExtractedPdfPage
       }
     }
   } finally {
-    await doc.destroy();
+    await loadingTask.destroy();
   }
 
   return pages;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: ^1.12.0
         version: 1.12.0
       pdfjs-dist:
-        specifier: ^5.7.284
-        version: 5.7.284
+        specifier: ^6.2.108
+        version: 6.2.108
       pdfkit:
         specifier: ^0.19.1
         version: 0.19.1
@@ -348,8 +348,8 @@ importers:
         specifier: 0.14.0
         version: 0.14.0
       pdfjs-dist:
-        specifier: ^5.7.284
-        version: 5.7.284
+        specifier: ^6.2.108
+        version: 6.2.108
       pdfkit:
         specifier: ^0.19.1
         version: 0.19.1
@@ -1585,34 +1585,16 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@napi-rs/canvas-android-arm64@0.1.100':
-    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
   '@napi-rs/canvas-android-arm64@1.0.3':
     resolution: {integrity: sha512-7kSCdUhoXiO+AaIMXdBGdtp6EctZNkmF62Rea/BmVQlwKaM3bBhOzyGUzxyxz9dv5vdBfpyAaxhSRSJF4kqK4A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-darwin-arm64@0.1.100':
-    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@napi-rs/canvas-darwin-arm64@1.0.3':
     resolution: {integrity: sha512-ds14V1BPagLszQyaDTeggny5fNeTCqsUQ5QhFj9VDxSEfzrVxXtdbR0LoFyKa0Siaaw8KvqSk4t7k/WoZJwvbg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-x64@0.1.100':
-    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [darwin]
 
   '@napi-rs/canvas-darwin-x64@1.0.3':
@@ -1621,24 +1603,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
-    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
   '@napi-rs/canvas-linux-arm-gnueabihf@1.0.3':
     resolution: {integrity: sha512-FU2kKZLmolHA9+KcUA+l1+xH3WTLUUTQDU/kLv9SEUr2TrRPu94aytOeizFJDHPs/QBcw4QL1mCQhetQXYBbag==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
-    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-GVSjntxKeA+/y/ZKf1F+cmUw1WeIkE5aMRPqnZUlBTBvBcrvgWccJAWuYCKPX4QJQwZILIIwhgdAbl51yj6fpA==}
@@ -1647,13 +1616,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
-    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@napi-rs/canvas-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-J51oK/axyZ13kxycumSMfLiDZMdWdOVvqDFI28BpuViZHE3A0bQfr8B5vg8YnPEnqLD3BSn1hkdlh2buspEcNQ==}
     engines: {node: '>= 10'}
@@ -1661,24 +1623,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
-    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@napi-rs/canvas-linux-riscv64-gnu@1.0.3':
     resolution: {integrity: sha512-CtQgQjoVTX67jS9XuCTtJ40Sl7wRLMguoFnnGnfDmCWf7kzKFZVwj5ynqUOIGKFMSB61ZCuQlwPvVNxYTTseaw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
-    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1689,13 +1637,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.100':
-    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@napi-rs/canvas-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-xTzaUCKUHTY4bCGadeeRZggbRVbGUT1petg7Z8r9AJR2+D9Bqu6nQAgqBGC6D47tA70LjaaaLTrJ7wNY1T74dg==}
     engines: {node: '>= 10'}
@@ -1703,22 +1644,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
-    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@napi-rs/canvas-win32-arm64-msvc@1.0.3':
     resolution: {integrity: sha512-ktVLuBkI6QVOm5BwO/WbdGwxgeetAMJa7TTmR8qBarXF0OU2NKjvjUtPJAl2y8t+zBRczJl/1VOl9gua6WcK2g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
-    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [win32]
 
   '@napi-rs/canvas-win32-x64-msvc@1.0.3':
@@ -1726,10 +1655,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@napi-rs/canvas@0.1.100':
-    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
-    engines: {node: '>= 10'}
 
   '@napi-rs/canvas@1.0.3':
     resolution: {integrity: sha512-OlI657a5XXvKGFX7kNeIzJ8rO7IXt87Mqu2H8rXE46viAuOfum/JA7ysX7+eBhxNKznT+RCZh418mndlcFX3+w==}
@@ -6526,8 +6451,8 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pdfjs-dist@5.7.284:
-    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
+  pdfjs-dist@6.2.108:
+    resolution: {integrity: sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==}
     engines: {node: '>=22.13.0 || >=24'}
 
   pdfkit@0.19.1:
@@ -9087,85 +9012,37 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@napi-rs/canvas-android-arm64@0.1.100':
-    optional: true
-
   '@napi-rs/canvas-android-arm64@1.0.3':
-    optional: true
-
-  '@napi-rs/canvas-darwin-arm64@0.1.100':
     optional: true
 
   '@napi-rs/canvas-darwin-arm64@1.0.3':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.100':
-    optional: true
-
   '@napi-rs/canvas-darwin-x64@1.0.3':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
     optional: true
 
   '@napi-rs/canvas-linux-arm-gnueabihf@1.0.3':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
-    optional: true
-
   '@napi-rs/canvas-linux-arm64-gnu@1.0.3':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     optional: true
 
   '@napi-rs/canvas-linux-arm64-musl@1.0.3':
     optional: true
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
-    optional: true
-
   '@napi-rs/canvas-linux-riscv64-gnu@1.0.3':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     optional: true
 
   '@napi-rs/canvas-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.100':
-    optional: true
-
   '@napi-rs/canvas-linux-x64-musl@1.0.3':
-    optional: true
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     optional: true
 
   '@napi-rs/canvas-win32-arm64-msvc@1.0.3':
     optional: true
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
-    optional: true
-
   '@napi-rs/canvas-win32-x64-msvc@1.0.3':
-    optional: true
-
-  '@napi-rs/canvas@0.1.100':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.100
-      '@napi-rs/canvas-darwin-arm64': 0.1.100
-      '@napi-rs/canvas-darwin-x64': 0.1.100
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-x64-musl': 0.1.100
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
     optional: true
 
   '@napi-rs/canvas@1.0.3':
@@ -14292,9 +14169,9 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pdfjs-dist@5.7.284:
+  pdfjs-dist@6.2.108:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.100
+      '@napi-rs/canvas': 1.0.3
 
   pdfkit@0.19.1:
     dependencies:


### PR DESCRIPTION
The third of the advisories `osv-scan` reports, and the only one that is not a lockfile-only move. The other two (mermaid, js-yaml) are in #1170.

## The advisory

**GHSA-hq66-cqwq-w95j / CVE-2026-16633, CVSS 8.6.** A crafted PDF can run attacker-controlled JavaScript in the hosting domain's context when scripting is enabled and no CSP intervenes. Affected range is 5.6.83 up to 6.2.108.

**There is no 5.x fix.** 5.7.284 — the version pinned here — is the last 5.x ever published, so the major bump is the only way out. Both declaring packages move together: `pinchy-files` (extraction) and `packages/web` (knowledge-base ingestion).

## How exposed is Pinchy, really

Stated plainly, because it governs how the 8.6 should be read: **pdfjs runs server-side only here.** `getDocument` from the legacy build, for text and image extraction; `next.config.ts` keeps it out of the client bundle via `serverExternalPackages`. No browser viewer renders PDFs through pdf.js, so the advisory's stated impact — XSS in the hosting domain — does not describe this deployment.

The bump is still the right call. That mitigation rests on a property of our code that **no test asserts**, and a future in-browser viewer would silently inherit the hole.

## The breaking change we hit

pdfjs 6 removes `PDFDocumentProxy.destroy()`. Four call sites used it, two of them production code:

| File | |
| --- | --- |
| `packages/plugins/pinchy-files/pdf-extract.ts` | production |
| `packages/web/src/lib/knowledge/pdf-extract.ts` | production |
| `packages/plugins/pinchy-files/pdf-render.test.ts` | test |
| `packages/plugins/pinchy-files/generate-file.test.ts` | test |

Each now keeps the loading task and tears down through it — which is what the removed method delegated to anyway. **No error path changes shape**: web keeps its `try/finally`, pinchy-files keeps its straight-line teardown. I did not "improve" either while passing through.

Verified empirically rather than from the release notes: the legacy build still exists in 6.2.108, and `loadingTask.destroy` is a function while `PDFDocumentProxy.destroy` is gone — the typecheck named all four sites before the change and none after.

## A duplicate drops out

The lockfile loses 139 lines. pdfjs 5 pulled `@napi-rs/canvas` **0.1.100** in transitively, a second copy beside the **1.0.3** that `pinchy-files` declares directly. pdfjs 6 does not, so the duplicate (and its eleven platform binaries) is gone. Rendering still runs through the plugin's own `CanvasFactory` — `pdf-render.test.ts` exercises that for real, against a fixture PDF.

## Verification

- `pnpm test` — **11893 passed** across 822 files
- `pnpm -C packages/plugins/pinchy-files test` — 259 passed
- `pnpm typecheck:plugins` — 0 errors
- `pnpm -C packages/web typecheck` — 0 errors
- `pnpm format:check`

all exit 0.