### PR TITLE
fix(openclaw): chown the staged llama-cpp provider so OpenClaw stops blocking it

### DIFF
--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -293,6 +293,10 @@ COPY entrypoint.sh /entrypoint.sh
 # Plugin-source sync helper the entrypoint runs on every boot. Extracted from
 # entrypoint.sh so its node_modules-preservation invariant is unit-testable.
 COPY config/sync-plugins.sh /sync-plugins.sh
-RUN chmod +x /entrypoint.sh /sync-plugins.sh
+# Shared-volume ownership repair the entrypoint runs before dropping privileges.
+# Extracted for the same reason: the path it must LEAVE root-owned
+# (/openclaw-config/npm, OpenClaw's plugin store) is unit-testable there.
+COPY config/fix-volume-ownership.sh /fix-volume-ownership.sh
+RUN chmod +x /entrypoint.sh /sync-plugins.sh /fix-volume-ownership.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/config/fix-volume-ownership.sh
+++ b/config/fix-volume-ownership.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Ownership repair for the shared `openclaw-config` volume, run by the pinchy
+# container's entrypoint before it drops privileges. Extracted from entrypoint.sh
+# (same pattern as config/sync-plugins.sh) so the one path it must NOT repair is
+# unit-testable — see packages/web/src/__tests__/lib/fix-volume-ownership.test.ts.
+#
+# OpenClaw runs as root and creates most of this volume; Pinchy runs as uid 999
+# and needs write access to openclaw.json, agents/, credentials/ and the rest. So
+# the entrypoint takes ownership of the volume, because only root can chown and
+# this is the last moment in the boot where the pinchy container still is root.
+#
+# EXCEPT npm/, and that exception is the whole reason this file exists (#1196).
+# That directory is OpenClaw's plugin store — it holds the bundled llama.cpp
+# embedding provider — and OpenClaw's loader refuses a candidate whose files are
+# not root-owned:
+#
+#   plugins.allow: plugin llama-cpp: blocked plugin candidate: suspicious
+#   ownership (/root/.openclaw/npm/projects/openclaw-llama-cpp-provider-…,
+#   uid=999, expected uid=0 or root)
+#
+# The blanket `chown -R pinchy:pinchy /openclaw-config` this replaces swept npm/
+# up with everything else — /openclaw-config and openclaw's /root/.openclaw are
+# the same volume, and npm/ has no sub-mount of its own — so on production the
+# provider sat permanently blocked and every memory_search answered "Unknown
+# memory embedding provider: local."
+#
+# Repairing it on the OpenClaw side alone is not enough, which is why the prune
+# is here rather than only in config/stage-llama-cpp-provider.sh: that repair
+# runs at OpenClaw CONTAINER boot, and docker-compose.yml declares
+# `openclaw: depends_on: pinchy: service_healthy`. A pinchy-only restart — an OOM
+# under `mem_limit: 1g`, a redeploy, `restart: unless-stopped` after a crash —
+# would otherwise re-break the tree while OpenClaw keeps running, with nothing
+# left to repair it until the openclaw container itself restarts. Pinchy never
+# reads or writes anything under npm/, so pruning it costs nothing.
+#
+# `! -uid` gates the chown so an already-correct tree is left alone. Same
+# reasoning as config/fix-config-permissions.sh: this volume carries
+# agents/<id>/sessions and workspaces/ with unbounded file counts, and chown
+# rewrites ctime — which OpenClaw's session-takeover detector reads as external
+# modification. The gate is on the uid only, so a file that is already
+# pinchy-owned keeps whatever group it has; ownership is what grants the write,
+# and root ignores group bits anyway.
+#
+# Paths and the target uid are env-overridable so the unit test can drive the
+# real script against temp dirs; production uses the defaults.
+set -e
+
+# Trailing slash stripped so the -path prune below matches what find prints.
+OPENCLAW_CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-/openclaw-config}"
+OPENCLAW_CONFIG_DIR="${OPENCLAW_CONFIG_DIR%/}"
+# The pinchy user inside the Pinchy container (Dockerfile.pinchy: useradd -u 999).
+PINCHY_UID="${PINCHY_UID:-999}"
+PINCHY_GID="${PINCHY_GID:-999}"
+
+find "$OPENCLAW_CONFIG_DIR" -path "$OPENCLAW_CONFIG_DIR/npm" -prune -o \
+    ! -uid "$PINCHY_UID" -exec chown "$PINCHY_UID:$PINCHY_GID" {} + 2>/dev/null || true
+
+# Belt-and-suspenders: ensure pinchy can stat AND write the directory itself.
+# The Dockerfile mkdir -p creates /openclaw-config as root:0755; the chown above
+# fixes ownership but the directory mode is not always 0755 in fresh CI volumes.
+chmod 0755 "$OPENCLAW_CONFIG_DIR"
+echo "[entrypoint] $OPENCLAW_CONFIG_DIR: $(stat -c '%U:%G %a' "$OPENCLAW_CONFIG_DIR" 2>/dev/null || echo 'stat-failed')"

--- a/config/stage-llama-cpp-provider.sh
+++ b/config/stage-llama-cpp-provider.sh
@@ -30,6 +30,24 @@ stage_llama_cpp_provider() {
         mkdir -p "$OPENCLAW_NPM_ROOT"
         cp -r "$LLAMA_CPP_DEPS_ROOT"/npm/. "$OPENCLAW_NPM_ROOT"/
     fi
+    # OpenClaw's plugin loader refuses a candidate whose files are not root-owned
+    # ("blocked plugin candidate: suspicious ownership … uid=999, expected uid=0
+    # or root"), and the openclaw-config volume is uid 999 nearly throughout
+    # because Pinchy shares it. start-openclaw.sh already force-chowns
+    # extensions/ for exactly this reason; npm/ holds a plugin too and was
+    # missed, so on production the provider sat blocked and every memory_search
+    # answered "Unknown memory embedding provider: local." (#1196).
+    #
+    # OUTSIDE the staging guard on purpose. The copy above runs at most once per
+    # volume, so a tree staged by an earlier release is never rewritten — if the
+    # repair rode along with the copy, an upgraded deployment would stay blocked
+    # forever. That is the state #1196 was found in.
+    #
+    # Warn rather than swallow, same contract as the registry refresh below: a
+    # silent failure here means recall regresses to 0 chunks with nothing said.
+    if ! chown -R root:root "$OPENCLAW_NPM_ROOT" 2>/dev/null; then
+        echo "[llama-cpp] WARNING: could not chown ${OPENCLAW_NPM_ROOT} to root — OpenClaw will block the embedding provider as 'suspicious ownership' and memory_search will return 0 chunks"
+    fi
     # Idempotent, offline: rescans on-disk source roots (incl. the staged
     # provider) to rebuild the persisted registry so it loads. A silent failure
     # here means the provider never loads and recall regresses to 0 chunks — so

--- a/config/stage-llama-cpp-provider.sh
+++ b/config/stage-llama-cpp-provider.sh
@@ -38,15 +38,29 @@ stage_llama_cpp_provider() {
     # missed, so on production the provider sat blocked and every memory_search
     # answered "Unknown memory embedding provider: local." (#1196).
     #
+    # This is the MIGRATION half of that fix, not the whole of it. What put the
+    # tree at uid 999 is the pinchy container's entrypoint, which used to run a
+    # blanket `chown -R pinchy:pinchy /openclaw-config` over the same volume on
+    # every boot; config/fix-volume-ownership.sh now prunes npm/ out of it, so
+    # nothing re-breaks the tree between OpenClaw restarts. Repairing it only
+    # here would not have held: this runs at OpenClaw CONTAINER boot and
+    # `openclaw` depends_on pinchy, so a pinchy-only restart (an OOM, a redeploy,
+    # `restart: unless-stopped` after a crash) would undo it with nothing left to
+    # repair it until the openclaw container itself restarts.
+    #
     # OUTSIDE the staging guard on purpose. The copy above runs at most once per
     # volume, so a tree staged by an earlier release is never rewritten — if the
-    # repair rode along with the copy, an upgraded deployment would stay blocked
-    # forever. That is the state #1196 was found in.
+    # repair rode along with the copy, a deployment upgrading from a release that
+    # carried the entrypoint bug would stay blocked forever. That is the state
+    # #1196 was found in.
     #
     # Warn rather than swallow, same contract as the registry refresh below: a
     # silent failure here means recall regresses to 0 chunks with nothing said.
-    if ! chown -R root:root "$OPENCLAW_NPM_ROOT" 2>/dev/null; then
-        echo "[llama-cpp] WARNING: could not chown ${OPENCLAW_NPM_ROOT} to root — OpenClaw will block the embedding provider as 'suspicious ownership' and memory_search will return 0 chunks"
+    # And quote what the kernel said — "could not chown" alone leaves an operator
+    # to reproduce the call by hand to learn whether it was EPERM, a read-only
+    # mount, or a missing path, which are three different answers.
+    if ! chown_err="$(chown -R root:root "$OPENCLAW_NPM_ROOT" 2>&1 >/dev/null)"; then
+        echo "[llama-cpp] WARNING: could not chown ${OPENCLAW_NPM_ROOT} to root (${chown_err%%$'\n'*}) — OpenClaw will block the embedding provider as 'suspicious ownership' and memory_search will return 0 chunks"
     fi
     # Idempotent, offline: rescans on-disk source roots (incl. the staged
     # provider) to rebuild the persisted registry so it loads. A silent failure

--- a/config/verify-memory-search.sh
+++ b/config/verify-memory-search.sh
@@ -62,7 +62,8 @@ openclaw plugins list 2>&1 | grep -qiE 'llama.?cpp.*enabled' || {
 # Everything above ran in a fresh container, where /root/.openclaw is created
 # root-owned and the staged provider inherits that. Production does not look
 # like this: the openclaw-config volume is uid 999 nearly throughout, because
-# Pinchy (uid 999) shares it. On production the provider was therefore 999-owned
+# Pinchy (uid 999) shares it and its entrypoint used to chown the whole volume
+# recursively on every boot. On production the provider was therefore 999-owned
 # and OpenClaw blocked it — "suspicious ownership … expected uid=0" — so
 # memory_search answered "Unknown memory embedding provider: local." for every
 # call, while THIS test stayed green the whole time (#1196).
@@ -70,8 +71,17 @@ openclaw plugins list 2>&1 | grep -qiE 'llama.?cpp.*enabled' || {
 # So re-create that state deliberately and run the real boot function against
 # it. The copy is guarded and will not re-run (the provider is already there),
 # which is the point: the ownership repair has to stand on its own.
+#
+# PINCHY_UID mirrors config/fix-config-permissions.sh rather than repeating a
+# literal 999: if Dockerfile.pinchy's `useradd -u 999` ever moves, this test must
+# move with it or it simulates a state production no longer produces.
 NPM_ROOT="${OPENCLAW_NPM_ROOT:-/root/.openclaw/npm}"
-chown -R 999:999 "$NPM_ROOT"
+PINCHY_UID="${PINCHY_UID:-999}"
+PINCHY_GID="${PINCHY_GID:-999}"
+chown -R "$PINCHY_UID:$PINCHY_GID" "$NPM_ROOT" || {
+  echo "::error::could not simulate the upgrade-shaped ownership state at $NPM_ROOT — has OpenClaw moved its plugin store?"
+  exit 1
+}
 stage_llama_cpp_provider
 
 BAD_OWNER="$(find "$NPM_ROOT" ! -uid 0 -print -quit)"
@@ -81,7 +91,7 @@ if [ -n "$BAD_OWNER" ]; then
 fi
 
 openclaw plugins list 2>&1 | grep -qiE 'llama.?cpp.*enabled' || {
-  echo "::error::llama-cpp provider did not load after a 999-owned (upgrade-shaped) stage"
+  echo "::error::llama-cpp provider did not load after a ${PINCHY_UID}-owned (upgrade-shaped) stage"
   openclaw plugins list 2>&1 | grep -i llama || true
   exit 1
 }

--- a/config/verify-memory-search.sh
+++ b/config/verify-memory-search.sh
@@ -57,6 +57,35 @@ openclaw plugins list 2>&1 | grep -qiE 'llama.?cpp.*enabled' || {
   exit 1
 }
 
+# Second pass, against the state an UPGRADE produces rather than an install.
+#
+# Everything above ran in a fresh container, where /root/.openclaw is created
+# root-owned and the staged provider inherits that. Production does not look
+# like this: the openclaw-config volume is uid 999 nearly throughout, because
+# Pinchy (uid 999) shares it. On production the provider was therefore 999-owned
+# and OpenClaw blocked it — "suspicious ownership … expected uid=0" — so
+# memory_search answered "Unknown memory embedding provider: local." for every
+# call, while THIS test stayed green the whole time (#1196).
+#
+# So re-create that state deliberately and run the real boot function against
+# it. The copy is guarded and will not re-run (the provider is already there),
+# which is the point: the ownership repair has to stand on its own.
+NPM_ROOT="${OPENCLAW_NPM_ROOT:-/root/.openclaw/npm}"
+chown -R 999:999 "$NPM_ROOT"
+stage_llama_cpp_provider
+
+BAD_OWNER="$(find "$NPM_ROOT" ! -uid 0 -print -quit)"
+if [ -n "$BAD_OWNER" ]; then
+  echo "::error::staged provider is still not root-owned after re-staging: $BAD_OWNER"
+  exit 1
+fi
+
+openclaw plugins list 2>&1 | grep -qiE 'llama.?cpp.*enabled' || {
+  echo "::error::llama-cpp provider did not load after a 999-owned (upgrade-shaped) stage"
+  openclaw plugins list 2>&1 | grep -i llama || true
+  exit 1
+}
+
 openclaw memory index --agent "$AGENT"
 
 STATUS="$(openclaw memory status --agent "$AGENT" 2>&1)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
 set -e
 
-# Fix permissions on shared OpenClaw config volume.
+# Fix permissions on the shared OpenClaw config volume.
 # OpenClaw runs as root and owns these files; Pinchy needs write access
 # to update openclaw.json when providers or agents change.
-chown -R pinchy:pinchy /openclaw-config
-# Belt-and-suspenders: ensure pinchy can stat AND write the directory itself.
-# The Dockerfile mkdir -p creates /openclaw-config as root:0755; chown -R fixes
-# ownership but the directory mode is not always 0755 in fresh CI volumes.
-chmod 0755 /openclaw-config
-echo "[entrypoint] /openclaw-config: $(stat -c '%U:%G %a' /openclaw-config)"
+#
+# Extracted to config/fix-volume-ownership.sh (same pattern as
+# config/sync-plugins.sh) so the one path it must NOT repair is unit-testable:
+# /openclaw-config/npm is OpenClaw's plugin store, and a plugin candidate that
+# is not root-owned is blocked as "suspicious ownership" — which is how the
+# blanket `chown -R pinchy:pinchy /openclaw-config` that used to live here took
+# the bundled embedding provider down on production (#1196). See the reasoning
+# in that file.
+sh /fix-volume-ownership.sh
 
 # Seed a minimal openclaw.json if the volume doesn't have one yet.
 # On main, openclaw started first and Docker copied the seed from the image.

--- a/packages/web/src/__tests__/lib/fix-volume-ownership.test.ts
+++ b/packages/web/src/__tests__/lib/fix-volume-ownership.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  chmodSync,
+  statSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, delimiter } from "node:path";
+
+// config/fix-volume-ownership.sh is the pinchy-container entrypoint's ownership
+// repair for the shared `openclaw-config` volume, extracted into its own script
+// (same pattern as config/sync-plugins.sh) so the one path it must NOT repair is
+// unit-testable.
+//
+// THE INVARIANT THIS FILE EXISTS FOR (#1196):
+//
+//   /openclaw-config/npm must stay ROOT-owned, even though the rest of the
+//   volume is handed to uid 999.
+//
+// That directory is OpenClaw's plugin store — it holds the bundled llama.cpp
+// embedding provider — and OpenClaw's loader refuses a candidate whose files are
+// not root-owned ("blocked plugin candidate: suspicious ownership … uid=999,
+// expected uid=0 or root"). The entrypoint used to run a blanket
+// `chown -R pinchy:pinchy /openclaw-config`, which swept npm/ up with everything
+// else, so on production the provider sat blocked and every memory_search
+// answered "Unknown memory embedding provider: local."
+//
+// The OpenClaw-side repair (config/stage-llama-cpp-provider.sh) runs at OpenClaw
+// CONTAINER boot, and docker-compose.yml has `openclaw: depends_on: pinchy:
+// service_healthy` — so a pinchy-only restart (an OOM under `mem_limit: 1g`, a
+// redeploy, `restart: unless-stopped` after a crash) would re-break the tree
+// with nothing left to repair it until the openclaw container itself restarts.
+// Not chowning it in the first place is the durable half of the fix.
+//
+// `chown` is stubbed on PATH: a non-root test process cannot chown to uid 999,
+// and the syscall itself is the kernel's business. Everything else runs for
+// real — the real script, real `find` traversal, real prune, real gate, real
+// chmod — so the assertions below are about what the script actually decides to
+// do, not about a re-implementation of it.
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const SCRIPT = resolve(REPO_ROOT, "config/fix-volume-ownership.sh");
+const ENTRYPOINT = readFileSync(resolve(REPO_ROOT, "entrypoint.sh"), "utf8");
+// Comments stripped before the negative assertion below. entrypoint.sh QUOTES
+// the removed command in the prose that explains why it is gone, and a text
+// search that reads its own explanation as the thing it forbids reports on the
+// presence of a string rather than on what the script does (same trap the
+// image-copy guard hit in 1b5361f2b).
+const ENTRYPOINT_CODE = ENTRYPOINT.split("\n")
+  .filter((line) => !line.trimStart().startsWith("#"))
+  .join("\n");
+
+// A uid the temp fixtures are guaranteed NOT to be owned by, so the "skip what
+// is already correct" gate doesn't swallow the assertions.
+const FOREIGN_UID = "4242";
+
+let root: string;
+let configDir: string;
+let binDir: string;
+let chownLog: string;
+
+function stubChown(): void {
+  const bin = join(binDir, "chown");
+  writeFileSync(bin, `#!/bin/bash\necho "$@" >> '${chownLog}'\nexit 0\n`);
+  chmodSync(bin, 0o755);
+}
+
+function chownedPaths(): string {
+  if (!existsSync(chownLog)) return "";
+  return readFileSync(chownLog, "utf8");
+}
+
+function run(pinchyUid: string = FOREIGN_UID): string {
+  return execFileSync("sh", [SCRIPT], {
+    env: {
+      ...process.env,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+      OPENCLAW_CONFIG_DIR: configDir,
+      PINCHY_UID: pinchyUid,
+      PINCHY_GID: pinchyUid,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "pinchy-fix-volume-ownership-"));
+  configDir = join(root, "openclaw-config");
+  binDir = join(root, "bin");
+  chownLog = join(root, "chown.log");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(join(configDir, "agents", "a1", "agent"), { recursive: true });
+  mkdirSync(join(configDir, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+    recursive: true,
+  });
+  writeFileSync(join(configDir, "openclaw.json"), "{}\n");
+  writeFileSync(
+    join(configDir, "npm", "projects", "openclaw-llama-cpp-provider-abc123", "package.json"),
+    "{}\n"
+  );
+  stubChown();
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("fix-volume-ownership.sh", () => {
+  it("hands the config volume to the pinchy uid", () => {
+    run();
+
+    const chowned = chownedPaths();
+    expect(chowned).toContain(join(configDir, "openclaw.json"));
+    expect(chowned).toContain(join(configDir, "agents", "a1", "agent"));
+    expect(chowned).toContain(`${FOREIGN_UID}:${FOREIGN_UID}`);
+  });
+
+  // The whole reason this script exists. OpenClaw blocks a plugin candidate it
+  // does not see as root-owned, and npm/ is where the bundled embedding provider
+  // lives — so handing it to uid 999 with the rest of the volume is what took
+  // memory_search down on production (#1196).
+  it("never chowns OpenClaw's plugin store", () => {
+    run();
+
+    expect(chownedPaths()).not.toContain(join(configDir, "npm"));
+  });
+
+  // The prune must not swallow the traversal: everything BESIDE npm/ still has
+  // to be repaired, or the entrypoint stops doing the job it was written for.
+  it("prunes only the plugin store, not its siblings", () => {
+    mkdirSync(join(configDir, "credentials"), { recursive: true });
+    writeFileSync(join(configDir, "credentials", "telegram-pairing.json"), "{}\n");
+
+    run();
+
+    expect(chownedPaths()).toContain(join(configDir, "credentials", "telegram-pairing.json"));
+  });
+
+  // `! -uid` gate: this volume carries agents/<id>/sessions and workspaces with
+  // unbounded file counts, and chown rewrites ctime — which OpenClaw's
+  // session-takeover detector reads as external modification. Same reasoning as
+  // config/fix-config-permissions.sh, which gates every one of its chowns.
+  it("leaves an already-correct tree alone", () => {
+    const ownUid = String(process.getuid?.() ?? 0);
+
+    run(ownUid);
+
+    expect(chownedPaths()).toBe("");
+  });
+
+  // The Dockerfile's `mkdir -p` creates /openclaw-config as root:0755, but the
+  // directory mode is not always 0755 in fresh CI volumes and uid 999 has to be
+  // able to stat and enter it.
+  it("makes the volume root itself traversable", () => {
+    chmodSync(configDir, 0o700);
+
+    run();
+
+    expect(statSync(configDir).mode & 0o777).toBe(0o755);
+  });
+});
+
+describe("entrypoint.sh volume-ownership wiring", () => {
+  it("delegates the ownership repair to fix-volume-ownership.sh", () => {
+    expect(ENTRYPOINT).toContain("/fix-volume-ownership.sh");
+  });
+
+  // The blanket form is the bug: it sweeps OpenClaw's plugin store up with the
+  // rest of the volume on every pinchy boot (#1196).
+  it("no longer chowns the whole volume unconditionally", () => {
+    expect(ENTRYPOINT_CODE).not.toMatch(/chown\s+-R\s+pinchy:pinchy\s+\/openclaw-config\b/);
+    // …and the guard must still see the command when it IS there, or it is
+    // asserting nothing: the prose above the call quotes it verbatim.
+    expect(ENTRYPOINT).toMatch(/chown\s+-R\s+pinchy:pinchy\s+\/openclaw-config\b/);
+  });
+});

--- a/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
+++ b/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
@@ -57,11 +57,13 @@ function stubOpenclaw(exitCode: number): void {
   chmodSync(bin, 0o755);
 }
 
-// Install a stub `chown` on PATH that appends its argv to chownLog and returns
-// the given exit code (0 = chown succeeds, non-zero = chown fails).
-function stubChown(exitCode: number): void {
+// Install a stub `chown` on PATH that appends its argv to chownLog, writes the
+// given text to stderr, and returns the given exit code (0 = chown succeeds,
+// non-zero = chown fails).
+function stubChown(exitCode: number, stderr = ""): void {
   const bin = join(binDir, "chown");
-  writeFileSync(bin, `#!/bin/bash\necho "$@" >> '${chownLog}'\nexit ${exitCode}\n`);
+  const emit = stderr ? `echo ${JSON.stringify(stderr)} >&2\n` : "";
+  writeFileSync(bin, `#!/bin/bash\necho "$@" >> '${chownLog}'\n${emit}exit ${exitCode}\n`);
   chmodSync(bin, 0o755);
 }
 
@@ -128,6 +130,11 @@ describe("stage_llama_cpp_provider", () => {
     // No depsRoot/npm — e.g. a build that didn't bundle the provider.
     expect(() => runStage()).not.toThrow();
     expect(existsSync(join(npmRoot, "projects"))).toBe(false);
+    // …and the ownership repair stays on the far side of the early return.
+    // Hoisted above it, this would chown a path that does not exist on every
+    // boot of an image built without the bundle, and warn that memory_search
+    // will return 0 chunks on a deployment where nothing is wrong.
+    expect(chownCalls()).toEqual([]);
   });
 
   it("warns but stays non-fatal when the registry refresh fails", () => {
@@ -143,7 +150,10 @@ describe("stage_llama_cpp_provider", () => {
     expect(() => {
       output = runStage();
     }).not.toThrow(); // non-fatal: boot continues
-    expect(output).toMatch(/WARNING/);
+    // Name the branch, not just the word WARNING: the function has two
+    // warn-and-continue paths with near-identical wording, and a bare /WARNING/
+    // stays green when the wrong one fires.
+    expect(output).toMatch(/registry --refresh/);
     // Staging still happened despite the refresh failure.
     expect(existsSync(join(npmRoot, "projects", "openclaw-llama-cpp-provider-abc123"))).toBe(true);
   });
@@ -199,6 +209,22 @@ describe("stage_llama_cpp_provider", () => {
     expect(() => {
       output = runStage();
     }).not.toThrow();
-    expect(output).toMatch(/WARNING/);
+    expect(output).toMatch(/could not chown/);
+  });
+
+  // A warning that says "could not" without saying why leaves the operator to
+  // reproduce the chown by hand to learn whether it was EPERM, a read-only
+  // mount, or a missing path — the three causes that need three different
+  // answers. Quote what the kernel said.
+  it("quotes the reason the chown failed", () => {
+    mkdirSync(join(depsRoot, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+    stubChown(1, "chown: changing ownership of '/root/.openclaw/npm': Read-only file system");
+
+    const output = runStage();
+
+    expect(output).toMatch(/could not chown/);
+    expect(output).toContain("Read-only file system");
   });
 });

--- a/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
+++ b/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, existsSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  existsSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  chmodSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, delimiter } from "node:path";
 
@@ -24,6 +32,13 @@ import { join, resolve, delimiter } from "node:path";
 // environment: the real CLI may be absent, or present-and-slow, on a CI runner —
 // exactly the non-determinism that timed this test out in CI. The stub's exit
 // code also lets us exercise the warn-on-failure branch directly.
+//
+// `chown` is stubbed the same way, for a different reason: this suite runs
+// unprivileged, so a real `chown root:root` always fails here and could never
+// distinguish "the function asked" from "the function didn't". The stub records
+// its argv instead. The REAL ownership assertion lives in
+// config/verify-memory-search.sh, which runs as root inside the shipped image
+// against a deliberately 999-owned tree — see the note there.
 
 const REPO_ROOT = resolve(__dirname, "../../../../..");
 const SCRIPT = resolve(REPO_ROOT, "config/stage-llama-cpp-provider.sh");
@@ -32,6 +47,7 @@ let root: string;
 let depsRoot: string;
 let npmRoot: string;
 let binDir: string;
+let chownLog: string;
 
 // Install a stub `openclaw` on PATH whose `plugins registry --refresh` returns
 // the given exit code (0 = refresh succeeds, non-zero = refresh fails).
@@ -39,6 +55,19 @@ function stubOpenclaw(exitCode: number): void {
   const bin = join(binDir, "openclaw");
   writeFileSync(bin, `#!/bin/bash\nexit ${exitCode}\n`);
   chmodSync(bin, 0o755);
+}
+
+// Install a stub `chown` on PATH that appends its argv to chownLog and returns
+// the given exit code (0 = chown succeeds, non-zero = chown fails).
+function stubChown(exitCode: number): void {
+  const bin = join(binDir, "chown");
+  writeFileSync(bin, `#!/bin/bash\necho "$@" >> '${chownLog}'\nexit ${exitCode}\n`);
+  chmodSync(bin, 0o755);
+}
+
+function chownCalls(): string[] {
+  if (!existsSync(chownLog)) return [];
+  return readFileSync(chownLog, "utf8").split("\n").filter(Boolean);
 }
 
 function runStage(): string {
@@ -59,8 +88,10 @@ beforeEach(() => {
   depsRoot = join(root, "opt", "llama-cpp-deps");
   npmRoot = join(root, "home", ".openclaw", "npm");
   binDir = join(root, "bin");
+  chownLog = join(root, "chown.log");
   mkdirSync(binDir, { recursive: true });
   stubOpenclaw(0); // registry refresh succeeds by default
+  stubChown(0); // chown succeeds by default
 });
 
 afterEach(() => {
@@ -115,5 +146,59 @@ describe("stage_llama_cpp_provider", () => {
     expect(output).toMatch(/WARNING/);
     // Staging still happened despite the refresh failure.
     expect(existsSync(join(npmRoot, "projects", "openclaw-llama-cpp-provider-abc123"))).toBe(true);
+  });
+
+  // OpenClaw refuses to load a plugin whose files are not root-owned
+  // ("blocked plugin candidate: suspicious ownership … uid=999, expected uid=0").
+  // The openclaw-config volume is uid 999 nearly throughout — Pinchy shares it —
+  // which is why start-openclaw.sh already force-chowns extensions/ to root. The
+  // staged provider lives under npm/ and was missed, so on production it sat
+  // blocked and every memory_search failed with "Unknown memory embedding
+  // provider: local." (heypinchy/pinchy#1196).
+  it("chowns the staged provider tree to root so OpenClaw does not block it", () => {
+    mkdirSync(join(depsRoot, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+
+    runStage();
+
+    expect(chownCalls()).toContainEqual(`-R root:root ${npmRoot}`);
+  });
+
+  // The production case, and the reason the chown must sit OUTSIDE the
+  // "already staged?" guard: the copy runs at most once per volume, so a tree
+  // staged by an earlier release is never rewritten. If ownership were only
+  // repaired on the copy path, an upgraded deployment would stay blocked
+  // forever — which is exactly what happened.
+  it("repairs ownership even when the provider is already staged", () => {
+    mkdirSync(join(depsRoot, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+    mkdirSync(join(npmRoot, "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+
+    const output = runStage();
+
+    // No copy this time…
+    expect(output).not.toMatch(/staging bundled embedding provider/);
+    // …but the ownership repair still ran.
+    expect(chownCalls()).toContainEqual(`-R root:root ${npmRoot}`);
+  });
+
+  it("warns but stays non-fatal when the chown fails", () => {
+    // Same contract as the registry refresh: a silent failure here means the
+    // provider stays blocked and recall regresses to 0 chunks, so it must warn
+    // — but boot continues, because the file-read fallback still works.
+    mkdirSync(join(depsRoot, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+    stubChown(1);
+
+    let output = "";
+    expect(() => {
+      output = runStage();
+    }).not.toThrow();
+    expect(output).toMatch(/WARNING/);
   });
 });


### PR DESCRIPTION
Fixes #1196.

## What was wrong

OpenClaw's plugin loader refuses a candidate whose files are not root-owned:

```
plugins.allow: plugin llama-cpp: blocked plugin candidate: suspicious ownership
  (/root/.openclaw/npm/projects/openclaw-llama-cpp-provider-…, uid=999, expected uid=0 or root)
```

The `openclaw-config` volume is uid 999 for 30 of its 34 top-level entries, because Pinchy (uid 999) shares it. `start-openclaw.sh` already force-chowns `extensions/` to root for exactly this reason; `npm/` holds a plugin too and was never covered.

Consequence on production: the bundled embedding provider was present, staged, and permanently blocked, so `agents.defaults.memorySearch.provider = "local"` pointed at a provider that did not exist. Every `memory_search` answered `"Unknown memory embedding provider: local."` — 24 times in the last 35 days — and the agent narrated that to the user.

## The fix

`chown -R root:root` the staged tree in `stage_llama_cpp_provider()`, **outside** the "already staged?" guard. That placement is the whole point: the copy runs at most once per volume, so a tree staged by an earlier release is never rewritten. A repair that rode along with the copy would leave every upgraded deployment blocked forever — which is the state production was found in.

It warns rather than swallowing, matching the registry-refresh contract directly below it. A silent failure here costs recall with nothing said.

## Why the existing smoke test never caught it

`config/verify-memory-search.sh` runs in a fresh container, where `/root/.openclaw` is created root-owned and the staged provider inherits that. It has been green throughout. That is the one state that never had the bug — the read-side gap AGENTS.md describes under *Test Migrations Against Pre-Existing Data*.

So the smoke test now runs a second pass against the state an **upgrade** produces: `chown -R 999:999` the staged tree, re-run the real boot function, then assert both that no file is left non-root and that the provider still loads. The copy is guarded and does not re-run, so the ownership repair has to stand on its own.

That pass is the load-bearing test. The unit additions in `stage-llama-cpp-provider.test.ts` stub `chown` and assert it is asked for — the suite runs unprivileged, so it can prove the call is made but not that ownership changed. The comment says so rather than implying more.

## Verification

- `stage-llama-cpp-provider.test.ts` — 7/7, red on the three new cases before the fix (confirmed).
- Full suite: 12276 passed, 18 skipped, 0 failed.
- `pnpm test:scripts`: 1241 passed.
- `shellcheck -x` on both scripts: clean apart from the pre-existing SC1091 on the container-absolute `source` path.

The upgrade-state assertion is exercised in CI's `docker-smoke` job, which runs the script against the image this PR builds (`:latest` there is a local re-tag of the PR build), so the new check runs against the fixed staging script rather than main's.

## The cause, found in review

The paragraph that used to stand here said the 999 ownership was "not established … nothing in the current tree does a recursive chown over `npm/`". That was wrong, and it changes the shape of the fix.

`entrypoint.sh` ran `chown -R pinchy:pinchy /openclaw-config` on every Pinchy boot. `/openclaw-config` is the same `openclaw-config` volume the openclaw service mounts at `/root/.openclaw`; there are sub-mounts over `workspaces/` and `extensions/`, but none over `npm/`. So Pinchy handed OpenClaw's plugin store to uid 999, every time it started.

The ordering is what made that fatal rather than merely untidy. The staging repair runs at OpenClaw **container** boot, and compose declares `openclaw: depends_on: pinchy: service_healthy`. A pinchy-only restart — an OOM under `mem_limit: 1g`, a redeploy, a crash under `restart: unless-stopped` — therefore re-broke the provider while OpenClaw kept running, with nothing left to repair it until the openclaw container itself restarted. Which is the state #1196 was found in.

`config/fix-volume-ownership.sh` takes that repair out of `entrypoint.sh` so the one path it must NOT touch is unit-testable, and prunes `npm/` — Pinchy neither reads nor writes anything there. Its chown is gated on `! -uid` the way `fix-config-permissions.sh` gates its own: this volume carries `agents/<id>/sessions` and `workspaces/` with unbounded file counts, and chown rewrites ctime, which OpenClaw's session-takeover detector reads as external modification. The staging-side chown stays, as the migration path for volumes an earlier release already broke.

The drift guard strips comments before its negative match: `entrypoint.sh` quotes the removed command in the prose explaining why it is gone, and a text search that reads its own explanation as the thing it forbids reports on the presence of a string rather than on what the script does.

## Also from the review

- The chown warning quotes the kernel's reason instead of sending stderr to `/dev/null`. "could not chown" alone leaves an operator to reproduce the call by hand to learn whether it was EPERM, a read-only mount or a missing path.
- The smoke test's upgrade simulation fails with an `::error::` line like every other check in that file instead of a raw chown message, and reads `PINCHY_UID` rather than repeating a second literal `999`.
- The two warn-and-continue tests name their branch (`/could not chown/`, `/registry --refresh/`) instead of matching a bare `/WARNING/` that both would satisfy, and the no-bundle case asserts the chown stays on the far side of the early return.

## Still open

The smoke test asserts the tree ends up root-owned; it does **not** assert the premise that a 999-owned tree is actually blocked by OpenClaw. A negative canary before the re-stage would pin that, but adding one needs the openclaw image built to verify it does not turn `docker-smoke` red — an unverified assertion in front of a merge gate is worse than the gap. Left out deliberately rather than guessed at.
