### PR TITLE
fix(eval): grade a Sources list by what it renders, not by its bullet character

### DIFF
--- a/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
+++ b/packages/web/src/__tests__/lib/eval/kb-resolve-cited-paths.test.ts
@@ -319,14 +319,17 @@ describe("premiseSourcePaths", () => {
   });
 
   it("cannot turn a failing run into a passing one — the bound the fallback rests on", () => {
-    // Every shape the fallback exists for is charged by gradeAttribution
-    // independently. Assert that rather than trusting the reasoning: if a
-    // future parser change made one of these shapes grade clean, the fallback's
-    // lower precision would start affecting verdicts and this test says so.
+    // The bound binds only where the fallback RUNS, so the partition is
+    // asserted rather than assumed. Three of these four shapes moved across it
+    // when `SOURCES_ENTRY_LINE` learned to read a Sources list that is not
+    // bulleted: the strict intersection resolves them now, and a shape the
+    // strict path handles is not a shape the fallback's lower precision can
+    // touch. The one that remains is the run-on, which has no per-entry
+    // structure to intersect on at all.
     //
-    // `passed`, not a chosen tag pair. Which axis charges a shape is an
-    // implementation detail that shifts as the parsers widen; that SOME axis
-    // does is the whole bound. An earlier draft asserted
+    // For the rest, `passed`, not a chosen tag pair. Which axis charges a shape
+    // is an implementation detail that shifts as the parsers widen; that SOME
+    // axis does is the whole bound. An earlier draft asserted
     // `sources-format || citation-unresolved` and was already too narrow — a
     // parsing list the body never cites is charged `source-uncited`, a third
     // tag the pair would have missed.
@@ -336,9 +339,20 @@ describe("premiseSourcePaths", () => {
     // above needs only the path and is typed accordingly.
     const graded = RETRIEVED.map((source, i) => ({ ...source, n: i + 1, page: 1 }));
 
-    for (const [label, answer] of SWEEP_SHAPES) {
+    let fallbackShapes = 0;
+    for (const [label, answer, expected] of SWEEP_SHAPES) {
+      const strict = resolveCitedSourcePaths(citedSourcePaths(answer), RETRIEVED);
+      if (strict.length > 0) {
+        expect(strict, `${label} (resolved strictly, fallback never runs)`).toEqual(expected);
+        continue;
+      }
+      fallbackShapes++;
       expect(gradeAttribution({ answer, retrieved: graded }).passed, label).toBe(false);
     }
+
+    // Without this the test goes vacuously green the day the strict path
+    // absorbs the last shape — asserting a bound on an empty set.
+    expect(fallbackShapes).toBeGreaterThan(0);
   });
 
   it("recovers nothing for an answer that never cites inline, the one shape nothing charges", () => {

--- a/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/attribution-graders.test.ts
@@ -993,3 +993,294 @@ Quelle: Statistisches Bundesamt
     expect(gradeSourcesFormat(input).tags).toEqual(["sources-format"]);
   });
 });
+
+/**
+ * Every answer quoted in this block is a verbatim Sources region from the
+ * 2026-08-05 groundedness sweep, named by the model and gold item that wrote
+ * it. They are here because the graders charged all of them, and the charge was
+ * the parser's rather than the model's: `BULLET_LINE` requires a `-`/`*` bullet,
+ * so a list written any other way parsed to ZERO entries — and an empty entry
+ * set makes every inline `[N]` read as a dead end (`citation-unresolved`) on a
+ * list that names the right documents on its own lines.
+ */
+describe("Sources-entry shapes the first real sweep produced", () => {
+  it("reads `[N] path` lines that carry no bullet (gpt-oss:120b, gqa-distractor-1)", () => {
+    const input: AttributionInput = {
+      answer: `Tickets are kept for 24 months【1】【2】.
+
+**Sources**
+
+[1] retention-correct.md (undefined)  
+[2] retention-correct.md (undefined)`,
+      retrieved: [src(1, "/data/retention-correct.md"), src(2, "/data/retention-correct.md")],
+    };
+
+    expect(gradeCitationResolution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("reads an ordered list's own number as the citation number (glm-5.2, gqa-pathcite-1)", () => {
+    // The model renumbered the list to its own 1..3 rather than reusing the
+    // numbers knowledge_search handed it — which is fine, because the reader
+    // pairs the inline [3] with the third entry, not with the tool's ordering.
+    const input: AttributionInput = {
+      answer: `The 2012 per diem is $60 [1]. Receipts are not required [2]. The 2011 rate was $45 [3].
+
+Sources:
+1. handbook-2012/policy.md
+2. handbook-2012/policy.md
+3. handbook-2011/policy.md`,
+      retrieved: [src(1, "/data/handbook-2012/policy.md"), src(2, "/data/handbook-2011/policy.md")],
+    };
+
+    expect(gradeCitationResolution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+    expect(citedSourcePaths(input.answer)).toEqual([
+      "handbook-2012/policy.md",
+      "handbook-2011/policy.md",
+    ]);
+  });
+
+  it("takes the marker, not the list position, when a line carries both (glm-5.2, gqa-multihop-1)", () => {
+    const input: AttributionInput = {
+      answer: `Training happens in week one [2]. The module code is SEC-100 [1].
+
+### Sources
+1. [1] onboarding-part2.md — module code SEC-100
+2. [2] onboarding-part1.md — first-week completion requirement`,
+      retrieved: [src(1, "/data/onboarding-part2.md"), src(2, "/data/onboarding-part1.md")],
+    };
+
+    expect(gradeCitationResolution(input).passed).toBe(true);
+    // Returned with the trailing gloss still attached — `PAGE_SUFFIX` strips
+    // "— p. N" and nothing else, and `matchRetrievedDocument` resolves the rest
+    // at segment boundaries downstream. The discriminating case (marker and
+    // ordinal DISAGREEING) is the test below; here they agree.
+    expect(citedSourcePaths(input.answer)).toEqual([
+      "onboarding-part2.md — module code SEC-100",
+      "onboarding-part1.md — first-week completion requirement",
+    ]);
+  });
+
+  it("disagreeing marker and list position: the marker wins", () => {
+    const answer = `Only the third source is cited [3].
+
+**Sources:**
+1. [3] c.md`;
+
+    expect(citedSourcePaths(answer)).toEqual(["c.md"]);
+  });
+
+  it("does not invent an entry from a line carrying neither a marker nor a number", () => {
+    const input: AttributionInput = {
+      answer: `A claim [1].
+
+**Sources:**
+
+- [1] a.md
+All of the above were retrieved on 2026-08-05.`,
+      retrieved: [src(1, "/data/a.md")],
+    };
+
+    // The trailing prose names no source; treating it as one would charge a
+    // spurious `source-uncited` (an entry nothing cites) and hand the
+    // groundedness premise lookup a document that does not exist.
+    expect(gradeCitationResolution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+});
+
+/**
+ * `sources-format` exists because a Sources list that renders as one paragraph
+ * is unreadable. That is a claim about RENDERING, and markdown separates lines
+ * in exactly three ways: a list item, a blank line, or a hard break (two
+ * trailing spaces). Counting bullet characters answered a narrower question,
+ * and charged the two separators that are not bullets.
+ */
+describe("gradeSourcesFormat measures what renders, not which character was typed", () => {
+  it("passes plain `[N]` entries separated by hard breaks (gpt-oss:120b, gqa-abstention-1)", () => {
+    const input: AttributionInput = {
+      answer: `The index lists the section but holds no policy text [3][5].
+
+**Sources**
+
+[3] absent-topic-pointer.md — lists "parental leave" among HR policy sections.  
+[5] absent-topic-pointer.md — notes the index gives section titles only.`,
+      retrieved: [src(3, "/data/absent-topic-pointer.md"), src(5, "/data/absent-topic-pointer.md")],
+    };
+
+    expect(gradeSourcesFormat(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("passes entries separated by blank lines (gpt-oss:120b, gqa-crosslingual-2)", () => {
+    const input: AttributionInput = {
+      answer: `Up to 10 days carry over [1][2].
+
+**Sources**
+
+[1] vacation-policy-en.md — "up to a maximum carryover cap of 10 days"
+
+[2] urlaub-policy-de.md — "bis zu einer maximalen Übertragungsgrenze von 10 Tagen"`,
+      retrieved: [src(1, "/data/vacation-policy-en.md"), src(2, "/data/urlaub-policy-de.md")],
+    };
+
+    expect(gradeSourcesFormat(input).passed).toBe(true);
+  });
+
+  it("passes an ordered list (gpt-oss:120b, gqa-multihop-1)", () => {
+    const input: AttributionInput = {
+      answer: `Week one, module SEC-100 [1][2].
+
+**Sources**
+
+1. onboarding-part1.md — "must complete mandatory IT security awareness training"
+2. onboarding-part2.md — "catalogued as module code SEC-100"`,
+      retrieved: [src(1, "/data/onboarding-part1.md"), src(2, "/data/onboarding-part2.md")],
+    };
+
+    expect(gradeSourcesFormat(input).passed).toBe(true);
+  });
+
+  it("fails consecutive plain lines, which really do collapse into one paragraph (qwen3.5:397b, gqa-abstention-1)", () => {
+    const input: AttributionInput = {
+      answer: `The index lists it but holds no text [1][2].
+
+**Sources:**
+[1] absent-topic-pointer.md
+[2] absent-topic-pointer.md`,
+      retrieved: [src(1, "/data/absent-topic-pointer.md"), src(2, "/data/absent-topic-pointer.md")],
+    };
+
+    expect(gradeSourcesFormat(input).tags).toEqual(["sources-format"]);
+  });
+
+  it("still fails a list whose first entry runs into the heading", () => {
+    // Unchanged from the bullet-counting rule, and deliberately so: this entry
+    // does not begin a rendered line of its own, it continues the heading's.
+    const input: AttributionInput = {
+      answer: `X [1].
+
+**Sources:** [1] /data/a.md — p. 1`,
+      retrieved: [src(1, "/data/a.md")],
+    };
+
+    expect(gradeSourcesFormat(input).tags).toEqual(["sources-format"]);
+  });
+});
+
+/**
+ * The inline half of the same lesson. Widening the Sources parser alone would
+ * have traded one artefact for another: with the list parsing and the body not,
+ * every entry reads as listed-but-never-cited (`source-uncited`) — a charge of
+ * dressing up a single source as corroborated, laid against an answer that
+ * cited every one of them.
+ *
+ * Both spellings below are from the 2026-08-05 sweep, and neither is a
+ * near-miss of the taught form: they are what two model families emit by
+ * default. As with the fullwidth brackets, only the MARKER is normalised — a
+ * marker delimits, it does not identify a document.
+ */
+describe("inline citation-marker spellings the sweep produced", () => {
+  it("reads a labelled marker `【N†file】` (gpt-oss:120b, gqa-dedup-1)", () => {
+    const input: AttributionInput = {
+      answer: `Replace every 6 months【1†quality-file.md (undefined)】【2†product-insert.md (undefined)】.
+
+**Sources**
+
+1. quality-file.md — "replaced every 6 months, or after filtering approximately 1,200 gallons"
+2. product-insert.md — "replaced every 6 months or after filtering 1,200 gallons"`,
+      retrieved: [src(1, "/data/quality-file.md"), src(2, "/data/product-insert.md")],
+    };
+
+    expect(gradeCitationResolution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("reads a comma-grouped marker `[3, 4]` (glm-5.2, gqa-abstention-2)", () => {
+    const input: AttributionInput = {
+      answer: `Both handbook revisions cover travel expense [3, 4].
+
+**Sources:**
+1. handbook-2011/policy.md — 2011 travel policy
+2. handbook-2012/policy.md — 2012 travel policy`,
+      // The list is renumbered by the model, so [3] and [4] resolve to nothing
+      // — but they ARE read as two citations, which is what this pins.
+      retrieved: [src(3, "/data/handbook-2011/policy.md"), src(4, "/data/handbook-2012/policy.md")],
+    };
+
+    const result = gradeCitationResolution(input);
+    expect(result.tags).toContain("citation-unresolved");
+    expect(result.notes[0]).toContain("[3], [4]");
+  });
+
+  it("leaves a path that merely contains a comma or a dagger alone", () => {
+    // The normalisation must not reach into the text that identifies a
+    // document: a renamed file keeps its name, and `path-not-cited` is right to
+    // charge a citation that mangles one.
+    const input: AttributionInput = {
+      answer: `A claim [1].
+
+**Sources:**
+
+- [1] reports/q1, q2 summary†draft.md`,
+      retrieved: [src(1, "/data/reports/q1, q2 summary†draft.md")],
+    };
+
+    expect(gradePathCitation(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+});
+
+describe("horizontal whitespace models actually type", () => {
+  it("reads an entry whose marker is followed by a narrow no-break space (gpt-oss:120b, gqa-distractor-2)", () => {
+    // U+202F, not U+0020. `gpt-oss:120b` types it between the marker and the
+    // path, and JS counts it as `\s` — so a `[ \t]`-separated parser skipped
+    // the marker and then refused the line for starting with whitespace. The
+    // entry vanished and its inline citation read as a dead end.
+    const input: AttributionInput = {
+      answer: `Marketing records are kept for 12 months [1].
+
+**Sources**  
+[1] retention-distractor.md – statement on 12-month retention.`,
+      retrieved: [src(1, "/data/retention-distractor.md")],
+    };
+
+    expect(gradeAttribution(input)).toEqual<KbGraderResult>({
+      passed: true,
+      tags: [],
+      notes: [],
+    });
+  });
+
+  it("reads a list marker followed by a no-break space", () => {
+    const input: AttributionInput = {
+      answer: `A claim [1].
+
+**Sources**
+
+- [1] a.md`,
+      retrieved: [src(1, "/data/a.md")],
+    };
+
+    expect(gradeAttribution(input).passed).toBe(true);
+  });
+});

--- a/packages/web/src/lib/eval/kb/__tests__/groundedness-grader.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/groundedness-grader.test.ts
@@ -364,3 +364,44 @@ describe("gradeGroundednessForGold", () => {
     expect(result.tags).toEqual(["ungrounded-claim"]);
   });
 });
+
+/**
+ * Every fragment below was produced by `splitSentences` against a real answer
+ * from the 2026-08-05 sweep, and each was then entailment-checked as if it were
+ * a claim. None of them asserts anything, so none of them can be entailed —
+ * they were free `ungrounded-claim` verdicts charged to the model for typing a
+ * horizontal rule.
+ */
+describe("splitSentences keeps claims and drops what cannot be one", () => {
+  it("drops a horizontal rule (kimi-k2.6, gqa-pathcite-1 and three others)", () => {
+    // The real shape: the rule sits between the prose and the Sources heading,
+    // so `answerBody` cuts at the heading and leaves it as the trailing
+    // fragment. A rule in mid-body has no `.!?` to split on and simply rides
+    // along with the sentence after it — no run in the sweep wrote one there,
+    // so nothing here pretends to handle it.
+    expect(splitSentences("The rate is $60 [1].\n\n---\n\n")).toEqual(["The rate is $60 [1]."]);
+  });
+
+  it("drops a citation marker left standing alone (kimi-k2.6, gqa-distractor-2)", () => {
+    expect(splitSentences("Tickets are kept for 24 months.\n\n[1]")).toEqual([
+      "Tickets are kept for 24 months.",
+    ]);
+  });
+
+  it("drops an ordered-list marker the splitter orphaned (gpt-oss:120b, gqa-happy-2)", () => {
+    // A list marker is followed by a space, so the splitter treats it as a
+    // sentence end: "1." and "2." each break off as fragments of their own.
+    // The claims survive intact; only the markers go.
+    expect(splitSentences("1. Laptops run a 3-year cycle. 2. Monitors are replaced too.")).toEqual([
+      "Laptops run a 3-year cycle.",
+      "Monitors are replaced too.",
+    ]);
+  });
+
+  it("keeps a claim that is short, numeric and citation-heavy", () => {
+    expect(splitSentences("It is $60 [1]. The cap is 10 days [2].")).toEqual([
+      "It is $60 [1].",
+      "The cap is 10 days [2].",
+    ]);
+  });
+});

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -66,11 +66,17 @@ export interface AttributionInput {
   nearDuplicateGroups?: string[][];
 }
 
-/** One parsed `- [N] <path> — p. <page>` bullet from the Sources list. */
+/** One parsed `- [N] <path> — p. <page>` line from the Sources list. */
 interface SourcesEntry {
   n: number;
   path: string;
   page: number | null;
+  /** Offset of the entry's line start within `sourcesText` — read by `gradeSourcesFormat`. */
+  index: number;
+  /** Whether markdown renders this line as a list item (so it starts a line of its own). */
+  isListItem: boolean;
+  /** Whether the number came from an explicit `[N]` rather than the ordered-list position. */
+  hasMarker: boolean;
 }
 
 /**
@@ -88,6 +94,14 @@ interface SourcesEntry {
  * answer. Because these graders also run against real Layer-3 model output, a
  * false positive corrupts the scorecard.
  *
+ * The two colon-less shapes match with a LOOKAHEAD for the line end rather
+ * than consuming it, and that is not cosmetic. `**Sources**` is very often
+ * followed by two spaces — a markdown hard break, and the only thing making the
+ * first entry render on a line of its own. Consuming them moved the break into
+ * the heading match, so `gradeSourcesFormat` looked at a bare `\n`, judged the
+ * entry to be running into the heading, and charged five of `gpt-oss:120b`'s
+ * runs for a separator that was there all along.
+ *
  * Deliberately NOT `$`-anchored (heading alone on its line): the real
  * run-on-paragraph bug puts the whole list on the SAME line as the heading
  * ("**Sources:** [1] ... [4] ..."), and a `$` anchor would make that shape
@@ -97,6 +111,13 @@ interface SourcesEntry {
  * want: the run-on heading begins its line (matches, list captured, run-on
  * caught) while an embedded mid-prose "Sources:" does not (no match, no
  * phantom list).
+ *
+ * `[^\S\r\n]` rather than `[ \t]` throughout — horizontal whitespace of any
+ * kind, but never a line break. `gpt-oss:120b` separates a marker from its path
+ * with U+202F (narrow no-break space), which JS counts as `\s`: the parser
+ * skipped the marker, then refused the line for beginning with whitespace, and
+ * the entry disappeared. Same lesson as the fullwidth brackets — these models do
+ * not type ASCII punctuation, and a separator is structure, not identity.
  *
  * Deliberately case-SENSITIVE on "Sources" (capital S) — the template always
  * capitalizes it, and matching case-insensitively would trip on ordinary
@@ -134,7 +155,7 @@ interface SourcesEntry {
  * the parser rather than the model.
  */
 const SOURCES_HEADING =
-  /^[ \t]*(?:#{0,3}[ \t]*\*{0,2}[ \t]*(?:Sources|Quellen?)[ \t]*(?::[ \t]*\*{0,2}|\*{0,2}[ \t]*:)|\*{2}[ \t]*(?:Sources|Quellen?)[ \t]*\*{2}[ \t]*$|#{1,3}[ \t]*(?:Sources|Quellen?)[ \t]*$)/gm;
+  /^[^\S\r\n]*(?:#{0,3}[^\S\r\n]*\*{0,2}[^\S\r\n]*(?:Sources|Quellen?)[^\S\r\n]*(?::[^\S\r\n]*\*{0,2}|\*{0,2}[^\S\r\n]*:)|\*{2}[^\S\r\n]*(?:Sources|Quellen?)[^\S\r\n]*\*{2}(?=[^\S\r\n]*$)|#{1,3}[^\S\r\n]*(?:Sources|Quellen?)(?=[^\S\r\n]*$))/gm;
 
 /** Any `[N]` marker, inline citation or Sources-bullet citation number alike. */
 const INLINE_CITATION = /\[(\d+)\]/g;
@@ -161,6 +182,33 @@ const MARKER_BRACKETS: [RegExp, string][] = [
 ];
 
 /**
+ * Two further marker spellings, normalised AFTER the brackets are ASCII so each
+ * is written once rather than twice.
+ *
+ * - `[1†quality-file.md (undefined)]` — `gpt-oss:120b`'s labelled marker, the
+ *   OpenAI citation form. The number is there; a document label rides behind a
+ *   dagger. `INLINE_CITATION` wants the bracket to close after the digits, so it
+ *   saw no citation at all.
+ * - `[3, 4]` — `glm-5.2` groups consecutive citations into one bracket. Read
+ *   literally that is not a number, so both citations vanished.
+ *
+ * Both were invisible while the Sources parser was equally blind, and both
+ * surfaced the moment it was not: a body whose citations cannot be seen against
+ * a list that now parses reads as a list nothing cites, so every entry would
+ * have been charged `source-uncited` — "a retrieved-but-unused chunk presented
+ * as if it independently corroborates the answer", said of an answer that cited
+ * every one of them. Widening one side alone would have traded an artefact for
+ * a worse-worded artefact.
+ *
+ * The label is DISCARDED rather than read. It is the model's gloss of the
+ * document, not the Sources entry, and `path-not-cited` grades what the entry
+ * names — resolving a citation through an inline label would let a body-side
+ * mention stand in for a list a model never wrote.
+ */
+const MARKER_LABEL = /\[(\d+)†[^\]\n]*\]/g;
+const MARKER_GROUP = /\[(\d+(?:[ \t]*,[ \t]*\d+)+)\]/g;
+
+/**
  * The answer with citation-marker brackets in ASCII, and NOTHING else touched.
  *
  * The line this draws is the whole point, so it is worth stating twice:
@@ -185,16 +233,83 @@ function normalizeCitationMarkers(answer: string): string {
   for (const [pattern, replacement] of MARKER_BRACKETS) {
     normalized = normalized.replace(pattern, replacement);
   }
-  return normalized;
+  normalized = normalized.replace(MARKER_LABEL, "[$1]");
+  return normalized.replace(MARKER_GROUP, (_match, numbers: string) =>
+    numbers
+      .split(",")
+      .map((n) => `[${n.trim()}]`)
+      .join("")
+  );
 }
 
 /**
- * A Sources-list bullet: `- [N] <rest of line>` (or `*` bullets), one per
- * line. Requires the `[N]` to be the first thing on a bulleted line — this is
- * exactly what distinguishes a real markdown list from the run-on-paragraph
- * bug, where citations appear mid-line with no bullet marker at all.
+ * One line of a Sources list, in every shape the first real sweep wrote.
+ *
+ * An entry is a line that OPENS with a citation number, in one of two
+ * spellings — an explicit `[N]` marker, or an ordered-list ordinal (`3.`) whose
+ * position IS the number the reader pairs an inline `[3]` with. Either may be
+ * preceded by a list marker (`-`, `*`, or the ordinal itself), and the two may
+ * co-occur (`1. [1] onboarding-part2.md`).
+ *
+ * The predecessor of this regex required a `-`/`*` bullet AND a leading `[N]`,
+ * which is the taught shape and nothing else. Measured against the 2026-08-05
+ * sweep, 20 of 48 runs were charged `citation-unresolved` and NOT ONE of them
+ * cited a source it had not listed: every one had written its list as plain
+ * `[N]` lines or as an ordered list, parsed to zero entries, and so had every
+ * inline marker read as a dead end. A grader that reports a citation-integrity
+ * failure on a list naming exactly the right documents is measuring which
+ * bullet character the model happened to pick.
+ *
+ * What is deliberately still NOT an entry: a line carrying neither spelling.
+ * A trailing "All sources retrieved on 2026-08-05." would otherwise become an
+ * entry that no inline marker cites (`source-uncited`) and that the
+ * groundedness premise lookup would try to resolve to a document.
+ *
+ * Three capture groups, in this order — the package targets below ES2018, so
+ * NAMED groups are a compile error here (`tsc` says so; vitest transpiles them
+ * happily, which is exactly the gap `pnpm typecheck` exists to close):
+ *   1. the ordinal (`3.` form), 2. the marker (`[3]` form), 3. the rest of the
+ * line, which `PAGE_SUFFIX` and `matchRetrievedDocument` read.
+ *
+ * When both numbers are present the MARKER wins — `1. [3] c.md` is the reader's
+ * [3], and a model that renumbers its list while keeping the tool's markers
+ * must not have its citations silently reassigned by position.
  */
-const BULLET_LINE = /^[ \t]*[-*][ \t]+\[(\d+)\]\s*(.+)$/gm;
+const SOURCES_ENTRY_LINE =
+  /^[^\S\r\n]*(?:(\d+)[.)][^\S\r\n]+|[-*][^\S\r\n]+)?(?:\[(\d+)\][^\S\r\n]*)?(\S.*)$/gm;
+
+/**
+ * Just the opening of a Sources line — list marker and/or `[N]`, nothing of the
+ * path. Matches the empty string on a line that has neither, which is what the
+ * buried-marker scan below wants: on a plain paragraph line, everything counts
+ * as "after the head".
+ */
+const SOURCES_ENTRY_HEAD = /^[^\S\r\n]*(?:\d+[.)][^\S\r\n]+|[-*][^\S\r\n]+)?(?:\[\d+\][^\S\r\n]*)?/;
+
+/** True for a Sources line that markdown renders as its own list item. */
+const LIST_ITEM_PREFIX = /^[^\S\r\n]*(?:[-*][^\S\r\n]+|\d+[.)][^\S\r\n]+)/;
+
+/**
+ * A citation marker that is NOT the head of its line and still has text after
+ * it on that line — i.e. a marker introducing a source mid-paragraph, which is
+ * the run-on shape: "**Sources:** [1] a.md — p. 1 [2] b.md — p. 2".
+ *
+ * The trailing-text condition is what separates a buried entry from a trailing
+ * ANNOTATION. `glm-5.2` writes "1. handbook-2012/policy.md — passage [1]",
+ * where the marker closes the line rather than opening a source; that list
+ * renders as cleanly as any other, and charging it would repeat the mistake
+ * this rewrite is undoing one shape further in.
+ */
+const BURIED_MARKER = /\[\d+\][^\S\r\n]*\S/;
+
+/**
+ * A separation that survives markdown rendering, at the END of the text
+ * preceding an entry: a blank line (new paragraph) or a hard break (two or more
+ * trailing spaces, or a backslash, before the newline). A lone `\n` is NOT one
+ * — markdown joins those lines into a single paragraph, which is the run-on the
+ * `sources-format` axis exists to catch.
+ */
+const RENDERED_SEPARATION = /(?:\n[^\S\r\n]*\n|(?:[ \t]{2,}|\\)\n)[^\S\r\n]*$/;
 
 /**
  * Trailing page suffix on a Sources entry's rest-of-line text — separates the
@@ -243,21 +358,24 @@ interface ParsedAnswer {
   sourcesText: string;
 }
 
-function countMatches(text: string, pattern: RegExp): number {
-  return [...text.matchAll(pattern)].length;
-}
-
 function parseSourcesEntries(sourcesText: string): SourcesEntry[] {
   const entries: SourcesEntry[] = [];
-  for (const match of sourcesText.matchAll(BULLET_LINE)) {
-    const n = Number(match[1]);
-    const rest = match[2].trim();
+  for (const match of sourcesText.matchAll(SOURCES_ENTRY_LINE)) {
+    const [, ordinal, marker, restRaw] = match;
+    // A line that opens with neither spelling of a number is not an entry.
+    if (marker === undefined && ordinal === undefined) continue;
+    const n = Number(marker ?? ordinal);
+    const rest = (restRaw ?? "").trim();
+    if (rest.length === 0) continue;
     const pageMatch = PAGE_SUFFIX.exec(rest);
-    entries.push(
-      pageMatch
-        ? { n, path: pageMatch[1].trim(), page: Number.parseInt(pageMatch[2], 10) }
-        : { n, path: rest, page: null }
-    );
+    entries.push({
+      n,
+      path: pageMatch ? pageMatch[1].trim() : rest,
+      page: pageMatch ? Number.parseInt(pageMatch[2], 10) : null,
+      index: match.index,
+      isListItem: LIST_ITEM_PREFIX.test(match[0]),
+      hasMarker: marker !== undefined,
+    });
   }
   return entries;
 }
@@ -495,42 +613,68 @@ export function gradePathCitation(input: AttributionInput): KbGraderResult {
 }
 
 /**
- * `sources-format`: the Sources list must be a markdown bullet list, one
- * entry per `- [N] ...` line — plain consecutive lines (or a single run-on
- * line) collapse into one unreadable paragraph when rendered. Detected by
- * comparing two counts within the text AFTER the "Sources:" heading: every
- * `[N]` marker found anywhere (`looseCount`) vs. only those that lead a
- * bulleted line (`bulletedCount`). A mismatch means at least one citation is
- * NOT on its own bulleted line — including the degenerate case where NONE
- * are (the real captured bug: "Sources: [1] ... p. 169 [4] ... p. 194" all on
- * one line, `bulletedCount === 0`).
+ * `sources-format`: every Sources entry must begin a line of its own IN THE
+ * RENDERED ANSWER — otherwise the list collapses into one paragraph a reader
+ * cannot walk. Two ways to fail it:
  *
- * A single source still must be bulleted: `looseCount === 1` with
- * `bulletedCount === 0` fails just as a multi-source run-on does.
+ * - **An entry does not start its own rendered line.** Markdown separates lines
+ *   in exactly three ways, and this accepts all three: a list item (`-`, `*`,
+ *   `3.`), a blank line before it, or a hard break (two trailing spaces) before
+ *   it. A lone `\n` is none of them, which is why "[1] a.md\n[2] b.md" fails
+ *   and "[1] a.md  \n[2] b.md" does not.
+ * - **A marker sits somewhere other than the head of an entry line**
+ *   (`markerCount > entries with an explicit marker`) — the captured run-on
+ *   bug, "**Sources:** [1] … p. 169 [4] … p. 194" on one line, where the second
+ *   citation is buried mid-paragraph.
+ *
+ * The predecessor compared every `[N]` in the region against those leading a
+ * `- `/`* ` bullet, and so charged the two separators that are not bullets. In
+ * the 2026-08-05 sweep 15 of 17 `sources-format` verdicts went to lists that
+ * render perfectly legibly — hard-break-separated, blank-line-separated, or
+ * ordered. The axis was reporting a typographic preference as a defect.
+ *
+ * What it still charges, unchanged, is a list whose FIRST entry runs into the
+ * heading ("**Sources:** [1] a.md"): that entry begins no line of its own, it
+ * continues the heading's. The rule below is one sentence and this case is
+ * inside it, rather than being a single-source exception bolted on.
  *
  * If the answer legitimately abstained and has NO Sources list at all, this
  * grader passes — there is no list to format-check.
  *
- * The `looseCount === 0` early return is why marker normalisation moves this
- * axis too, and in the FAILING direction: a run-on written entirely in
- * fullwidth brackets ("**Sources:** 【1】 a.md 【2】 b.md") had zero markers this
- * grader could see, so it took that return and passed — a run-on excused by the
- * same typography that emptied the premise set. It is charged now. Both
- * directions are one fix, not a regression traded for an improvement.
+ * Marker normalisation moves this axis too, in the FAILING direction: a run-on
+ * written entirely in fullwidth brackets ("**Sources:** 【1】 a.md 【2】 b.md") had
+ * no markers this grader could see and passed — a run-on excused by the same
+ * typography that emptied the premise set.
  */
 export function gradeSourcesFormat(input: AttributionInput): KbGraderResult {
-  const { hasSourcesList, sourcesText } = parseAnswer(input.answer);
+  const { hasSourcesList, sourcesText, entries } = parseAnswer(input.answer);
   if (!hasSourcesList) return passKb();
 
-  const looseCount = countMatches(sourcesText, INLINE_CITATION);
-  if (looseCount === 0) return passKb();
+  const notes: string[] = [];
 
-  const bulletedCount = countMatches(sourcesText, BULLET_LINE);
-  if (looseCount === bulletedCount) return passKb();
+  const runOn = entries.filter(
+    (entry) => !entry.isListItem && !RENDERED_SEPARATION.test(sourcesText.slice(0, entry.index))
+  );
+  if (runOn.length > 0) {
+    notes.push(
+      `Sources entry/entries [${runOn.map((entry) => entry.n).join("], [")}] do not begin a rendered line of their own — no list marker, blank line or hard break separates them from what precedes, so markdown runs them into one paragraph.`
+    );
+  }
 
-  return failKb("sources-format", [
-    `Sources list has ${looseCount} citation marker(s) but only ${bulletedCount} sit on their own "- [N] ..." bulleted line — likely a run-on paragraph instead of a markdown bullet list.`,
-  ]);
+  // Per line, and only AFTER whatever opens it: a marker at the head of an
+  // entry line is that entry, not a buried one.
+  const buried = sourcesText.split(/\r?\n/).filter((line) => {
+    const head = SOURCES_ENTRY_HEAD.exec(line);
+    return BURIED_MARKER.test(head ? line.slice(head[0].length) : line);
+  });
+  if (buried.length > 0) {
+    notes.push(
+      `Sources list carries a citation marker mid-line, with the source following it on the same line — a second entry buried in the paragraph rather than starting its own line: "${buried[0].trim()}"`
+    );
+  }
+
+  if (notes.length === 0) return passKb();
+  return failKb("sources-format", notes);
 }
 
 /**

--- a/packages/web/src/lib/eval/kb/groundedness-grader.ts
+++ b/packages/web/src/lib/eval/kb/groundedness-grader.ts
@@ -46,12 +46,34 @@ import type { GoldQA, KbGraderResult } from "./types";
  */
 const SENTENCE_BOUNDARY = /(?<=[.!?])\s+(?=\S)/g;
 
-/** Splits an answer BODY (Sources list already stripped) into sentences. */
+/**
+ * A fragment that asserts nothing, so nothing can entail it. Three shapes, one
+ * test — a fragment carrying no letter in any script:
+ *
+ * - `---`, a horizontal rule. Four of the 2026-08-05 sweep's runs typed one.
+ * - `[1]`, a citation marker the splitter left standing after the sentence it
+ *   belonged to ended in `.` before it.
+ * - `2.`, an ordered-list marker. `SENTENCE_BOUNDARY` cannot tell it from a
+ *   sentence end (a `.` followed by a space), so every numbered list in an
+ *   answer body sheds one fragment per item.
+ *
+ * Each was entailment-scored as if it were a claim, scored ~0 by construction,
+ * and charged the model `ungrounded-claim`. `\p{L}` rather than `[a-z]`: the
+ * corpus is bilingual and the axis it feeds has a cross-lingual gold item.
+ *
+ * A claim contains a word. Nothing else is dropped — a short, numeric,
+ * citation-heavy sentence ("It is $60 [1].") carries letters and stays.
+ */
+function isClaimBearing(fragment: string): boolean {
+  return /\p{L}/u.test(fragment);
+}
+
+/** Splits an answer BODY (Sources list already stripped) into claim sentences. */
 export function splitSentences(text: string): string[] {
   return text
     .split(SENTENCE_BOUNDARY)
     .map((sentence) => sentence.trim())
-    .filter((sentence) => sentence.length > 0);
+    .filter((sentence) => sentence.length > 0 && isClaimBearing(sentence));
 }
 
 /**


### PR DESCRIPTION
## What

The KB attribution graders read a Sources list through one regex requiring a `-`/`*` bullet **and** a leading `[N]`. That is the shape the template teaches and nothing else, so a list written any other way parsed to **zero** entries — and an empty entry set turns every inline `[N]` into a dead end.

Replayed over the 48 archived runs of the 2026-08-05 groundedness sweep (`eval/kb/data`, on #1156):

| tag | before | after |
| --- | --- | --- |
| `citation-unresolved` | 20 | **1** |
| `sources-format` | 17 | **4** |
| `source-uncited` | 3 | 6 |
| attribution-clean runs | 22 | **38** |

Not one of the 20 `citation-unresolved` verdicts was a citation the answer had failed to list. Every one named the right documents, on its own lines, in a shape the parser could not see. I read all 10 runs that are still charged: each is a real defect (a source listed but never cited inline, or a list that genuinely collapses into one paragraph).

## Five gaps, each evidenced by the model that wrote it

- **Entry lines** — plain `[N] path`, an ordered list whose ordinal *is* the citation number, and `1. [1] path` where both appear. A line carrying neither spelling is still not an entry, so trailing prose ("All sources retrieved on…") cannot become a phantom source.
- **`sources-format` binds to rendering** — an entry must begin its own *rendered* line: a list item, a blank line, or a hard break. 15 of its 17 verdicts went to lists that render perfectly legibly. A list whose first entry runs into the heading is still charged, which keeps the existing single-source rule intact rather than overruling it.
- **Inline markers** — `[1†file.md]` (gpt-oss's OpenAI citation form) and `[3, 4]` (glm's comma grouping). Widening only the list side would have traded one artefact for a worse-worded one: with the list parsing and the body not, every entry reads as listed-but-never-cited.
- **Horizontal whitespace** — gpt-oss separates a marker from its path with U+202F, which JS counts as `\s`. `[^\S\r\n]` throughout. Same lesson as the fullwidth brackets: these models do not type ASCII punctuation.
- **The heading no longer eats the hard break** — `**Sources**  ` matched with `[ \t]*$`, consuming the two spaces that *are* the separator, so five runs looked like run-ons.

`splitSentences` also stops entailment-checking fragments that assert nothing — a `---`, a marker the splitter left standing, an orphaned `2.` — each of which was a free `ungrounded-claim`.

## The bound the premise fallback rests on

Three of its four shapes now resolve through the strict intersection, so the fallback's lower precision cannot touch them. The test partitions them explicitly and asserts the partition instead of assuming it — plus a counter, so it cannot go vacuously green the day the strict path absorbs the last shape.

## Test plan

- [x] `pnpm test` — 11912 passed, 4 files skipped (pre-existing)
- [x] `pnpm test:scripts` — 1240 passed
- [x] `pnpm -C packages/web typecheck` (caught named capture groups: this package targets below ES2018)
- [x] `pnpm format:check`
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] `pnpm build` (pre-push)
- [x] Replayed against all 48 archived trajectories, old grader vs new, with every remaining charge read by hand

Every fixture in the new tests is a verbatim Sources region from the sweep, named by the model and gold item that produced it.

Refs #869. #1156 stays in draft until its dataset is re-graded through this.