### PR TITLE
docs(kb): say what the reindex now takes in, and where scans go

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,8 @@ PINCHY_VERSION=v0.9.1
 # PINCHY_ENTERPRISE_KEY=
 # PINCHY_ADMIN_EMAIL=admin@example.com
 # PINCHY_ADMIN_PASSWORD=change-me
+# Knowledge Base: indexing a scanned PDF renders its pages and sends them to
+# your model provider so a vision model can read them. Set this to 'off' to
+# skip that step — scans are then reported as unsearchable instead.
+# PINCHY_KB_OCR=off
 # PINCHY_TRUSTED_PROXIES=10.0.0.0/8,173.245.48.0/20   # extra proxy hops in front of your own

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -199,6 +199,16 @@ So after upgrading, a Knowledge Base agent finds nothing until you reindex it: o
 
 The `ollama pull bge-m3` step from the v0.9.0 notes no longer applies. If nothing else on your machine uses that model, you can remove it.
 
+#### The reindex takes more file types now — and scans go to your model provider
+
+The same run picks up four things it couldn't read before: **Word documents** (`.doc` and `.docx`), **slide decks** (`.ppt`, `.pptx`), **Excel workbooks** (`.xlsx`, `.xlsm`), and **scanned PDFs**. Citations land where each format actually has an anchor — a slide number, a heading, a sheet and row range — and open in the viewer like a PDF page does. Older `.xls` workbooks, plain text and Markdown are still out; [Supported file types](/guides/mount-data-directories/#supported-file-types) has the full split.
+
+Scans are the part worth a look before you click. A page with no text layer is rendered and handed to a vision model — the same one that already reads a scan when an agent opens it in chat — so **indexing now sends document content to your model provider**. It happens once per document, for every scanned page in the corpus, including documents nobody ever asks about. That's a wider statement than "only the question and the retrieved snippets leave the building", so it's worth deciding rather than discovering.
+
+If that isn't right for your instance, set `PINCHY_KB_OCR=off` in your `.env` and restart before you reindex. Scans are then reported as `unsearchable` — listed by name, not quietly skipped — and nothing leaves the building. On an air-gapped install there's nothing to do either way: Pinchy picks the vision model from your configured cloud providers, so a local-only stack has none and never sends anything.
+
+These calls run on your own API key and show up in the Usage Dashboard, and the reindex entry in the audit trail records how many documents and pages were sent, and to which model. [What indexing sends to your provider](/guides/mount-data-directories/#what-indexing-sends-to-your-provider) has the rest, including the 200-page-per-document limit.
+
 #### Deleting in Odoo now requires reading the record first
 
 `odoo_delete` no longer takes record IDs. It takes the opaque references (`_pinchy_ref`) that `odoo_read` and `odoo_create` hand back, so an agent can only delete a record it actually retrieved — from this connection, on the model it says it is deleting. Every other Odoo write tool already worked this way; delete, the one that cannot be undone, was the exception.


### PR DESCRIPTION
Two gaps in the open `v0.9.1 → %%PINCHY_VERSION%%` section, both cheap now and not after the tag.

## The reindex sends scans to the provider, and no note said so

The section's KB note ends by telling the reader to click **Reindex now** for the embedder swap. On this release that click also renders every page with no text layer and hands it to a vision model — document content leaving the building, once per document, including documents nobody ever asks about.

None of the section's 18 `####` notes mentioned it. The KB guide and `mount-data-directories` both state the data flow properly, but the reader of the *upgrade* notes is the one about to press the button, and they were the one reader not told.

The new note also names the three formats the same run gains — Word, slide decks, workbooks — since a reader who knows only about the embedder swap has no reason to expect them, and repeats the boundary that stays (`.xls`, plain text, Markdown).

## `PINCHY_KB_OCR` was missing from `.env.example`

The switch that turns the sending off is documented on two docs pages and was in no `.env` template, so an operator who wanted it found it only by reading the right page first. Added, commented, next to the other optional keys.

## Why now

`upgrading.mdx` sections freeze at the tag (AGENTS.md § *A Released Upgrade Section Is Immutable*). After the cut this same edit needs an `Allow-upgrade-note-edit:` trailer and re-renders under the wrong version until then.

## Test plan

- [x] `prettier --check .` — clean
- [x] `pnpm test:scripts` — 1241 pass, 0 fail (includes the upgrading-section guards)
- [x] `pnpm -C docs test` — 0 fail
- [x] `pnpm -C docs build` — 71 pages
- [x] `pnpm -C docs check:anchors` — 74 pages, no broken internal links (verifies the two new links)
- [x] `pnpm -C docs check:rendered` — 74 pages, every table rendered

Docs-only; no code paths touched.