### PR TITLE
feat(kb): index spreadsheets, anchored on sheet and row range

### DIFF
--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -60,7 +60,7 @@ The same action is available over the API, which is what you'd script for schedu
 curl -X POST -b session_cookie "https://pinchy.example.com/api/agents/<agentId>/knowledge/reindex"
 ```
 
-This reads the agent's granted folders, extracts text from each PDF, splits it into overlapping chunks, embeds every chunk with a bundled local model (`embeddinggemma`), and stores the result in Pinchy's own Postgres database (using `pgvector`) so it can be searched later.
+This reads the agent's granted folders, extracts text from each PDF and reads the cells of each Excel workbook, splits the result into overlapping chunks, embeds every chunk with a bundled local model (`embeddinggemma`), and stores the result in Pinchy's own Postgres database (using `pgvector`) so it can be searched later.
 
 Indexing is idempotent — unchanged files are skipped on the next run, changed files are re-indexed, and files removed from disk are dropped from the index. **Re-run reindex whenever documents change** — new files, edits, or deletions. Pinchy does not watch the directory and does not sweep it on a schedule: a reindex happens because somebody asked for one.
 
@@ -140,11 +140,13 @@ Sources are named by their path, not just the filename. In a real document tree 
 
 The path you see is the one you'd recognise: it starts at the folder you mounted, not at the container path underneath. If you mounted a share as `quality`, a citation reads `quality/QM/Handbook.pdf` — the same tree you see in Explorer, minus the plumbing.
 
-Not every document has pages, which is why a citation says "the spot" rather than "the page". A PDF is cited by page and a slide deck by slide number, because both are properties of the file itself. A Word document is cited by its heading path instead: where a Word page break falls depends on fonts and printer settings, so a page number would describe our rendering of the document rather than yours, and a citation should never state something you can't verify in the file you open.
+Not every document has pages, which is why a citation says "the spot" rather than "the page". A PDF is cited by page and a slide deck by slide number, because both are properties of the file itself. A Word document is cited by its heading path instead: where a Word page break falls depends on fonts and printer settings, so a page number would describe our rendering of the document rather than yours, and a citation should never state something you can't verify in the file you open. A spreadsheet is cited by sheet and row range — `Suppliers, rows 5-12` — which is what you scroll to in Excel, and what a page number could never be for a sheet forty columns wide.
 
 ### Open a source and check it
 
 Each source path in an answer is a link. Click it and the PDF opens in a viewer over the chat, at the cited page, with the answer still visible behind it — the same viewer a PDF you attach to a message opens into. Checking a claim takes a click instead of a hunt through folders.
+
+A spreadsheet is the exception: its citation names the sheet and rows, and you open the workbook itself from your share rather than a preview in the chat. Nothing renders a sheet as pages, and showing you an invented page layout would be worse than sending you to the file you already know how to read.
 
 Word documents and slide decks open in that same viewer. No browser renders a `.doc`, so what you see is the PDF Pinchy converted on its way into the index — the same rendering the citation was measured against, which is what lets it point at a spot you can actually find. The original is never modified and never replaced; it stays exactly where it is on your share.
 
@@ -188,7 +190,7 @@ We cap how many passages any one document can contribute to a single answer, so 
 
 What the knowledge base does is deliberately narrow:
 
-- Only **text-based PDFs** are indexed and searchable via `knowledge_search`. Scanned or image-only PDFs, Office documents, plain text and Markdown are not. Pointed at one directly, the agent's file tools read more than the index does — Word documents, scanned PDFs, plain text — so a document can be readable on request and still not come back as a search hit. [Supported file types](/guides/mount-data-directories/#supported-file-types) has the full split.
+- Only **text-based PDFs** and **Excel workbooks** (`.xlsx`, `.xlsm`) are indexed and searchable via `knowledge_search`. Scanned or image-only PDFs, Word documents, slide decks, older `.xls` workbooks, plain text and Markdown are not. Pointed at one directly, the agent's file tools read more than the index does — Word documents, scanned PDFs, plain text — so a document can be readable on request and still not come back as a search hit. [Supported file types](/guides/mount-data-directories/#supported-file-types) has the full split.
 - Indexing is a manual admin action (step 6). It runs in the background and reports its progress in the app, but you still have to ask for it: nothing watches the directory and nothing sweeps it on a schedule.
 
 ### Documents that can't be searched

--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -161,11 +161,13 @@ Nothing is re-indexed or re-uploaded by this — the mounts point at the same ho
 
 Two different paths read the files under `/data/`, and they support different formats. The distinction matters when you plan a corpus, so it's worth knowing before you mount one.
 
-**Knowledge Base search** (`knowledge_search`) indexes **text-based PDFs**, and nothing else. Scanned PDFs, Office documents, plain text and Markdown files under `/data/` are not indexed — see [Create a Knowledge Base Agent — Scope in this release](/guides/create-knowledge-base-agent/#scope-in-this-release).
+**Knowledge Base search** (`knowledge_search`) indexes **text-based PDFs** and **Excel workbooks** (`.xlsx`, `.xlsm`). Scanned PDFs, Word documents, slide decks, plain text and Markdown files under `/data/` are not indexed — see [Create a Knowledge Base Agent — Scope in this release](/guides/create-knowledge-base-agent/#scope-in-this-release).
+
+A workbook is read from its cells rather than converted to a page layout, so a row that is too wide for its column keeps its full text instead of being clipped at a page edge. Older `.xls` workbooks are not indexed: they use a different file format that our reader does not open, so we leave them out rather than list every one of them as unreadable.
 
 **Reading a file directly** (the agent's file tools) handles more: PDFs of either kind, **Word documents** (`.docx`), plain text and Markdown. Scanned PDFs are analyzed using the configured model's vision capabilities.
 
-So a scanned certificate under `/data/` can be opened and read on request, but it won't come back as a search hit — the agent has to be pointed at it. If a large part of your corpus is scans, the reindex report tells you so: it counts them under `unsearchable` rather than `indexed`. A file whose type the index doesn't take at all — a `.md` runbook, a `.docx` — never enters the run, so no count mentions it: mount a corpus of those and the report comes back the way it would for an empty folder.
+So a scanned certificate under `/data/` can be opened and read on request, but it won't come back as a search hit — the agent has to be pointed at it. If a large part of your corpus is scans, the reindex report tells you so: it counts them under `unsearchable` rather than `indexed`. A workbook whose every sheet is hidden lands in the same count, for the same reason: it was read without error and holds nothing to search. A file whose type the index doesn't take at all — a `.md` runbook, a `.docx` — never enters the run, so no count mentions it: mount a corpus of those and the report comes back the way it would for an empty folder.
 
 ## Knowledge Base vs. workspace files
 

--- a/packages/web/src/__tests__/lib/knowledge/exclude-globs.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/exclude-globs.test.ts
@@ -21,7 +21,7 @@ describe("isHiddenSegment", () => {
 
 describe("isAllowedExtension", () => {
   it("defaults to PDF-only (MVP Scope A)", () => {
-    expect(DEFAULT_ALLOWED_EXTENSIONS).toEqual([".pdf"]);
+    expect(DEFAULT_ALLOWED_EXTENSIONS).toEqual([".pdf", ".xlsx", ".xlsm"]);
     expect(isAllowedExtension("handbook.pdf")).toBe(true);
     expect(isAllowedExtension("handbook.PDF")).toBe(true);
     expect(isAllowedExtension("handbook.docx")).toBe(false);

--- a/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/ingest.integration.test.ts
@@ -24,6 +24,7 @@ import {
   type IngestProgress,
   type IngestResult,
 } from "@/lib/knowledge/ingest";
+import type { XlsxExtraction } from "@/lib/knowledge/xlsx-extract";
 
 const ORG_ID = "org-kb-ingest-test";
 
@@ -44,17 +45,49 @@ afterEach(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
+const SHEET_ROWS_TEXT =
+  "Supplier: Nordwind GmbH | Material: Petrifilm plates | Lead time: 14 days. " +
+  "Supplier: Acme Labor | Material: Agar | Lead time: 5 days.";
+
+/**
+ * A spreadsheet extraction with no chunks and every sheet hidden — the shape
+ * `extractXlsx` reports for a workbook whose author hid all of it, and the one
+ * that must land as `unsearchable` rather than `indexed`.
+ */
+const EMPTY_XLSX = { chunks: [], sheets: [], hiddenSheets: ["Internal"], hiddenRows: 0 };
+
+/**
+ * For the PDF-only tests below that build their deps inline. A spreadsheet
+ * never reaches them, and a stub that THROWS says so — a silent empty
+ * extraction would let a dispatch bug route a .pdf here and still pass.
+ */
+const neverCalledXlsx = async (): Promise<XlsxExtraction> => {
+  throw new Error("extractXlsx must not be called for a PDF");
+};
+
 function fakeDeps(
   pages = [
     { page: 1, text: PAGE_1_TEXT },
     { page: 2, text: PAGE_2_TEXT },
-  ]
-): { deps: IngestDeps; embed: ReturnType<typeof vi.fn>; extractPdf: ReturnType<typeof vi.fn> } {
+  ],
+  xlsx: XlsxExtraction = {
+    chunks: [{ text: SHEET_ROWS_TEXT, sheet: "Suppliers", startRow: 2, endRow: 3 }],
+    sheets: ["Suppliers"],
+    hiddenSheets: [],
+    hiddenRows: 0,
+  }
+): {
+  deps: IngestDeps;
+  embed: ReturnType<typeof vi.fn>;
+  extractPdf: ReturnType<typeof vi.fn>;
+  extractXlsx: ReturnType<typeof vi.fn>;
+} {
   const embed = vi.fn(async (texts: string[]) =>
     texts.map((_, i) => Array(768).fill(0.001 * (i + 1)))
   );
   const extractPdf = vi.fn(async () => pages);
-  return { deps: { embed, extractPdf }, embed, extractPdf };
+  const extractXlsx = vi.fn(async () => xlsx);
+  return { deps: { embed, extractPdf, extractXlsx }, embed, extractPdf, extractXlsx };
 }
 
 async function chunksFor(documentId: string) {
@@ -387,7 +420,11 @@ it("keeps ingesting the rest of the corpus when one file's extraction throws", a
 
   const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
   try {
-    const result = await ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf });
+    const result = await ingestDirectory(ORG_ID, tmpRoot, {
+      embed,
+      extractPdf,
+      extractXlsx: neverCalledXlsx,
+    });
 
     expect(result).toEqual(counts({ indexed: 1, failed: 1 }));
 
@@ -422,9 +459,9 @@ it("surfaces an embedding outage as a run failure instead of blaming every file"
   });
   const extractPdf = vi.fn(async () => [{ page: 1, text: PAGE_1_TEXT }]);
 
-  await expect(ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf })).rejects.toThrow(
-    /ECONNREFUSED/
-  );
+  await expect(
+    ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf, extractXlsx: neverCalledXlsx })
+  ).rejects.toThrow(/ECONNREFUSED/);
   // Bailed on the first file rather than walking the rest of the corpus.
   expect(embed).toHaveBeenCalledTimes(1);
 });
@@ -453,7 +490,11 @@ it("keeps the last indexed version searchable when a file changes into one that 
     throw new Error("Invalid PDF structure");
   });
 
-  const result = await ingestDirectory(ORG_ID, tmpRoot, { embed, extractPdf });
+  const result = await ingestDirectory(ORG_ID, tmpRoot, {
+    embed,
+    extractPdf,
+    extractXlsx: neverCalledXlsx,
+  });
   expect(result).toEqual(counts({ failed: 1 }));
 
   // The last good version is still there, chunks and all: same document row,
@@ -801,4 +842,90 @@ it("heals a stored status that disagrees with the archive rule on the next skip 
     .from(kbDocuments)
     .where(and(eq(kbDocuments.orgId, ORG_ID), eq(kbDocuments.sourcePath, archivedPath)));
   expect(doc.status).toBe("archived");
+});
+
+it("indexes a spreadsheet with sheet + row-range locators, and never converts it", async () => {
+  const xlsxPath = join(tmpRoot, "suppliers.xlsx");
+  writeFileSync(xlsxPath, "fake-xlsx-bytes-v1");
+
+  const { deps, extractPdf, extractXlsx } = fakeDeps();
+
+  const result = await ingestDirectory(ORG_ID, tmpRoot, deps);
+
+  expect(result).toEqual(counts({ indexed: 1 }));
+  expect(extractXlsx).toHaveBeenCalledWith(xlsxPath);
+  // The dispatch, asserted from both sides. A spreadsheet reaching the PDF
+  // extractor is the failure this whole format split exists to prevent, and it
+  // would otherwise show up only as an unreadable citation much later.
+  expect(extractPdf).not.toHaveBeenCalled();
+
+  const [doc] = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  expect(doc.sourcePath).toBe(xlsxPath);
+  // A sheet is not a page. Writing the sheet COUNT here would make the row
+  // state something false about the document; the column is nullable for it.
+  expect(doc.pageCount).toBeNull();
+
+  const chunks = await chunksFor(doc.id);
+  expect(chunks).toHaveLength(1);
+  expect(chunks[0].locator).toEqual({
+    kind: "sheet",
+    sheet: "Suppliers",
+    startRow: 2,
+    endRow: 3,
+  });
+  expect(chunks[0].embedding).toHaveLength(768);
+  expect(chunks[0].sourcePath).toBe(xlsxPath);
+});
+
+it("books a workbook it could read nothing out of as unsearchable, not indexed", async () => {
+  // Every sheet hidden by its author: `extractXlsx` reports the hidden sheets
+  // and no chunks. "0 chunks" is exactly what an unreadable file gives, so it
+  // must land in the same bucket a text-less scan does — visible in the
+  // unreadable list rather than counted as a successful index (#935).
+  const xlsxPath = join(tmpRoot, "internal.xlsx");
+  writeFileSync(xlsxPath, "fake-xlsx-all-hidden");
+
+  const { deps } = fakeDeps(undefined, EMPTY_XLSX);
+
+  expect(await ingestDirectory(ORG_ID, tmpRoot, deps)).toEqual(counts({ unsearchable: 1 }));
+
+  const [doc] = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  expect(await chunksFor(doc.id)).toHaveLength(0);
+});
+
+it("keeps PDFs indexed before spreadsheets existed working, untouched", async () => {
+  // AGENTS.md § Test Migrations Against Pre-Existing Data. Every other test
+  // here starts from a clean slate where the dispatch is live from the first
+  // write, so none of them can see what an UPGRADE produces: rows written by
+  // the PDF-only pipeline, read by code that now dispatches on extension.
+  //
+  // Simulated by ingesting the PDF alone (which is exactly what the old
+  // pipeline did), then dropping a spreadsheet beside it and re-running.
+  const pdfPath = join(tmpRoot, "handbook.pdf");
+  writeFileSync(pdfPath, "fake-pdf-bytes-v1");
+
+  const { deps } = fakeDeps();
+  expect(await ingestDirectory(ORG_ID, tmpRoot, deps)).toEqual(counts({ indexed: 1 }));
+
+  const [before] = await db.select().from(kbDocuments).where(eq(kbDocuments.orgId, ORG_ID));
+  const chunksBefore = await chunksFor(before.id);
+
+  writeFileSync(join(tmpRoot, "suppliers.xlsx"), "fake-xlsx-bytes-v1");
+  const rerun = await ingestDirectory(ORG_ID, tmpRoot, deps);
+
+  // The PDF is SKIPPED, not re-indexed: the content hash still matches, and a
+  // widened allowlist must not invalidate what was already there.
+  expect(rerun).toEqual(counts({ skipped: 1, indexed: 1 }));
+
+  const [pdfDoc] = await db
+    .select()
+    .from(kbDocuments)
+    .where(and(eq(kbDocuments.orgId, ORG_ID), eq(kbDocuments.sourcePath, pdfPath)));
+  expect(pdfDoc.id).toBe(before.id);
+  expect(pdfDoc.pageCount).toBe(2);
+  const chunksAfter = await chunksFor(pdfDoc.id);
+  expect(chunksAfter.map((c) => c.id).sort()).toEqual(chunksBefore.map((c) => c.id).sort());
+  for (const chunk of chunksAfter) {
+    expect(chunk.locator).toEqual({ kind: "page", page: expect.any(Number) });
+  }
 });

--- a/packages/web/src/__tests__/lib/knowledge/office-formats.test.ts
+++ b/packages/web/src/__tests__/lib/knowledge/office-formats.test.ts
@@ -10,7 +10,12 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { convertedPdfName, isOfficeFile, OFFICE_EXTENSIONS } from "@/lib/knowledge/office-formats";
+import {
+  convertedPdfName,
+  isOfficeFile,
+  isSpreadsheetFile,
+  OFFICE_EXTENSIONS,
+} from "@/lib/knowledge/office-formats";
 
 describe("isOfficeFile", () => {
   it("recognises every converted format, whatever the case", () => {
@@ -57,5 +62,33 @@ describe("convertedPdfName", () => {
 
   it("leaves a doubled extension alone apart from the last one", () => {
     expect(convertedPdfName("/data/report.v2.docx")).toBe("report.v2.pdf");
+  });
+});
+
+describe("isSpreadsheetFile", () => {
+  it("recognises the OOXML workbooks the extractor can open", () => {
+    expect(isSpreadsheetFile("/data/quality/Lieferanten.xlsx")).toBe(true);
+    expect(isSpreadsheetFile("/data/quality/Makros.xlsm")).toBe(true);
+  });
+
+  it("matches the extension case-insensitively, as a Windows share writes it", () => {
+    // Not hypothetical for this product: a corpus arriving over SMB routinely
+    // carries `.XLSX`. Discovery lowercases (isAllowedExtension) and so must
+    // the dispatch, or a file would be admitted to the ingest and then handed
+    // to the PDF extractor.
+    expect(isSpreadsheetFile("/data/QF_2012/LIEFERANTEN.XLSX")).toBe(true);
+    expect(isSpreadsheetFile("/data/QF_2012/Liste.XlSm")).toBe(true);
+  });
+
+  it("leaves out the formats the extractor cannot open", () => {
+    // `.xls` is BIFF, not OOXML: `workbook.xlsx.readFile` does not parse it,
+    // and a `.csv` has no sheet to anchor half the citation on.
+    expect(isSpreadsheetFile("/data/legacy/Preise.xls")).toBe(false);
+    expect(isSpreadsheetFile("/data/export.csv")).toBe(false);
+  });
+
+  it("is not confused by a page-shaped Office document, or by a dotfile", () => {
+    expect(isSpreadsheetFile("/data/Angebot.docx")).toBe(false);
+    expect(isSpreadsheetFile("/data/.xlsx")).toBe(false);
   });
 });

--- a/packages/web/src/__tests__/server/kb-index-worker.integration.test.ts
+++ b/packages/web/src/__tests__/server/kb-index-worker.integration.test.ts
@@ -43,6 +43,11 @@ function fakeDeps(): IngestDeps {
     extractPdf: vi.fn(async () => [
       { page: 1, text: "Onboarding starts on day one and every hire receives a laptop." },
     ]),
+    // This suite indexes PDFs only; a spreadsheet reaching it would mean the
+    // dispatch is broken, so the stub throws rather than returning nothing.
+    extractXlsx: vi.fn(async () => {
+      throw new Error("extractXlsx must not be called for a PDF");
+    }),
   };
 }
 

--- a/packages/web/src/lib/knowledge/exclude-globs.ts
+++ b/packages/web/src/lib/knowledge/exclude-globs.ts
@@ -21,9 +21,21 @@
  * Kept as plain data + small predicates (no glob DSL) so it's easy to read,
  * test, and override.
  */
+import { SPREADSHEET_EXTENSIONS } from "./office-formats";
 
-/** File extensions eligible for ingest. MVP (Scope A) is text PDFs only. */
-export const DEFAULT_ALLOWED_EXTENSIONS: readonly string[] = [".pdf"];
+/**
+ * File extensions eligible for ingest.
+ *
+ * PDFs, plus the OOXML spreadsheets #940 wired in. A spreadsheet is read
+ * cell-by-cell rather than converted (`xlsx-extract.ts` argues why), so it
+ * needs no conversion chain in front of it — which is what lets it join this
+ * list before its page-shaped Office siblings do.
+ *
+ * `SPREADSHEET_EXTENSIONS` is spread rather than re-typed: this list and the
+ * extractor's capability are the same fact, and two spellings of one fact is
+ * how an allowlist ends up naming a format nothing can read.
+ */
+export const DEFAULT_ALLOWED_EXTENSIONS: readonly string[] = [".pdf", ...SPREADSHEET_EXTENSIONS];
 
 /** Exact (case-insensitive) file names that are always OS artifacts. */
 const DENYLIST_EXACT_NAMES: readonly string[] = ["thumbs.db", "desktop.ini"];

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -23,10 +23,18 @@
  * reachable from two overlapping roots counts once. ingestDirectory() is the
  * single-root wrapper over it.
  *
- * The embedder and PDF extractor are dependency-injected: production wires
- * `embedTexts` (./embeddings.ts) and a pdfjs-based extractor
- * (./pdf-extract.ts); tests inject deterministic fakes so the integration
- * suite stays hermetic (real Postgres, no Ollama, no real PDF parsing).
+ * The embedder and the extractors are dependency-injected: production wires
+ * `embedTexts` (./embeddings.ts), a pdfjs-based PDF extractor
+ * (./pdf-extract.ts) and `extractXlsx` (./xlsx-extract.ts); tests inject
+ * deterministic fakes so the integration suite stays hermetic (real Postgres,
+ * no Ollama, no real PDF or workbook parsing).
+ *
+ * WHICH extractor runs is decided per file by `extractDocument`, on the
+ * extension, and so is the anchor the chunks carry: a PDF page for a PDF, a
+ * sheet + row range for a spreadsheet (#940). Everything downstream of that
+ * dispatch — embedding, writing, idempotency, the removal pass — is
+ * format-blind on purpose, which is what makes #938's heading and slide
+ * producers a change to one function rather than to the pipeline.
  */
 import { createHash } from "node:crypto";
 import { readdir, readFile, stat } from "node:fs/promises";
@@ -48,7 +56,9 @@ import { isArchivedPath, statusForPath } from "./archive-paths";
 import { chunkPages } from "./chunk";
 import { DEFAULT_BATCH_SIZE } from "./embeddings";
 import { detectLang } from "./lid";
+import { isSpreadsheetFile } from "./office-formats";
 import type { ChunkLocator } from "./locator";
+import type { XlsxExtraction } from "./xlsx-extract";
 import type { IngestPage, IngestResult } from "./types";
 
 // IngestPage/IngestResult live in ./types (a runtime-free module) because
@@ -62,6 +72,17 @@ export interface IngestDeps {
   embed: (texts: string[]) => Promise<number[][]>;
   /** Extracts per-page text from a PDF at an absolute path. Prod: pdfjs-based (./pdf-extract.ts). */
   extractPdf: (absPath: string) => Promise<IngestPage[]>;
+  /**
+   * Reads a spreadsheet's cells into row-grouped chunks. Prod: `extractXlsx`
+   * (./xlsx-extract.ts).
+   *
+   * Required rather than optional, and the reason is the allowlist: the moment
+   * `DEFAULT_ALLOWED_EXTENSIONS` names `.xlsx`, every caller's ingest WILL meet
+   * one. An optional extractor would make that a runtime surprise in whichever
+   * deployment happens to hold a spreadsheet, instead of a compile error at the
+   * one call site that needs updating.
+   */
+  extractXlsx: (absPath: string) => Promise<XlsxExtraction>;
 }
 
 export interface IngestOptions {
@@ -249,22 +270,80 @@ export const EMBED_PROGRESS_BATCH = DEFAULT_BATCH_SIZE;
 /** Reports that `embedded` of `total` chunks of the CURRENT document are done. */
 export type ChunkProgressCallback = (embedded: number, total: number) => void | Promise<void>;
 
+/** A chunk with the anchor a citation will point at. Every format producer converges here. */
+interface LocatedChunk {
+  text: string;
+  locator: ChunkLocator;
+}
+
 /**
- * Chunks `pages`, embeds every chunk, and inserts the resulting kb_chunks rows
- * for `documentId`. Returns the number of chunks written — zero means the
+ * One document, read into the two things the pipeline needs: the chunks to
+ * embed, and the facts the `kb_documents` row carries.
+ */
+interface ExtractedDocument {
+  chunks: LocatedChunk[];
+  /**
+   * Pages, when the format HAS pages — null for a spreadsheet.
+   *
+   * Not "number of sheets". The column is called `pageCount` and a sheet is
+   * not a page; writing one into the other would make the row state something
+   * false about the document, which is the same mistake `ChunkLocator` exists
+   * to prevent one level down. The column is nullable, so null is a spelling
+   * the schema already has for "this format has no pages".
+   */
+  pageCount: number | null;
+  /** Everything the document says, concatenated — read only for language detection. */
+  text: string;
+}
+
+/**
+ * Reads one file into chunks with locators, dispatching on its extension.
+ *
+ * The dispatch is the whole Wave-2 shape: a PDF's pages are chunked by
+ * `chunkPages` and anchored on the page they came from, a spreadsheet is read
+ * by `extractXlsx` and anchored on sheet + row range. `XlsxChunk` is
+ * field-for-field the `sheet` locator, so that half is a spread rather than a
+ * mapping (locator.ts says so, and this is the producer it was said for).
+ */
+async function extractDocument(absPath: string, deps: IngestDeps): Promise<ExtractedDocument> {
+  if (isSpreadsheetFile(absPath)) {
+    const extraction = await deps.extractXlsx(absPath);
+    return {
+      chunks: extraction.chunks.map(({ text, sheet, startRow, endRow }) => ({
+        text,
+        locator: { kind: "sheet", sheet, startRow, endRow },
+      })),
+      pageCount: null,
+      text: extraction.chunks.map((chunk) => chunk.text).join("\n"),
+    };
+  }
+
+  const pages = await deps.extractPdf(absPath);
+  return {
+    chunks: chunkPages(pages).map((chunk) => ({
+      text: chunk.text,
+      locator: { kind: "page", page: chunk.page },
+    })),
+    pageCount: pages.length,
+    text: pages.map((page) => page.text).join("\n"),
+  };
+}
+
+/**
+ * Embeds every chunk and inserts the resulting kb_chunks rows for
+ * `documentId`. Returns the number of chunks written — zero means the
  * document is indexed but unsearchable (e.g. an image-only scan whose text
- * layer is empty), which callers must report as such rather than as a
- * successful index.
+ * layer is empty, or a workbook whose every sheet is hidden), which callers
+ * must report as such rather than as a successful index.
  */
 async function writeChunks(
   documentId: string,
   orgId: string,
   sourcePath: string,
-  pages: IngestPage[],
+  chunks: LocatedChunk[],
   deps: IngestDeps,
   onChunkProgress?: ChunkProgressCallback
 ): Promise<number> {
-  const chunks = chunkPages(pages);
   if (chunks.length === 0) return 0;
 
   const vectors: number[][] = [];
@@ -283,10 +362,12 @@ async function writeChunks(
       orgId,
       sourcePath,
       chunkText: chunk.text,
-      // The only locator producer that exists today. PDF pages are intrinsic,
-      // so `page` is the honest anchor here; Wave 2 adds the heading/slide/
-      // sheet producers against the same closed union (locator.ts, #933).
-      locator: { kind: "page", page: chunk.page } satisfies ChunkLocator,
+      // Decided by `extractDocument`, per format, against the closed union in
+      // locator.ts (#933): a page for a PDF, a sheet + row range for a
+      // spreadsheet. This function no longer knows which, which is the point —
+      // adding the heading and slide producers (#938) touches the dispatch and
+      // not the write.
+      locator: chunk.locator,
       lang: detectLang(chunk.text),
       embedding: vectors[i],
     }))
@@ -376,8 +457,8 @@ async function ingestFile(
     // A file with no text at all lands here too, on every run, and rebuilds
     // to zero chunks again — the write result, not the branch, is what tells
     // the two apart.
-    const pages = await fileStep(absPath, () => deps.extractPdf(absPath));
-    const written = await writeChunks(existing.id, orgId, absPath, pages, deps, onChunkProgress);
+    const { chunks } = await fileStep(absPath, () => extractDocument(absPath, deps));
+    const written = await writeChunks(existing.id, orgId, absPath, chunks, deps, onChunkProgress);
     return written > 0 ? "indexed" : "unsearchable";
   }
 
@@ -385,7 +466,7 @@ async function ingestFile(
   // something unparseable throws here and stays a `failed` update, with the
   // last good document and its chunks still searchable. Deleting first would
   // turn that same failure into silent data loss on a success response.
-  const pages = await fileStep(absPath, () => deps.extractPdf(absPath));
+  const extracted = await fileStep(absPath, () => extractDocument(absPath, deps));
 
   if (existing) {
     // Content changed since the last ingest: replace wholesale. Deleting
@@ -394,8 +475,6 @@ async function ingestFile(
     await db.delete(kbDocuments).where(eq(kbDocuments.id, existing.id));
   }
 
-  const wholeDocText = pages.map((p) => p.text).join("\n");
-
   const [doc] = await db
     .insert(kbDocuments)
     .values({
@@ -403,13 +482,20 @@ async function ingestFile(
       contentHash,
       sourcePath: absPath,
       status: statusForPath(absPath),
-      pageCount: pages.length,
+      pageCount: extracted.pageCount,
       mtime: fileStat.mtime,
-      lang: detectLang(wholeDocText),
+      lang: detectLang(extracted.text),
     })
     .returning();
 
-  const written = await writeChunks(doc.id, orgId, absPath, pages, deps, onChunkProgress);
+  const written = await writeChunks(
+    doc.id,
+    orgId,
+    absPath,
+    extracted.chunks,
+    deps,
+    onChunkProgress
+  );
   return written > 0 ? "indexed" : "unsearchable";
 }
 

--- a/packages/web/src/lib/knowledge/ingest.ts
+++ b/packages/web/src/lib/knowledge/ingest.ts
@@ -86,7 +86,13 @@ export interface IngestDeps {
 }
 
 export interface IngestOptions {
-  /** Overrides the default extension allowlist (`[".pdf"]` for the MVP). */
+  /**
+   * Overrides `DEFAULT_ALLOWED_EXTENSIONS` (exclude-globs.ts).
+   *
+   * Naming a type here does NOT teach `extractDocument` to read it: the
+   * dispatch is by extension, and anything it does not recognise goes to the
+   * PDF extractor. Widening this is half a change.
+   */
   allowedExtensions?: readonly string[];
   /**
    * Called once with the discovery total before the first file is touched, then

--- a/packages/web/src/lib/knowledge/office-formats.ts
+++ b/packages/web/src/lib/knowledge/office-formats.ts
@@ -23,6 +23,20 @@
 export const OFFICE_EXTENSIONS = [".doc", ".docx", ".ppt", ".pptx"] as const;
 
 /**
+ * The spreadsheet formats the knowledge base reads directly, cells and all,
+ * instead of converting (see `xlsx-extract.ts` for the three reasons).
+ *
+ * OOXML only, and that is a capability statement rather than a preference:
+ * `extractXlsx` reads through `workbook.xlsx.readFile`, which parses the
+ * zipped XML formats and not legacy BIFF. Listing `.xls` here would index
+ * every legacy workbook straight into the unreadable list (#935) — an
+ * allowlist that names what we cannot read is a promise the extractor breaks
+ * one file at a time. `.csv` is out for a different reason: it has no sheet,
+ * so half of the `sheet + rows` anchor would have to be invented.
+ */
+export const SPREADSHEET_EXTENSIONS = [".xlsx", ".xlsm"] as const;
+
+/**
  * The lowercased extension of `path`, or "" — `node:path`'s `extname` written
  * as string surgery, including its rule that a leading dot is a dotfile and
  * not an extension (`.doc` → "", never ".doc").
@@ -36,6 +50,11 @@ function extensionOf(path: string): string {
 /** Is this a page-shaped Office document the knowledge base converts? */
 export function isOfficeFile(path: string): boolean {
   return (OFFICE_EXTENSIONS as readonly string[]).includes(extensionOf(path));
+}
+
+/** Is this a spreadsheet the knowledge base reads directly, rather than converts? */
+export function isSpreadsheetFile(path: string): boolean {
+  return (SPREADSHEET_EXTENSIONS as readonly string[]).includes(extensionOf(path));
 }
 
 /**

--- a/packages/web/src/server/kb-index-worker.ts
+++ b/packages/web/src/server/kb-index-worker.ts
@@ -21,6 +21,7 @@ import { recordAuditFailure } from "@/lib/audit-deferred";
 import { embedTexts } from "@/lib/knowledge/embeddings";
 import { kbEmbedderAvailable, kbEmbeddingConfig } from "@/lib/knowledge/kb-embedder";
 import { extractPdfPages } from "@/lib/knowledge/pdf-extract";
+import { extractXlsx } from "@/lib/knowledge/xlsx-extract";
 import { ingestPaths, type IngestDeps } from "@/lib/knowledge/ingest";
 import {
   claimNextIndexJob,
@@ -40,6 +41,7 @@ function resolveIngestDeps(): IngestDeps | null {
   return {
     embed: (texts) => embedTexts(texts, cfg),
     extractPdf: extractPdfPages,
+    extractXlsx,
   };
 }
 


### PR DESCRIPTION
Wires #937's extractor into the ingest. Closes the indexing half of #940; the preview half is called out at the bottom.

`xlsx-extract.ts` has existed since #937 and **nothing called it**. An Excel workbook under a granted folder was simply not in the corpus.

## What changed

The ingest dispatches on extension. `extractDocument` reads a PDF through `chunkPages` and anchors each chunk on its page; a workbook through `extractXlsx` and anchors on **sheet + row range**. `XlsxChunk` is field-for-field the `sheet` locator, so that half is a spread rather than a mapping — exactly what `locator.ts` predicted when it declared the union.

Everything downstream of the dispatch — embedding, writing, idempotency, the removal pass — is format-blind on purpose. That is what makes #938's heading and slide producers a change to **one function** instead of to the pipeline.

## Three decisions worth arguing

**`pageCount` is `null` for a workbook, not the sheet count.** A sheet is not a page, and writing one into a column called `pageCount` makes the row state something false about the document — the same mistake `ChunkLocator` exists to prevent one level down. The column is nullable for it.

**`.xls` and `.csv` stay out of the allowlist.** `extractXlsx` reads via `workbook.xlsx.readFile`, which parses OOXML and not legacy BIFF, so naming `.xls` would index every legacy workbook straight into the unreadable list — an allowlist that names what we cannot read is a promise the extractor breaks one file at a time. A CSV has no sheet, so half the anchor would have to be invented.

**`IngestDeps.extractXlsx` is required, not optional.** The moment `DEFAULT_ALLOWED_EXTENSIONS` names `.xlsx`, every deployment's ingest *will* meet one. An optional extractor makes that a runtime surprise in whichever customer happens to hold a spreadsheet; a required one made the typechecker name all six call sites.

## Unsearchable, not indexed

A workbook whose every sheet is hidden reads without error and yields nothing. `extractXlsx` reports the hidden sheets and no chunks, and "0 chunks" is exactly what an unreadable file gives — so it lands in the same bucket a text-less scan does, visible in the unreadable list (#935) rather than counted as a successful index.

## Tested against pre-existing data

Per AGENTS.md § *Test Migrations Against Pre-Existing Data*: every other test here starts from a clean slate where the dispatch is live from the first write, so none of them can see what an **upgrade** produces. The added test ingests a PDF alone (what the old pipeline did), then drops a workbook beside it and re-runs — the PDF must be `skipped`, keep its chunk ids, its page locators and its `pageCount: 2`. A widened allowlist must not invalidate what was already indexed.

## Not in scope

The **citation link**. `source-links.ts` deliberately does not linkify a spreadsheet, because nothing renders one, and its drift guard explicitly sanctions the ingest accepting a type before the viewer can show it. The docs now say what a reader does instead — the citation names sheet and rows, and you open the workbook from your share. Showing an invented page layout would be worse than sending someone to the file they already know how to read.

## Docs

`mount-data-directories` (supported types, the `.xls` exclusion, the all-hidden workbook count) and `create-knowledge-base-agent` (what indexing reads, how a spreadsheet is cited, what opening one does, scope).

## Verification

- `pnpm test` — 844 files / 12 156 tests
- `pnpm -C packages/web test:db` — **582 tests**, the suite that actually covers this
- `pnpm test:scripts` — 1240
- `tsc --noEmit -p tsconfig.typecheck.json`, `prettier --check .`, pre-push build