### PR TITLE
feat(approvals): per-model confirmation for the Odoo permission matrix

### DIFF
--- a/docs/src/content/docs/guides/tool-confirmation.mdx
+++ b/docs/src/content/docs/guides/tool-confirmation.mdx
@@ -24,6 +24,31 @@ Confirmation is set per agent, by an admin:
   always adjust the list later.
 </Aside>
 
+## Per record type, for Odoo
+
+"Ask before deleting" is often too broad. Deleting an invoice deserves a second look; deleting a note does not, and an agent that stops for both trains people to click through without reading.
+
+So for Odoo the setting also lives in the **model table** on the same page, where each cell has three states:
+
+|                 |                                                |
+| --------------- | ---------------------------------------------- |
+| **Not allowed** | The agent cannot do this at all.               |
+| **Ask first**   | The agent pauses and waits for a confirmation. |
+| **Allowed**     | The agent goes ahead on its own.               |
+
+A cell you have never touched shows what it **inherits** from the tool setting above. That is deliberate, and it is what keeps the table honest: if you gate deletion for the agent, every model is gated — including ones you add next month. Setting a single cell to **Allowed** is how you make an exception, and it stays an exception.
+
+The confirmation card names the record type, so the person deciding sees "Delete a record in Odoo — account.move" rather than a question they cannot answer.
+
+<Aside type="caution">
+  The check sees the call, not everything it sets off. Approving a write to an
+  invoice also writes that invoice's lines, and confirming a stock transfer
+  moves every line on it. Gate the operation you care about, and read the card's
+  details rather than assuming the scope is one record.
+</Aside>
+
+Where a single action touches two record types — reconciling a bill against a payment, for instance — the **stricter** of the two settings wins.
+
 ## What the person sees
 
 When the agent reaches a gated tool, it doesn't run it — it **waits**, mid-turn, holding the call open. A card appears **at the end of the conversation**, where the agent stopped, with the action and its details — for example, _"Smithers needs your confirmation: run `email_send` with to: ada@example.com?"_ — and two buttons:
@@ -47,6 +72,7 @@ Every step lands in the [audit trail](/concepts/audit-trail): the request, the d
 - **It's per person.** A confirmation you approve is yours; it never clears the same action for a teammate on a shared agent.
 - **It fails safe.** If a confirmation isn't approved within 10 minutes, it expires and the action stays blocked. The same goes for anything the agent does outside a conversation with a person — a scheduled run has nobody to ask, so a gated tool simply doesn't run there.
 - **You won't be buried in cards.** One agent can have at most 20 confirmations waiting for you at once. If an agent keeps asking, it's told to stop and to let you catch up first.
+- **There is no "always allow".** The card offers approve-once and deny, and nothing else. A member tapping "always" would permanently overturn a policy an admin set, invisibly — so a more specific decision here may be equal or stricter than the one above it, never looser. The agent runtime enforces that, not the button.
 - **Confirmations live in the Pinchy app.** On other channels (say, Telegram) there's no way to approve yet, so a gated tool stays blocked there — the safe default. If you want an agent to act freely on a channel, leave its tools un-gated; channel-side approval is on our list.
 
 <Aside type="note">

--- a/packages/web/e2e/odoo/odoo-permissions.spec.ts
+++ b/packages/web/e2e/odoo/odoo-permissions.spec.ts
@@ -136,7 +136,24 @@ test.describe.serial("Odoo Permission Setup", () => {
     await expect(page.getByRole("button", { name: /add model/i })).toBeVisible();
   });
 
-  test("add a model and verify checkboxes", async ({ page }) => {
+  /**
+   * The matrix cell is a three-state radiogroup since #1133 (not allowed ·
+   * ask first · allowed), so an assertion has to name WHICH state is set
+   * rather than checked/unchecked. That is stricter than what it replaced:
+   * "not checked" could not tell "not allowed" from "allowed but pausing".
+   */
+  // Exact string rather than a constructed RegExp: `new RegExp(op)` trips
+  // security/detect-non-literal-regexp, and an exact name is the stronger
+  // assertion anyway — "read Orders" must not be satisfied by a cell whose
+  // label merely contains it.
+  const cell = (page: Page, op: string, model = "Orders") =>
+    page.getByRole("radiogroup", { name: `${op} ${model}`, exact: true });
+  const expectState = (page: Page, op: string, state: RegExp) =>
+    expect(cell(page, op).getByRole("radio", { name: state })).toBeChecked();
+  const ALLOWED = /^allowed/i;
+  const NOT_ALLOWED = /^not allowed/i;
+
+  test("add a model and verify its access states", async ({ page }) => {
     await loginViaUI(page);
 
     await page.goto(`/chat/${agentId}/settings?tab=permissions`);
@@ -166,18 +183,11 @@ test.describe.serial("Odoo Permission Setup", () => {
     // Model should now appear in the table
     await expect(page.getByText("sale.order")).toBeVisible();
 
-    // At Read-only: Read checkbox should be checked
-    const readCheckbox = page.getByRole("checkbox", { name: /read orders/i });
-    await expect(readCheckbox).toBeChecked();
-
-    // Create, Write, Delete should be unchecked at Read-only level
-    const createCheckbox = page.getByRole("checkbox", { name: /create orders/i });
-    const writeCheckbox = page.getByRole("checkbox", { name: /write orders/i });
-    const deleteCheckbox = page.getByRole("checkbox", { name: /delete orders/i });
-
-    await expect(createCheckbox).not.toBeChecked();
-    await expect(writeCheckbox).not.toBeChecked();
-    await expect(deleteCheckbox).not.toBeChecked();
+    // At Read-only: read is granted and ungated, the rest not granted at all.
+    await expectState(page, "read", ALLOWED);
+    await expectState(page, "create", NOT_ALLOWED);
+    await expectState(page, "write", NOT_ALLOWED);
+    await expectState(page, "delete", NOT_ALLOWED);
   });
 
   test("change access level updates existing models", async ({ page }) => {
@@ -201,20 +211,20 @@ test.describe.serial("Odoo Permission Setup", () => {
       .first()
       .click();
 
-    // Verify only Read is checked
-    await expect(page.getByRole("checkbox", { name: /read orders/i })).toBeChecked();
-    await expect(page.getByRole("checkbox", { name: /create orders/i })).not.toBeChecked();
-    await expect(page.getByRole("checkbox", { name: /write orders/i })).not.toBeChecked();
-    await expect(page.getByRole("checkbox", { name: /delete orders/i })).not.toBeChecked();
+    // Verify only Read is granted
+    await expectState(page, "read", ALLOWED);
+    await expectState(page, "create", NOT_ALLOWED);
+    await expectState(page, "write", NOT_ALLOWED);
+    await expectState(page, "delete", NOT_ALLOWED);
 
     // Switch to "Read & Write"
     await page.getByRole("radio", { name: "Read & Write" }).click();
 
-    // Now Read, Create, Write should be checked; Delete still unchecked
-    await expect(page.getByRole("checkbox", { name: /read orders/i })).toBeChecked();
-    await expect(page.getByRole("checkbox", { name: /create orders/i })).toBeChecked();
-    await expect(page.getByRole("checkbox", { name: /write orders/i })).toBeChecked();
-    await expect(page.getByRole("checkbox", { name: /delete orders/i })).not.toBeChecked();
+    // Now Read, Create and Write are granted; Delete still is not
+    await expectState(page, "read", ALLOWED);
+    await expectState(page, "create", ALLOWED);
+    await expectState(page, "write", ALLOWED);
+    await expectState(page, "delete", NOT_ALLOWED);
   });
 
   test("remove a model", async ({ page }) => {

--- a/packages/web/src/__tests__/api/approvals.integration.test.ts
+++ b/packages/web/src/__tests__/api/approvals.integration.test.ts
@@ -647,4 +647,86 @@ describe("approval routes (integration, real DB)", () => {
       expect(await db.select().from(auditLog)).toHaveLength(0);
     });
   });
+
+  /**
+   * #1133: the policy resolves per resource, not only per tool. These run at
+   * route level because that is where the three pieces meet — the stored
+   * config, the model read out of the call, and the resolution rule. Each unit
+   * test sees only one of them.
+   *
+   * Note that every OTHER test in this file seeds `confirmTools`, the pre-#1133
+   * shape. That is deliberate and is the migration evidence AGENTS.md § "Test
+   * Migrations Against Pre-Existing Data" asks for: the suite proves an agent
+   * configured before the switch still gets gated by the new code, using the
+   * new code's own route.
+   */
+  describe("per-resource policy", () => {
+    async function seedWithConfirm(confirm: Record<string, "confirm" | "allow">) {
+      const [a] = await db
+        .insert(agents)
+        .values({
+          name: "Per-model",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          greetingMessage: "Hi",
+          ownerId: user.id,
+          pluginConfig: { "pinchy-approvals": { confirm } },
+        })
+        .returning();
+      return a;
+    }
+    const check = (agentId: string, toolName: string, params: object) =>
+      gateCheck(
+        gateReq({
+          agentId,
+          sessionKey: `agent:${agentId}:direct:${user.id}`,
+          toolName,
+          params,
+        })
+      ).then((r) => r.json());
+
+    it("exempts one model from a tool that is otherwise gated", async () => {
+      const a = await seedWithConfirm({
+        odoo_delete: "confirm",
+        "odoo_delete:note.note": "allow",
+      });
+      expect((await check(a.id, "odoo_delete", { model: "note.note", ids: [1] })).decision).toBe(
+        "allow"
+      );
+      expect((await check(a.id, "odoo_delete", { model: "account.move", ids: [1] })).decision).toBe(
+        "block"
+      );
+    });
+
+    // The rule that keeps a per-model grid from becoming an allowlist: a model
+    // nobody has ticked inherits the tool setting. If it defaulted to allow, a
+    // model added after the admin configured the agent would arrive ungated.
+    it("gates a model the admin never ticked, because it inherits the tool", async () => {
+      const a = await seedWithConfirm({
+        odoo_delete: "confirm",
+        "odoo_delete:note.note": "allow",
+      });
+      const res = await check(a.id, "odoo_delete", { model: "a.model.nobody.ticked", ids: [1] });
+      expect(res.decision).toBe("block");
+    });
+
+    it("gates a single model while leaving the tool itself open", async () => {
+      const a = await seedWithConfirm({ "odoo_write:account.move": "confirm" });
+      expect((await check(a.id, "odoo_write", { model: "res.partner", values: {} })).decision).toBe(
+        "allow"
+      );
+      expect(
+        (await check(a.id, "odoo_write", { model: "account.move", values: {} })).decision
+      ).toBe("block");
+    });
+
+    // Without the model on the card, "Delete a record in Odoo" is not a
+    // decision anyone can make — which would make the whole setting pointless
+    // for the person it exists to inform.
+    it("names the resource on the card the person reads", async () => {
+      const a = await seedWithConfirm({ odoo_delete: "confirm" });
+      const res = await check(a.id, "odoo_delete", { model: "account.move", ids: [1] });
+      expect(res.decision).toBe("block");
+      expect(res.approval.title).toContain("account.move");
+    });
+  });
 });

--- a/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
@@ -672,8 +672,35 @@ describe("AgentSettingsPermissions", () => {
           allowedPaths: [],
           integrations: [],
           webSearchConfig: {},
-          confirmTools: [],
+          confirm: {},
         },
+        false
+      );
+    });
+
+    // The read side of the #1133 storage switch, at the form. An agent whose
+    // admin ticked confirmations before the upgrade carries `confirmTools`;
+    // opening the page must show that policy rather than an empty one, because
+    // the next save persists whatever the form is holding — an empty form
+    // would silently write the policy away.
+    it("loads a pre-#1133 confirmTools policy into the form", () => {
+      const onChange = vi.fn();
+      render(
+        <AgentSettingsPermissions
+          agent={{
+            ...defaultAgent,
+            allowedTools: ["pinchy_web_search"],
+            pluginConfig: { "pinchy-approvals": { confirmTools: ["pinchy_web_search"] } },
+          }}
+          directories={defaultDirectories}
+          connections={[]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ confirm: { pinchy_web_search: "confirm" } }),
         false
       );
     });

--- a/packages/web/src/__tests__/db/schema.test.ts
+++ b/packages/web/src/__tests__/db/schema.test.ts
@@ -139,9 +139,15 @@ describe("JSON column types — compile-time contracts", () => {
     expectTypeOf<NonNullable<AgentPluginConfig["pinchy-web"]>["allowedDomains"]>().toEqualTypeOf<
       string[] | undefined
     >();
+    expectTypeOf<NonNullable<AgentPluginConfig["pinchy-approvals"]>["confirm"]>().toEqualTypeOf<
+      Record<string, "confirm" | "allow"> | undefined
+    >();
+    // Pre-#1133, kept readable so an agent nobody has saved since the upgrade
+    // keeps its policy. Optional on purpose: required would make every new
+    // config object carry a key nothing writes any more.
     expectTypeOf<
       NonNullable<AgentPluginConfig["pinchy-approvals"]>["confirmTools"]
-    >().toEqualTypeOf<string[]>();
+    >().toEqualTypeOf<string[] | undefined>();
   });
 
   it("auditLog.detail is typed AuditDetail | null (not unknown)", () => {

--- a/packages/web/src/__tests__/lib/approvals-prompt.test.ts
+++ b/packages/web/src/__tests__/lib/approvals-prompt.test.ts
@@ -76,4 +76,57 @@ describe("buildApprovalPrompt", () => {
     expect(description).not.toContain("undefined");
     expect(description).not.toContain("{}");
   });
+
+  // #1133. Once deletion can be gated per model, "Delete a record in Odoo" is
+  // not a decision anyone can make — the whole point of the setting is that
+  // an invoice and a note are different answers. The resources the gate
+  // resolved are what the card has to show.
+  it("names the resource the call acts on", () => {
+    const { title } = buildApprovalPrompt("odoo_delete", { ids: [7] }, ["account.move"]);
+    expect(title).toContain("account.move");
+  });
+
+  it("names every resource of a call that spans more than one", () => {
+    const { title } = buildApprovalPrompt("odoo_reconcile", {}, [
+      "account.move",
+      "account.payment",
+    ]);
+    expect(title).toContain("account.move");
+    expect(title).toContain("account.payment");
+  });
+
+  it("says nothing about resources when the call names none", () => {
+    const bare = buildApprovalPrompt("email_send", { to: "ada@example.com" });
+    const empty = buildApprovalPrompt("email_send", { to: "ada@example.com" }, []);
+    expect(empty.title).toBe(bare.title);
+    expect(empty.title).not.toContain("—");
+  });
+
+  // A ref the model garbled resolves to `null`. Printing that would put the
+  // word "null" on a security prompt; the honest rendering is to leave the
+  // resource unstated and let the tool name carry the meaning.
+  it("does not print an unnamed resource", () => {
+    const { title } = buildApprovalPrompt("odoo_confirm_order", {}, [null]);
+    expect(title.toLowerCase()).not.toContain("null");
+  });
+
+  it("keeps the title inside the cap even with many resources", () => {
+    const { title } = buildApprovalPrompt(
+      "odoo_write",
+      {},
+      Array.from({ length: 20 }, (_, i) => `a.very.long.model.name.number.${i}`)
+    );
+    expect(title.length).toBeLessThanOrEqual(APPROVAL_TITLE_MAX);
+  });
+
+  // An opaque ref is 200+ characters of base64 and says nothing to a human.
+  // Left in the summary it also eats the entire 256-character description,
+  // pushing out the arguments that carry the meaning.
+  it("does not fill the description with an opaque ref token", () => {
+    const ref = `pinchy_ref:v1:${"A".repeat(300)}`;
+    const { description } = buildApprovalPrompt("odoo_confirm_order", { target: ref }, [
+      "sale.order",
+    ]);
+    expect(description).not.toContain("AAAA");
+  });
 });

--- a/packages/web/src/__tests__/lib/domain-validation.test.ts
+++ b/packages/web/src/__tests__/lib/domain-validation.test.ts
@@ -221,6 +221,45 @@ describe("pluginConfigSchema — pinchy-approvals", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a confirm map, including a per-resource key", () => {
+    const result = pluginConfigSchema.safeParse({
+      "pinchy-approvals": {
+        confirm: { odoo_delete: "confirm", "odoo_delete:note.note": "allow" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty confirm map", () => {
+    const result = pluginConfigSchema.safeParse({ "pinchy-approvals": { confirm: {} } });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a confirm value that is neither confirm nor allow", () => {
+    const result = pluginConfigSchema.safeParse({
+      "pinchy-approvals": { confirm: { odoo_delete: "off" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // The write side of the #1133 storage switch. `.strict()` means a config the
+  // schema no longer knows is REJECTED, not ignored — so an agent configured
+  // before the switch would fail its next save with a validation error until
+  // someone re-ticked its policy by hand.
+  it("still accepts a pre-#1133 config that carries only confirmTools", () => {
+    const result = pluginConfigSchema.safeParse({
+      "pinchy-approvals": { confirmTools: ["odoo_write"] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an agent mid-migration carrying both shapes", () => {
+    const result = pluginConfigSchema.safeParse({
+      "pinchy-approvals": { confirm: { odoo_write: "confirm" }, confirmTools: ["odoo_write"] },
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects unknown fields in pinchy-approvals config", () => {
     const result = pluginConfigSchema.safeParse({
       "pinchy-approvals": { confirmTools: [], evil_field: "x" },

--- a/packages/web/src/__tests__/lib/odoo-operation-tools.test.ts
+++ b/packages/web/src/__tests__/lib/odoo-operation-tools.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  ODOO_OPERATION_TOOLS,
+  ODOO_MODEL_AGNOSTIC_TOOLS,
+  getOdooTools,
+  odooToolsForOperation,
+} from "@/lib/tool-registry";
+
+/**
+ * The Odoo permission matrix is (model × read|create|write|delete). #1133 gives
+ * each cell a third state — "ask" — which has to be stored as a confirmation
+ * key per TOOL (`odoo_delete:account.move`), because that is what the gate
+ * matches on. So a cell needs to know which tools it speaks for.
+ *
+ * That mapping is the one hand-maintained list this feature could not avoid,
+ * and AGENTS.md is unambiguous about what happens to those: the lists with a
+ * guard stay correct, the ones without drift. The failure here is quiet in the
+ * dangerous direction — a new Odoo tool nobody classified is a tool the "ask"
+ * state cannot reach, so an admin who set a cell to "ask" gets an unconfirmed
+ * call and no indication that anything is missing.
+ */
+describe("Odoo operation → tool mapping", () => {
+  it("classifies every Odoo tool exactly once", () => {
+    const classified = new Set([
+      ...Object.values(ODOO_OPERATION_TOOLS).flat(),
+      ...ODOO_MODEL_AGNOSTIC_TOOLS,
+    ]);
+    const unclassified = getOdooTools()
+      .filter((t) => !t.deprecated)
+      .map((t) => t.id)
+      .filter((id) => !classified.has(id));
+
+    expect(
+      unclassified,
+      `Odoo tools with no operation: ${unclassified.join(", ")}. Add each to ` +
+        `ODOO_OPERATION_TOOLS (it acts on a model) or ODOO_MODEL_AGNOSTIC_TOOLS ` +
+        `(it does not), or the per-model "ask" state cannot reach it.`
+    ).toEqual([]);
+  });
+
+  it("puts no tool in two operations", () => {
+    const all = Object.values(ODOO_OPERATION_TOOLS).flat();
+    expect(all).toHaveLength(new Set(all).size);
+  });
+
+  it("never classifies a model-agnostic tool as an operation too", () => {
+    const ops = new Set(Object.values(ODOO_OPERATION_TOOLS).flat());
+    expect(ODOO_MODEL_AGNOSTIC_TOOLS.filter((id) => ops.has(id))).toEqual([]);
+  });
+
+  // The record-action tools (odoo_confirm_order, odoo_validate_picking, …) all
+  // mutate an existing record. Filing them anywhere but `write` would put them
+  // under a cell an admin never associates with them.
+  it("files the record-action tools under write", () => {
+    expect(odooToolsForOperation("write")).toContain("odoo_confirm_order");
+    expect(odooToolsForOperation("write")).toContain("odoo_reconcile");
+    expect(odooToolsForOperation("write")).toContain("odoo_validate_picking");
+  });
+
+  it("keeps create, write and delete apart", () => {
+    expect(odooToolsForOperation("create")).toEqual(["odoo_create"]);
+    expect(odooToolsForOperation("delete")).toEqual(["odoo_delete"]);
+    expect(odooToolsForOperation("write")).not.toContain("odoo_create");
+    expect(odooToolsForOperation("write")).not.toContain("odoo_delete");
+  });
+
+  // odoo_list_models / odoo_describe_model answer questions about the schema
+  // itself, so there is no model row they belong to.
+  it("treats the schema tools as model-agnostic", () => {
+    expect(ODOO_MODEL_AGNOSTIC_TOOLS).toContain("odoo_list_models");
+    expect(ODOO_MODEL_AGNOSTIC_TOOLS).toContain("odoo_describe_model");
+  });
+
+  it("files the reading tools under read", () => {
+    expect(odooToolsForOperation("read")).toContain("odoo_read");
+    expect(odooToolsForOperation("read")).toContain("odoo_count");
+    expect(odooToolsForOperation("read")).toContain("odoo_aggregate");
+  });
+});

--- a/packages/web/src/app/api/internal/approvals/gate-check/route.ts
+++ b/packages/web/src/app/api/internal/approvals/gate-check/route.ts
@@ -7,11 +7,21 @@ import { decideGate } from "@/lib/approvals/service";
 import { computeArgsDigest } from "@/lib/approvals/digest";
 import { summarizeArgs } from "@/lib/approvals/summary";
 import { buildApprovalPrompt } from "@/lib/approvals/prompt";
-import { getConfirmTools } from "@/lib/approvals/policy";
+import { resolveConfirmation, toolIsConfigured } from "@/lib/approvals/policy";
+import { collectCallModels } from "@/lib/approvals/call-models";
+import { readPluginSecret } from "@/lib/plugin-secrets-source";
 import { appendAuditLog, type AuditLogEntry } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { db } from "@/db";
 import { agents, users } from "@/db/schema";
+
+/**
+ * The AES key the opaque `_pinchy_ref` tokens are encrypted under. Pinchy
+ * generates it (`collectPluginSecrets`) and materialises it into secrets.json
+ * for the OC-side plugin, so reading it back here decodes a ref without any
+ * round trip — which is how a ref-based tool call names the model it touches.
+ */
+const REF_TOKEN_KEY = "pinchy-odoo:ref-token-key";
 
 /**
  * The pinchy-approvals gate calls this for every tool it has decided is gated.
@@ -65,7 +75,16 @@ export async function POST(request: NextRequest) {
     .from(agents)
     .where(eq(agents.id, agentId))
     .limit(1);
-  if (!agent || !getConfirmTools(agent.pluginConfig).includes(toolName)) {
+  if (!agent || !toolIsConfigured(agent.pluginConfig, toolName)) {
+    return NextResponse.json({ decision: "allow" });
+  }
+
+  // Which records this call touches, so a policy can be set per resource and
+  // not only per tool (#1133). Only reached for a tool the policy mentions —
+  // reading the ref key is a second settings query, and the answer for almost
+  // every tool call is already decided above.
+  const resources = collectCallModels(params, await readPluginSecret(REF_TOKEN_KEY));
+  if (resolveConfirmation(agent.pluginConfig, toolName, resources) === "allow") {
     return NextResponse.json({ decision: "allow" });
   }
 
@@ -175,6 +194,6 @@ export async function POST(request: NextRequest) {
     //
     // The plugin keys on the presence of this field to decide whether to pause
     // the run, so it is absent from every non-blocking answer.
-    approval: buildApprovalPrompt(toolName, params),
+    approval: buildApprovalPrompt(toolName, params, resources),
   });
 }

--- a/packages/web/src/components/__tests__/access-cell.test.tsx
+++ b/packages/web/src/components/__tests__/access-cell.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AccessCell } from "@/components/access-cell";
+
+describe("AccessCell", () => {
+  it("exposes exactly one selected state", () => {
+    render(<AccessCell value="ask" onChange={() => {}} label="delete account.move" />);
+    const checked = screen.getAllByRole("radio", { checked: true });
+    expect(checked).toHaveLength(1);
+    expect(checked[0]).toHaveAccessibleName(/ask first/i);
+  });
+
+  // The reason this is a radiogroup and not a tri-state checkbox: `mixed` is
+  // standardised as "partially checked" and reads as system-set, so reusing it
+  // for "needs approval" would break a convention on a security setting.
+  it("is a radiogroup, not a mixed checkbox", () => {
+    render(<AccessCell value="off" onChange={() => {}} label="delete account.move" />);
+    expect(screen.getByRole("radiogroup")).toHaveAccessibleName("delete account.move");
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("reports the state the user picked", async () => {
+    const onChange = vi.fn();
+    render(<AccessCell value="allow" onChange={onChange} label="write res.partner" />);
+    await userEvent.click(screen.getByRole("radio", { name: /ask first/i }));
+    expect(onChange).toHaveBeenCalledWith("ask");
+  });
+
+  it("moves between states with the arrow keys", async () => {
+    const onChange = vi.fn();
+    render(<AccessCell value="off" onChange={onChange} label="read note.note" />);
+    screen.getByRole("radio", { checked: true }).focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenCalledWith("ask");
+  });
+
+  it("does not fire when disabled", async () => {
+    const onChange = vi.fn();
+    render(<AccessCell value="off" onChange={onChange} label="read note.note" disabled />);
+    await userEvent.click(screen.getByRole("radio", { name: /allowed —/i }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/__tests__/approval-confirmation-section.test.tsx
+++ b/packages/web/src/components/__tests__/approval-confirmation-section.test.tsx
@@ -2,42 +2,68 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ApprovalConfirmationSection } from "../approval-confirmation-section";
+import type { ConfirmMap } from "@/lib/approvals/policy";
 
 // pinchy_web_search is powerful; odoo_list_models is safe (read-only).
 const ALLOWED = ["pinchy_web_search", "odoo_list_models"];
 
 describe("ApprovalConfirmationSection", () => {
-  it("renders a checkbox per allowed tool, pre-checked from confirmTools", () => {
+  it("renders a checkbox per allowed tool, pre-checked from the policy", () => {
     render(
       <ApprovalConfirmationSection
         allowedTools={ALLOWED}
-        confirmTools={["pinchy_web_search"]}
+        confirm={{ pinchy_web_search: "confirm" }}
         onChange={() => {}}
       />
     );
     expect(screen.getByRole("checkbox", { name: /Search the web/i })).toBeChecked();
   });
 
-  it("toggles a tool into confirmTools", () => {
+  it("toggles a tool into the policy", () => {
+    const onChange = vi.fn();
+    render(<ApprovalConfirmationSection allowedTools={ALLOWED} confirm={{}} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText(/Search the web/i));
+    expect(onChange).toHaveBeenCalledWith({ pinchy_web_search: "confirm" });
+  });
+
+  it("removes the key when a tool is unticked", () => {
     const onChange = vi.fn();
     render(
-      <ApprovalConfirmationSection allowedTools={ALLOWED} confirmTools={[]} onChange={onChange} />
+      <ApprovalConfirmationSection
+        allowedTools={ALLOWED}
+        confirm={{ pinchy_web_search: "confirm" }}
+        onChange={onChange}
+      />
     );
     fireEvent.click(screen.getByLabelText(/Search the web/i));
-    expect(onChange).toHaveBeenCalledWith(["pinchy_web_search"]);
+    expect(onChange).toHaveBeenCalledWith({});
   });
 
   it("'Use recommended' selects only the powerful tools", () => {
     const onChange = vi.fn();
+    render(<ApprovalConfirmationSection allowedTools={ALLOWED} confirm={{}} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /use recommended/i }));
+    expect(onChange).toHaveBeenCalledWith({ pinchy_web_search: "confirm" });
+  });
+
+  // A per-model exception is a decision someone made about a specific record
+  // type, in a different part of the page. A one-click default for the TOOL
+  // level has no business discarding it.
+  it("'Use recommended' leaves per-model exceptions alone", () => {
+    const onChange = vi.fn();
+    const confirm: ConfirmMap = { "odoo_delete:note.note": "allow" };
     render(
-      <ApprovalConfirmationSection allowedTools={ALLOWED} confirmTools={[]} onChange={onChange} />
+      <ApprovalConfirmationSection allowedTools={ALLOWED} confirm={confirm} onChange={onChange} />
     );
     fireEvent.click(screen.getByRole("button", { name: /use recommended/i }));
-    expect(onChange).toHaveBeenCalledWith(["pinchy_web_search"]);
+    expect(onChange).toHaveBeenCalledWith({
+      pinchy_web_search: "confirm",
+      "odoo_delete:note.note": "allow",
+    });
   });
 
   it("shows a hint when the agent has no allowed tools", () => {
-    render(<ApprovalConfirmationSection allowedTools={[]} confirmTools={[]} onChange={() => {}} />);
+    render(<ApprovalConfirmationSection allowedTools={[]} confirm={{}} onChange={() => {}} />);
     expect(screen.getByText(/choose which ones require confirmation/i)).toBeInTheDocument();
   });
 
@@ -54,14 +80,14 @@ describe("ApprovalConfirmationSection", () => {
     render(
       <ApprovalConfirmationSection
         allowedTools={["pinchy_save_user_context"]}
-        confirmTools={[]}
+        confirm={{}}
         onChange={onChange}
       />
     );
     const box = screen.getByRole("checkbox", { name: /pinchy_save_user_context/i });
     expect(box).toBeInTheDocument();
     fireEvent.click(box);
-    expect(onChange).toHaveBeenCalledWith(["pinchy_save_user_context"]);
+    expect(onChange).toHaveBeenCalledWith({ pinchy_save_user_context: "confirm" });
   });
 
   it("keeps a registry-less tool out of 'Use recommended'", () => {
@@ -72,11 +98,11 @@ describe("ApprovalConfirmationSection", () => {
     render(
       <ApprovalConfirmationSection
         allowedTools={["pinchy_web_search", "pinchy_save_user_context"]}
-        confirmTools={[]}
+        confirm={{}}
         onChange={onChange}
       />
     );
     fireEvent.click(screen.getByRole("button", { name: /use recommended/i }));
-    expect(onChange).toHaveBeenCalledWith(["pinchy_web_search"]);
+    expect(onChange).toHaveBeenCalledWith({ pinchy_web_search: "confirm" });
   });
 });

--- a/packages/web/src/components/access-cell.tsx
+++ b/packages/web/src/components/access-cell.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Check, Ban, HelpCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type AccessState = "off" | "ask" | "allow";
+
+const STATES: Array<{ value: AccessState; icon: typeof Check; title: string }> = [
+  { value: "off", icon: Ban, title: "Not allowed" },
+  { value: "ask", icon: HelpCircle, title: "Ask first — the agent pauses for a confirmation" },
+  { value: "allow", icon: Check, title: "Allowed — the agent acts on its own" },
+];
+
+interface AccessCellProps {
+  value: AccessState;
+  onChange: (next: AccessState) => void;
+  /** What this cell governs, e.g. "delete account.move". Read by screen readers. */
+  label: string;
+  disabled?: boolean;
+}
+
+/**
+ * One cell of a permission matrix: not allowed · ask first · allowed.
+ *
+ * Deliberately NOT a tri-state checkbox. `aria-checked="mixed"` is standardised
+ * with a different meaning — "partially checked", a group whose children differ
+ * — and it reads as system-set, because users cannot click into it. Reusing
+ * that dash for "needs approval" would break a convention rather than adopt
+ * one, and would do it on a security setting.
+ *
+ * It is a radiogroup instead, which is what this actually is: exactly one of
+ * three. That also gives arrow-key navigation for free, where three separate
+ * buttons would give none.
+ */
+export function AccessCell({ value, onChange, label, disabled }: AccessCellProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      className={cn("inline-flex rounded-md border", disabled && "opacity-50")}
+    >
+      {STATES.map(({ value: state, icon: Icon, title }) => {
+        const selected = value === state;
+        return (
+          <button
+            key={state}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={title}
+            title={title}
+            disabled={disabled}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => onChange(state)}
+            onKeyDown={(e) => {
+              if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+              e.preventDefault();
+              const i = STATES.findIndex((s) => s.value === value);
+              const next = e.key === "ArrowRight" ? i + 1 : i - 1;
+              const wrapped = (next + STATES.length) % STATES.length;
+              onChange(STATES[wrapped].value);
+            }}
+            className={cn(
+              "flex h-7 w-7 items-center justify-center first:rounded-l-[5px] last:rounded-r-[5px]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              selected
+                ? state === "ask"
+                  ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                  : state === "allow"
+                    ? "bg-primary/10 text-primary"
+                    : "bg-muted text-muted-foreground"
+                : "text-muted-foreground/40 hover:text-muted-foreground"
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -92,7 +92,7 @@ interface PermissionsValues {
     permissions: Array<{ model: string; operation: string }>;
   }>;
   webSearchConfig?: AgentPluginConfig["pinchy-web"];
-  confirmTools?: string[];
+  confirm?: Record<string, "confirm" | "allow">;
 }
 
 interface AccessValues {
@@ -354,7 +354,10 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
           ...agent?.pluginConfig,
           "pinchy-files": { allowed_paths: permissionsDraft.current.allowedPaths },
           "pinchy-web": permissionsDraft.current.webSearchConfig,
-          "pinchy-approvals": { confirmTools: permissionsDraft.current.confirmTools ?? [] },
+          // Writes only the new shape, never `confirmTools`. A saved agent is
+          // therefore migrated for good, and the read-side fallback in
+          // getConfirmMap only ever covers agents nobody has saved yet.
+          "pinchy-approvals": { confirm: permissionsDraft.current.confirm ?? {} },
         };
 
         // Save each active integration separately, or clear all if none

--- a/packages/web/src/components/agent-settings-permissions.tsx
+++ b/packages/web/src/components/agent-settings-permissions.tsx
@@ -14,6 +14,7 @@ import { EmailPermissionSection } from "@/components/email-permission-section";
 import { WebSearchPermissionSection } from "@/components/web-search-permission-section";
 import { KnowledgeReindexSection } from "@/components/knowledge-reindex-section";
 import { ApprovalConfirmationSection } from "@/components/approval-confirmation-section";
+import { getConfirmMap, type ConfirmMap } from "@/lib/approvals/policy";
 import type { Connection as OdooConnection } from "@/hooks/use-odoo-permissions";
 import type { AgentPluginConfig } from "@/db/schema";
 import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
@@ -26,7 +27,34 @@ export interface PermissionsValues {
     permissions: Array<{ model: string; operation: string }>;
   }>;
   webSearchConfig?: AgentPluginConfig["pinchy-web"];
-  confirmTools: string[];
+  confirm: ConfirmMap;
+}
+
+/**
+ * Key-by-key, because a confirm map is written from two places (the tool
+ * section and the Odoo matrix) and neither controls insertion order — so
+ * comparing serialized JSON would report a form as dirty for having reordered.
+ */
+function sameConfirmMap(a: ConfirmMap, b: ConfirmMap): boolean {
+  const keys = Object.keys(a);
+  return keys.length === Object.keys(b).length && keys.every((k) => a[k] === b[k]);
+}
+
+/**
+ * Drop entries for tools the agent may no longer call. A stale key is not
+ * merely untidy: revoke a tool, grant it again later, and a confirmation
+ * setting nobody can see on the page would come back with it.
+ *
+ * Resource keys (`odoo_delete:account.move`) are matched on their tool half,
+ * so removing a MODEL from the matrix leaves its exception in place — which is
+ * deliberate. Models come and go from that grid while the agent's tools stay,
+ * and an exception that survives a model being re-added is the kinder answer.
+ */
+function pruneConfirmMap(confirm: ConfirmMap, allowedTools: string[]): ConfirmMap {
+  const allowed = new Set(allowedTools);
+  return Object.fromEntries(
+    Object.entries(confirm).filter(([key]) => allowed.has(key.split(":")[0]))
+  );
 }
 
 interface Connection {
@@ -99,14 +127,16 @@ export function AgentSettingsPermissions({
   const [webSearchConfig, setWebSearchConfig] = useState<AgentPluginConfig["pinchy-web"]>(
     agent.pluginConfig?.["pinchy-web"] ?? {}
   );
-  const [confirmTools, setConfirmTools] = useState<string[]>(
-    agent.pluginConfig?.["pinchy-approvals"]?.confirmTools ?? []
-  );
+  // Normalized through getConfirmMap, which reads a pre-#1133 `confirmTools`
+  // list when the agent has not been saved since the upgrade. Without that the
+  // form would open showing no confirmations on an agent that has them, and
+  // saving would then persist that as the truth.
+  const [confirm, setConfirm] = useState<ConfirmMap>(() => getConfirmMap(agent.pluginConfig));
 
   const initialKbToolsRef = useRef(initialKbTools);
   const initialAllowedPaths = useRef(agent.pluginConfig?.["pinchy-files"]?.allowed_paths ?? []);
   const initialWebSearchConfig = useRef(agent.pluginConfig?.["pinchy-web"] ?? {});
-  const initialConfirmTools = useRef(agent.pluginConfig?.["pinchy-approvals"]?.confirmTools ?? []);
+  const initialConfirm = useRef<ConfirmMap>(getConfirmMap(agent.pluginConfig));
 
   // Re-sync the "initial" snapshot when the agent prop changes (the parent
   // refetches the agent after a successful save, so the prop now reflects the
@@ -121,7 +151,7 @@ export function AgentSettingsPermissions({
     );
     initialAllowedPaths.current = agent.pluginConfig?.["pinchy-files"]?.allowed_paths ?? [];
     initialWebSearchConfig.current = agent.pluginConfig?.["pinchy-web"] ?? {};
-    initialConfirmTools.current = agent.pluginConfig?.["pinchy-approvals"]?.confirmTools ?? [];
+    initialConfirm.current = getConfirmMap(agent.pluginConfig);
   }, [agent.allowedTools, agent.pluginConfig]);
 
   const hasWebToolChecked = webTools.some((tool) => allowedKbTools.includes(tool.id));
@@ -210,10 +240,8 @@ export function AgentSettingsPermissions({
         JSON.stringify([...initialAllowedPaths.current].sort());
     const webConfigDirty =
       JSON.stringify(webSearchConfig) !== JSON.stringify(initialWebSearchConfig.current);
-    const confirmToolsDirty =
-      JSON.stringify([...confirmTools].sort()) !==
-      JSON.stringify([...initialConfirmTools.current].sort());
-    const isDirty = kbDirty || odooIsDirty || emailIsDirty || webConfigDirty || confirmToolsDirty;
+    const confirmDirty = !sameConfirmMap(confirm, initialConfirm.current);
+    const isDirty = kbDirty || odooIsDirty || emailIsDirty || webConfigDirty || confirmDirty;
     // Collect all active integrations
     const integrations: Array<{
       connectionId: string;
@@ -227,7 +255,7 @@ export function AgentSettingsPermissions({
         allowedPaths,
         integrations,
         webSearchConfig,
-        confirmTools: confirmTools.filter((id) => allAllowedTools.includes(id)),
+        confirm: pruneConfirmMap(confirm, allAllowedTools),
       },
       isDirty
     );
@@ -239,7 +267,7 @@ export function AgentSettingsPermissions({
     emailIntegration,
     emailIsDirty,
     webSearchConfig,
-    confirmTools,
+    confirm,
     onChange,
     computeAllowedTools,
   ]);
@@ -384,6 +412,8 @@ export function AgentSettingsPermissions({
             agentId={agent.id}
             connections={odooConnections}
             onChange={handleOdooChange}
+            confirm={confirm}
+            onConfirmChange={setConfirm}
           />
         </section>
       )}
@@ -407,8 +437,8 @@ export function AgentSettingsPermissions({
           <h3 className="text-lg font-semibold">Require confirmation before</h3>
           <ApprovalConfirmationSection
             allowedTools={computeAllowedTools(allowedKbTools, odooIntegration, emailIntegration)}
-            confirmTools={confirmTools}
-            onChange={setConfirmTools}
+            confirm={confirm}
+            onChange={setConfirm}
           />
         </section>
       )}

--- a/packages/web/src/components/approval-confirmation-section.tsx
+++ b/packages/web/src/components/approval-confirmation-section.tsx
@@ -4,24 +4,30 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { TOOL_REGISTRY } from "@/lib/tool-registry";
-import { defaultConfirmTools } from "@/lib/approvals/policy";
+import { defaultConfirmMap, type ConfirmMap } from "@/lib/approvals/policy";
 
 interface ApprovalConfirmationSectionProps {
   /** The agent's currently-allowed tool ids. */
   allowedTools: string[];
-  /** Tool ids that require confirmation. */
-  confirmTools: string[];
-  onChange: (next: string[]) => void;
+  /** The agent's confirmation policy, keyed by tool (and optionally resource). */
+  confirm: ConfirmMap;
+  onChange: (next: ConfirmMap) => void;
 }
 
 /**
  * Admin control for #124 Tier 2: pick which of the agent's tools pause and ask
  * the acting user to confirm before running. "Use recommended" pre-selects the
  * powerful (write/side-effecting) tools so the common case is one click.
+ *
+ * This is the TOOL level. Per-model exceptions for Odoo ("ask before deleting
+ * an invoice, just do it for a note", #1133) are set in the Odoo permission
+ * matrix, where the model rows already are — a second model grid here would
+ * duplicate that table and let the two disagree. What is set here is what an
+ * untouched model cell inherits.
  */
 export function ApprovalConfirmationSection({
   allowedTools,
-  confirmTools,
+  confirm,
   onChange,
 }: ApprovalConfirmationSectionProps) {
   // Every tool the agent may call is offerable here, whether or not it is in
@@ -48,13 +54,27 @@ export function ApprovalConfirmationSection({
   }
 
   const toggle = (id: string, checked: boolean) => {
-    const next = new Set(confirmTools);
-    if (checked) next.add(id);
-    else next.delete(id);
-    onChange([...next]);
+    const next = { ...confirm };
+    if (checked) next[id] = "confirm";
+    // Deleting rather than writing "allow": an unset tool key is the absence of
+    // a policy, which is what an admin means by unticking. Writing "allow"
+    // would look identical here and behave identically at the gate, but it
+    // would also be an explicit decision that a later "Use recommended" has to
+    // reason about.
+    else delete next[id];
+    onChange(next);
   };
 
-  const recommended = defaultConfirmTools(allowedTools);
+  // The recommended set replaces the tool-level entries and leaves per-model
+  // exceptions alone: those are decisions someone made about a specific record
+  // type, and a one-click default has no business discarding them.
+  const recommended = defaultConfirmMap(allowedTools);
+  const applyRecommended = () => {
+    const exceptions = Object.fromEntries(
+      Object.entries(confirm).filter(([key]) => key.includes(":"))
+    );
+    onChange({ ...recommended, ...exceptions });
+  };
 
   return (
     <div className="space-y-4">
@@ -66,8 +86,8 @@ export function ApprovalConfirmationSection({
           type="button"
           variant="outline"
           size="sm"
-          onClick={() => onChange(recommended)}
-          disabled={recommended.length === 0}
+          onClick={applyRecommended}
+          disabled={Object.keys(recommended).length === 0}
         >
           Use recommended
         </Button>
@@ -77,7 +97,7 @@ export function ApprovalConfirmationSection({
           <div key={tool.id} className="flex items-center gap-2">
             <Checkbox
               id={`confirm-${tool.id}`}
-              checked={confirmTools.includes(tool.id)}
+              checked={confirm[tool.id] === "confirm"}
               onCheckedChange={(checked) => toggle(tool.id, checked === true)}
             />
             <Label htmlFor={`confirm-${tool.id}`} className="font-normal">

--- a/packages/web/src/components/odoo-permission-section.tsx
+++ b/packages/web/src/components/odoo-permission-section.tsx
@@ -10,8 +10,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
+import { AccessCell, type AccessState } from "@/components/access-cell";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
@@ -30,6 +30,8 @@ import {
   type Connection,
 } from "@/hooks/use-odoo-permissions";
 import type { OdooAccessLevel } from "@/lib/tool-registry";
+import type { ConfirmMap } from "@/lib/approvals/policy";
+import { cellStateFor, applyCellState } from "@/lib/approvals/matrix-cell";
 import { MODEL_CATEGORIES } from "@/lib/integrations/odoo-sync";
 
 const OPERATIONS: readonly Operation[] = ["read", "create", "write", "delete"];
@@ -76,12 +78,22 @@ interface OdooPermissionSectionProps {
     } | null,
     isDirty: boolean
   ) => void;
+  /**
+   * The agent's confirmation policy (#1133). The matrix owns the per-model
+   * half of it: a cell set to "ask" writes `<tool>:<model>` keys for every
+   * tool that column speaks for. The tool level itself is set in the
+   * confirmation section, and is what an untouched cell inherits.
+   */
+  confirm: ConfirmMap;
+  onConfirmChange: (next: ConfirmMap) => void;
 }
 
 export function OdooPermissionSection({
   agentId,
   connections,
   onChange,
+  confirm,
+  onConfirmChange,
 }: OdooPermissionSectionProps) {
   const {
     connectionId,
@@ -101,6 +113,17 @@ export function OdooPermissionSection({
   } = useOdooPermissions(agentId, connections);
 
   const [addModelOpen, setAddModelOpen] = useState(false);
+
+  const cellState = (model: string, op: Operation, granted: boolean) =>
+    cellStateFor(confirm, model, op, granted);
+
+  const setCellState = (model: string, op: Operation, granted: boolean, next: AccessState) => {
+    // The grant and the confirmation are two stores; the cell is one control.
+    // Flip the grant only when the off-ness actually changed, so moving between
+    // ask and allow does not revoke the permission underneath.
+    if ((next === "off") === granted) toggleOperation(model, op);
+    if (next !== "off") onConfirmChange(applyCellState(confirm, model, op, next));
+  };
 
   // Stable ref for onChange to avoid infinite re-render loops
   const onChangeRef = useRef(onChange);
@@ -212,7 +235,7 @@ export function OdooPermissionSection({
               {addedModels.size > 0 && (
                 <div className="rounded-md border">
                   {/* Header */}
-                  <div className="grid grid-cols-[1fr_60px_60px_60px_60px_40px] gap-2 border-b px-4 py-2 text-sm font-medium text-muted-foreground">
+                  <div className="grid grid-cols-[1fr_88px_88px_88px_88px_40px] gap-2 border-b px-4 py-2 text-sm font-medium text-muted-foreground">
                     <span>Model</span>
                     <span className="text-center">Read</span>
                     <span className="text-center">Create</span>
@@ -237,7 +260,7 @@ export function OdooPermissionSection({
                       return (
                         <div
                           key={modelId}
-                          className="grid grid-cols-[1fr_60px_60px_60px_60px_40px] gap-2 border-b px-4 py-2 last:border-b-0 items-center"
+                          className="grid grid-cols-[1fr_88px_88px_88px_88px_40px] gap-2 border-b px-4 py-2 last:border-b-0 items-center"
                         >
                           <div>
                             <div className="text-sm font-medium">
@@ -252,12 +275,12 @@ export function OdooPermissionSection({
                           </div>
                           {OPERATIONS.map((op) => {
                             const restricted = !modelAccess[op];
-                            const checkbox = (
-                              <Checkbox
-                                checked={ops[op]}
-                                onCheckedChange={() => toggleOperation(modelId, op)}
+                            const cell = (
+                              <AccessCell
+                                value={cellState(modelId, op, ops[op])}
+                                onChange={(next) => setCellState(modelId, op, ops[op], next)}
                                 disabled={restricted}
-                                aria-label={`${op} ${displayName}`}
+                                label={`${op} ${displayName}`}
                               />
                             );
 
@@ -267,7 +290,7 @@ export function OdooPermissionSection({
                                   <TooltipProvider>
                                     <Tooltip>
                                       <TooltipTrigger asChild>
-                                        <span>{checkbox}</span>
+                                        <span>{cell}</span>
                                       </TooltipTrigger>
                                       <TooltipContent>
                                         Not available — Odoo user lacks this permission
@@ -275,7 +298,7 @@ export function OdooPermissionSection({
                                     </Tooltip>
                                   </TooltipProvider>
                                 ) : (
-                                  checkbox
+                                  cell
                                 )}
                               </div>
                             );

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -83,7 +83,18 @@ export type AgentPluginConfig = {
    * the gate (pinchy-approvals) enforces it server-side.
    */
   "pinchy-approvals"?: {
-    confirmTools: string[];
+    /**
+     * Per tool, optionally per resource: `"odoo_delete"` covers the tool,
+     * `"odoo_delete:account.move"` is an exception for one model (#1133).
+     * See `lib/approvals/policy.ts` for how the two resolve.
+     */
+    confirm?: Record<string, "confirm" | "allow">;
+    /**
+     * Pre-#1133 shape, still READ so an agent configured before the switch
+     * keeps its policy (`getConfirmMap`). Nothing writes it any more; an agent
+     * converges to `confirm` the first time it is saved.
+     */
+    confirmTools?: string[];
   };
 };
 

--- a/packages/web/src/lib/approvals/call-models.test.ts
+++ b/packages/web/src/lib/approvals/call-models.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { collectCallModels } from "./call-models";
+// The pinchy-odoo encoder, imported across the package boundary on purpose:
+// this file is the drift guard for the ref format. `call-models.ts` reimplements
+// the decode half (the plugin's copy reads a container path for its key, which
+// pinchy-web has no business touching), and a textual comparison would not
+// notice a changed IV length or cipher. A round trip does, immediately.
+import { encodeRef, _resetKeyCacheForTest } from "../../../../plugins/pinchy-odoo/integration-ref";
+
+const KEY = "a".repeat(64);
+
+beforeAll(() => {
+  process.env.PINCHY_REF_TOKEN_KEY = KEY;
+  _resetKeyCacheForTest();
+});
+
+const ref = (model: string, id = 42) =>
+  encodeRef({ integrationType: "odoo", connectionId: "c1", model, id, label: `${model}/${id}` });
+
+describe("collectCallModels", () => {
+  it("reads an explicit model parameter", () => {
+    expect(collectCallModels({ model: "account.move", ids: [1] }, KEY)).toEqual(["account.move"]);
+  });
+
+  it("returns nothing for a call that names no resource", () => {
+    expect(collectCallModels({ to: "ada@example.com" }, KEY)).toEqual([]);
+    expect(collectCallModels({}, KEY)).toEqual([]);
+    expect(collectCallModels(undefined, KEY)).toEqual([]);
+  });
+
+  it("reads the model out of an opaque ref", () => {
+    expect(collectCallModels({ target: ref("sale.order") }, KEY)).toEqual(["sale.order"]);
+  });
+
+  // odoo_reconcile takes two refs and touches both models. Reading only the
+  // first would let a grant for the payment satisfy a gated invoice.
+  it("reads every ref in a multi-ref call", () => {
+    const params = { moveRef: ref("account.move"), counterpartRef: ref("account.payment") };
+    expect(collectCallModels(params, KEY).sort()).toEqual(["account.move", "account.payment"]);
+  });
+
+  it("finds refs nested in objects and arrays", () => {
+    const params = {
+      batch: [{ target: ref("stock.picking") }],
+      meta: { other: ref("mrp.production") },
+    };
+    expect(collectCallModels(params, KEY).sort()).toEqual(["mrp.production", "stock.picking"]);
+  });
+
+  // A model garbles a ref often enough that pinchy-odoo has a dedicated error
+  // class for it. The gate must not read "no model in play" out of that — the
+  // call still touches SOMETHING. `null` is a resource we cannot name, which
+  // `resolveConfirmation` resolves to the tool-level setting rather than allow.
+  it("reports an undecodable ref as an unnamed resource, not as none", () => {
+    expect(collectCallModels({ target: "pinchy_ref:v1:garbled" }, KEY)).toEqual([null]);
+  });
+
+  it("reports every resource when only some refs decode", () => {
+    const params = { a: ref("account.move"), b: "pinchy_ref:v1:garbled" };
+    expect(collectCallModels(params, KEY)).toEqual(["account.move", null]);
+  });
+
+  // Not a ref, not a model — a plain string must not be mistaken for either.
+  it("ignores strings that are not refs", () => {
+    expect(collectCallModels({ note: "pinchy_ref is a thing we use" }, KEY)).toEqual([]);
+  });
+
+  it("reports refs as unnamed when no key is configured", () => {
+    expect(collectCallModels({ target: ref("sale.order") }, null)).toEqual([null]);
+  });
+
+  it("combines an explicit model with a ref in the same call", () => {
+    const params = { model: "ir.attachment", targetRef: ref("account.move") };
+    expect(collectCallModels(params, KEY).sort()).toEqual(["account.move", "ir.attachment"]);
+  });
+});

--- a/packages/web/src/lib/approvals/call-models.ts
+++ b/packages/web/src/lib/approvals/call-models.ts
@@ -1,0 +1,105 @@
+import { createDecipheriv } from "crypto";
+
+/**
+ * Which resources a tool call touches, so the confirmation policy can be read
+ * per resource and not only per tool (#1133).
+ *
+ * Two sources, and neither is a hand-maintained table:
+ *
+ * 1. An explicit `model` parameter — `odoo_read` / `create` / `write` /
+ *    `delete` / `count` / `aggregate` take one.
+ * 2. The opaque `_pinchy_ref` tokens the record-action tools take instead
+ *    (`odoo_confirm_order`, `odoo_validate_picking`, `odoo_reconcile`, …).
+ *    **The ref carries its own model**, so reading it beats mirroring a
+ *    tool→model list from the plugin: a list is wrong the moment someone adds
+ *    a ref tool and forgets it, and it needs a drift guard to say so. A ref
+ *    cannot drift from itself, and a new ref tool works here on the day it
+ *    ships.
+ *
+ * The decode half of pinchy-odoo's `integration-ref.ts` is reimplemented rather
+ * than imported: the plugin resolves its key from a container path
+ * (`/openclaw-secrets/secrets.json`) that pinchy-web has no business reading,
+ * and pinchy-web already holds the same key in its settings DB, which is where
+ * it was generated. What keeps the two in step is `call-models.test.ts`, which
+ * encodes with the plugin's own encoder and decodes here — a format change
+ * fails that round trip immediately, where a textual comparison would let a
+ * changed IV length through.
+ */
+
+const PREFIX = "pinchy_ref:v1:";
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+const HEX_64 = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * A resource the call touches. `null` is one we could not name — a ref that
+ * did not decode, or none configured. It is deliberately not the same as "no
+ * resource": the call still acts on something, so it must inherit the
+ * tool-level setting rather than fall through to allow.
+ */
+export type CallResource = string | null;
+
+function decodeRefModel(ref: string, key: string): string | null {
+  try {
+    const raw = Buffer.from(ref.slice(PREFIX.length), "base64url");
+    if (raw.length <= IV_LENGTH + TAG_LENGTH) return null;
+    const decipher = createDecipheriv(
+      ALGORITHM,
+      Buffer.from(key, "hex"),
+      raw.subarray(0, IV_LENGTH)
+    );
+    decipher.setAuthTag(raw.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH));
+    const plaintext = Buffer.concat([
+      decipher.update(raw.subarray(IV_LENGTH + TAG_LENGTH)),
+      decipher.final(),
+    ]).toString("utf8");
+    const payload: unknown = JSON.parse(plaintext);
+    if (!payload || typeof payload !== "object") return null;
+    const model = (payload as Record<string, unknown>).model;
+    return typeof model === "string" && model.length > 0 ? model : null;
+  } catch {
+    // Every decode failure is the same answer here — an unnamed resource.
+    // Telling a garbled ref from a rotated key matters to the tool that has to
+    // explain itself to the model; it does not change what the gate must do.
+    return null;
+  }
+}
+
+/**
+ * Walks the call's arguments for resources. Refs are found by their prefix
+ * wherever they sit — no parameter-name list, because the tools spell it
+ * `target`, `targetRef`, `moveRef`, … and a name list is the same maintenance
+ * trap as a model table.
+ */
+export function collectCallModels(params: unknown, key: string | null): CallResource[] {
+  const found: CallResource[] = [];
+  const usableKey = key && HEX_64.test(key) ? key : null;
+
+  const visit = (value: unknown): void => {
+    if (typeof value === "string") {
+      if (value.startsWith(PREFIX)) {
+        found.push(usableKey ? decodeRefModel(value, usableKey) : null);
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (value && typeof value === "object") {
+      Object.values(value).forEach(visit);
+    }
+  };
+
+  if (params && typeof params === "object" && !Array.isArray(params)) {
+    const explicit = (params as Record<string, unknown>).model;
+    // Scoped by tool name downstream (`<tool>:<model>`), so a non-Odoo tool
+    // that happens to carry a `model` argument produces a key nobody has
+    // configured — which inherits the tool setting and changes nothing.
+    if (typeof explicit === "string" && explicit.length > 0) found.push(explicit);
+  }
+  visit(params);
+
+  return found;
+}

--- a/packages/web/src/lib/approvals/matrix-cell.test.ts
+++ b/packages/web/src/lib/approvals/matrix-cell.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { cellStateFor, applyCellState } from "./matrix-cell";
+import type { ConfirmMap } from "./policy";
+
+describe("cellStateFor", () => {
+  it("is off when the operation is not granted, whatever the policy says", () => {
+    expect(cellStateFor({ odoo_delete: "confirm" }, "account.move", "delete", false)).toBe("off");
+  });
+
+  it("is allow when nothing gates the tool", () => {
+    expect(cellStateFor({}, "account.move", "delete", true)).toBe("allow");
+  });
+
+  // The inheritance made visible. An admin who gated odoo_delete at tool level
+  // should see every delete cell reading "ask" without having ticked each one —
+  // a blank cell would misdescribe what the gate is going to do.
+  it("shows a cell nobody touched as what it inherits", () => {
+    expect(cellStateFor({ odoo_delete: "confirm" }, "a.new.model", "delete", true)).toBe("ask");
+  });
+
+  it("shows an explicit exception over the inherited value", () => {
+    const confirm: ConfirmMap = { odoo_delete: "confirm", "odoo_delete:note.note": "allow" };
+    expect(cellStateFor(confirm, "note.note", "delete", true)).toBe("allow");
+    expect(cellStateFor(confirm, "account.move", "delete", true)).toBe("ask");
+  });
+
+  // `write` speaks for odoo_write plus every record action. If one of them
+  // still pauses, the honest reading is "ask" — claiming "allow" would be the
+  // looser of the two, on a security control.
+  it("reads ask when any tool of a multi-tool column would ask", () => {
+    const confirm: ConfirmMap = { "odoo_reconcile:account.move": "confirm" };
+    expect(cellStateFor(confirm, "account.move", "write", true)).toBe("ask");
+  });
+});
+
+describe("applyCellState", () => {
+  it("writes an ask key for every tool the column speaks for", () => {
+    const next = applyCellState({}, "account.move", "write", "ask");
+    expect(next["odoo_write:account.move"]).toBe("confirm");
+    expect(next["odoo_reconcile:account.move"]).toBe("confirm");
+    expect(next["odoo_confirm_order:account.move"]).toBe("confirm");
+  });
+
+  // The exception the whole feature exists for. Clearing the key instead would
+  // resolve back to the tool-level "ask", so "just do it for a note" would
+  // quietly not take effect.
+  it("writes an explicit allow that survives a gated tool level", () => {
+    const next = applyCellState({ odoo_delete: "confirm" }, "note.note", "delete", "allow");
+    expect(next["odoo_delete:note.note"]).toBe("allow");
+    expect(cellStateFor(next, "note.note", "delete", true)).toBe("allow");
+    expect(cellStateFor(next, "account.move", "delete", true)).toBe("ask");
+  });
+
+  it("touches no other model's keys", () => {
+    const next = applyCellState(
+      { "odoo_delete:note.note": "allow" },
+      "account.move",
+      "delete",
+      "ask"
+    );
+    expect(next["odoo_delete:note.note"]).toBe("allow");
+  });
+
+  it("leaves the map alone when the cell is turned off", () => {
+    const confirm: ConfirmMap = { "odoo_delete:note.note": "allow" };
+    expect(applyCellState(confirm, "note.note", "delete", "off")).toEqual(confirm);
+  });
+});

--- a/packages/web/src/lib/approvals/matrix-cell.ts
+++ b/packages/web/src/lib/approvals/matrix-cell.ts
@@ -1,0 +1,59 @@
+import { odooToolsForOperation, type ODOO_OPERATION_TOOLS } from "@/lib/tool-registry";
+import { resolveConfirmation, type ConfirmMap } from "@/lib/approvals/policy";
+
+export type AccessState = "off" | "ask" | "allow";
+type Operation = keyof typeof ODOO_OPERATION_TOOLS;
+
+/**
+ * What one cell of the Odoo permission matrix shows.
+ *
+ * An untouched cell displays what it INHERITS from the tool level rather than
+ * a blank, because the blank would be a lie about what happens: the gate
+ * resolves inheritance whether or not the grid shows it, and an admin who has
+ * gated `odoo_delete` should see the delete column reading "ask" on every model
+ * without having ticked each one.
+ *
+ * A column speaks for several tools — `write` covers `odoo_write` and every
+ * record action — so it reads "ask" when ANY of them would ask. Showing
+ * "allow" while one of the tools still pauses would be the looser of the two
+ * claims, and the wrong one to make on a security control.
+ */
+export function cellStateFor(
+  confirm: ConfirmMap,
+  model: string,
+  operation: Operation,
+  granted: boolean
+): AccessState {
+  if (!granted) return "off";
+  const cfg = { "pinchy-approvals": { confirm } };
+  const asks = odooToolsForOperation(operation).some(
+    (tool) => resolveConfirmation(cfg, tool, [model]) === "confirm"
+  );
+  return asks ? "ask" : "allow";
+}
+
+/**
+ * The confirmation map after an admin sets a cell.
+ *
+ * Both non-off states write an EXPLICIT key rather than clearing one. "Allow"
+ * has to mean allow even when the tool level says ask — that exception is the
+ * entire point of the per-model control ("ask before deleting an invoice, just
+ * do it for a note"), and a cleared key would resolve straight back to ask.
+ *
+ * Turning a cell off leaves its keys behind on purpose. The permission is what
+ * stops the call; the confirmation setting is a preference that should still be
+ * there if the operation is granted again, rather than something the admin has
+ * to rediscover.
+ */
+export function applyCellState(
+  confirm: ConfirmMap,
+  model: string,
+  operation: Operation,
+  next: AccessState
+): ConfirmMap {
+  if (next === "off") return confirm;
+  const value = next === "ask" ? "confirm" : "allow";
+  const updated = { ...confirm };
+  for (const tool of odooToolsForOperation(operation)) updated[`${tool}:${model}`] = value;
+  return updated;
+}

--- a/packages/web/src/lib/approvals/policy.test.ts
+++ b/packages/web/src/lib/approvals/policy.test.ts
@@ -1,33 +1,152 @@
 import { describe, it, expect } from "vitest";
-import { getConfirmTools, defaultConfirmTools } from "./policy";
+import { getConfirmMap, resolveConfirmation, defaultConfirmMap, toolIsConfigured } from "./policy";
 
-describe("getConfirmTools", () => {
-  it("returns the configured confirm tools", () => {
-    expect(getConfirmTools({ "pinchy-approvals": { confirmTools: ["odoo_write"] } })).toEqual([
-      "odoo_write",
-    ]);
+describe("getConfirmMap", () => {
+  it("returns the configured map", () => {
+    expect(getConfirmMap({ "pinchy-approvals": { confirm: { odoo_write: "confirm" } } })).toEqual({
+      odoo_write: "confirm",
+    });
   });
 
-  it("returns [] when unset or null", () => {
-    expect(getConfirmTools(null)).toEqual([]);
-    expect(getConfirmTools(undefined)).toEqual([]);
-    expect(getConfirmTools({})).toEqual([]);
+  it("returns {} when unset or null", () => {
+    expect(getConfirmMap(null)).toEqual({});
+    expect(getConfirmMap(undefined)).toEqual({});
+    expect(getConfirmMap({})).toEqual({});
+  });
+
+  // AGENTS.md § "Test Migrations Against Pre-Existing Data". Every agent whose
+  // admin turned confirmation on before #1133 carries `confirmTools`, and this
+  // is the read side of the switch: without the fallback the map comes back
+  // empty, the gate allows, and a policy an admin set silently stops applying.
+  // Loudly wrong would be survivable; this failure mode looks like success.
+  it("reads a pre-#1133 confirmTools list when no map has been written", () => {
+    expect(
+      getConfirmMap({ "pinchy-approvals": { confirmTools: ["odoo_write", "email_send"] } })
+    ).toEqual({ odoo_write: "confirm", email_send: "confirm" });
+  });
+
+  // The distinction the fallback turns on: `confirm: {}` is an admin who
+  // migrated and gated nothing, `confirm: undefined` is an agent that has not
+  // been saved since the upgrade. Falling back on the former would resurrect a
+  // policy the admin deliberately cleared.
+  it("does not fall back once a map exists, even an empty one", () => {
+    expect(
+      getConfirmMap({ "pinchy-approvals": { confirm: {}, confirmTools: ["odoo_write"] } })
+    ).toEqual({});
   });
 });
 
-describe("defaultConfirmTools", () => {
+describe("resolveConfirmation", () => {
+  const cfg = (confirm: Record<string, "confirm" | "allow">) => ({
+    "pinchy-approvals": { confirm },
+  });
+
+  it("allows a tool nobody gated", () => {
+    expect(resolveConfirmation(cfg({}), "odoo_write", [])).toBe("allow");
+  });
+
+  it("confirms a gated tool with no model in play", () => {
+    expect(resolveConfirmation(cfg({ email_send: "confirm" }), "email_send", [])).toBe("confirm");
+  });
+
+  it("lets an explicit model exception override the tool setting", () => {
+    const c = cfg({ odoo_delete: "confirm", "odoo_delete:note.note": "allow" });
+    expect(resolveConfirmation(c, "odoo_delete", ["note.note"])).toBe("allow");
+    expect(resolveConfirmation(c, "odoo_delete", ["account.move"])).toBe("confirm");
+  });
+
+  it("gates a single model while the tool itself is ungated", () => {
+    const c = cfg({ "odoo_write:account.move": "confirm" });
+    expect(resolveConfirmation(c, "odoo_write", ["account.move"])).toBe("confirm");
+    expect(resolveConfirmation(c, "odoo_write", ["res.partner"])).toBe("allow");
+  });
+
+  // The rule that keeps the control safe. "odoo_delete requires confirmation"
+  // covers every model, including ones nobody has heard of yet; a per-model
+  // grid only covers cells someone touched. If an untouched cell defaulted to
+  // allow, a model added next month would be silently ungated for an admin who
+  // believes deletion is gated — the allowlist failure mode AGENTS.md keeps
+  // naming: a positive list cannot report what is not in it.
+  it("makes an untouched model cell inherit the tool setting, never allow", () => {
+    const c = cfg({ odoo_delete: "confirm", "odoo_delete:note.note": "allow" });
+    expect(resolveConfirmation(c, "odoo_delete", ["a.model.added.later"])).toBe("confirm");
+  });
+
+  // odoo_reconcile touches account.move AND account.payment. Without a stated
+  // rule the behaviour of a call spanning a gated and an ungated model is
+  // undefined, and "undefined" resolves to whichever the loop happens to see.
+  it("takes the strictest setting when a call spans several models", () => {
+    const c = cfg({ "odoo_write:account.move": "confirm", "odoo_write:res.partner": "allow" });
+    expect(resolveConfirmation(c, "odoo_write", ["res.partner", "account.move"])).toBe("confirm");
+    expect(resolveConfirmation(c, "odoo_write", ["account.move", "res.partner"])).toBe("confirm");
+  });
+
+  // A ref the model garbled decodes to nothing, but the call still acts on
+  // something. Reading that as "no resource" would drop it to the tool level
+  // silently; reading it as a cell nobody configured makes it inherit — same
+  // answer, arrived at by the rule that is written down.
+  it("makes an unnamed resource inherit the tool setting", () => {
+    expect(resolveConfirmation(cfg({ odoo_write: "confirm" }), "odoo_write", [null])).toBe(
+      "confirm"
+    );
+    expect(resolveConfirmation(cfg({}), "odoo_write", [null])).toBe("allow");
+  });
+
+  it("still confirms when one of several resources cannot be named", () => {
+    const c = cfg({ odoo_reconcile: "confirm", "odoo_reconcile:account.payment": "allow" });
+    expect(resolveConfirmation(c, "odoo_reconcile", ["account.payment", null])).toBe("confirm");
+  });
+
+  it("resolves a pre-#1133 config at the tool level", () => {
+    const legacy = { "pinchy-approvals": { confirmTools: ["odoo_delete"] } };
+    expect(resolveConfirmation(legacy, "odoo_delete", ["account.move"])).toBe("confirm");
+    expect(resolveConfirmation(legacy, "odoo_write", ["account.move"])).toBe("allow");
+  });
+});
+
+describe("toolIsConfigured", () => {
+  it("sees a tool-level setting", () => {
+    expect(
+      toolIsConfigured({ "pinchy-approvals": { confirm: { odoo_write: "confirm" } } }, "odoo_write")
+    ).toBe(true);
+  });
+
+  // The short-circuit must not skip a tool that is only gated on one model —
+  // that would make every per-model exception a no-op, silently.
+  it("sees a tool that only appears in a resource cell", () => {
+    const cfg = { "pinchy-approvals": { confirm: { "odoo_write:account.move": "confirm" } } };
+    expect(toolIsConfigured(cfg, "odoo_write")).toBe(true);
+  });
+
+  it("does not match a tool whose name merely prefixes another", () => {
+    const cfg = { "pinchy-approvals": { confirm: { odoo_write_off: "confirm" } } };
+    expect(toolIsConfigured(cfg, "odoo_write")).toBe(false);
+  });
+
+  it("sees a pre-#1133 confirmTools entry", () => {
+    expect(
+      toolIsConfigured({ "pinchy-approvals": { confirmTools: ["email_send"] } }, "email_send")
+    ).toBe(true);
+  });
+
+  it("is false for an unmentioned tool", () => {
+    expect(toolIsConfigured({ "pinchy-approvals": { confirm: {} } }, "odoo_write")).toBe(false);
+    expect(toolIsConfigured(null, "odoo_write")).toBe(false);
+  });
+});
+
+describe("defaultConfirmMap", () => {
   it("selects only the agent's powerful tools (real registry)", () => {
     // odoo_write is powerful; odoo_list_models is safe (read-only).
-    const result = defaultConfirmTools(["odoo_write", "odoo_list_models"]);
-    expect(result).toContain("odoo_write");
-    expect(result).not.toContain("odoo_list_models");
+    const result = defaultConfirmMap(["odoo_write", "odoo_list_models"]);
+    expect(result).toEqual({ odoo_write: "confirm" });
   });
 
   it("ignores tool ids the agent is not allowed to use", () => {
-    expect(defaultConfirmTools([])).toEqual([]);
+    expect(defaultConfirmMap([])).toEqual({});
   });
 
   it("ignores unknown tool ids not in the registry", () => {
-    expect(defaultConfirmTools(["not_a_real_tool"])).toEqual([]);
+    expect(defaultConfirmMap(["not_a_real_tool"])).toEqual({});
   });
 });

--- a/packages/web/src/lib/approvals/policy.test.ts
+++ b/packages/web/src/lib/approvals/policy.test.ts
@@ -104,6 +104,10 @@ describe("resolveConfirmation", () => {
   });
 });
 
+const cfgWith = (confirm: Record<string, "confirm" | "allow">) => ({
+  "pinchy-approvals": { confirm },
+});
+
 describe("toolIsConfigured", () => {
   it("sees a tool-level setting", () => {
     expect(
@@ -114,12 +118,12 @@ describe("toolIsConfigured", () => {
   // The short-circuit must not skip a tool that is only gated on one model —
   // that would make every per-model exception a no-op, silently.
   it("sees a tool that only appears in a resource cell", () => {
-    const cfg = { "pinchy-approvals": { confirm: { "odoo_write:account.move": "confirm" } } };
+    const cfg = cfgWith({ "odoo_write:account.move": "confirm" });
     expect(toolIsConfigured(cfg, "odoo_write")).toBe(true);
   });
 
   it("does not match a tool whose name merely prefixes another", () => {
-    const cfg = { "pinchy-approvals": { confirm: { odoo_write_off: "confirm" } } };
+    const cfg = cfgWith({ odoo_write_off: "confirm" });
     expect(toolIsConfigured(cfg, "odoo_write")).toBe(false);
   });
 

--- a/packages/web/src/lib/approvals/policy.ts
+++ b/packages/web/src/lib/approvals/policy.ts
@@ -1,12 +1,108 @@
 import { TOOL_REGISTRY } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
+import type { CallResource } from "@/lib/approvals/call-models";
 
 /**
- * Tools an admin marked as requiring inline confirmation for this agent.
- * The policy is agent-level (shared); the grant it produces is per-user.
+ * What an admin decided about one tool, or one (tool, model) cell.
+ *
+ * Deliberately two values and not three. The UI shows three states per cell
+ * (✘ off · ! ask · ✔ allow), but "off" is not stored here — it is the absence
+ * of the tool from `allowedTools`, which is what gets emitted into OpenClaw's
+ * `tools.allow` and is therefore the boundary the runtime actually enforces.
+ * Storing "off" twice would let the two copies disagree, and the copy the
+ * runtime does not read would be the one an admin was looking at.
  */
-export function getConfirmTools(pluginConfig: AgentPluginConfig | null | undefined): string[] {
-  return pluginConfig?.["pinchy-approvals"]?.confirmTools ?? [];
+export type ConfirmSetting = "confirm" | "allow";
+
+/**
+ * Flat keys, optionally suffixed with the resource the call touches:
+ *
+ *   { "odoo_delete": "confirm", "odoo_delete:note.note": "allow" }
+ *
+ * The suffix carries every shape we have without a second dimension: for Odoo
+ * it is the model, for email/files/KB there is none, and MCP tools already
+ * carry their server in the name (`<serverKey>__<tool>`, #1134).
+ */
+export type ConfirmMap = Record<string, ConfirmSetting>;
+
+const KEY_SEPARATOR = ":";
+
+/**
+ * The confirmation policy for an agent, normalized.
+ *
+ * Reads the pre-#1133 `confirmTools: string[]` when no map has been written
+ * yet. That fallback is not politeness — it is the read side of a storage
+ * switch, and AGENTS.md § "Test Migrations Against Pre-Existing Data" exists
+ * for exactly this: every agent whose admin turned confirmation on before
+ * #1133 carries the old key, and without the fallback the map comes back
+ * empty, the gate allows, and a policy an admin set stops applying silently.
+ * A security control that fails this way looks indistinguishable from one that
+ * works.
+ *
+ * The fallback keys on `confirm` being ABSENT, not on it being empty. `{}` is
+ * an admin who migrated and gated nothing; falling back there would resurrect
+ * a policy they deliberately cleared. Writing always emits the new shape, so
+ * an agent converges the first time anyone saves it.
+ */
+export function getConfirmMap(pluginConfig: AgentPluginConfig | null | undefined): ConfirmMap {
+  const cfg = pluginConfig?.["pinchy-approvals"];
+  if (cfg?.confirm) return cfg.confirm;
+  if (!cfg?.confirmTools) return {};
+  return Object.fromEntries(cfg.confirmTools.map((id) => [id, "confirm" as const]));
+}
+
+/**
+ * Does this call need a confirmation?
+ *
+ * Resolution is most-specific-wins: an explicit `tool:model` cell decides, and
+ * an untouched one **inherits the tool setting**. That inheritance is the rule
+ * that keeps the control safe. "odoo_delete requires confirmation" covers every
+ * model, including ones added next month; a per-model grid only covers cells
+ * someone touched. If an untouched cell defaulted to allow, a new model would
+ * arrive silently ungated for an admin who believes deletion is gated — the
+ * allowlist failure mode AGENTS.md keeps naming, where a positive list cannot
+ * report what is not in it.
+ *
+ * A call spanning several models (`odoo_reconcile` touches `account.move` and
+ * `account.payment`) takes the **strictest** result. Without that stated rule
+ * the outcome is whichever model the loop happened to see first.
+ *
+ * A `null` resource is one the call touches but we could not name — a ref the
+ * model garbled. It resolves through the same inheritance as an unconfigured
+ * cell, which is the honest answer: we know a resource is involved and we do
+ * not know which, so the tool-level decision stands.
+ */
+export function resolveConfirmation(
+  pluginConfig: AgentPluginConfig | null | undefined,
+  toolName: string,
+  resources: CallResource[]
+): ConfirmSetting {
+  const map = getConfirmMap(pluginConfig);
+  const toolLevel = map[toolName] ?? "allow";
+  if (resources.length === 0) return toolLevel;
+  const cell = (resource: CallResource) =>
+    resource === null ? toolLevel : (map[`${toolName}${KEY_SEPARATOR}${resource}`] ?? toolLevel);
+  return resources.some((resource) => cell(resource) === "confirm") ? "confirm" : "allow";
+}
+
+/**
+ * Does this agent's policy mention this tool at all — at tool level or in any
+ * of its resource cells?
+ *
+ * The gate calls this before resolving, so the overwhelmingly common answer
+ * ("nobody gated this tool") costs one already-loaded object and no further
+ * work. Resolving needs the ref-token key, which is a second DB read, and
+ * paying it on every tool call to answer "no" would put a settings query in
+ * front of every action every agent takes.
+ */
+export function toolIsConfigured(
+  pluginConfig: AgentPluginConfig | null | undefined,
+  toolName: string
+): boolean {
+  const map = getConfirmMap(pluginConfig);
+  if (map[toolName] !== undefined) return true;
+  const prefix = `${toolName}${KEY_SEPARATOR}`;
+  return Object.keys(map).some((key) => key.startsWith(prefix));
 }
 
 const POWERFUL_TOOL_IDS = new Set(
@@ -17,7 +113,13 @@ const POWERFUL_TOOL_IDS = new Set(
  * Auto-default when an admin first enables confirmation: every `powerful`
  * (write/side-effecting) tool the agent is allowed to use. Safe/read-only
  * tools are left ungated so prompts stay rare (approval-fatigue mitigation).
+ *
+ * Tool level only — a per-model default would be a guess about which records
+ * matter, and the inheritance rule above already carries the tool setting into
+ * every model cell.
  */
-export function defaultConfirmTools(allowedTools: string[]): string[] {
-  return allowedTools.filter((id) => POWERFUL_TOOL_IDS.has(id));
+export function defaultConfirmMap(allowedTools: string[]): ConfirmMap {
+  return Object.fromEntries(
+    allowedTools.filter((id) => POWERFUL_TOOL_IDS.has(id)).map((id) => [id, "confirm" as const])
+  );
 }

--- a/packages/web/src/lib/approvals/prompt.ts
+++ b/packages/web/src/lib/approvals/prompt.ts
@@ -48,7 +48,15 @@ function describeArgs(params: unknown): string {
 
 export function buildApprovalPrompt(
   toolName: string,
-  params: unknown
+  params: unknown,
+  /**
+   * The resources the gate resolved this call to touch (#1133). Naming them is
+   * not decoration: once deletion can be gated per model, "Delete a record in
+   * Odoo" is not a decision anyone can make — an invoice and a note are the
+   * whole reason the setting exists. `null` entries are resources we could not
+   * name and are left unsaid rather than printed.
+   */
+  resources: (string | null)[] = []
 ): { title: string; description: string } {
   const known = TOOL_REGISTRY.find((tool) => tool.id === toolName);
 
@@ -56,7 +64,12 @@ export function buildApprovalPrompt(
   // `knowledge_search` is the standing example: it is granted by the Knowledge
   // Base template and appears in no registry, which is exactly how #865's
   // confirmation list rendered empty.
-  const title = truncate(known?.label ?? `Run ${toolName}`, APPROVAL_TITLE_MAX);
+  const action = known?.label ?? `Run ${toolName}`;
+  const named = [...new Set(resources.filter((r): r is string => r !== null))];
+  const title = truncate(
+    named.length > 0 ? `${action} — ${named.join(", ")}` : action,
+    APPROVAL_TITLE_MAX
+  );
 
   const args = describeArgs(params);
   const lead = known?.description ?? `The agent wants to run ${toolName}.`;

--- a/packages/web/src/lib/approvals/summary.ts
+++ b/packages/web/src/lib/approvals/summary.ts
@@ -13,8 +13,17 @@ const SECRET_KEY = /(token|secret|password|passwd|api[-_]?key|authorization|cook
 const MAX_VALUE_LEN = 200;
 const MAX_KEYS = 25;
 
+/** pinchy-odoo's opaque record handle. See `call-models.ts`. */
+const REF_PREFIX = "pinchy_ref:v1:";
+
 function summarizeValue(value: unknown): unknown {
   if (typeof value === "string") {
+    // An opaque ref is 200+ characters of base64 that mean nothing to a reader,
+    // and left in place it consumes the whole 256-character approval
+    // description — pushing out the arguments that do carry meaning. What the
+    // ref points AT reaches the reader through the card's title, which names
+    // the resolved model.
+    if (value.startsWith(REF_PREFIX)) return "(record reference)";
     return value.length > MAX_VALUE_LEN ? `${value.slice(0, MAX_VALUE_LEN)}…` : value;
   }
   if (value === null || ["number", "boolean"].includes(typeof value)) {

--- a/packages/web/src/lib/domain-validation.ts
+++ b/packages/web/src/lib/domain-validation.ts
@@ -121,7 +121,17 @@ export const pluginConfigSchema = z
       .optional(),
     "pinchy-approvals": z
       .object({
-        confirmTools: z.array(z.string()),
+        /** Per tool, optionally per resource — see lib/approvals/policy.ts. */
+        confirm: z.record(z.string(), z.enum(["confirm", "allow"])).optional(),
+        /**
+         * Pre-#1133. Still accepted because this schema is `.strict()`: an
+         * agent configured before the switch carries this key, and dropping it
+         * would REJECT that agent's next save rather than ignore the field —
+         * an admin editing anything else on the page would get a validation
+         * error about a policy they never touched. Nothing writes it; the
+         * agent converges to `confirm` the first time it is saved.
+         */
+        confirmTools: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),

--- a/packages/web/src/lib/plugin-secrets-source.ts
+++ b/packages/web/src/lib/plugin-secrets-source.ts
@@ -26,3 +26,19 @@ export async function getOrCreatePluginSecret(name: string): Promise<string> {
   await setSetting(key, secret);
   return secret;
 }
+
+/**
+ * Read a plugin secret without minting one.
+ *
+ * The get-or-create form above belongs on the config-generation path, which
+ * runs once and owns the value. A read path must not write: the approvals gate
+ * calls this on tool calls, where creating a key would mean an encryption key
+ * appears in the settings DB as a side effect of an agent using a tool — and a
+ * key generated there is not the key anything was encrypted under anyway.
+ * Returns null when no usable secret is stored, which callers read as "nothing
+ * here can be decoded" rather than as an error.
+ */
+export async function readPluginSecret(name: string): Promise<string | null> {
+  const stored = await getSetting(`${SETTING_PREFIX}${name}`);
+  return stored && HEX_64.test(stored) ? stored : null;
+}

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -474,6 +474,53 @@ export function getEmailTools(): ToolDefinition[] {
   return TOOL_REGISTRY.filter((t) => t.integration === "email");
 }
 
+/**
+ * Which tools each column of the Odoo permission matrix speaks for.
+ *
+ * The matrix is (model × read|create|write|delete) and #1133 gives each cell a
+ * third state, "ask". That state is stored per tool (`odoo_delete:account.move`)
+ * because the gate matches on tool name, so a cell has to know its tools.
+ *
+ * This is the one hand-maintained list the feature could not derive, and
+ * `odoo-operation-tools.test.ts` guards it: every non-deprecated Odoo tool must
+ * appear here or in `ODOO_MODEL_AGNOSTIC_TOOLS`, exactly once. Without that,
+ * a new Odoo tool would be one the "ask" state cannot reach — an admin sets a
+ * cell to ask, the call runs unconfirmed, and nothing says why.
+ *
+ * The record-action tools sit under `write`: each mutates an existing record,
+ * and filing them elsewhere would hide them under a column nobody associates
+ * with them.
+ */
+export const ODOO_OPERATION_TOOLS: Record<"read" | "create" | "write" | "delete", string[]> = {
+  read: ["odoo_read", "odoo_count", "odoo_aggregate"],
+  create: ["odoo_create"],
+  write: [
+    "odoo_write",
+    "odoo_attach_file",
+    "odoo_schedule_activity",
+    "odoo_complete_activity",
+    "odoo_reschedule_activity",
+    "odoo_confirm_order",
+    "odoo_apply_inventory",
+    "odoo_validate_picking",
+    "odoo_mark_mo_done",
+    "odoo_set_approval",
+    "odoo_reconcile",
+  ],
+  delete: ["odoo_delete"],
+};
+
+/**
+ * Odoo tools that act on the schema rather than on records, so no row of the
+ * model matrix owns them. They are listed rather than left out, so the drift
+ * guard can tell "deliberately not in a cell" from "nobody classified it".
+ */
+export const ODOO_MODEL_AGNOSTIC_TOOLS: string[] = ["odoo_list_models", "odoo_describe_model"];
+
+export function odooToolsForOperation(operation: keyof typeof ODOO_OPERATION_TOOLS): string[] {
+  return ODOO_OPERATION_TOOLS[operation];
+}
+
 /** Returns the odoo_* tool IDs that should be enabled for the given access level. */
 export function getOdooToolsForAccessLevel(level: OdooAccessLevel): string[] {
   switch (level) {


### PR DESCRIPTION
Closes #1133. Carries the #1133 half of #1135.

`odoo_delete` covers every model the agent may touch, so "ask before deleting" was all-or-nothing. This makes it per record type: ask before deleting an invoice, just do it for a note.

## The policy

`confirmTools: string[]` becomes a flat map whose keys carry an optional resource suffix — `odoo_delete` for the tool, `odoo_delete:account.move` for one model. Most specific wins, and **an untouched cell inherits the tool setting rather than defaulting to allow**. That rule is what stops the grid from becoming an allowlist: a per-model table only covers cells someone ticked, so a model added next month would otherwise arrive silently ungated for an admin who believes deletion is gated.

## Reading the model instead of tabulating it

The issue proposed mirroring a tool→model list out of the plugin, with a drift guard. That turned out to be unnecessary: the generic tools take an explicit `model`, and the record-action tools take an opaque `_pinchy_ref` that **carries its own model** — Pinchy holds the key it was encrypted under, because Pinchy generated it (`collectPluginSecrets`). A list is wrong the day someone adds a ref tool and forgets it; a ref cannot drift from itself, and a new ref tool works on the day it ships. `odoo_reconcile`'s two refs fall out of the same read, so "strictest wins" needed no special case.

`call-models.test.ts` encodes with the **plugin's own encoder** and decodes with Pinchy's copy, so a format change fails the round trip immediately — where a textual comparison would let a changed IV length through.

A ref the model garbled decodes to nothing. That is not "no resource" — the call still acts on something — so it inherits the tool setting rather than falling through to allow.

## The one list that could not be derived

The matrix columns (`read | create | write | delete`) map to tools, and that mapping is hand-maintained: `create` and `write` are one preset list in the registry but two columns in the grid. `odoo-operation-tools.test.ts` requires every non-deprecated Odoo tool to be classified once — under an operation or explicitly as model-agnostic. An unclassified tool is one the "ask" state cannot reach, which is quiet in the dangerous direction. **Verified by canary**: dropping `odoo_reconcile` fails the guard and names it.

## Migration

Every agent whose admin turned confirmation on before this carries `confirmTools`. Without a read-side fallback the map comes back empty, the gate allows, and a policy an admin set stops applying with nothing to show for it — the failure mode looks exactly like success. So:

- `getConfirmMap` reads the old key when no map has been written, keying on `confirm` being **absent** rather than empty (`{}` is an admin who migrated and gated nothing).
- The schema keeps accepting the old field. It is `.strict()`, so dropping it would **reject** such an agent's next save rather than ignore it.
- Nothing writes it; an agent converges on first save.

Covered at three layers: unit (`policy.test.ts`), form (`agent-settings-permissions.test.tsx` loads a legacy config), and route — every other test in `approvals.integration.test.ts` seeds the pre-#1133 shape and still gates, through the new code.

## The control

Three states in the cell that already exists in the Odoo matrix, rather than a second model grid in the confirmation section that could disagree with it. A radiogroup, not a tri-state checkbox: `mixed` is standardised as "partially checked" and reads as system-set, so reusing that dash for "needs approval" would break a convention on a security setting.

The card now names the resource — without it "Delete a record in Odoo" is not a decision anyone can make — and stops printing 200 characters of base64 ref that ate the whole 256-character description.

## Docs

The `#1132` half of #1135 was already correct on main; this carries the rest: the three states, the inheritance rule, and two things the guide never said — cascading writes are not covered (approving a write to an invoice writes its lines), and the absence of "always allow" is a governance decision rather than an oversight.

## Gates

`pnpm test` (12015 passed), `test:db` (579), `test:scripts` (1240), `format:check`, `typecheck:plugins`, `test:plugins`, `tsc -p tsconfig.typecheck.json`, docs build + `check:anchors` + `check:rendered`, and `next build` via pre-push.
