### PR TITLE
fix(eval): read the citation position the knowledge tool actually prints

### DIFF
--- a/packages/web/src/lib/eval/kb/__tests__/cited-position.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/cited-position.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The Sources-entry position parser, pinned against what `formatLocator`
+ * actually emits.
+ *
+ * `parseCitedPosition` splits `<path> (p. 12)` into the document a citation
+ * names and the position inside it. The round-trip tests below are the reason
+ * this module exists as its own file: they take a locator, render it exactly as
+ * the `pinchy-knowledge` tool renders it, parse it back, and require the two to
+ * be equal. A new `ChunkLocator` kind then cannot be added without either
+ * teaching this parser or failing here — and because `SAMPLES` is a mapped type
+ * over the union, forgetting the sample itself is a compile error, which
+ * `tsconfig.typecheck.json` turns into a CI failure rather than a silent gap.
+ */
+import { describe, expect, it } from "vitest";
+
+import { formatLocator, type ChunkLocator } from "../../../knowledge/locator";
+import { parseCitedPosition } from "../cited-position";
+
+/**
+ * One representative locator per kind. The mapped type is load-bearing: add a
+ * fifth kind to `ChunkLocator` and this object stops compiling until it carries
+ * a sample, so the round-trip pins below can never quietly cover three of four.
+ */
+const SAMPLES: { [K in ChunkLocator["kind"]]: Extract<ChunkLocator, { kind: K }> } = {
+  page: { kind: "page", page: 12 },
+  slide: { kind: "slide", slide: 4 },
+  heading: { kind: "heading", headings: ["Quality", "Incoming goods"] },
+  sheet: { kind: "sheet", sheet: "Suppliers", startRow: 5, endRow: 12 },
+};
+
+const EVERY_KIND = Object.values(SAMPLES);
+
+describe("parseCitedPosition", () => {
+  describe("round-trips every shape formatLocator emits", () => {
+    // The parenthesised form is what the tool prints and what the citation
+    // contract asks the model to repeat "exactly as written above", so this is
+    // the shape a well-behaved answer really carries.
+    it.each(EVERY_KIND)("parenthesised: $kind", (locator) => {
+      const parsed = parseCitedPosition(`quality-file.md (${formatLocator(locator)})`);
+
+      expect(parsed.path).toBe("quality-file.md");
+      expect(parsed.locator).toEqual(locator);
+    });
+
+    it.each(EVERY_KIND.filter((l) => l.kind !== "sheet"))("em-dashed: $kind", (locator) => {
+      const parsed = parseCitedPosition(`quality-file.md — ${formatLocator(locator)}`);
+
+      expect(parsed.path).toBe("quality-file.md");
+      expect(parsed.locator).toEqual(locator);
+    });
+  });
+
+  it("reads the en dash and the plain hyphen too, as the page form always has", () => {
+    // `gpt-oss:120b` writes U+2013 where the template writes U+2014. A
+    // separator delimits, it does not identify — same line `PAGE_SUFFIX` and
+    // the product's own `TRAILING_PAGE` already drew.
+    for (const dash of ["—", "–", "-"]) {
+      expect(parseCitedPosition(`a.md ${dash} p. 3`)).toEqual({
+        path: "a.md",
+        locator: { kind: "page", page: 3 },
+      });
+    }
+  });
+
+  it("keeps a hyphen inside the path out of the split", () => {
+    // The failure the `p.` literal has always prevented: `handbook-2012` must
+    // not be read as `handbook` plus a position of `2012/policy.md — p. 12`.
+    expect(parseCitedPosition("handbook-2012/policy.md — p. 12")).toEqual({
+      path: "handbook-2012/policy.md",
+      locator: { kind: "page", page: 12 },
+    });
+  });
+
+  it("keeps a hyphen inside a sheet name out of the split", () => {
+    expect(parseCitedPosition("suppliers.xlsx (Sheet-A, rows 3-4)")).toEqual({
+      path: "suppliers.xlsx",
+      locator: { kind: "sheet", sheet: "Sheet-A", startRow: 3, endRow: 4 },
+    });
+  });
+
+  it("reads a single-row sheet range, the other branch formatLocator has", () => {
+    expect(parseCitedPosition("suppliers.xlsx (Suppliers, row 5)")).toEqual({
+      path: "suppliers.xlsx",
+      locator: { kind: "sheet", sheet: "Suppliers", startRow: 5, endRow: 5 },
+    });
+  });
+
+  it("reads a page range, keeping the first page as the anchor", () => {
+    expect(parseCitedPosition("a.md — pp. 12-14")).toEqual({
+      path: "a.md",
+      locator: { kind: "page", page: 12 },
+    });
+  });
+
+  it("reads a single-level heading path", () => {
+    expect(parseCitedPosition("report.docx (§ Quality)")).toEqual({
+      path: "report.docx",
+      locator: { kind: "heading", headings: ["Quality"] },
+    });
+  });
+
+  describe("leaves alone what is not a position", () => {
+    it("does not strip an embellishing gloss after a dash", () => {
+      // THE trap this parser is written around. Widening the split to "any
+      // dash-space separator" would consume this title as if it were a
+      // position — and `gradePathCitation` fails this shape today, on evidence
+      // committed in packages/web/eval/data. A parser change must not move a
+      // published number.
+      const entry = "a/study.pdf – AOAC Performance Tested Method Study";
+
+      expect(parseCitedPosition(entry)).toEqual({ path: entry, locator: null });
+    });
+
+    it("does not strip a parenthesised gloss that is not a locator shape", () => {
+      const entry = "a/study.pdf (second edition)";
+
+      expect(parseCitedPosition(entry)).toEqual({ path: entry, locator: null });
+    });
+
+    it("does not strip the `(undefined)` the published sweep really contains", () => {
+      // Every 2026-08-05 answer that repeated the tool's rendering carries
+      // this, from a chunk whose locator was undefined. It is not a position,
+      // and treating it as one would rewrite `entry.path` under a committed
+      // dataset.
+      const entry = "quality-file.md (undefined)";
+
+      expect(parseCitedPosition(entry)).toEqual({ path: entry, locator: null });
+    });
+
+    it("returns the whole entry when there is no position at all", () => {
+      expect(parseCitedPosition("it-equipment-policy.md")).toEqual({
+        path: "it-equipment-policy.md",
+        locator: null,
+      });
+    });
+
+    it("does not split a sheet range behind a plain hyphen", () => {
+      // A deliberate, stated bound. A sheet name is free text, so unlike
+      // `p.`/`slide`/`§` there is no literal at the boundary to prove the
+      // hyphen is a separator rather than part of a path. Em and en dash are
+      // accepted; a plain hyphen is not, and the entry stays whole — which
+      // costs nothing, because `matchRetrievedDocument` scans the whole entry
+      // and still resolves the document.
+      const entry = "suppliers.xlsx - Suppliers, rows 5-12";
+
+      expect(parseCitedPosition(entry)).toEqual({ path: entry, locator: null });
+    });
+  });
+
+  it("trims the path it hands back", () => {
+    expect(parseCitedPosition("  a.md   (p. 2)  ").path).toBe("a.md");
+  });
+});

--- a/packages/web/src/lib/eval/kb/__tests__/cited-position.test.ts
+++ b/packages/web/src/lib/eval/kb/__tests__/cited-position.test.ts
@@ -13,7 +13,8 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { formatLocator, type ChunkLocator } from "../../../knowledge/locator";
+import { formatLocator, type ChunkLocator } from "@/lib/knowledge/locator";
+
 import { parseCitedPosition } from "../cited-position";
 
 /**
@@ -46,6 +47,18 @@ describe("parseCitedPosition", () => {
       const parsed = parseCitedPosition(`quality-file.md — ${formatLocator(locator)}`);
 
       expect(parsed.path).toBe("quality-file.md");
+      expect(parsed.locator).toEqual(locator);
+    });
+
+    // The tool's full line: position in parentheses, passage after it. Pinned
+    // per kind for the same reason as the two above — a fifth kind must not
+    // arrive readable only when it happens to end the entry.
+    it.each(EVERY_KIND)("parenthesised, with the passage after it: $kind", (locator) => {
+      const parsed = parseCitedPosition(
+        `quality-file.md (${formatLocator(locator)}): "the passage"`
+      );
+
+      expect(parsed.path).toBe('quality-file.md: "the passage"');
       expect(parsed.locator).toEqual(locator);
     });
   });
@@ -96,6 +109,60 @@ describe("parseCitedPosition", () => {
     expect(parseCitedPosition("report.docx (§ Quality)")).toEqual({
       path: "report.docx",
       locator: { kind: "heading", headings: ["Quality"] },
+    });
+  });
+
+  describe("reads a position the entry continues past", () => {
+    // The tool prints `[1] quality-file.md (p. 1): "…"` — the position is
+    // FOLLOWED by the passage, and a model repeating the line "exactly as
+    // written above" carries all of it. Measured on the 2026-08-05 sweep: 22 of
+    // 98 Sources entries repeat that rendering, and 12 of those 22 keep text
+    // after the position. An end-anchored read sees a position on 10 of 22 —
+    // and a 10 that means "not asked" for the other 12 is the shape #1181 spent
+    // two defects correcting.
+    it("reads the tool's own rendering: position, colon, quoted passage", () => {
+      expect(parseCitedPosition('it-equipment-policy.md (p. 3): "Northwind issues …"')).toEqual({
+        path: 'it-equipment-policy.md: "Northwind issues …"',
+        locator: { kind: "page", page: 3 },
+      });
+    });
+
+    it("reads it when a dash and a gloss follow instead", () => {
+      // The other half of the 12: `gpt-oss:120b` writes the passage behind an
+      // en dash rather than a colon.
+      expect(parseCitedPosition('quality-file.md (p. 3) – "Per the specification …"')).toEqual({
+        path: 'quality-file.md – "Per the specification …"',
+        locator: { kind: "page", page: 3 },
+      });
+    });
+
+    it("hands the rest back joined to the path, so the document still resolves", () => {
+      // `matchRetrievedDocument` scans whatever it is given, and the trailing
+      // passage is where a second, real path can appear. Dropping it here would
+      // narrow a hole `cited-path-match.ts` documents as deliberately open —
+      // a change of grading behaviour smuggled in as a parser fix.
+      expect(parseCitedPosition("fabricated.md (p. 3): see handbook-2012/policy.md").path).toBe(
+        "fabricated.md: see handbook-2012/policy.md"
+      );
+    });
+
+    it("still closes on the OUTER parenthesis when the position ends the entry", () => {
+      // A Word heading may carry parentheses of its own. The end-anchored
+      // spelling is tried first for exactly this reason: reading trailing text
+      // first would close at the inner `)` and hand back `report.docx)`.
+      expect(parseCitedPosition("report.docx (§ Quality (2012 revision))")).toEqual({
+        path: "report.docx",
+        locator: { kind: "heading", headings: ["Quality (2012 revision)"] },
+      });
+    });
+
+    it("leaves the DASHED spelling end-anchored", () => {
+      // A stated bound. A parenthesis closes; a dash does not, so there is
+      // nothing to prove where a position behind a dash ends — and reading one
+      // mid-entry is how the AOAC title below would start parsing.
+      const entry = "a.md — p. 3 of the printed annex";
+
+      expect(parseCitedPosition(entry)).toEqual({ path: entry, locator: null });
     });
   });
 

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -38,6 +38,9 @@
 import { toCitationPath } from "@/lib/knowledge/citation-path";
 
 import { matchRetrievedDocument } from "./cited-path-match";
+import { parseCitedPosition } from "./cited-position";
+
+import type { ChunkLocator } from "@/lib/knowledge/locator";
 
 import type { KbFailureTag, KbGraderResult } from "./types";
 
@@ -73,10 +76,22 @@ export interface AttributionInput {
   nearDuplicateGroups?: string[][];
 }
 
-/** One parsed `- [N] <path> — p. <page>` line from the Sources list. */
+/** One parsed `- [N] <path> (<position>)` line from the Sources list. */
 interface SourcesEntry {
   n: number;
   path: string;
+  /**
+   * The position the entry cites, in whatever shape the document's format has
+   * — `parseCitedPosition` reads all four, so a slide or a sheet range no
+   * longer folds into `path` and grades as a fabricated citation (#982).
+   */
+  locator: ChunkLocator | null;
+  /**
+   * The cited page, when the position IS a page. Kept beside `locator` because
+   * it is what `RetrievedSource.page` can be compared against; null for every
+   * other locator kind, which is honest rather than lossy — a slide is not a
+   * page, and the reserved position-mismatch grader must not compare them.
+   */
   page: number | null;
   /** Offset of the entry's line start within `sourcesText` — read by `gradeSourcesFormat`. */
   index: number;
@@ -319,38 +334,18 @@ const BURIED_MARKER = /\[\d+\][^\S\r\n]*\S/;
 const RENDERED_SEPARATION = /(?:\n[^\S\r\n]*\n|(?:[ \t]{2,}|\\)\n)[^\S\r\n]*$/;
 
 /**
- * Trailing page suffix on a Sources entry's rest-of-line text — separates the
- * PATH (group 1) from the page reference (group 2). Non-greedy path capture so
- * a hyphen inside the path itself (e.g. "/data/handbook-2012/policy.md") is not
- * mistaken for the dash separator — the required "p."/"pp." literal after the
- * dash disambiguates. Accepts a single page (`— p. 12`), a page range
- * (`— p. 12-14`), and the `pp.` plural (`— pp. 12-14`). A Sources entry with no
- * page suffix at all (a legitimate, if degraded, shape) leaves `pageMatch`
- * null and parses with `page: null` — the point of widening this is to keep a
- * range from folding into `entry.path` and spuriously failing the exact
- * path-match in `gradePathCitation`. `page` stores the FIRST page number
- * (`parseInt` of the range) — it is not asserted downstream yet.
+ * Where the path/position split used to live as `PAGE_SUFFIX`, a regex that
+ * knew one position shape (`— p. 12`) and one separator. `parseCitedPosition`
+ * (`cited-position.ts`) replaced it in #982: it reads every shape
+ * `formatLocator` emits, in the parenthesised spelling the knowledge tool
+ * actually prints as well as the dashed one the older contract taught, and its
+ * round-trip pin fails when a fifth `ChunkLocator` kind arrives unparsed.
  *
- * The SEPARATOR takes em dash, en dash and hyphen alike, for the same reason
- * the markers above take fullwidth brackets: it delimits, it does not identify.
- * `gpt-oss:120b` writes U+2013 where the template writes `—`, and an
- * unrecognised separator leaves `– p. 1` glued to `entry.path` — where the
- * whole-entry matcher in `cited-path-match.ts` still resolves the document, but
- * `gradeNoDuplicateCorroboration`, which compares `entry.path` by string
- * equality against its near-duplicate groups, silently stops matching. The
- * product's own `TRAILING_PAGE` (`source-links.ts`) already accepts all three.
- *
- * Only pages, deliberately, and only correct while only pages exist. Since
- * #933 the anchor is a `ChunkLocator` and the contract asks for a POSITION:
- * `slide 4`, `§ Quality > Incoming goods`, `Suppliers, rows 5-12`. None of
- * those match here, so the whole line would fall into `entry.path` and grade a
- * correct citation as a fabricated one. Nothing writes a non-page locator yet
- * (xlsx-extract is not wired into the ingest, the Office path produces pages),
- * so this cannot fire today — but the producer that changes that must
- * generalise this parser in the same change. #982 has the trap and the reason
- * a naive "split on any dash" fix would move committed eval numbers.
+ * The trap that governs both is unchanged and worth keeping in view from here:
+ * the split may never widen to "any dash-space separator", or
+ * `a/study.pdf – AOAC Performance Tested Method Study` starts parsing as a
+ * position and moves numbers committed under `packages/web/eval/data`.
  */
-const PAGE_SUFFIX = /^(.*?)\s*[—–-]\s*pp?\.?\s*(\d+(?:\s*[-–]\s*\d+)?)\s*$/i;
 
 interface ParsedAnswer {
   /** Raw text BEFORE the Sources heading (or the whole answer if there is none). */
@@ -374,11 +369,12 @@ function parseSourcesEntries(sourcesText: string): SourcesEntry[] {
     const n = Number(marker ?? ordinal);
     const rest = (restRaw ?? "").trim();
     if (rest.length === 0) continue;
-    const pageMatch = PAGE_SUFFIX.exec(rest);
+    const { path, locator } = parseCitedPosition(rest);
     entries.push({
       n,
-      path: pageMatch ? pageMatch[1].trim() : rest,
-      page: pageMatch ? Number.parseInt(pageMatch[2], 10) : null,
+      path,
+      locator,
+      page: locator?.kind === "page" ? locator.page : null,
       index: match.index,
       isListItem: LIST_ITEM_PREFIX.test(match[0]),
       hasMarker: marker !== undefined,

--- a/packages/web/src/lib/eval/kb/attribution-graders.ts
+++ b/packages/web/src/lib/eval/kb/attribution-graders.ts
@@ -84,15 +84,13 @@ interface SourcesEntry {
    * The position the entry cites, in whatever shape the document's format has
    * — `parseCitedPosition` reads all four, so a slide or a sheet range no
    * longer folds into `path` and grades as a fabricated citation (#982).
+   *
+   * The union is kept whole rather than flattened to the `page` this replaced:
+   * a slide is not a page, and the reserved position-mismatch grader must
+   * narrow on `kind` before it compares anything against `RetrievedSource.page`
+   * — which a `page: number | null` field beside this one would let it skip.
    */
   locator: ChunkLocator | null;
-  /**
-   * The cited page, when the position IS a page. Kept beside `locator` because
-   * it is what `RetrievedSource.page` can be compared against; null for every
-   * other locator kind, which is honest rather than lossy — a slide is not a
-   * page, and the reserved position-mismatch grader must not compare them.
-   */
-  page: number | null;
   /** Offset of the entry's line start within `sourcesText` — read by `gradeSourcesFormat`. */
   index: number;
   /** Whether markdown renders this line as a list item (so it starts a line of its own). */
@@ -333,20 +331,6 @@ const BURIED_MARKER = /\[\d+\][^\S\r\n]*\S/;
  */
 const RENDERED_SEPARATION = /(?:\n[^\S\r\n]*\n|(?:[ \t]{2,}|\\)\n)[^\S\r\n]*$/;
 
-/**
- * Where the path/position split used to live as `PAGE_SUFFIX`, a regex that
- * knew one position shape (`— p. 12`) and one separator. `parseCitedPosition`
- * (`cited-position.ts`) replaced it in #982: it reads every shape
- * `formatLocator` emits, in the parenthesised spelling the knowledge tool
- * actually prints as well as the dashed one the older contract taught, and its
- * round-trip pin fails when a fifth `ChunkLocator` kind arrives unparsed.
- *
- * The trap that governs both is unchanged and worth keeping in view from here:
- * the split may never widen to "any dash-space separator", or
- * `a/study.pdf – AOAC Performance Tested Method Study` starts parsing as a
- * position and moves numbers committed under `packages/web/eval/data`.
- */
-
 interface ParsedAnswer {
   /** Raw text BEFORE the Sources heading (or the whole answer if there is none). */
   body: string;
@@ -360,6 +344,19 @@ interface ParsedAnswer {
   sourcesText: string;
 }
 
+/**
+ * The path/position split used to live here as `PAGE_SUFFIX`, a regex that knew
+ * one position shape (`— p. 12`) and one separator. `parseCitedPosition`
+ * (`cited-position.ts`) replaced it in #982: it reads every shape
+ * `formatLocator` emits, in the parenthesised spelling the knowledge tool
+ * actually prints as well as the dashed one the older contract taught, and its
+ * round-trip pin fails when a fifth `ChunkLocator` kind arrives unparsed.
+ *
+ * The trap that governs both is unchanged and worth keeping in view from here:
+ * the split may never widen to "any dash-space separator", or
+ * `a/study.pdf – AOAC Performance Tested Method Study` starts parsing as a
+ * position and moves numbers committed under `packages/web/eval/data`.
+ */
 function parseSourcesEntries(sourcesText: string): SourcesEntry[] {
   const entries: SourcesEntry[] = [];
   for (const match of sourcesText.matchAll(SOURCES_ENTRY_LINE)) {
@@ -374,7 +371,6 @@ function parseSourcesEntries(sourcesText: string): SourcesEntry[] {
       n,
       path,
       locator,
-      page: locator?.kind === "page" ? locator.page : null,
       index: match.index,
       isListItem: LIST_ITEM_PREFIX.test(match[0]),
       hasMarker: marker !== undefined,

--- a/packages/web/src/lib/eval/kb/cited-position.ts
+++ b/packages/web/src/lib/eval/kb/cited-position.ts
@@ -1,0 +1,126 @@
+/**
+ * Splits a Sources entry into the document it names and the position inside it.
+ *
+ * A Sources bullet is `<path> <position>`, and until #982 this file's job was
+ * done by a single regex (`PAGE_SUFFIX`) that knew one position shape: `— p.
+ * 12`. Two things were wrong with that, and the second is the one that bites.
+ *
+ * **Only pages.** Since #933 the anchor is a `ChunkLocator`, and a page is what
+ * only a PDF has. A slide is `slide 4`, a Word section is `§ Quality > Incoming
+ * goods`, a spreadsheet range is `Suppliers, rows 5-12`. None of those matched,
+ * so the whole line fell into `entry.path` — and a correct citation graded as a
+ * fabricated one is the worst kind of grader defect, because it reads as a
+ * model failure.
+ *
+ * **And the wrong separator.** The dash form is what the OLD contract taught.
+ * `pinchy-knowledge/index.ts` renders a hit as `` `[1] quality-file.md (p. 1):
+ * "…"` `` — the position in PARENTHESES — and the contract asks the model to
+ * repeat the path and position "exactly as written above". So the shape a
+ * well-behaved answer really carries never matched at all. Both are parsed now.
+ *
+ * ── What this deliberately will NOT split ─────────────────────────────────
+ * `[1] a/study.pdf – AOAC Performance Tested Method Study` is a path followed
+ * by an embellishing title, and `gradePathCitation` fails it today on evidence
+ * committed in `packages/web/eval/data`. Widening the split to "any dash-space
+ * separator" would consume that title as a position and move a published
+ * number. So this parser recognises the position SHAPES `formatLocator` emits
+ * and nothing else — `cited-position.test.ts` round-trips every one of them
+ * through `formatLocator`, and a fifth `ChunkLocator` kind fails that pin
+ * rather than silently arriving unparsed.
+ */
+import type { ChunkLocator } from "../../knowledge/locator";
+
+/** What a Sources entry names: the document, and where in it. */
+export interface CitedPosition {
+  /** The entry with its position suffix removed, trimmed. */
+  path: string;
+  /** The parsed position, or null when the entry carries none this parser knows. */
+  locator: ChunkLocator | null;
+}
+
+/**
+ * The position shapes, each anchored to the END of the string it is given.
+ *
+ * Three of the four open with a literal no path fragment can produce (`p.`,
+ * `slide`, `§`), which is what lets them accept a plain hyphen as the
+ * separator without `handbook-2012/policy.md` splitting at its own hyphen —
+ * exactly the guarantee `PAGE_SUFFIX`'s required `p.` gave.
+ *
+ * `sheet` is the exception and is treated as one: a sheet name is free text, so
+ * there is no literal at the boundary to prove a hyphen separates rather than
+ * belongs to the path. It is accepted behind an em or en dash, and inside
+ * parentheses where the delimiter is unambiguous. Behind a plain hyphen the
+ * entry stays whole, which costs little: `matchRetrievedDocument` scans the
+ * whole entry and resolves the document either way.
+ */
+const POSITION_SHAPES: {
+  pattern: RegExp;
+  /** Whether a plain `-` may introduce it (see above). */
+  plainHyphen: boolean;
+  /** Receives the SHAPE's own capture groups — the wrapper's path group is stripped first. */
+  build: (groups: (string | undefined)[]) => ChunkLocator;
+}[] = [
+  {
+    pattern: /pp?\.?\s*(\d+)(?:\s*[-–]\s*\d+)?/,
+    plainHyphen: true,
+    // The FIRST page of a range is the anchor, as `PAGE_SUFFIX` has always
+    // stored it: a citation spanning pages 12-14 points the reader at 12.
+    build: (g) => ({ kind: "page", page: Number.parseInt(g[0] ?? "", 10) }),
+  },
+  {
+    pattern: /slide\s*(\d+)/,
+    plainHyphen: true,
+    build: (g) => ({ kind: "slide", slide: Number.parseInt(g[0] ?? "", 10) }),
+  },
+  {
+    pattern: /§\s*(\S.*?)/,
+    plainHyphen: true,
+    build: (g) => ({
+      kind: "heading",
+      headings: (g[0] ?? "").split(">").map((heading) => heading.trim()),
+    }),
+  },
+  {
+    pattern: /(\S.*?),\s*rows?\s*(\d+)(?:\s*[-–]\s*(\d+))?/,
+    plainHyphen: false,
+    build: (g) => ({
+      kind: "sheet",
+      sheet: (g[0] ?? "").trim(),
+      startRow: Number.parseInt(g[1] ?? "", 10),
+      // `formatLocator` collapses a one-row range to "row 5"; parsing it back
+      // has to restore both ends, or the round-trip pin would need a special
+      // case and the two would be free to drift where it looks away.
+      endRow: Number.parseInt(g[2] ?? g[1] ?? "", 10),
+    }),
+  },
+];
+
+/** `<path> (<position>)` — what the knowledge tool prints and the contract asks for back. */
+function parenthesised(shape: RegExp): RegExp {
+  return new RegExp(`^(.*?)\\s*\\(\\s*${shape.source}\\s*\\)\\s*$`, "i");
+}
+
+/** `<path> — <position>` — the shape the older contract taught, still written by models. */
+function dashed(shape: RegExp, plainHyphen: boolean): RegExp {
+  return new RegExp(`^(.*?)\\s*[—–${plainHyphen ? "-" : ""}]\\s*${shape.source}\\s*$`, "i");
+}
+
+/**
+ * Reads the position off the end of a Sources entry.
+ *
+ * Returns the entry unchanged with a null locator when it carries no position
+ * this parser recognises — which is a legitimate, if degraded, shape and not an
+ * error. Shapes are tried in `POSITION_SHAPES` order; they are mutually
+ * exclusive by their opening literal, except `sheet`, which is last because its
+ * leading group is free text and would otherwise swallow the others.
+ */
+export function parseCitedPosition(entry: string): CitedPosition {
+  for (const { pattern, plainHyphen, build } of POSITION_SHAPES) {
+    for (const wrapped of [parenthesised(pattern), dashed(pattern, plainHyphen)]) {
+      const match = wrapped.exec(entry);
+      // Group 1 is the wrapper's path; everything after it belongs to the shape.
+      if (match) return { path: match[1].trim(), locator: build(match.slice(2)) };
+    }
+  }
+  return { path: entry.trim(), locator: null };
+}

--- a/packages/web/src/lib/eval/kb/cited-position.ts
+++ b/packages/web/src/lib/eval/kb/cited-position.ts
@@ -14,9 +14,15 @@
  *
  * **And the wrong separator.** The dash form is what the OLD contract taught.
  * `pinchy-knowledge/index.ts` renders a hit as `` `[1] quality-file.md (p. 1):
- * "…"` `` — the position in PARENTHESES — and the contract asks the model to
- * repeat the path and position "exactly as written above". So the shape a
- * well-behaved answer really carries never matched at all. Both are parsed now.
+ * "…"` `` — the position in PARENTHESES, and the passage AFTER it — and the
+ * contract asks the model to repeat the path and position "exactly as written
+ * above". So the shape a well-behaved answer really carries never matched at
+ * all. Both separators are parsed now, and the parenthesised one is read
+ * wherever it sits rather than only at the end of the entry: of the 22 entries
+ * in the 2026-08-05 sweep that repeat the tool's rendering, 12 keep the quoted
+ * passage after the position, and an end-anchored read would hand the reserved
+ * position-mismatch grader a number covering 10 of 22 — a partial count
+ * indistinguishable from "not asked", which is the defect #1181 corrected.
  *
  * ── What this deliberately will NOT split ─────────────────────────────────
  * `[1] a/study.pdf – AOAC Performance Tested Method Study` is a path followed
@@ -28,18 +34,25 @@
  * through `formatLocator`, and a fifth `ChunkLocator` kind fails that pin
  * rather than silently arriving unparsed.
  */
-import type { ChunkLocator } from "../../knowledge/locator";
+import type { ChunkLocator } from "@/lib/knowledge/locator";
 
 /** What a Sources entry names: the document, and where in it. */
 export interface CitedPosition {
-  /** The entry with its position suffix removed, trimmed. */
+  /**
+   * The entry with its position excised, trimmed — NOT the text before the
+   * position. Anything that followed it is handed back joined to the front
+   * half, because `matchRetrievedDocument` scans whatever it is given and a
+   * trailing passage is where a second, real path can appear. Dropping it would
+   * narrow the fabrication hole `cited-path-match.ts` documents as deliberately
+   * open, which is a change of grading behaviour, not a parser fix.
+   */
   path: string;
   /** The parsed position, or null when the entry carries none this parser knows. */
   locator: ChunkLocator | null;
 }
 
 /**
- * The position shapes, each anchored to the END of the string it is given.
+ * The position shapes, each a fragment the wrappers below anchor and delimit.
  *
  * Three of the four open with a literal no path fragment can produce (`p.`,
  * `slide`, `§`), which is what lets them accept a plain hyphen as the
@@ -57,7 +70,10 @@ const POSITION_SHAPES: {
   pattern: RegExp;
   /** Whether a plain `-` may introduce it (see above). */
   plainHyphen: boolean;
-  /** Receives the SHAPE's own capture groups — the wrapper's path group is stripped first. */
+  /**
+   * Receives the shape's OWN capture groups, and only those: the wrappers below
+   * contribute none, so `match.slice(1)` is exactly this list at every spelling.
+   */
   build: (groups: (string | undefined)[]) => ChunkLocator;
 }[] = [
   {
@@ -95,31 +111,62 @@ const POSITION_SHAPES: {
   },
 ];
 
-/** `<path> (<position>)` — what the knowledge tool prints and the contract asks for back. */
-function parenthesised(shape: RegExp): RegExp {
-  return new RegExp(`^(.*?)\\s*\\(\\s*${shape.source}\\s*\\)\\s*$`, "i");
+/**
+ * `<path> (<position>)` — what the knowledge tool prints and the contract asks
+ * for back. `atEnd` requires the closing parenthesis to end the entry; without
+ * it the entry may continue, as the tool's own line does past its position.
+ */
+function parenthesised(shape: RegExp, atEnd: boolean): RegExp {
+  return new RegExp(`\\s*\\(\\s*${shape.source}\\s*\\)${atEnd ? "\\s*$" : ""}`, "i");
 }
 
 /** `<path> — <position>` — the shape the older contract taught, still written by models. */
 function dashed(shape: RegExp, plainHyphen: boolean): RegExp {
-  return new RegExp(`^(.*?)\\s*[—–${plainHyphen ? "-" : ""}]\\s*${shape.source}\\s*$`, "i");
+  return new RegExp(`\\s*[—–${plainHyphen ? "-" : ""}]\\s*${shape.source}\\s*$`, "i");
 }
 
 /**
- * Reads the position off the end of a Sources entry.
+ * Every spelling of every shape, compiled once, in the order they are tried.
+ *
+ * Shapes come in `POSITION_SHAPES` order: they are mutually exclusive by their
+ * opening literal, except `sheet`, which is last because its leading group is
+ * free text and would otherwise swallow the others.
+ *
+ * Within a shape the END-ANCHORED spellings come first, and that ordering is
+ * load-bearing rather than tidy. A Word heading may carry parentheses of its
+ * own (`§ Quality (2012 revision)`), and the trailing-text spelling closes at
+ * the FIRST `)` it can, which would cut that heading in half and leave a
+ * stray `)` on the path. Trying the anchored spelling first means every entry
+ * that parsed before this spelling existed still parses exactly as it did.
+ */
+const SPELLINGS = POSITION_SHAPES.map(({ pattern, plainHyphen, build }) => ({
+  spellings: [
+    parenthesised(pattern, true),
+    dashed(pattern, plainHyphen),
+    parenthesised(pattern, false),
+  ],
+  build,
+}));
+
+/**
+ * Reads the position out of a Sources entry.
+ *
+ * The spellings match the POSITION BLOCK alone rather than the whole entry, so
+ * the path is the entry with the matched span cut out — which is what lets the
+ * entry carry text on both sides of its position, and is why `build` sees the
+ * shape's own groups at `slice(1)` with nothing of the wrapper's in front.
  *
  * Returns the entry unchanged with a null locator when it carries no position
  * this parser recognises — which is a legitimate, if degraded, shape and not an
- * error. Shapes are tried in `POSITION_SHAPES` order; they are mutually
- * exclusive by their opening literal, except `sheet`, which is last because its
- * leading group is free text and would otherwise swallow the others.
+ * error.
  */
 export function parseCitedPosition(entry: string): CitedPosition {
-  for (const { pattern, plainHyphen, build } of POSITION_SHAPES) {
-    for (const wrapped of [parenthesised(pattern), dashed(pattern, plainHyphen)]) {
-      const match = wrapped.exec(entry);
-      // Group 1 is the wrapper's path; everything after it belongs to the shape.
-      if (match) return { path: match[1].trim(), locator: build(match.slice(2)) };
+  for (const { spellings, build } of SPELLINGS) {
+    for (const spelling of spellings) {
+      const match = spelling.exec(entry);
+      if (match === null) continue;
+      const path = entry.slice(0, match.index) + entry.slice(match.index + match[0].length);
+      return { path: path.trim(), locator: build(match.slice(1)) };
     }
   }
   return { path: entry.trim(), locator: null };


### PR DESCRIPTION
Closes the parser half of #982. The grader half is deliberately left open — see the bottom.

## Two defects, and the second is the one nobody would have guessed

**Only pages.** Since #933 the anchor is a `ChunkLocator`, and a page is what only a PDF has. A slide is `slide 4`, a Word section `§ Quality > Incoming goods`, a spreadsheet range `Suppliers, rows 5-12`. `PAGE_SUFFIX` matched none of them, so the whole line fell into `entry.path`. That is the defect #982 describes, and it lands the moment #940 wires the xlsx extractor into the ingest.

**And the wrong separator.** `PAGE_SUFFIX` splits on a dash — the shape the *old* contract taught. `pinchy-knowledge/index.ts` renders a hit as:

```
[1] quality-file.md (p. 1): "…"
```

…the position in **parentheses**, and `CITATION_CONTRACT` asks the model to repeat path and position "exactly as written above". So the shape a well-behaved answer really carries was never parsed at all — not for pages either. Measured against the published sweep: **0 of 98 Sources entries carry a position this parser could read.**

## What changed

`parseCitedPosition` (`cited-position.ts`) reads all four locator kinds, parenthesised and dashed, and `SourcesEntry` carries a `locator` beside its `page`.

`cited-position.test.ts` round-trips **every kind** through `formatLocator`, and its sample table is a mapped type over the union — so a fifth `ChunkLocator` kind is a compile error in the test, not a shape that silently arrives unparsed. Verified by canary: adding a `timecode` kind fails `tsc` naming the missing sample.

## What deliberately did NOT widen

`a/study.pdf – AOAC Performance Tested Method Study` must keep failing — it does today, on evidence committed under `packages/web/eval/data`, and "split on any dash-space" would consume that title as a position and move a published number.

Three of the four shapes open with a literal no path fragment can produce (`p.`, `slide`, `§`), which is exactly what lets them accept a plain hyphen without `handbook-2012/policy.md` splitting at its own. A **sheet** name is free text and has no such literal, so it is read behind an em/en dash and inside parentheses only. That bound is stated in a test and costs little: `matchRetrievedDocument` scans the whole entry and resolves the document either way.

## Correcting the issue's premise

#982 says a non-page locator makes `gradePathCitation` "report `path-not-cited` — a correct citation graded as a fabricated one". That is not what happens today. The matcher scans the whole entry, so a trailing position is *"irrelevant instead of fatal"*, as its own header puts it. The real cost was narrower and quieter: **no grader could see a position at all**, and `entry.page` has been dead since it was added.

## The position-mismatch grader is NOT in this PR

#982 suggests adding it "at the same time". Measured first, as the last two eval PRs earned the right to insist on: of 98 Sources entries in the published dataset, **0 carry a comparable position** — every one predates the locator rendering and repeats the tool's `(undefined)`.

So the tag would ship reading 0, and that 0 would mean "not asked" — the exact shape #1181 spent two defects and a re-grade correcting. It becomes measurable from the next sweep, because `seed-corpus.ts` writes `{kind: "page", page}` and the tool now renders it. Shipping the parser is what makes it possible; shipping the tag now would only add another zero nobody may trust.

## Verification

- `pnpm test` — 845 files / 12 157 tests
- `pnpm test:scripts` — 1240
- `tsc --noEmit -p tsconfig.typecheck.json`, `prettier --check .`, pre-push build
- **No published number moves**: `data-reproducibility.test.ts` re-derives all 48 citation verdicts unchanged

---

## Two follow-up commits went further than the description above

**`e98a37a4a` — the position is read wherever it sits, not only at the entry's end.**

The first commit landed end-anchored, and the tool's own line is not: it renders `[1] quality-file.md (p. 1): "…"` — position, then passage. Measured against the committed sweep: **22 of 98 Sources entries repeat the tool's rendering, and 12 of those keep text after the position.** Substituting a real `(p. 3)` for the `(undefined)` those answers carry — which is exactly what the next sweep produces — an end-anchored read finds a position on 10 of 22. A 10 that means "not asked" for the other 12 is the shape #1181 corrected, so the parenthesised spelling is now read mid-entry.

Three things keep that from widening into the trap:

- **End-anchored spellings are tried first.** A Word heading may carry parentheses of its own (`§ Quality (2012 revision)`), and the trailing-text spelling closes at the first `)` — which would halve that heading. Anchored-first means every entry that parsed before still parses identically: **0 of 98 committed entries change their `path`.**
- **The dashed spelling stays end-anchored.** A parenthesis closes; a dash does not.
- **`path` excises the position rather than truncating at it.** `matchRetrievedDocument` scans whatever it is given, and a trailing passage is where a second, real path can appear — dropping it would narrow the fabrication hole `cited-path-match.ts` documents as deliberately open. That is a grading-behaviour change, not a parser fix.

**`859030ae4` — `SourcesEntry.page` is gone.** It was derived from `locator` and read by nothing. The reserved position-mismatch grader has to narrow on `locator.kind` before comparing against `RetrievedSource.page` anyway, and a flattened `page: number | null` beside the union is precisely what would let it skip that and compare a slide to a page.
