### PR TITLE
fix(automations): drop the dead Automations tab from personal agents

### DIFF
--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -15,9 +15,9 @@ Every agent in Pinchy is configured through a settings page. To open it, navigat
 | **Permissions**                                       | Tool allow-list, directory access     | Admins only, shared agents |
 | **Access** <Badge text="Enterprise" variant="note" /> | Visibility mode, group assignment     | Admins only, shared agents |
 | **Telegram**                                          | Connect a Telegram bot to this agent  | Admins only                |
-| **Automations**                                       | Email workflows the agent runs itself | Owner (personal) or admins |
+| **Automations**                                       | Email workflows the agent runs itself | Admins only, shared agents |
 
-The Permissions and Access tabs exist only for shared agents. Personal agents (the auto-created Smithers each user gets) don't show them because there's nothing to share. Admins still see the Telegram tab on Smithers, but the main Smithers bot is managed centrally via **Settings → Telegram** rather than per-agent.
+The Permissions, Access and Automations tabs exist only for shared agents. Personal agents (the auto-created Smithers each user gets) don't show Permissions or Access because there's nothing to share — and Automations follows them, because an automation needs a mailbox the agent may read, and email access is granted on the Permissions tab. A personal agent has no way to hold one, so the tab would only ever offer an empty mailbox list. Admins still see the Telegram tab on Smithers, but the main Smithers bot is managed centrally via **Settings → Telegram** rather than per-agent.
 
 :::note[Enterprise feature]
 The **Access** tab requires a Pinchy Enterprise license. Without a license, the tab shows an upgrade prompt. See [Enterprise Setup](/guides/enterprise-setup/) for details.
@@ -158,7 +158,9 @@ For the full flow including BotFather setup and account linking, see [Set Up Tel
 
 The Automations tab is where an agent's **email workflows** live — standing rules that let the agent act on incoming mail on its own, without anyone opening a chat. A workflow pairs a deterministic **trigger** (which mail it fires on) with an **instruction** (what the agent does with each matching message). Pinchy checks the connected mailboxes on a schedule and runs the instruction once per new matching mail, tracking exactly which messages it has already handled so nothing is processed twice — and it never relies on the read/unread state you see in your own inbox.
 
-You'll see this tab on your personal Smithers and, as an admin, on shared agents that can read email. It's gated the same way the underlying API is: you can manage automations on a personal agent you own, and admins can manage them on any shared agent. A colleague's personal agent is nobody else's to manage — personal agents stay private to their owner, admins included. One thing survives that rule, and it lives in the API rather than in this tab: an admin who already has a workflow's ID can still stop it, so a runaway automation is never unstoppable. See the [API reference](/reference/api/#automations).
+As an admin, you'll see this tab on shared agents. It isn't on personal agents — including your own Smithers — for a practical reason rather than a permission one: an automation watches a mailbox the agent is allowed to read, that access is granted on the **Permissions** tab, and personal agents don't have one. The tab there could only ever show an empty mailbox list and a form you couldn't finish. Give a shared agent email access first and its Automations tab has something to offer.
+
+The API is deliberately a little wider than this tab, and a colleague's personal agent is still nobody else's to manage — personal agents stay private to their owner, admins included. One thing survives that rule: an admin who already has a workflow's ID can still stop it, so a runaway automation is never unstoppable. See the [API reference](/reference/api/#automations).
 
 ### Create an automation
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -312,7 +312,7 @@ Two things to know. Links handed out **before** this upgrade cannot be checked â
 
 #### Automations move into the agent
 
-Email workflows now have their own **Automations** tab in an agent's settings, where you can review, create, enable, disable and delete them. It is visible to admins on any shared agent, and to the owner of a personal agent. Existing workflows are listed as-is; nothing changes on upgrade until you edit one.
+Email workflows now have their own **Automations** tab in an agent's settings, where you can review, create, enable, disable and delete them. It is visible to admins on shared agents â€” the same place email access is granted, since a workflow needs a mailbox the agent may read. Existing workflows are listed as-is; nothing changes on upgrade until you edit one.
 
 #### An agent you may not see now answers "not found"
 

--- a/packages/web/src/__tests__/components/agent-settings-page-content-automations-tab.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-page-content-automations-tab.test.tsx
@@ -4,12 +4,23 @@ import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 
 // The Automations tab (#139) is the review-and-activate surface for an agent's
-// email workflows. It carries the same scope as managing the agent itself: a
-// personal agent's owner (a non-admin) may manage it, and an admin may manage a
-// shared agent's — mirroring the Telegram tab's gate. (A non-admin on a shared
-// agent never reaches this page at all — canEdit is false and the page
-// redirects to chat — so there is no "visible page without the tab" case to
-// assert for them.)
+// email workflows. Automations are email-only, and an agent's email access is
+// granted on the Permissions tab — which exists only for SHARED agents, and
+// only for admins (`showPermissions = isAdmin && !isPersonal`).
+//
+// This tab used to be gated the other way round (`isAdmin || isPersonal`,
+// mirroring Telegram), which put an Automations tab on every personal agent —
+// including Smithers — where there is no way to grant email access at all. The
+// tab could therefore only ever show an empty mailbox picker and a create form
+// that cannot be completed: pure confusion, zero capability.
+//
+// So the gate is now the SAME condition under which the agent can hold an email
+// connection in the first place. These tests pin both halves of that: where it
+// must not appear, and that it appears exactly alongside Permissions.
+//
+// (A non-admin on a shared agent never reaches this page at all — canEdit is
+// false and the page redirects to chat — so there is no "visible page without
+// the tab" case to assert for them.)
 
 const mockSession = vi.fn();
 vi.mock("@/lib/auth-client", () => ({
@@ -76,7 +87,28 @@ describe("AgentSettingsPageContent — Automations tab visibility (#139)", () =>
     vi.clearAllMocks();
   });
 
-  it("shows the Automations tab to a non-admin owner of a personal agent", async () => {
+  // The Smithers case, and the reason this gate changed: the very first user is
+  // an admin, and their own personal agent is the one they open first. Being an
+  // admin does not conjure a Permissions tab for a personal agent, so it must
+  // not conjure an Automations tab either.
+  it("hides the Automations tab on a personal agent, even from an admin", async () => {
+    mockSession.mockReturnValue({
+      data: { user: { id: "admin-1", role: "admin" } },
+      isPending: false,
+    });
+    mockFetchReturning({ ...baseAgent, isPersonal: true });
+
+    render(<AgentSettingsPageContent />);
+
+    // Wait for the page to actually render its tabs before asserting absence —
+    // otherwise this passes on the loading state and proves nothing.
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /general/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("tab", { name: /automations/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the Automations tab from a non-admin owner of a personal agent", async () => {
     mockSession.mockReturnValue({
       data: { user: { id: "u1", role: "member" } },
       isPending: false,
@@ -86,11 +118,15 @@ describe("AgentSettingsPageContent — Automations tab visibility (#139)", () =>
     render(<AgentSettingsPageContent />);
 
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: /automations/i })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /general/i })).toBeInTheDocument();
     });
+    expect(screen.queryByRole("tab", { name: /automations/i })).not.toBeInTheDocument();
   });
 
-  it("shows the Automations tab to an admin on a shared agent", async () => {
+  // Pins the coupling itself, not just the outcome: Automations is offered
+  // exactly where the email access it depends on can be granted. If someone
+  // moves one gate later, this fails rather than silently re-opening the split.
+  it("shows the Automations tab to an admin on a shared agent, alongside Permissions", async () => {
     mockSession.mockReturnValue({
       data: { user: { id: "admin-1", role: "admin" } },
       isPending: false,
@@ -102,5 +138,6 @@ describe("AgentSettingsPageContent — Automations tab visibility (#139)", () =>
     await waitFor(() => {
       expect(screen.getByRole("tab", { name: /automations/i })).toBeInTheDocument();
     });
+    expect(screen.getByRole("tab", { name: /permissions/i })).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -162,19 +162,28 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
   // being an admin. The page is only viewable by the owner or an admin (see
   // `canEdit`), so `isPersonal` here implies the viewer owns it. (#476 gap 2)
   const canManageTelegram = isAdmin || agent?.isPersonal === true;
-  // Same scope as Telegram: a personal agent's owner (non-admin) manages its own
-  // automations; a shared agent's are admin-only. That mirrors the scope gate the
-  // management API applies (canManageAgentWorkflows), so for a member the tab and
-  // the routes agree on every agent this page will load.
+  // Deliberately NOT the Telegram gate above, though it used to be.
   //
-  // For an admin on a COLLEAGUE'S personal agent they no longer do, and the whole
-  // page is already in that state rather than this tab alone: since #880 the
-  // agentId-keyed Automations routes run the visibility gate first, and a personal
-  // agent stays private to its owner — admins included. The agent fetch above
-  // (`GET /api/agents/[agentId]`) has answered 404 for that case since #1148, so
-  // `agent` stays null and every tab renders empty. Listing the tab grants
-  // nothing; the routes behind it answer 404 too.
-  const canManageAutomations = isAdmin || agent?.isPersonal === true;
+  // Automations are email-only, and an agent's email access is granted on the
+  // Permissions tab — which exists for SHARED agents and admins alone. A
+  // personal agent has no way to hold an email connection at all, so an
+  // Automations tab there could only ever offer an empty mailbox picker and a
+  // create form that cannot be completed: a dead tab on every personal agent,
+  // Smithers included. Telegram earns its broader gate because a personal
+  // agent's owner really can manage a bot; there is no equivalent here.
+  //
+  // So the gate is the condition under which the agent can hold an email
+  // connection in the first place — one value feeding both tabs (see
+  // `showPermissions`), so the surface that configures email workflows cannot
+  // drift away from the surface that grants the access they need.
+  //
+  // The management API stays deliberately broader (`canManageAgentWorkflows`
+  // still admits a personal agent's owner) and that is not a disagreement: this
+  // is UI reachability, not an authorization boundary. The write routes refuse
+  // any workflow pointed at a mailbox the agent cannot read, so nothing here is
+  // load-bearing for security.
+  const canManageAgentConnections = isAdmin && agent?.isPersonal === false;
+  const canManageAutomations = canManageAgentConnections;
   const visibleTabs: AgentSettingsTab[] =
     isPending || isAdmin
       ? [...AGENT_SETTINGS_TABS]
@@ -461,7 +470,12 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
   }
 
   const canDelete = isAdmin && !agent.isPersonal;
-  const showPermissions = isAdmin && !agent.isPersonal;
+  // Same value as the Automations gate, on purpose and by reference rather than
+  // by a second copy of the expression: this tab is where an agent's email
+  // access is granted, so the tab that configures email workflows must appear
+  // exactly where that grant is possible. Two hand-maintained copies are what
+  // let them drift apart in the first place.
+  const showPermissions = canManageAgentConnections;
 
   // Non-admins cannot edit shared agents — redirect handled by effect above
   if (!canEdit) {


### PR DESCRIPTION
## Why

Smithers — and every other personal agent — showed an **Automations** tab that could never do anything.

Two gates in `agent-settings-page-content.tsx` were exact opposites:

```ts
showPermissions      = isAdmin && !agent.isPersonal   // where email access is granted
canManageAutomations = isAdmin ||  agent.isPersonal   // where email workflows are configured
```

Automations are email-only. An agent's email access is granted on the **Permissions** tab, which exists only for shared agents. A personal agent therefore has **no way to ever hold an email connection** — so its Automations tab could only ever offer an empty mailbox picker and a create form that cannot be submitted (`connectionIds` requires at least one). Pure confusion, zero capability.

The tab was modelled on Telegram's gate, but Telegram earns it: a personal agent's owner really can manage its bot. There is no equivalent here.

## What

One value feeds both tabs, by reference rather than as a second copy of the expression:

```ts
const canManageAgentConnections = isAdmin && agent?.isPersonal === false;
const canManageAutomations = canManageAgentConnections;
// ...
const showPermissions = canManageAgentConnections;
```

The surface that configures email workflows can no longer drift away from the surface that grants the access those workflows need — two hand-maintained copies are exactly what let them diverge.

## What this is *not*

**Not a permission change.** `canManageAgentWorkflows` (the management API gate) is deliberately left broader and still admits a personal agent's owner. This is **UI reachability**, not an authorization boundary: the write routes independently refuse any workflow pointed at a mailbox the agent cannot read, so nothing here is load-bearing for security.

## Tests (TDD, RED→GREEN)

`agent-settings-page-content-automations-tab.test.tsx` had encoded the old rule (*"shows the Automations tab to a non-admin owner of a personal agent"*). That expectation is what this PR deliberately reverses — a product decision, not a weakened test. It is rewritten, and the file goes **2 → 3** cases:

- **hides the tab on a personal agent, even from an admin** — the Smithers case, and the reason this shipped wrong: the first user *is* an admin, and their own personal agent is the first thing they open.
- **hides the tab from a non-admin owner of a personal agent** (inverted).
- **shows the tab to an admin on a shared agent, alongside Permissions** — pins the *coupling*, not just the outcome, so moving one gate later fails loudly.

Absence assertions wait for the tabs to render first, so they cannot pass on the loading state.

## Docs

Tab table, the Automations concept section, and the (still **unreleased** 0.10.0) upgrade note — corrected in place, not rewriting shipped history.

Worth noting: `guides/email-automations.mdx` already required *"**A shared agent** to own the workflow"*. The prose was consistent with this behavior all along; only the tab was not.

## Gates

typecheck 0 · eslint 0/0 · prettier clean (incl. docs) · `check-docs-required` passes · full web unit suite **12126 passed / 0 failed**.