### PR TITLE
fix(setup): move the runtime wait out of the provider request (#1150)

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -64,6 +64,8 @@ Your API key is encrypted at rest using AES-256-GCM before being stored in the d
 
 If the provider you configure has no vision-capable model, the wizard shows an amber warning: **No vision-capable model configured.** Adding Anthropic, OpenAI, or Google as a provider enables image uploads and scanned-PDF support.
 
+Once the key is saved, the wizard shows **Provider connected!** and briefly waits on **Getting Smithers ready…** — this is Pinchy handing the new configuration to the agent runtime, and **Continue to Pinchy** unlocks as soon as the runtime has it. On a fresh install that step occasionally takes most of a minute, because saving the first API key also provisions the runtime's secrets store and restarts it. If it is still going after 30 seconds the wizard lets you through anyway with a note; your first message just takes a moment longer to land.
+
 ## 6. Chat with Smithers
 
 Once your provider is configured, Pinchy redirects you to the chat interface. Your default agent — **Smithers** — greets you automatically and starts a short onboarding interview to learn about you (and your organization, if you're an admin). This builds context that every agent on the platform can use.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -132,10 +132,10 @@ default is an explicit action ([`PATCH /api/settings/providers/default`](#patch-
 
 **Response:** `{ "success": true }`, plus:
 
-| Field     | Type   | When                                                                                                                               |
-| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `warning` | string | The credential was saved but applying it to the agent runtime failed. Not an error — the runtime picks it up on its next restart.  |
-| `agentId` | string | The config was regenerated. Poll [`GET /api/health/openclaw?agentId=…`](#get-apihealthopenclaw) until `agentDispatchable` is true. |
+| Field     | Type   | When                                                                                                                                                                                                                               |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `warning` | string | The credential was saved but applying it to the agent runtime failed. Not an error — the runtime picks it up on its next restart.                                                                                                  |
+| `agentId` | string | This was the instance's **first** provider and the config regenerated. The id of the Smithers agent it was configured for — poll [`GET /api/health/openclaw?agentId=…`](#get-apihealthopenclaw) until `agentDispatchable` is true. |
 
 The route does not wait for the runtime itself. Pinchy hands OpenClaw the new
 config in the background, so an agent becomes dispatchable shortly after this
@@ -143,6 +143,10 @@ call answers — and on a fresh install "shortly" can be most of a minute, becau
 the first saved key also provisions the runtime's secrets store and restarts it.
 `agentId` is what lets a caller render that wait instead of holding a request
 open through it; the setup wizard uses it to gate **Continue to Pinchy**.
+
+Later provider saves send no `agentId`: they change no agent, so there is no
+particular one to wait for. To know when such a change has reached the runtime,
+poll `configPushesPending` on the same health endpoint until it is `0`.
 
 ## Agents
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -76,6 +76,8 @@ Useful for monitoring the WebSocket gateway separately from the web process.
 
 `configPushesPending` is the number of configuration updates Pinchy has accepted but not yet confirmed inside the OpenClaw runtime (for example while OpenClaw's config-apply rate limit defers an update). A value of `0` means the runtime reflects every change you've made — useful for automation that needs to act right after a settings or permission change. While the gateway restarts, the response is `{ "status": "restarting", "connected": false, "since": <timestamp> }` instead.
 
+With `?agentId=<uuid>`, the response additionally includes `agentDispatchable` — `true` when the OpenClaw runtime currently carries that agent, i.e. a chat sent to it right now would not be rejected as unknown. This is how a client waits out the gap between a route that changed an agent answering and the runtime having the change; the setup wizard polls it after saving the first provider. It reveals no agent metadata, so it stays public, and every failure on the OpenClaw side reports `false` rather than an error status.
+
 With `?channelHealth=1`, the response additionally includes a `channelHealth` array — the channel-health watchdog's per-account snapshot (used by the admin Telegram settings UI to show a "degraded" badge). **This mode requires an admin session** and returns `401`/`403` otherwise: entries carry `accountId` (a Pinchy agent id) and `lastError` (worker error text, passed through the same scrubbing used for the audit trail). The rest of this endpoint — the default `{ status, connected }` check and `?agentId=` — stays public.
 
 ## Setup (public)
@@ -128,7 +130,19 @@ API keys are encrypted at rest with AES-256-GCM. Only the **first** provider
 configured on an instance becomes the default automatically; afterwards the
 default is an explicit action ([`PATCH /api/settings/providers/default`](#patch-apisettingsprovidersdefault)).
 
-**Response:** `{ "success": true }`
+**Response:** `{ "success": true }`, plus:
+
+| Field     | Type   | When                                                                                                                               |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `warning` | string | The credential was saved but applying it to the agent runtime failed. Not an error — the runtime picks it up on its next restart.  |
+| `agentId` | string | The config was regenerated. Poll [`GET /api/health/openclaw?agentId=…`](#get-apihealthopenclaw) until `agentDispatchable` is true. |
+
+The route does not wait for the runtime itself. Pinchy hands OpenClaw the new
+config in the background, so an agent becomes dispatchable shortly after this
+call answers — and on a fresh install "shortly" can be most of a minute, because
+the first saved key also provisions the runtime's secrets store and restarts it.
+`agentId` is what lets a caller render that wait instead of holding a request
+open through it; the setup wizard uses it to gate **Continue to Pinchy**.
 
 ## Agents
 

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -403,6 +403,25 @@ describe("POST /api/setup/provider", () => {
       expect(data.agentId).toBeUndefined();
       expect(typeof data.warning).toBe("string");
     });
+
+    it("omits the agent id when this is not the instance's first provider", async () => {
+      // Despite the path, this route also serves Settings → AI Provider, where
+      // the instance has many agents and `findFirst()` answers whichever row
+      // comes back first. An id picked that way names nobody in particular, and
+      // the API reference tells callers to poll it — so it is only sent on the
+      // wizard's first-provider path, where the route already treats that row as
+      // Smithers.
+      vi.mocked(getSetting).mockResolvedValue("anthropic");
+
+      const response = await POST(
+        makeRequest({ provider: "openai", apiKey: "sk-openai-key" }) as any
+      );
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.warning).toBeUndefined();
+      expect(data.agentId).toBeUndefined();
+    });
   });
 
   it("should reset model cache after saving provider", async () => {

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -64,6 +64,17 @@ vi.mock("@/lib/openclaw-config", () => ({
   regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
 }));
 
+// The only OpenClaw round trip this route can reach is `config.get`. Handing a
+// test a controllable one is what lets it model the state #1150 describes: a
+// `config.apply` parked in OpenClaw's rate-limit window, so the runtime does
+// not yet carry Smithers and a poll for him would never finish.
+const { openClawConfigGet } = vi.hoisted(() => ({
+  openClawConfigGet: vi.fn(),
+}));
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => ({ config: { get: openClawConfigGet } }),
+}));
+
 vi.mock("@/lib/audit", () => ({
   appendAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
@@ -133,9 +144,38 @@ import { resolveAvailableModelForTemplate } from "@/lib/model-resolver/resolve-a
 import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
 import { SMITHERS_MODEL_HINT } from "@/lib/personal-agent";
 
+/**
+ * Race `promise` against a 2 s timer and fail with a message that names the
+ * defect rather than "test timed out after 20000ms".
+ *
+ * The timer only ever runs to completion on the red path — a handler that
+ * answers wins the race immediately — so the budget is free on green and can
+ * be generous enough to survive a loaded machine.
+ */
+const BLOCKED = Symbol("blocked");
+async function answersWithoutBlocking(promise: Promise<Response>): Promise<Response> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const blocked = new Promise<typeof BLOCKED>((resolve) => {
+    timer = setTimeout(() => resolve(BLOCKED), 2000);
+  });
+  const settled = await Promise.race([promise, blocked]);
+  clearTimeout(timer);
+  if (settled === BLOCKED) {
+    throw new Error(
+      "POST /api/setup/provider did not answer within 2 s while OpenClaw's runtime was " +
+        "unreachable. The handler is waiting on the runtime inside the request — that wait " +
+        "belongs to the wizard, which can render it (#1150)."
+    );
+  }
+  return settled;
+}
+
 describe("POST /api/setup/provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    openClawConfigGet.mockResolvedValue({
+      config: { agents: { list: [{ id: "agent-1" }] } },
+    });
     vi.mocked(getSetting).mockResolvedValue(null);
     vi.mocked(db.query.agents.findFirst).mockResolvedValue({
       id: "agent-1",
@@ -312,6 +352,57 @@ describe("POST /api/setup/provider", () => {
     const data = await response.json();
     expect(data.success).toBe(true);
     expect(data.warning).toBeUndefined();
+  });
+
+  // #1150 — the wizard's provider step sat on a disabled "Validating..." button
+  // until the request came back, and the request came back when OpenClaw's
+  // runtime did. On a fresh install those are tens of seconds apart: the first
+  // secrets.json provisioning restarts the gateway, the restarts spend the
+  // ~3-per-45 s `config.apply` budget, and Pinchy's push is then parked for the
+  // advertised retry-after (49 s in the reported run). Nothing crashed and no
+  // timeout fired — the handler was simply waiting, behind a spinner
+  // indistinguishable from a hang.
+  describe("runtime readiness is the wizard's wait, not the request's (#1150)", () => {
+    it("answers while OpenClaw's runtime has not caught up yet", async () => {
+      // A `config.get` that never settles is what a parked push looks like from
+      // inside the request: the agent is not in `agents.list` and no poll for
+      // him can finish.
+      openClawConfigGet.mockReturnValue(new Promise(() => {}));
+
+      const response = await answersWithoutBlocking(
+        POST(makeRequest({ provider: "anthropic", apiKey: "sk-ant-key" }) as any)
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("hands the wizard the agent id it needs to poll readiness itself", async () => {
+      const response = await POST(
+        makeRequest({ provider: "anthropic", apiKey: "sk-ant-key" }) as any
+      );
+
+      const data = await response.json();
+      // `GET /api/health/openclaw?agentId=…` answers `agentDispatchable`, which
+      // is the same question `waitForAgentInRuntime` used to ask in here.
+      expect(data.agentId).toBe("agent-1");
+    });
+
+    it("omits the agent id when the config never regenerated", async () => {
+      // Nothing was pushed, so OpenClaw's runtime will not change and polling it
+      // would only burn the wizard's budget before letting the user through. The
+      // warning already tells them the runtime did not get the change.
+      vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(new Error("EACCES"));
+
+      const response = await POST(
+        makeRequest({ provider: "anthropic", apiKey: "sk-ant-key" }) as any
+      );
+
+      const data = await response.json();
+      expect(data.agentId).toBeUndefined();
+      expect(typeof data.warning).toBe("string");
+    });
   });
 
   it("should reset model cache after saving provider", async () => {

--- a/packages/web/src/__tests__/app/setup-provider-page.test.tsx
+++ b/packages/web/src/__tests__/app/setup-provider-page.test.tsx
@@ -219,6 +219,33 @@ describe("Setup Provider Page", () => {
       }
     });
 
+    // The budget has to hold against a request that never answers, not only
+    // against one that keeps saying "not yet". `apiGet` issues a bare `fetch`
+    // with no signal, and `/api/health/openclaw?agentId=` waits on an OpenClaw
+    // RPC — so a gateway wedged mid-restart, or a Pinchy container that goes
+    // away between two polls, leaves the poll suspended. A deadline that is
+    // only read after the request settles is not a deadline: the button stays
+    // disabled for as long as the browser keeps the socket, which is the hang
+    // this whole change removes, one layer up.
+    it("gives up on the budget even when the health request never answers", async () => {
+      vi.useFakeTimers();
+      try {
+        apiGetMock.mockReturnValue(new Promise(() => {}));
+
+        render(<SetupProviderPage />);
+        saveProvider("agent-1");
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(RUNTIME_READY_BUDGET_MS + RUNTIME_READY_POLL_MS);
+        });
+
+        expect(screen.getByRole("button", { name: /continue to pinchy/i })).toBeEnabled();
+        expect(screen.getByText(/still catching up/i)).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not gate Continue when the save reported no agent id", async () => {
       render(<SetupProviderPage />);
       act(() => {

--- a/packages/web/src/__tests__/app/setup-provider-page.test.tsx
+++ b/packages/web/src/__tests__/app/setup-provider-page.test.tsx
@@ -3,12 +3,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import SetupProviderPage from "@/app/setup/provider/page";
+import {
+  RUNTIME_READY_BUDGET_MS,
+  RUNTIME_READY_POLL_MS,
+} from "@/hooks/use-agent-runtime-readiness";
 import type { ProviderName } from "@/lib/providers";
 
 const pushMock = vi.fn();
 
+const { apiGetMock } = vi.hoisted(() => ({ apiGetMock: vi.fn() }));
+vi.mock("@/lib/api-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api-client")>()),
+  apiGet: apiGetMock,
+}));
+
 // Capture onSaved so tests can call it with different providers
-let capturedOnSaved: ((provider: ProviderName, hasVision: boolean) => void) | undefined;
+let capturedOnSaved:
+  ((provider: ProviderName, hasVision: boolean, agentId?: string) => void) | undefined;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -34,7 +45,7 @@ vi.mock("@/components/provider-key-form", () => ({
     onSaved,
   }: {
     onSuccess: (provider?: ProviderName) => void;
-    onSaved?: (provider: ProviderName, hasVision: boolean) => void;
+    onSaved?: (provider: ProviderName, hasVision: boolean, agentId?: string) => void;
   }) => {
     capturedOnSuccess = onSuccess;
     capturedOnSaved = onSaved;
@@ -57,6 +68,7 @@ describe("Setup Provider Page", () => {
     vi.clearAllMocks();
     capturedOnSuccess = null;
     capturedOnSaved = undefined;
+    apiGetMock.mockResolvedValue({ agentDispatchable: true });
   });
 
   it("should render the Pinchy logo", () => {
@@ -146,5 +158,77 @@ describe("Setup Provider Page", () => {
     });
     fireEvent.click(screen.getByTestId("mock-provider-form"));
     expect(pushMock).toHaveBeenCalledWith("/");
+  });
+
+  // #1150 — the gap between "provider saved" and "OpenClaw can dispatch to
+  // Smithers" used to be spent inside POST /api/setup/provider, which on a
+  // fresh install can be tens of seconds (the first secrets.json restarts the
+  // gateway, and the restarts leave `config.apply` rate-limited). The wizard
+  // showed a disabled "Validating..." button for the whole of it — a spinner
+  // indistinguishable from a hang. The wait now lives here, where it has a
+  // name, a budget and a way out.
+  describe("agent runtime readiness", () => {
+    function saveProvider(agentId?: string) {
+      act(() => {
+        capturedOnSaved?.("anthropic", true, agentId);
+        capturedOnSuccess!("anthropic");
+      });
+    }
+
+    it("holds Continue until OpenClaw reports the agent dispatchable", async () => {
+      apiGetMock
+        .mockResolvedValueOnce({ agentDispatchable: false })
+        .mockResolvedValue({ agentDispatchable: true });
+
+      render(<SetupProviderPage />);
+      saveProvider("agent-1");
+
+      const button = await screen.findByRole("button", { name: /continue to pinchy/i });
+      expect(button).toBeDisabled();
+      await waitFor(() => expect(button).toBeEnabled(), { timeout: 5000 });
+      expect(apiGetMock).toHaveBeenCalledWith("/api/health/openclaw?agentId=agent-1");
+    });
+
+    it("names what it is waiting for rather than showing a bare spinner", async () => {
+      apiGetMock.mockResolvedValue({ agentDispatchable: false });
+
+      render(<SetupProviderPage />);
+      saveProvider("agent-1");
+
+      expect(await screen.findByText(/getting smithers ready/i)).toBeInTheDocument();
+    });
+
+    it("lets you through once the budget is spent, and says why", async () => {
+      vi.useFakeTimers();
+      try {
+        apiGetMock.mockResolvedValue({ agentDispatchable: false });
+
+        render(<SetupProviderPage />);
+        saveProvider("agent-1");
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(RUNTIME_READY_BUDGET_MS + RUNTIME_READY_POLL_MS);
+        });
+
+        // A runtime that is merely slow must never trap someone in the wizard —
+        // the first chat has its own dispatch-race retry behind it.
+        expect(screen.getByRole("button", { name: /continue to pinchy/i })).toBeEnabled();
+        expect(screen.getByText(/still catching up/i)).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not gate Continue when the save reported no agent id", async () => {
+      render(<SetupProviderPage />);
+      act(() => {
+        capturedOnSuccess!("anthropic");
+      });
+
+      expect(await screen.findByRole("button", { name: /continue to pinchy/i })).toBeEnabled();
+      // Nothing was pushed to OpenClaw (or the response predates the field), so
+      // there is no reload to wait for and polling would only delay the user.
+      expect(apiGetMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -8,8 +8,6 @@ import {
 } from "@/lib/providers";
 import { getSetting, setSetting } from "@/lib/settings";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
-import { waitForAgentInRuntime } from "@/lib/wait-for-agent-in-runtime";
-import { getOpenClawClient } from "@/server/openclaw-client";
 import {
   resetCache,
   fetchOllamaLocalModelsFromUrl,
@@ -205,38 +203,35 @@ export async function POST(request: NextRequest) {
   }
   resetCache();
 
-  // Wait until OC's runtime has Smithers visible in `agents.list`. Same race
-  // as POST /api/agents (see wait-for-agent-in-runtime.ts): Pinchy's
-  // regenerate is fire-and-forget via pushConfigInBackground, and OC applies
-  // the hot reload asynchronously. Without this gate the wizard's
-  // "Continue to Pinchy" navigates to /chat/:smithersId and the first
-  // chat dispatch races OC's reload, hitting "invalid agent params:
-  // unknown agent id" — the message never reaches the LLM and the user
-  // sees the chat hang on a fresh install.
+  // Runtime readiness is the WIZARD's wait, not this request's (#1150).
   //
-  // 30 s cap (vs the 5 s default used by POST /api/agents): on a fresh
-  // wizard the Layer 1 bootstrap pkill in start-openclaw.sh can fire
-  // mid-regenerate, taking the gateway down for ~10–40 s before respawn.
-  // Within that window the config.get poll waitForAgentInRuntime uses
-  // gets WS errors and the 5 s budget elapses while OC is still
-  // restarting — wizard returns 200, browser navigates to /chat, dispatch
-  // races, "unknown agent id". 30 s comfortably covers one restart cycle
-  // while still failing fast if OC is genuinely broken. PR #445 CI showed
-  // 23 s pass / 1.7 m fail on the same commit on the 5 s default —
-  // textbook timing flake.
-  // Only worth waiting when the config actually regenerated — if it threw,
-  // OC's runtime won't be reloading and the poll would just burn its budget.
+  // The race is real and unchanged: `regenerateOpenClawConfig()` pushes to
+  // OpenClaw in the background, so Smithers reaches OC's `agents.list` some
+  // time AFTER this handler answers. Reach /chat/:smithersId before that and
+  // the first dispatch fails with "invalid agent params: unknown agent id" —
+  // the message never gets to the LLM and the chat looks hung (#445).
+  //
+  // What changed is who absorbs the gap. This route used to poll `agents.list`
+  // for up to 30 s before answering, which is the wrong shape for a route a
+  // human is watching: on a fresh install the gap is not small. Writing the
+  // first secrets.json restarts the gateway, the restarts spend OC's
+  // ~3-per-45 s `config.apply` budget, and Pinchy's push is then parked for the
+  // advertised retry-after — 49 s in the run this was measured on. Nothing
+  // crashed and no timeout fired; the request simply stayed open while the
+  // wizard sat on a disabled "Validating..." button, a spinner indistinguishable
+  // from a hang.
+  //
+  // So the wait moved to where it can be rendered. The id below lets the wizard
+  // poll `GET /api/health/openclaw?agentId=…` — which already answers exactly
+  // this question via `agentDispatchable` — show it as a named step, and time
+  // out of it into an honest note instead of holding a connection open.
+  //
+  // Omitted when the regenerate threw: nothing was pushed, so OC's runtime is
+  // not about to change and polling it would only delay the user past a gap
+  // that `warning` already describes.
+  let agentId: string | undefined;
   if (!runtimeWarning) {
-    const smithersForWait = await db.query.agents.findFirst();
-    if (smithersForWait) {
-      let client = null;
-      try {
-        client = getOpenClawClient();
-      } catch {
-        // OC client not initialised (rare in tests / pre-setup). Skip the wait.
-      }
-      await waitForAgentInRuntime(client, smithersForWait.id, 30000);
-    }
+    agentId = (await db.query.agents.findFirst())?.id;
   }
 
   // Build a CLAUDE.md-compliant audit detail: snapshot the human-readable
@@ -275,5 +270,5 @@ export async function POST(request: NextRequest) {
     })
   );
 
-  return NextResponse.json({ success: true, warning: runtimeWarning });
+  return NextResponse.json({ success: true, warning: runtimeWarning, agentId });
 }

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -166,22 +166,22 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Only update agent model when adding the first provider
-  if (isFirstProvider) {
-    const smithers = await db.query.agents.findFirst();
-    if (smithers) {
-      try {
-        const resolved = await resolveAvailableModelForTemplate({
-          hint: SMITHERS_MODEL_HINT,
-          provider: provider as ProviderName,
-        });
-        await db.update(agents).set({ model: resolved.model }).where(eq(agents.id, smithers.id));
-      } catch (err) {
-        if (!(err instanceof TemplateCapabilityUnavailableError)) {
-          throw err;
-        }
-        // Provider has no model matching Smithers' hint — keep existing model.
+  // Only update agent model when adding the first provider. Looked up once:
+  // the readiness id further down means this same agent, and an unfiltered
+  // `findFirst()` only names Smithers on the first-provider path — see there.
+  const smithers = isFirstProvider ? await db.query.agents.findFirst() : undefined;
+  if (smithers) {
+    try {
+      const resolved = await resolveAvailableModelForTemplate({
+        hint: SMITHERS_MODEL_HINT,
+        provider: provider as ProviderName,
+      });
+      await db.update(agents).set({ model: resolved.model }).where(eq(agents.id, smithers.id));
+    } catch (err) {
+      if (!(err instanceof TemplateCapabilityUnavailableError)) {
+        throw err;
       }
+      // Provider has no model matching Smithers' hint — keep existing model.
     }
   }
 
@@ -226,13 +226,18 @@ export async function POST(request: NextRequest) {
   // this question via `agentDispatchable` — show it as a named step, and time
   // out of it into an honest note instead of holding a connection open.
   //
-  // Omitted when the regenerate threw: nothing was pushed, so OC's runtime is
-  // not about to change and polling it would only delay the user past a gap
-  // that `warning` already describes.
-  let agentId: string | undefined;
-  if (!runtimeWarning) {
-    agentId = (await db.query.agents.findFirst())?.id;
-  }
+  // Omitted in two cases. When the regenerate threw: nothing was pushed, so
+  // OC's runtime is not about to change and polling it would only delay the
+  // user past a gap that `warning` already describes. And when this is not the
+  // instance's first provider: despite the path, this route also serves
+  // Settings → AI Provider, where the instance has many agents and the
+  // unfiltered `findFirst()` above answers whichever row comes back first. An
+  // id chosen that way names nobody in particular, and this one is documented
+  // as the agent a caller should poll — so it is only sent where it is true.
+  // A Settings save that wants to know when its change landed has
+  // `configPushesPending` on the same health endpoint, which is the question
+  // it is actually asking.
+  const agentId = runtimeWarning ? undefined : smithers?.id;
 
   // Build a CLAUDE.md-compliant audit detail: snapshot the human-readable
   // provider name alongside its id, and never log secrets. For URL-based

--- a/packages/web/src/app/setup/provider/page.tsx
+++ b/packages/web/src/app/setup/provider/page.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CheckCircle2 } from "lucide-react";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { SmithersModelInfoLine } from "@/components/setup/smithers-model-info-line";
+import { useAgentRuntimeReadiness } from "@/hooks/use-agent-runtime-readiness";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
 import { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
 
@@ -15,9 +16,15 @@ export default function SetupProviderPage() {
   const router = useRouter();
   const [configuredProvider, setConfiguredProvider] = useState<ProviderName | null>(null);
   const [noVision, setNoVision] = useState(false);
+  // Set from the save response. Null means there is nothing to wait for — the
+  // regenerate never reached OpenClaw, so no reload is coming (the save's own
+  // warning toast covers that case).
+  const [runtimeAgentId, setRuntimeAgentId] = useState<string | null>(null);
+  const runtime = useAgentRuntimeReadiness(runtimeAgentId);
 
-  function handleSaved(_provider: ProviderName, hasVision: boolean) {
+  function handleSaved(_provider: ProviderName, hasVision: boolean, agentId?: string) {
     setNoVision(!hasVision);
+    setRuntimeAgentId(agentId ?? null);
   }
 
   if (configuredProvider) {
@@ -41,7 +48,32 @@ export default function SetupProviderPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <SmithersModelInfoLine modelId={defaultModel} />
-              <Button onClick={() => router.push("/")} className="w-full">
+              {/*
+                The provider is saved; Smithers still has to reach OpenClaw's
+                runtime before a chat can be dispatched to him (#1150). That
+                step is usually instant and occasionally takes most of a minute
+                on a fresh install, so it gets named here instead of being
+                hidden inside the save request. `slow` is not a failure — the
+                first chat has its own dispatch-race retry behind it — so it
+                unlocks the button and says what to expect.
+              */}
+              {runtime === "preparing" && (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
+                  Getting Smithers ready…
+                </p>
+              )}
+              {runtime === "slow" && (
+                <p className="text-sm text-muted-foreground">
+                  Smithers is still catching up. You can continue — your first message may take a
+                  moment to land.
+                </p>
+              )}
+              <Button
+                onClick={() => router.push("/")}
+                className="w-full"
+                disabled={runtime === "preparing"}
+              >
                 Continue to Pinchy
               </Button>
             </CardContent>

--- a/packages/web/src/app/setup/provider/page.tsx
+++ b/packages/web/src/app/setup/provider/page.tsx
@@ -57,14 +57,19 @@ export default function SetupProviderPage() {
                 first chat has its own dispatch-race retry behind it — so it
                 unlocks the button and says what to expect.
               */}
+              {/*
+                `role="status"` because the only other cue that the wait ended
+                is a disabled attribute coming off a button, which announces
+                nothing. The spinner is decorative; the sentence is the status.
+              */}
               {runtime === "preparing" && (
-                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
                   Getting Smithers ready…
                 </p>
               )}
               {runtime === "slow" && (
-                <p className="text-sm text-muted-foreground">
+                <p role="status" className="text-sm text-muted-foreground">
                   Smithers is still catching up. You can continue — your first message may take a
                   moment to land.
                 </p>

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -337,10 +337,13 @@ interface ProviderKeyFormProps {
   defaultProvider?: string | null;
   onDirtyChange?: (isDirty: boolean) => void;
   /**
-   * Called after a successful save. Receives the provider name and whether
-   * the provider's default models include vision capability.
+   * Called after a successful save. Receives the provider name, whether the
+   * provider's default models include vision capability, and — when the save
+   * actually regenerated OpenClaw's config — the id of the agent whose arrival
+   * in OC's runtime the caller may want to wait for (#1150). Absent when
+   * nothing was pushed, i.e. when there is no reload to wait for.
    */
-  onSaved?: (provider: ProviderName, hasVision: boolean) => void;
+  onSaved?: (provider: ProviderName, hasVision: boolean, agentId?: string) => void;
   /**
    * Setup wizard only (#894): offer a "Custom provider" action below the
    * built-in tiles that swaps in the multi-field custom provider form. Off by
@@ -542,7 +545,7 @@ export function ProviderKeyForm({
         ? { provider, url: values.apiKey }
         : { provider, apiKey: values.apiKey };
 
-      const data = await apiPost<{ warning?: string }, SetupProviderInput>(
+      const data = await apiPost<{ warning?: string; agentId?: string }, SetupProviderInput>(
         "/api/setup/provider",
         body
       );
@@ -561,7 +564,11 @@ export function ProviderKeyForm({
         toast.success(isUrlProvider ? "URL saved" : "API key saved");
       }
       triggerRestart();
-      onSaved?.(provider, VISION_CAPABLE_PROVIDERS.has(provider));
+      onSaved?.(
+        provider,
+        VISION_CAPABLE_PROVIDERS.has(provider),
+        typeof data?.agentId === "string" ? data.agentId : undefined
+      );
       onSuccess(provider);
     } catch (err) {
       // Session expired — redirect to login rather than showing an inline error.

--- a/packages/web/src/hooks/use-agent-runtime-readiness.ts
+++ b/packages/web/src/hooks/use-agent-runtime-readiness.ts
@@ -59,7 +59,20 @@ export function useAgentRuntimeReadiness(agentId: string | null): AgentRuntimeRe
     if (!agentId) return;
 
     let cancelled = false;
-    const deadline = Date.now() + RUNTIME_READY_BUDGET_MS;
+
+    // The budget runs on its own timer rather than being read between polls,
+    // and that is the load-bearing part. `apiGet` issues a bare `fetch` with no
+    // signal, and the endpoint behind it waits on an OpenClaw RPC — so a
+    // gateway wedged mid-restart, or a Pinchy container that goes away between
+    // two polls, suspends the loop wherever it happens to be. A deadline only
+    // consulted after the request settles is not a deadline: the caller would
+    // stay in `preparing` for as long as the browser keeps the socket open,
+    // which is precisely the unbounded wait this hook exists to replace.
+    const budget = setTimeout(() => {
+      if (cancelled) return;
+      cancelled = true;
+      setOutcome({ agentId, state: "slow" });
+    }, RUNTIME_READY_BUDGET_MS);
 
     void (async () => {
       while (!cancelled) {
@@ -69,6 +82,7 @@ export function useAgentRuntimeReadiness(agentId: string | null): AgentRuntimeRe
           );
           if (cancelled) return;
           if (health.agentDispatchable) {
+            clearTimeout(budget);
             setOutcome({ agentId, state: "ready" });
             return;
           }
@@ -76,16 +90,13 @@ export function useAgentRuntimeReadiness(agentId: string | null): AgentRuntimeRe
           // A gateway that is mid-restart is the common case here, not an
           // anomaly — keep polling until the budget says otherwise.
         }
-        if (Date.now() >= deadline) {
-          if (!cancelled) setOutcome({ agentId, state: "slow" });
-          return;
-        }
         await new Promise((resolve) => setTimeout(resolve, RUNTIME_READY_POLL_MS));
       }
     })();
 
     return () => {
       cancelled = true;
+      clearTimeout(budget);
     };
   }, [agentId]);
 

--- a/packages/web/src/hooks/use-agent-runtime-readiness.ts
+++ b/packages/web/src/hooks/use-agent-runtime-readiness.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiGet } from "@/lib/api-client";
+
+/**
+ * Poll interval and total budget for {@link useAgentRuntimeReadiness}.
+ *
+ * The budget is deliberately the SAME 30 s that `POST /api/setup/provider` used
+ * to spend inside the request before #1150 — the wait did not get longer, it
+ * got visible. Anything shorter would hand the user through into a chat that is
+ * still going to race OpenClaw's reload; anything longer starts to look like
+ * the hang this replaced.
+ */
+export const RUNTIME_READY_POLL_MS = 1_000;
+export const RUNTIME_READY_BUDGET_MS = 30_000;
+
+/**
+ * - `unknown` — nothing to wait for (no agent id: the caller's save never
+ *   reached OpenClaw, so there is no reload coming).
+ * - `preparing` — OpenClaw does not carry the agent yet.
+ * - `ready` — a chat dispatched now would not hit "unknown agent id".
+ * - `slow` — the budget ran out. Not an error: the runtime is still catching
+ *   up, and the caller should let the user through rather than trap them.
+ */
+export type AgentRuntimeReadiness = "unknown" | "preparing" | "ready" | "slow";
+
+/**
+ * Watch OpenClaw's runtime until it can dispatch to `agentId`.
+ *
+ * Why this exists on the client at all (#1150): Pinchy pushes config to
+ * OpenClaw in the background, so an agent reaches OC's `agents.list` some time
+ * after the route that created it has answered. That gap is normally
+ * sub-second, but on a fresh install it is not — writing the first secrets.json
+ * restarts the gateway, the restarts spend OC's ~3-per-45 s `config.apply`
+ * budget, and Pinchy's push is then parked for the advertised retry-after (49 s
+ * in the run this was measured on).
+ *
+ * The setup wizard used to absorb that gap by leaving `POST /api/setup/provider`
+ * open, which turned a legitimate wait into a disabled button and a spinner
+ * nobody can tell from a hang. Polling it here instead means the wait can be
+ * named, bounded, and escaped.
+ *
+ * `GET /api/health/openclaw?agentId=…` is the existing endpoint for exactly
+ * this question — it reports `agentDispatchable`, i.e. whether OC's
+ * `agents.list` carries the id right now. It is unauthenticated and returns no
+ * agent metadata, and every failure mode on its side already collapses to
+ * `agentDispatchable: false`, so this poll never has to interpret an error.
+ */
+export function useAgentRuntimeReadiness(agentId: string | null): AgentRuntimeReadiness {
+  // Only the two OUTCOMES are stored, and they carry the id they were reached
+  // for. `unknown` and `preparing` are derived below rather than written here,
+  // so the effect never has to setState synchronously to reset itself when the
+  // id changes — that would be a cascading render, and the derivation is the
+  // shorter way to say the same thing.
+  const [outcome, setOutcome] = useState<{ agentId: string; state: "ready" | "slow" } | null>(null);
+
+  useEffect(() => {
+    if (!agentId) return;
+
+    let cancelled = false;
+    const deadline = Date.now() + RUNTIME_READY_BUDGET_MS;
+
+    void (async () => {
+      while (!cancelled) {
+        try {
+          const health = await apiGet<{ agentDispatchable?: boolean }>(
+            `/api/health/openclaw?agentId=${encodeURIComponent(agentId)}`
+          );
+          if (cancelled) return;
+          if (health.agentDispatchable) {
+            setOutcome({ agentId, state: "ready" });
+            return;
+          }
+        } catch {
+          // A gateway that is mid-restart is the common case here, not an
+          // anomaly — keep polling until the budget says otherwise.
+        }
+        if (Date.now() >= deadline) {
+          if (!cancelled) setOutcome({ agentId, state: "slow" });
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, RUNTIME_READY_POLL_MS));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  if (!agentId) return "unknown";
+  return outcome?.agentId === agentId ? outcome.state : "preparing";
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the setup wizard hanging on `Validating...` when OpenClaw rate-limits `config.apply`.

Refs #1150 — deliberately **not** `Closes`. That issue opened on the sparse-regenerate `size-drop` mechanism in the Telegram E2E; this PR fixes the user-visible symptom reported in [this comment](https://github.com/heypinchy/pinchy/issues/1150#issuecomment-5238634968) and leaves the original subject open.

### One correction to the diagnosis in that comment

The comment reads the ~50 s as an in-request sleep. It isn't: `pushConfigInBackground` is a `void (async () => …)()` (`write.ts:267`), so the parked rate-limit retry blocks nobody.

What actually held `POST /api/setup/provider` open was `waitForAgentInRuntime(client, smithersId, 30000)` in the route — up to 30 s. The chain is the one the comment describes (the parked `config.apply` keeps Smithers out of `agents.list`, so the poll burns its whole budget), but the distinction matters: **tuning the rate-limit retry would not have fixed the hang.** 30 s blows the 15 s assertion just as reliably, and a human on a fresh install watches the same spinner.

### The fix

The wait is not dropped — the race it exists for (#445) is real and still has to be closed before the first dispatch. It moves to where it can be rendered.

- **Route** answers as soon as the credential is committed and the regenerate has been kicked off, and returns `agentId`. Omitted when the regenerate threw: nothing was pushed, so no reload is coming and polling would only delay the user past a gap the existing `warning` already describes.
- **Wizard** polls `GET /api/health/openclaw?agentId=…` — the endpoint that already answers exactly this question via `agentDispatchable` — shows **Getting Smithers ready…** and holds **Continue to Pinchy** until the runtime has the agent. New hook: `src/hooks/use-agent-runtime-readiness.ts`.
- **The budget is the same 30 s** the request used to spend, so wall-clock is no worse — the wait became visible, not longer. Past it the button unlocks with an honest note rather than trapping anyone in the wizard; the first chat has its own dispatch-race retry behind it.

### For the reviewer

- **The route test is the reproduction.** It races the handler against a 2 s timer with `config.get` never settling, so a re-introduced in-request round trip fails **by name** instead of as a 20 s test timeout. Both new guards were canary-verified (red without the `disabled` prop; red before the route change).
- **`onSaved` grew a third argument** (`agentId?`). `settings-page-content.tsx` passes no `onSaved`, so the Settings → AI Provider path is unaffected.
- **`waitForAgentInRuntime` stays** — `/api/invite/claim` and `lib/agents.ts` still use it, both on the bounded 5 s default.
- **Two things from the issue comment are deliberately out of scope.** Ordering the first-`secrets.json` provisioning is independently right but lowers the *frequency* of the collision rather than the blockage, and it touches the OpenClaw bootstrap — its own PR. `path-mismatch` is an observation about #1150's original fix; this route now waits on neither rejection reason.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

Gates run locally: `pnpm test` (12003 ✓), `pnpm test:scripts` (1240 ✓), `pnpm build`, `tsc --noEmit -p tsconfig.typecheck.json`, `prettier --check .`, ESLint (0 errors), and `pnpm -C docs build && check:anchors && check:rendered`.
