### PR TITLE
docs(eval): say why two KB axes are unmeasured — and that one tag cannot fire

### DIFF
--- a/packages/web/eval/kb/data/README.md
+++ b/packages/web/eval/kb/data/README.md
@@ -80,11 +80,36 @@ one supports.
 ## Coverage gap, stated rather than left to be noticed
 
 `KB_EVAL_AXES` declares **eight** axes; the gold set covers **six**.
-`freshness` and `crowding` were added to the axis list by #858 and never given
-gold questions, so their cells are present and empty. Present is the point: an
-axis with no data must read as _unmeasured_, not vanish from the report. Do not
-read `n=0` as "passed" or as "not applicable" — it means nobody has written the
-questions yet.
+`freshness` and `crowding` were added to the axis list by #858 and have no gold
+Q/A items, so their cells are present and empty. Present is the point: an axis
+with no data must read as _unmeasured_, not vanish from the report. Do not read
+`n=0` as "passed" or as "not applicable".
+
+**The gap is structural, not clerical.** Writing the two questions is the easy
+part — `gold-queries.ts` already carries four of each for Layer 1 — and doing
+only that would produce two cells that look measured and measure nothing the
+axis is named for:
+
+- **`freshness` is invisible to an entailment judge.** The archived certificate
+  says, in as many words, "certificate number NF-2013-0092". An answer citing it
+  as current accreditation is **entailed by the passage it cites**, so
+  `ungrounded-claim` cannot fire. Grounded and stale is a distinct failure, and
+  no `KbFailureTag` names it. (Default retrieval also excludes archived
+  documents, so the stale source only reaches the model when it sets
+  `include_archived` itself — which is exactly the behaviour worth measuring,
+  and exactly what a pass rate over the current tags would hide.) Measuring this
+  axis needs a grader, not a question.
+- **`crowding` is a ranking property, and Layer 3 grades text.** Both
+  `petrifilm-datasheet#c2` and `quality-binder#c3` state the same incubation
+  fact, so an answer citing the binder is grounded, relevant and correctly
+  attributed — it passes. The only Layer-3-visible failure is citing both as
+  independent corroboration, which is `dedup-inflation`, i.e. the `dedup` axis
+  `gqa-dedup-1` already covers. Layer 1 measures crowding where it lives, with
+  four gold queries against `retrieve()`'s ranking.
+
+So the empty cells stay empty on purpose until someone decides the grader
+question, and this note exists so the next person does not close the gap by
+writing two questions and reporting a green axis.
 
 The `distractor` axis carries the two abstention items (`gqa-abstention-1/2`)
 by design; see the note at the top of `../corpus/gold-qa.ts`.

--- a/packages/web/eval/kb/data/README.md
+++ b/packages/web/eval/kb/data/README.md
@@ -57,11 +57,23 @@ a groundedness property) and grades the answer on nine tags:
 | `false-abstention`    | refused where the corpus did contain the answer        | 0          |
 | `off-topic-grounded`  | grounded, but does not answer the question             | 0          |
 
-All nine are reachable in this sweep's pipeline; the last column is what it
-actually charged. The four that read 0 are listed for the same reason the two
-gold-less axes below keep their empty cells: a tag missing from this table is
-one a reader meets in the data with nothing to look it up against, and "did
-not fire" is a measurement, not an absence.
+The last column is what this sweep actually charged. The five tags that read 0
+are listed for the same reason the two gold-less axes below keep their empty
+cells: a tag missing from this table is one a reader meets in the data with
+nothing to look it up against, and "did not fire" is a measurement, not an
+absence.
+
+Four of those zeros are measurements. **`dedup-inflation`'s is not**, and the
+difference matters more than the number: `gradeNoDuplicateCorroboration` scores
+the Sources list against `nearDuplicateGroups`, and passes unconditionally when
+that list is empty — which it always is, because `gradeKbRun` calls
+`gradeAttribution` without it. The tag is therefore unreachable in every
+pipeline that produces a published number, and its 0 means "not asked", not
+"did not happen". Wiring the corpus's known duplicate pairs through would make
+the `dedup` axis grade the thing it is named for, and it is a fine change to
+make — `answer-graders.test.ts` goes red the day someone does, so this paragraph
+is corrected in that change rather than left standing over a tag that by then
+can fire.
 
 A run **passes** only with zero tags. That is a deliberately strict bar: these
 are conjunctive quality gates, not a score.
@@ -90,26 +102,39 @@ part — `gold-queries.ts` already carries four of each for Layer 1 — and doin
 only that would produce two cells that look measured and measure nothing the
 axis is named for:
 
-- **`freshness` is invisible to an entailment judge.** The archived certificate
-  says, in as many words, "certificate number NF-2013-0092". An answer citing it
-  as current accreditation is **entailed by the passage it cites**, so
-  `ungrounded-claim` cannot fire. Grounded and stale is a distinct failure, and
-  no `KbFailureTag` names it. (Default retrieval also excludes archived
-  documents, so the stale source only reaches the model when it sets
-  `include_archived` itself — which is exactly the behaviour worth measuring,
-  and exactly what a pass rate over the current tags would hide.) Measuring this
-  axis needs a grader, not a question.
+- **`freshness` asks about a document this sweep never puts in front of the
+  model.** `retrieve()` appends `AND d.status = 'active'` unless the caller sets
+  `includeArchived`, and the expired certificate is seeded `archived` by its
+  `OLD/` path segment. A gold question like "what is the current AFNOR
+  certificate?" therefore retrieves the 2024 cert alone: the model answers it
+  correctly, the cell goes green, and the stale document was never in the
+  running. It reaches the model only when the model sets `include_archived`
+  itself — which is the behaviour worth measuring, and which a pass rate over
+  today's tags reports as a plain pass either way. Measuring this axis means
+  controlling that flag in a sweep variant, not writing a question.
+
+  Where a stale answer _is_ possible, only half of it is caught. Our archived
+  chunk announces its own expiry ("expired in December 2016 … retained for
+  historical reference only"), so an answer calling NF-2013-0092 current is
+  contradicted by the passage it cites and the judge should charge
+  `ungrounded-claim`. What no tag names is the honest-sounding half: citing the
+  expired certificate for something it really does say, without claiming
+  currency. Grounded and stale is its own failure mode, and it needs a grader.
+
 - **`crowding` is a ranking property, and Layer 3 grades text.** Both
   `petrifilm-datasheet#c2` and `quality-binder#c3` state the same incubation
-  fact, so an answer citing the binder is grounded, relevant and correctly
-  attributed — it passes. The only Layer-3-visible failure is citing both as
-  independent corroboration, which is `dedup-inflation`, i.e. the `dedup` axis
-  `gqa-dedup-1` already covers. Layer 1 measures crowding where it lives, with
-  four gold queries against `retrieve()`'s ranking.
+  fact, so an answer citing the binder rather than the datasheet is grounded,
+  relevant and correctly attributed — every Layer-3 grader passes it, and
+  passing is the right verdict on the text. Which of the two the retrieval
+  ranked first is the actual question, and Layer 1 is where it is asked, with
+  four gold queries scored against `retrieve()`'s ranking. The one Layer-3 tag
+  that could speak to crowding — `dedup-inflation`, for citing both copies as
+  independent corroboration — is the unreachable one described above.
 
-So the empty cells stay empty on purpose until someone decides the grader
-question, and this note exists so the next person does not close the gap by
-writing two questions and reporting a green axis.
+So the empty cells stay empty on purpose. Closing the gap honestly means a sweep
+variant for `freshness` and a wired-up `dedup-inflation` for `crowding`, both of
+which carry a real design decision. This note exists so the next person does not
+close it instead by writing two questions and reporting a green axis.
 
 The `distractor` axis carries the two abstention items (`gqa-abstention-1/2`)
 by design; see the note at the top of `../corpus/gold-qa.ts`.

--- a/packages/web/eval/kb/readme-tag-coverage.test.ts
+++ b/packages/web/eval/kb/readme-tag-coverage.test.ts
@@ -3,10 +3,16 @@
  *
  * It is a hand-maintained list that mirrors code, which AGENTS.md says will be
  * wrong — and it already was on the day it was written: it listed six of the
- * nine tags `gradeKbRun` composes, so `path-not-cited`, `dedup-inflation` and
- * `false-abstention` were reachable with nothing in the published dataset's
- * own documentation to look them up against. Nothing was red, because nothing
- * was looking.
+ * nine tags `gradeKbRun` composes, so `path-not-cited` and `false-abstention`
+ * were reachable with nothing in the published dataset's own documentation to
+ * look them up against. Nothing was red, because nothing was looking.
+ *
+ * (The third missing tag, `dedup-inflation`, turned out not to be reachable at
+ * all: `gradeKbRun` passes `gradeAttribution` no `nearDuplicateGroups`, so the
+ * grader passes unconditionally. It is documented anyway, and the README says
+ * why its 0 is not a measurement — guarded by a behavioural test next to
+ * `gradeKbRun` rather than by this file, which only checks that a tag is
+ * named.)
  *
  * Same shape as `scripts/lib/docs-coverage.test.mjs` one level up: read the
  * union from the source, and fail rather than shrink when the source stops

--- a/packages/web/src/lib/eval/kb/__tests__/answer-graders.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/answer-graders.test.ts
@@ -283,6 +283,42 @@ describe("gradeKbRun", () => {
     expect(relevanceJudgeCalled).toBe(false);
   });
 
+  it("cannot charge dedup-inflation, because it passes gradeAttribution no near-duplicate groups", async () => {
+    // `data/README.md` publishes `dedup-inflation` with a 0 and now says in
+    // print that this particular zero is structural rather than measured:
+    // `gradeNoDuplicateCorroboration` compares the Sources list against
+    // `nearDuplicateGroups`, and passes unconditionally when that list is
+    // empty — which it always is here, because `gradeKbRun` never supplies one.
+    // So the tag cannot reach a published number no matter what a model writes.
+    //
+    // This is the guard on that sentence. Wiring the corpus's duplicate pairs
+    // through is a fine change to make; it must go red here first, so the
+    // README stops claiming "not asked" about a tag that by then can fire.
+    const traj = baseTraj({
+      // The crowding pair from the eval corpus: one fact, two documents, both
+      // cited as if they corroborated each other independently.
+      answer: `Aerobic plates are incubated at 32 degrees Celsius for 48 hours [1][2].
+
+**Sources:**
+
+- [1] /data/petrifilm-datasheet.md — p. 1
+- [2] /data/quality-binder.md — p. 1`,
+      retrieved: [src(1, "/data/petrifilm-datasheet.md"), src(2, "/data/quality-binder.md")],
+    });
+
+    const result = await gradeKbRun(traj, baseGold, {
+      nli: highScoreNli(),
+      relevance: fixedRelevanceJudge(0.9),
+      abstention: ANSWERED,
+    });
+
+    // Asserted as a clean pass, not merely as "dedup-inflation absent": a run
+    // that failed for some unrelated reason would satisfy a bare `not.toContain`
+    // while proving nothing about the grader under test.
+    expect(result.tags).toEqual([]);
+    expect(result.passed).toBe(true);
+  });
+
   it("a missed-abstention run (gold expects abstention, model answered anyway) is flagged", async () => {
     const gold: GoldQA = { ...baseGold, expectAbstention: true };
     const traj = baseTraj();


### PR DESCRIPTION
## The sentence this replaces

> `freshness` and `crowding` … Do not read `n=0` as "passed" or as "not applicable" — **it means nobody has written the questions yet.**

True, and misleading. It frames the gap as clerical — and `gold-queries.ts` already carries **four Layer-1 gold queries for each axis**, so the obvious next move is to copy them into `gold-qa.ts` and report two populated cells.

I started to do exactly that. It would have measured nothing either axis is named for.

## Why not

**`freshness` asks about a document Layer 3 never puts in front of the model.** `retrieve()` appends `AND d.status = 'active'` unless the caller sets `includeArchived`, and the expired certificate is seeded `archived` by its `OLD/` path segment. So "what is the current AFNOR certificate?" retrieves the 2024 cert alone: the model answers correctly, the cell goes green, and the stale document was never in the running. It reaches the model only when the model itself sets `include_archived` — which is precisely the behaviour worth measuring, and which a pass rate over today's tags reports as a plain pass either way.

Where a stale answer *is* possible, only half of it is catchable. The archived chunk announces its own expiry ("expired in December 2016 … retained for historical reference only"), so an answer calling NF-2013-0092 *current* is contradicted by the passage it cites and the judge should charge `ungrounded-claim`. What no `KbFailureTag` names is the honest-sounding half: citing the expired certificate for something it really does say, without claiming currency.

**`crowding` is a ranking property, and Layer 3 grades text.** `petrifilm-datasheet#c2` and `quality-binder#c3` both state "32 degrees Celsius for 48 hours". An answer citing the binder is grounded, relevant and correctly attributed — every Layer-3 grader passes it, and passing is the right verdict *on the text*. Which of the two was ranked first is the real question, and Layer 1 is where it is asked, with four gold queries against `retrieve()`'s ranking.

## What the review turned up

Verifying the above against the code found a third thing, and it is the most interesting one: **`dedup-inflation` cannot fire at all.** `gradeNoDuplicateCorroboration` scores the Sources list against `nearDuplicateGroups`, passes unconditionally when that list is empty, and `gradeKbRun` calls `gradeAttribution` without it. The only other caller passes `[]` explicitly. So the tag is unreachable in every pipeline that produces a published number, and the dataset's `0` for it means "not asked", not "did not happen".

That also corrected two sentences already in the file: "all nine are reachable in this sweep's pipeline" (eight are), and "the four that read 0" (five do).

A hand-maintained claim about code is exactly what AGENTS.md says will rot, so it gets a **behavioural guard** rather than a comment: `gradeKbRun` grading a co-cited near-duplicate pair must stay clean. Canary-verified — wiring the groups through turns it red and names the tag, so whoever makes that change corrects this README in the same commit.

## What this does NOT do

It does not decide whether Layer-3 `freshness` is worth building (that needs a new `KbFailureTag` for grounded-but-stale **and** a sweep variant where the archived source is reachable), and it does not wire `nearDuplicateGroups` through. Both are scoped pieces of work with real design questions in them, not something to smuggle into a docs fix.

No data changes. The empty cells stay empty on purpose, and now say why.

## Test plan

- [x] `vitest run eval/kb/ src/lib/eval/kb/` — 277 pass (276 + the new guard)
- [x] Canary: added `nearDuplicateGroups` to `gradeKbRun`'s `gradeAttribution` call → new test fails with `expected [ 'dedup-inflation' ] to deeply equal []`; reverted
- [x] `pnpm -C packages/web typecheck`, `eslint`, `prettier --check`

Refs #869, #858
