### PR TITLE
fix(chat): a retry re-sends the message's attachments, not just its text

### DIFF
--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -948,6 +948,84 @@ describe("useWsRuntime", () => {
     expect(messages[1].content[0].text).toBe("Hi!");
   });
 
+  // #1195: the retry affordance outlives a reload — ChatErrorBanner re-surfaces
+  // the session's last un-resolved agent error on mount and offers Retry for
+  // it. The client's `attachmentIds` do NOT outlive a reload (nothing persists
+  // the message list), so without the ids on the history frame that Retry sends
+  // the text alone: exactly the production symptom, one layer further out than
+  // the in-tab path the rest of this fix covers.
+  it("re-sends the attachments of a user turn rebuilt from history", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0];
+
+    act(() => {
+      ws.simulateOpen();
+    });
+
+    act(() => {
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          {
+            role: "user",
+            content: "here are the invoices",
+            timestamp: "2026-01-01T00:00:00Z",
+            files: [
+              { filename: "a.pdf", mimeType: "application/pdf", uploadId: "upload-a" },
+              { filename: "b.pdf", mimeType: "application/pdf", uploadId: "upload-b" },
+            ],
+          },
+          { role: "assistant", content: "…", timestamp: "2026-01-01T00:00:01Z" },
+        ],
+      });
+    });
+
+    act(() => {
+      result.current.onRetryContinue("partial_stream_failure");
+    });
+
+    const retry = JSON.parse(ws.send.mock.calls.at(-1)![0]);
+    expect(retry.isRetry).toBe(true);
+    expect(retry.attachmentIds).toEqual(["upload-a", "upload-b"]);
+  });
+
+  it("sends no attachment ids when the server could resolve only some of them", () => {
+    // All-or-nothing: a partial manifest would have the agent answer about
+    // three of five invoices with nothing naming the missing two.
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0];
+
+    act(() => {
+      ws.simulateOpen();
+    });
+
+    act(() => {
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          {
+            role: "user",
+            content: "here are the invoices",
+            timestamp: "2026-01-01T00:00:00Z",
+            files: [
+              { filename: "a.pdf", mimeType: "application/pdf", uploadId: "upload-a" },
+              { filename: "gone.pdf", mimeType: "application/pdf" },
+            ],
+          },
+          { role: "assistant", content: "…", timestamp: "2026-01-01T00:00:01Z" },
+        ],
+      });
+    });
+
+    act(() => {
+      result.current.onRetryContinue("partial_stream_failure");
+    });
+
+    const retry = JSON.parse(ws.send.mock.calls.at(-1)![0]);
+    expect(retry.isRetry).toBe(true);
+    expect("attachmentIds" in retry).toBe(false);
+  });
+
   it("should map system role to assistant in history messages", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0];

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -3645,6 +3645,9 @@ describe("useWsRuntime", () => {
       expect(messageFrames[1].retryReason).toBe("send_failure");
     });
 
+    // Attachment round-trip on this path is covered in the "Two-phase upload"
+    // describe below, which already has the upload-endpoint harness (#1195).
+
     it("retrying a 'partial_stream_failure' resends the original user message with retryReason", async () => {
       const { result } = renderHook(() => useWsRuntime("agent-42"));
 
@@ -3888,11 +3891,21 @@ describe("useWsRuntime", () => {
       expect(result.current.isRunning).toBe(true);
     });
 
-    // "preserves image attachments when retrying" was removed together with
-    // the legacy base64-over-WS flow. The two-phase upload pipeline doesn't
-    // round-trip attachmentIds on retry (they materialize at send time and
-    // the row is already in `attached` state). Retry just re-sends text.
-    // See src/__tests__/hooks/use-pending-uploads.test.ts for the new shape.
+    // Retry DOES round-trip attachmentIds (#1195).
+    //
+    // It used not to, on the reasoning recorded here when the legacy
+    // base64-over-WS flow was removed: "they materialize at send time and the
+    // row is already in `attached` state". That holds only when the first
+    // attempt reached the server. A `send_failure` retry is the case where it
+    // did not — the rows are still `staged`, nothing was materialized, and
+    // re-sending text alone hands the agent a message about files it has never
+    // been given. Production hit exactly that: a message with five invoices
+    // arrived a second time with the attachment block gone.
+    //
+    // The server tells the two states apart (`isRetry` in
+    // attachment-pipeline.ts): staged rows are attached, already-attached rows
+    // are re-referenced rather than refused. Both retry paths are covered in
+    // the "Two-phase upload" describe below, which has the upload harness.
 
     it("restarts the 10s ack timer after retry", async () => {
       const { result } = renderHook(() => useWsRuntime("agent-1"));
@@ -4435,6 +4448,82 @@ describe("Two-phase upload: attachmentIds in WS payload", () => {
     const sentMessage = JSON.parse(ws.send.mock.calls[1][0]);
     expect(sentMessage.type).toBe("message");
     expect(sentMessage.attachmentIds).toEqual(["upload-id-1"]);
+  });
+
+  // #1195: a retry re-sends the message it retries, attachments included.
+  //
+  // Both retry paths used to send `content` alone. That was reasoned from "the
+  // row is already in `attached` state" — true only when the first attempt
+  // reached the server, which is precisely not the case a `send_failure` retry
+  // covers. Production hit it: a message carrying five invoices arrived a
+  // second time with the attachment block gone, and the agent was left
+  // answering about files it had never been handed.
+  async function sendWithOneAttachment(agentId: string) {
+    vi.mocked(uploadModule.uploadAttachment).mockResolvedValue({
+      id: "upload-id-retry",
+      filename: "invoice.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 4,
+    });
+
+    const { result } = renderHook(() => useWsRuntime(agentId));
+    const ws = wsInstances[0];
+
+    act(() => {
+      ws.simulateOpen();
+    });
+
+    await act(async () => {
+      result.current.addPendingUpload(
+        new File(["data"], "invoice.pdf", { type: "application/pdf" })
+      );
+    });
+    expect(result.current.pendingUploads[0]?.state).toBe("ready");
+
+    act(() => {
+      store(result.current.runtime).onNew({
+        content: [{ type: "text", text: "here are the invoices" }],
+        parentId: "root",
+      });
+    });
+
+    const firstSend = JSON.parse(ws.send.mock.calls.at(-1)![0]);
+    expect(firstSend.attachmentIds).toEqual(["upload-id-retry"]);
+    return { result, ws, firstSend };
+  }
+
+  it("onRetryContinue re-sends the original message's attachment ids", async () => {
+    const { result, ws, firstSend } = await sendWithOneAttachment("agent-retry-1");
+
+    act(() => {
+      ws.simulateMessage({ type: "error", message: "Agent runtime not available" });
+    });
+
+    act(() => {
+      result.current.onRetryContinue("send_failure");
+    });
+
+    const retry = JSON.parse(ws.send.mock.calls.at(-1)![0]);
+    expect(retry.isRetry).toBe(true);
+    expect(retry.attachmentIds).toEqual(firstSend.attachmentIds);
+  });
+
+  it("onRetryResend re-sends the original message's attachment ids", async () => {
+    const { result, ws, firstSend } = await sendWithOneAttachment("agent-retry-2");
+
+    // Let the 10s ack timer fire so the message is in `failed` state, which is
+    // the only state onRetryResend acts on.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    act(() => {
+      result.current.onRetryResend(firstSend.clientMessageId);
+    });
+
+    const retry = JSON.parse(ws.send.mock.calls.at(-1)![0]);
+    expect(retry.isRetry).toBe(true);
+    expect(retry.attachmentIds).toEqual(firstSend.attachmentIds);
   });
 
   it("clears ready pendingUploads after send", async () => {

--- a/packages/web/src/__tests__/server/attachment-pipeline-materialize.integration.test.ts
+++ b/packages/web/src/__tests__/server/attachment-pipeline-materialize.integration.test.ts
@@ -97,6 +97,7 @@ async function seedStagedUpload(
     expiresAt?: Date | null;
     status?: "staged" | "attached";
     draftId?: string;
+    messageId?: string;
   } = {}
 ) {
   const filename = opts.filename ?? "test.png";
@@ -122,6 +123,7 @@ async function seedStagedUpload(
       status,
       stagingPath: `.staging/${draftId}/${filename}`,
       expiresAt,
+      ...(opts.messageId !== undefined && { messageId: opts.messageId }),
     })
     .returning();
 
@@ -129,6 +131,41 @@ async function seedStagedUpload(
   const stagingDir = join(tmpRoot, agentId, ".staging", draftId);
   mkdirSync(stagingDir, { recursive: true });
   writeFileSync(join(stagingDir, filename), buffer);
+
+  return row;
+}
+
+/**
+ * The state a message leaves behind once its attachments have been
+ * materialized: the row is `attached` and stamped with the message id, and the
+ * bytes sit in `uploads/<filename>` rather than `.staging/`.
+ *
+ * This is what a RETRY of that message meets (heypinchy/pinchy#1195), so it
+ * needs its own seeder — `seedStagedUpload({ status: "attached" })` leaves the
+ * file in `.staging/`, which is a state no real attach produces.
+ */
+async function seedAttachedUpload(
+  userId: string,
+  agentId: string,
+  messageId: string,
+  opts: { filename?: string; mimeType?: string; buffer?: Buffer; writeFile?: boolean } = {}
+) {
+  const filename = opts.filename ?? "test.png";
+  const buffer = opts.buffer ?? PNG;
+  const row = await seedStagedUpload(userId, agentId, {
+    filename,
+    mimeType: opts.mimeType,
+    buffer,
+    status: "attached",
+    expiresAt: null,
+    messageId,
+  });
+
+  if (opts.writeFile !== false) {
+    const uploadsDir = join(tmpRoot, agentId, "uploads");
+    mkdirSync(uploadsDir, { recursive: true });
+    writeFileSync(join(uploadsDir, filename), buffer);
+  }
 
   return row;
 }
@@ -314,6 +351,96 @@ describe("materializeAttachments", () => {
     const detail = entries[0].detail as Record<string, unknown>;
     expect(detail.reason).toBe("already_attached");
     expect(detail.uploadId).toBe(row.id);
+  });
+
+  // #1195. A retry re-sends the message it retries, attachment ids and all, so
+  // the rows it names are already `attached` from the first attempt. Treating
+  // that as the "you cannot reuse an upload" error would reject the retry
+  // outright, which is worse than the bug it replaced.
+  //
+  // Note the correlation is `isRetry`, NOT the message id: client-router mints
+  // a fresh `messageId` per frame (`crypto.randomUUID()`), so a retry never
+  // carries the id its first attempt was stored under. Keying on messageId
+  // equality looks right and matches nothing in production.
+  it("re-references a retry's already-attached uploads instead of refusing them", async () => {
+    const { materializeAttachments } = await import("@/server/attachment-pipeline");
+
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const row = await seedAttachedUpload(user.id, agent.id, "msg-first-attempt");
+
+    const result = await materializeAttachments({
+      agentId: agent.id,
+      userId: user.id,
+      attachmentIds: [row.id],
+      messageId: "msg-a-different-id-than-the-first-attempt",
+      agentName: agent.name,
+      isRetry: true,
+    });
+
+    // The workspace ref the agent is handed must be the durable uploads/ path,
+    // identical to the one the first attempt produced.
+    expect(result.workspaceRefs).toHaveLength(1);
+    expect(result.workspaceRefs[0].relativePath).toBe("uploads/test.png");
+    expect(result.workspaceRefs[0].absolutePath).toMatch(/\/uploads\/test\.png$/);
+    // Vision has to keep working on a retry too, so an image is re-encoded.
+    expect(result.chatAttachments).toHaveLength(1);
+    expect(result.chatAttachments[0].fileName).toBe("test.png");
+    expect(result.chatAttachments[0].content.length).toBeGreaterThan(0);
+  });
+
+  it("refuses to hand back a ref when the retried message's file is gone from uploads/", async () => {
+    // The ref is rebuilt from the row rather than read back from a column, so
+    // the one thing this must never do is emit a path that resolves to
+    // nothing: the agent would be told to read a file that is not there and
+    // would report the attachment as unreadable. Fail loud instead.
+    const { materializeAttachments, AttachmentAlreadyAttachedError } =
+      await import("@/server/attachment-pipeline");
+
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const row = await seedAttachedUpload(user.id, agent.id, "msg-first-attempt", {
+      writeFile: false,
+    });
+
+    // Assert on the REASON, not just that something threw: before the retry
+    // path existed this rejected with AttachmentAlreadyAttachedError, so a bare
+    // `.rejects.toThrow()` here would have passed against the old code and
+    // proved nothing about the missing file.
+    const err = await materializeAttachments({
+      agentId: agent.id,
+      userId: user.id,
+      attachmentIds: [row.id],
+      messageId: "msg-retry",
+      agentName: agent.name,
+      isRetry: true,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(AttachmentAlreadyAttachedError);
+    expect((err as Error).message).toMatch(/uploads\/test\.png/);
+  });
+
+  it("still refuses an already-attached upload on an ordinary send", async () => {
+    // The negative control for the test above, on the SAME fixture: the only
+    // difference is `isRetry`. Without it, re-referencing an attached upload
+    // stays an error — otherwise the guard would be gone rather than gated.
+    const { materializeAttachments, AttachmentAlreadyAttachedError } =
+      await import("@/server/attachment-pipeline");
+
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const row = await seedAttachedUpload(user.id, agent.id, "msg-first-attempt");
+
+    await expect(
+      materializeAttachments({
+        agentId: agent.id,
+        userId: user.id,
+        attachmentIds: [row.id],
+        messageId: "msg-fresh-send",
+        agentName: agent.name,
+      })
+    ).rejects.toBeInstanceOf(AttachmentAlreadyAttachedError);
   });
 
   it("base64-encodes the promoted image file in chatAttachments content", async () => {

--- a/packages/web/src/__tests__/server/attachment-pipeline-materialize.integration.test.ts
+++ b/packages/web/src/__tests__/server/attachment-pipeline-materialize.integration.test.ts
@@ -137,21 +137,37 @@ async function seedStagedUpload(
 
 /**
  * The state a message leaves behind once its attachments have been
- * materialized: the row is `attached` and stamped with the message id, and the
- * bytes sit in `uploads/<filename>` rather than `.staging/`.
+ * materialized: the row is `attached`, stamped with the message id and with
+ * `attachedAt`, and the bytes sit in `uploads/<filename>` with the `.staging/`
+ * copy gone.
  *
  * This is what a RETRY of that message meets (heypinchy/pinchy#1195), so it
  * needs its own seeder — `seedStagedUpload({ status: "attached" })` leaves the
- * file in `.staging/`, which is a state no real attach produces.
+ * file in `.staging/` and `attachedAt` null, which is a state no real attach
+ * produces. Reproducing the real end state matters here rather than being
+ * tidiness: the whole point of these tests is what the retry path meets on
+ * disk, and a fixture that keeps a staged copy around could mask a step-6
+ * regression that reads from `.staging/` instead of `uploads/`.
+ *
+ * `stagingPath` is deliberately left populated: `materializeAttachments`
+ * step 5b sets status/messageId/attachedAt/expiresAt and does NOT clear the
+ * column, so a real attached row still carries it.
  */
 async function seedAttachedUpload(
   userId: string,
   agentId: string,
   messageId: string,
-  opts: { filename?: string; mimeType?: string; buffer?: Buffer; writeFile?: boolean } = {}
+  opts: {
+    filename?: string;
+    mimeType?: string;
+    buffer?: Buffer;
+    writeFile?: boolean;
+    draftId?: string;
+  } = {}
 ) {
   const filename = opts.filename ?? "test.png";
   const buffer = opts.buffer ?? PNG;
+  const draftId = opts.draftId ?? "draft-1";
   const row = await seedStagedUpload(userId, agentId, {
     filename,
     mimeType: opts.mimeType,
@@ -159,7 +175,16 @@ async function seedAttachedUpload(
     status: "attached",
     expiresAt: null,
     messageId,
+    draftId,
   });
+
+  await db
+    .update(uploadedFiles)
+    .set({ attachedAt: new Date() })
+    .where(eq(uploadedFiles.id, row.id));
+
+  // A real promote renames the staged file away and removes its directory.
+  rmSync(join(tmpRoot, agentId, ".staging", draftId), { recursive: true, force: true });
 
   if (opts.writeFile !== false) {
     const uploadsDir = join(tmpRoot, agentId, "uploads");
@@ -167,7 +192,7 @@ async function seedAttachedUpload(
     writeFileSync(join(uploadsDir, filename), buffer);
   }
 
-  return row;
+  return { ...row, attachedAt: new Date() };
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -394,7 +419,7 @@ describe("materializeAttachments", () => {
     // the one thing this must never do is emit a path that resolves to
     // nothing: the agent would be told to read a file that is not there and
     // would report the attachment as unreadable. Fail loud instead.
-    const { materializeAttachments, AttachmentAlreadyAttachedError } =
+    const { materializeAttachments, AttachmentAlreadyAttachedError, AttachmentFileMissingError } =
       await import("@/server/attachment-pipeline");
 
     const user = await seedUser();
@@ -416,9 +441,142 @@ describe("materializeAttachments", () => {
       isRetry: true,
     }).catch((e: unknown) => e);
 
-    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AttachmentFileMissingError);
     expect(err).not.toBeInstanceOf(AttachmentAlreadyAttachedError);
     expect((err as Error).message).toMatch(/uploads\/test\.png/);
+  });
+
+  it("audits the missing retried file the way every other refusal in this function is audited", async () => {
+    // The other three refusals (not_found / expired / already_attached) each
+    // leave a `file.upload.attached` failure row naming the reason. Without
+    // one here, a user retrying into a permanently-failing send leaves no
+    // trace at all on the Pinchy side — the only record is a console.error in
+    // the server process, which is the shape #599 was diagnosed the hard way.
+    const { materializeAttachments } = await import("@/server/attachment-pipeline");
+
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const row = await seedAttachedUpload(user.id, agent.id, "msg-first-attempt", {
+      writeFile: false,
+    });
+
+    await expect(
+      materializeAttachments({
+        agentId: agent.id,
+        userId: user.id,
+        attachmentIds: [row.id],
+        messageId: "msg-retry",
+        agentName: agent.name,
+        isRetry: true,
+      })
+    ).rejects.toThrow();
+
+    const entries = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.eventType, "file.upload.attached"));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].outcome).toBe("failure");
+    const detail = entries[0].detail as Record<string, unknown>;
+    expect(detail.reason).toBe("file_missing");
+    expect(detail.uploadId).toBe(row.id);
+  });
+
+  it("records the re-reference in the audit trail, distinguishable from a real attach", async () => {
+    // A retry hands files to the agent, so "which files did this turn deliver"
+    // must be answerable from the audit trail — `chat.retry_triggered` names
+    // the agent and the reason but no filenames. `reason: "retry_reference"`
+    // keeps the row distinguishable, so a query counting real attaches can
+    // exclude it instead of the event going unrecorded.
+    const { materializeAttachments } = await import("@/server/attachment-pipeline");
+
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const row = await seedAttachedUpload(user.id, agent.id, "msg-first-attempt");
+
+    await materializeAttachments({
+      agentId: agent.id,
+      userId: user.id,
+      attachmentIds: [row.id],
+      messageId: "msg-retry",
+      agentName: agent.name,
+      isRetry: true,
+    });
+
+    const entries = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.eventType, "file.upload.attached"));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].outcome).toBe("success");
+    const detail = entries[0].detail as Record<string, unknown>;
+    expect(detail.reason).toBe("retry_reference");
+    expect(detail.uploadId).toBe(row.id);
+    expect(detail.messageId).toBe("msg-retry");
+    expect(detail.filename).toBe("test.png");
+  });
+
+  it("collapses a repeated attachment id into a single ref", async () => {
+    // attachmentIdsSchema bounds the list to 10 UUIDs but does not require
+    // them to be distinct. Emitting one ref per occurrence would list the same
+    // file N times in the attachment block and, for an image, put N base64
+    // copies of it into the model request.
+    const { materializeAttachments } = await import("@/server/attachment-pipeline");
+
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const row = await seedAttachedUpload(user.id, agent.id, "msg-first-attempt");
+
+    const result = await materializeAttachments({
+      agentId: agent.id,
+      userId: user.id,
+      attachmentIds: [row.id, row.id, row.id],
+      messageId: "msg-retry",
+      agentName: agent.name,
+      isRetry: true,
+    });
+
+    expect(result.workspaceRefs).toHaveLength(1);
+    expect(result.chatAttachments).toHaveLength(1);
+  });
+
+  it("orders refs by the caller's attachmentIds even when a retry mixes staged and attached rows", async () => {
+    // The partial-failure recovery case: the first attempt promoted one file
+    // and died before the other. The retry re-references the first and
+    // promotes the second, and the manifest the agent reads must still list
+    // them in the order the user attached them — not "everything promoted
+    // this turn, then everything re-referenced".
+    const { materializeAttachments } = await import("@/server/attachment-pipeline");
+
+    const user = await seedUser();
+    const agent = await seedAgent(user.id);
+    const alreadyAttached = await seedAttachedUpload(user.id, agent.id, "msg-first-attempt", {
+      filename: "first.pdf",
+      mimeType: "application/pdf",
+      buffer: PDF,
+      draftId: "draft-attached",
+    });
+    const stillStaged = await seedStagedUpload(user.id, agent.id, {
+      filename: "second.pdf",
+      mimeType: "application/pdf",
+      buffer: PDF,
+      draftId: "draft-staged",
+    });
+
+    const result = await materializeAttachments({
+      agentId: agent.id,
+      userId: user.id,
+      attachmentIds: [alreadyAttached.id, stillStaged.id],
+      messageId: "msg-retry",
+      agentName: agent.name,
+      isRetry: true,
+    });
+
+    expect(result.workspaceRefs.map((r) => r.relativePath)).toEqual([
+      "uploads/first.pdf",
+      "uploads/second.pdf",
+    ]);
+    expect(result.workspaceRefs.map((r) => r.reused)).toEqual([true, false]);
   });
 
   it("still refuses an already-attached upload on an ordinary send", async () => {

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -25,6 +25,7 @@ const {
   mockRecordChatSessionError,
   mockSupersedeChatSessionErrors,
   mockAgentRanToolSince,
+  mockUploadedFileRows,
 } = vi.hoisted(() => ({
   mockChat: vi.fn(),
   mockSessionsHistory: vi.fn(),
@@ -45,6 +46,10 @@ const {
   mockRecordChatSessionError: vi.fn().mockResolvedValue(undefined),
   mockSupersedeChatSessionErrors: vi.fn().mockResolvedValue(undefined),
   mockAgentRanToolSince: vi.fn().mockResolvedValue(false),
+  // Rows the #1195 upload-id recovery reads back for history user turns.
+  // Empty by default: every other history test asserts `files` without an
+  // `uploadId`, which is what "no matching upload row" produces.
+  mockUploadedFileRows: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/lib/agent-access", async (importOriginal) => {
@@ -94,7 +99,19 @@ vi.mock("@/db", () => ({
     // turns AND by the #703 delivery glue's grant-existence lookup (both resolve
     // to an array; [] means "no rows", which the delivery path reads as "no
     // pre-existing grant").
-    select: () => ({ from: () => ({ where: () => mockListVisionModels() }) }),
+    //
+    // Routed by table for `uploaded_files` (#1195 upload-id recovery), via the
+    // `__table` marker on the schema mock below: it runs on the SAME history
+    // path as the grants lookup, so a single shared resolver would make a test
+    // that seeds upload rows depend on which of the two queries fires first.
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () =>
+          (table as { __table?: string } | undefined)?.__table === "uploaded_files"
+            ? mockUploadedFileRows()
+            : mockListVisionModels(),
+      }),
+    }),
     // db.insert(agentDeliveredFiles).values(...) — the #703 delivery grant write.
     insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
   },
@@ -110,6 +127,14 @@ vi.mock("@/db/schema", () => ({
     createdAt: "created_at",
     sessionKey: "session_key",
   },
+  uploadedFiles: {
+    __table: "uploaded_files",
+    id: "id",
+    filename: "filename",
+    agentId: "agent_id",
+    userId: "user_id",
+    status: "status",
+  },
 }));
 
 vi.mock("@/lib/model-vision", () => ({
@@ -124,6 +149,7 @@ vi.mock("@/lib/openclaw-config/write", () => ({
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((col, val) => ({ col, val })),
   and: vi.fn((...conds) => ({ and: conds })),
+  inArray: vi.fn((col, vals) => ({ col, vals })),
 }));
 
 vi.mock("@/lib/audit", async (importOriginal) => {
@@ -1774,6 +1800,61 @@ describe("ClientRouter", () => {
     );
   });
 
+  it("tells materializeAttachments that a retry frame is a retry", async () => {
+    // The one line connecting the client half of #1195 to the server half. The
+    // client tests assert only the outgoing frame and the pipeline integration
+    // tests set `isRetry` by hand, so without this the wiring can be deleted
+    // with every other test still green — and the regression that returns is
+    // the whole bug: a retry of a message whose first attempt materialized is
+    // refused outright with AttachmentAlreadyAttachedError.
+    const attachmentId = "550e8400-e29b-41d4-a716-446655440000";
+    mockMaterializeAttachments.mockResolvedValue({ chatAttachments: [], workspaceRefs: [] });
+
+    async function* fakeStream() {
+      yield { type: "text" as const, text: "ok" };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(createMockClientWs() as any, {
+      type: "message",
+      content: "Analyze this file",
+      agentId: "agent-1",
+      attachmentIds: [attachmentId],
+      isRetry: true,
+      retryReason: "send_failure",
+    });
+
+    expect(mockMaterializeAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ attachmentIds: [attachmentId], isRetry: true })
+    );
+  });
+
+  it("does not claim a retry on an ordinary send", async () => {
+    // The negative control: `isRetry` is what gates the already-attached
+    // exemption, so a send that reports itself as a retry would hand any of
+    // the user's own earlier uploads back into a fresh message.
+    const attachmentId = "550e8400-e29b-41d4-a716-446655440001";
+    mockMaterializeAttachments.mockResolvedValue({ chatAttachments: [], workspaceRefs: [] });
+
+    async function* fakeStream() {
+      yield { type: "text" as const, text: "ok" };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(createMockClientWs() as any, {
+      type: "message",
+      content: "Analyze this file",
+      agentId: "agent-1",
+      attachmentIds: [attachmentId],
+    });
+
+    expect(mockMaterializeAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ isRetry: false })
+    );
+  });
+
   it("rejects attachmentIds with more than the configured maximum (10)", async () => {
     // Clients are bounded by attachmentIdsSchema to 10 ids/message. A frame
     // that exceeds this is almost certainly malicious (or a buggy client) and
@@ -1895,6 +1976,37 @@ describe("ClientRouter", () => {
     expect(userMsg.role).toBe("user");
     expect(userMsg.content).toBe("Was steht in dieser Datei?");
     expect(userMsg.files).toEqual([{ filename: "invoice.pdf", mimeType: "application/pdf" }]);
+  });
+
+  it("surfaces the upload id behind each history file chip so a retry can re-send it", async () => {
+    // #1195. The client keeps `attachmentIds` in message state, which dies on
+    // reload — while the retry affordance does not (ChatErrorBanner
+    // re-surfaces the session's last agent error on mount). Without the id on
+    // the history frame, that Retry sends the text alone: the production
+    // symptom, one layer out from the in-tab path the client fix covers.
+    const clientWs = createMockClientWs();
+    mockUploadedFileRows.mockResolvedValueOnce([{ id: "upload-42", filename: "invoice.pdf" }]);
+    mockSessionsHistory.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Was steht in dieser Datei?\n\n<pinchy:attachments>\n" +
+            "The user attached these files (already saved into your workspace). Read each file with the listed tool, using the exact absolute path:\n" +
+            "- `/root/.openclaw/workspaces/agent-1/uploads/invoice.pdf` (application/pdf, 240 KB) — analyze with `pinchy_read`\n" +
+            "\nIf you delegate this task to a sub-agent or another tool, pass these exact paths verbatim — do not retype from memory.\n" +
+            "</pinchy:attachments>",
+          timestamp: 1708460000000,
+        },
+      ],
+    });
+
+    await router.handleMessage(clientWs as any, { type: "history", agentId: "agent-1" });
+
+    const sent = clientWs.sent.map((s) => JSON.parse(s));
+    expect(sent[0].messages[0].files).toEqual([
+      { filename: "invoice.pdf", mimeType: "application/pdf", uploadId: "upload-42" },
+    ]);
   });
 
   it("should preserve user messages that contain ONLY an attachment block (no accompanying text)", async () => {

--- a/packages/web/src/__tests__/server/history-upload-ids.test.ts
+++ b/packages/web/src/__tests__/server/history-upload-ids.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectAttachmentFilenames,
+  indexUploadIdsByFilename,
+  attachUploadIdsToHistory,
+} from "@/server/history-upload-ids";
+
+describe("collectAttachmentFilenames", () => {
+  it("returns each distinct filename a user turn carries a chip for", () => {
+    const names = collectAttachmentFilenames([
+      { role: "user", files: [{ filename: "a.pdf", mimeType: "application/pdf" }] },
+      { role: "assistant" },
+      {
+        role: "user",
+        files: [
+          { filename: "b.png", mimeType: "image/png" },
+          { filename: "a.pdf", mimeType: "application/pdf" },
+        ],
+      },
+    ]);
+    expect(names.sort()).toEqual(["a.pdf", "b.png"]);
+  });
+
+  it("ignores assistant turns", () => {
+    // Assistant chips come from agent_delivered_files and have no upload row.
+    // Querying for them cannot match — and if an upload of the same name did
+    // exist, stamping its id onto an assistant turn would put a retryable id
+    // on a turn that can never be retried.
+    expect(
+      collectAttachmentFilenames([
+        { role: "assistant", files: [{ filename: "report.xlsx", mimeType: "application/xlsx" }] },
+      ])
+    ).toEqual([]);
+  });
+
+  it("returns nothing when no turn has files", () => {
+    expect(collectAttachmentFilenames([{ role: "user" }, { role: "assistant" }])).toEqual([]);
+  });
+});
+
+describe("indexUploadIdsByFilename", () => {
+  it("maps each filename to its upload id", () => {
+    const index = indexUploadIdsByFilename([
+      { id: "id-a", filename: "a.pdf" },
+      { id: "id-b", filename: "b.png" },
+    ]);
+    expect(index.get("a.pdf")).toBe("id-a");
+    expect(index.get("b.png")).toBe("id-b");
+  });
+
+  it("drops a filename two rows claim rather than picking one", () => {
+    // Guessing here would re-send a DIFFERENT file under the right name on the
+    // next retry — a silent wrong answer. No id degrades to re-sending the text
+    // alone, which is merely the old behaviour.
+    const index = indexUploadIdsByFilename([
+      { id: "id-1", filename: "invoice.pdf" },
+      { id: "id-2", filename: "invoice.pdf" },
+      { id: "id-3", filename: "other.pdf" },
+    ]);
+    expect(index.has("invoice.pdf")).toBe(false);
+    expect(index.get("other.pdf")).toBe("id-3");
+  });
+});
+
+describe("attachUploadIdsToHistory", () => {
+  it("stamps the id onto a user turn's chips", () => {
+    const messages = [
+      { role: "user" as const, files: [{ filename: "a.pdf", mimeType: "application/pdf" }] },
+    ];
+    const out = attachUploadIdsToHistory(messages, new Map([["a.pdf", "id-a"]]));
+    expect(out[0].files?.[0].uploadId).toBe("id-a");
+  });
+
+  it("leaves an unresolvable chip without an id", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        files: [
+          { filename: "a.pdf", mimeType: "application/pdf" },
+          { filename: "gone.pdf", mimeType: "application/pdf" },
+        ],
+      },
+    ];
+    const out = attachUploadIdsToHistory(messages, new Map([["a.pdf", "id-a"]]));
+    expect(out[0].files?.[0].uploadId).toBe("id-a");
+    expect(out[0].files?.[1].uploadId).toBeUndefined();
+  });
+
+  it("never stamps an assistant turn", () => {
+    const messages = [
+      { role: "assistant" as const, files: [{ filename: "a.pdf", mimeType: "application/pdf" }] },
+    ];
+    const out = attachUploadIdsToHistory(messages, new Map([["a.pdf", "id-a"]]));
+    expect(out[0].files?.[0].uploadId).toBeUndefined();
+  });
+
+  it("returns the same references for turns it does not touch", () => {
+    // Same contract as attachDeliveredFilesToHistory, which runs right after
+    // this one: the history-reconcile path on the client compares message
+    // identity, so gratuitous cloning is not free.
+    const untouched = { role: "assistant" as const };
+    const messages = [
+      untouched,
+      { role: "user" as const, files: [{ filename: "a.pdf", mimeType: "application/pdf" }] },
+    ];
+    const out = attachUploadIdsToHistory(messages, new Map([["a.pdf", "id-a"]]));
+    expect(out[0]).toBe(untouched);
+    expect(out[1]).not.toBe(messages[1]);
+  });
+
+  it("returns the input array when nothing resolved", () => {
+    const messages = [
+      { role: "user" as const, files: [{ filename: "a.pdf", mimeType: "application/pdf" }] },
+    ];
+    expect(attachUploadIdsToHistory(messages, new Map())).toBe(messages);
+  });
+});

--- a/packages/web/src/__tests__/server/history-upload-ids.test.ts
+++ b/packages/web/src/__tests__/server/history-upload-ids.test.ts
@@ -3,6 +3,7 @@ import {
   collectAttachmentFilenames,
   indexUploadIdsByFilename,
   attachUploadIdsToHistory,
+  type HistoryFileMeta,
 } from "@/server/history-upload-ids";
 
 describe("collectAttachmentFilenames", () => {
@@ -65,7 +66,10 @@ describe("indexUploadIdsByFilename", () => {
 describe("attachUploadIdsToHistory", () => {
   it("stamps the id onto a user turn's chips", () => {
     const messages = [
-      { role: "user" as const, files: [{ filename: "a.pdf", mimeType: "application/pdf" }] },
+      {
+        role: "user" as const,
+        files: [{ filename: "a.pdf", mimeType: "application/pdf" }] as HistoryFileMeta[],
+      },
     ];
     const out = attachUploadIdsToHistory(messages, new Map([["a.pdf", "id-a"]]));
     expect(out[0].files?.[0].uploadId).toBe("id-a");
@@ -78,7 +82,7 @@ describe("attachUploadIdsToHistory", () => {
         files: [
           { filename: "a.pdf", mimeType: "application/pdf" },
           { filename: "gone.pdf", mimeType: "application/pdf" },
-        ],
+        ] as HistoryFileMeta[],
       },
     ];
     const out = attachUploadIdsToHistory(messages, new Map([["a.pdf", "id-a"]]));
@@ -88,7 +92,10 @@ describe("attachUploadIdsToHistory", () => {
 
   it("never stamps an assistant turn", () => {
     const messages = [
-      { role: "assistant" as const, files: [{ filename: "a.pdf", mimeType: "application/pdf" }] },
+      {
+        role: "assistant" as const,
+        files: [{ filename: "a.pdf", mimeType: "application/pdf" }] as HistoryFileMeta[],
+      },
     ];
     const out = attachUploadIdsToHistory(messages, new Map([["a.pdf", "id-a"]]));
     expect(out[0].files?.[0].uploadId).toBeUndefined();

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -42,6 +42,13 @@ import { attachmentAdapter } from "@/lib/attachment-adapters";
 export interface WsFileMeta {
   filename: string;
   mimeType: string;
+  /**
+   * Server-side upload id, present only on user turns rebuilt from history
+   * (#1195) — the server recovers it from `uploaded_files` so a retry after a
+   * reload can still name the files. Display code ignores it; the hook lifts it
+   * into the message's `attachmentIds`.
+   */
+  uploadId?: string;
 }
 
 /** Tracks a file dropped in the composer while it uploads to the server. */
@@ -71,8 +78,10 @@ export interface WsMessage {
    * — without the ids, a retry delivered the text with the attachments silently
    * dropped, and the agent answered about files it had never been given.
    *
-   * Only ever set on user messages this client sent; a message rebuilt from
-   * history has no ids, which is correct — there is nothing to retry there.
+   * Set both on user messages this client sent and on user turns rebuilt from
+   * history, where the server recovers the ids from `uploaded_files` — the
+   * retry affordance outlives a reload (ChatErrorBanner), so the ids have to
+   * as well.
    */
   attachmentIds?: string[];
   timestamp?: string;
@@ -328,6 +337,28 @@ export function preserveRicherLocalOverOversizedHistory(
     const localHasContent = local.content.length > 0 || (local.files?.length ?? 0) > 0;
     return localHasContent ? local : serverMsg;
   });
+}
+
+/**
+ * Lift the upload ids the server recovered for a history-rebuilt user turn
+ * (#1195) into the message's `attachmentIds`, so the retry affordance that
+ * survives a reload can re-send the files with the text.
+ *
+ * All-or-nothing on purpose. A partially-resolved set would send a manifest
+ * naming SOME of the user's files — the agent then answers about three of five
+ * invoices with nothing to say which two are missing, which is worse than the
+ * old behaviour of sending none and leaving the first attempt's block in the
+ * transcript as the only reference. An id goes unresolved when the row is gone
+ * (an operator cleaned the workspace) or the filename is ambiguous, and neither
+ * is something to paper over.
+ */
+export function historyAttachmentIds(msg: { role: string; files?: WsFileMeta[] }): {
+  attachmentIds?: string[];
+} {
+  if (msg.role !== "user" || !msg.files || msg.files.length === 0) return {};
+  const ids = msg.files.map((f) => f.uploadId);
+  if (ids.some((id) => id === undefined)) return {};
+  return { attachmentIds: ids as string[] };
 }
 
 export function useWsRuntime(
@@ -1222,6 +1253,7 @@ export function useWsRuntime(
             // here so the file chip renders on reload.
             ...(msg.files && msg.files.length > 0 ? { files: msg.files } : {}),
             ...(msg.oversized ? { oversized: true } : {}),
+            ...historyAttachmentIds(msg),
           }));
 
           // Prefer a richer LOCAL copy over an oversized-history placeholder
@@ -1691,11 +1723,15 @@ export function useWsRuntime(
           // All attachment-related server error codes map onto the dedicated
           // "Invalid file" UI so the user sees the server's actionable message
           // instead of a generic "unknown error" fallback (issue #324).
+          //
+          // Matched by prefix rather than enumerated: the list was a
+          // hand-maintained mirror of client-router's `code:` literals, and a
+          // new one added there (`attachment_file_missing`, #1195) would
+          // silently fall through to "An unknown error occurred." — the exact
+          // fallback #324 removed. Every code Pinchy emits for this family is
+          // namespaced `attachment_`, and nothing else in the protocol is.
           const isAttachmentErrorCode =
-            data.code === "attachment_invalid" ||
-            data.code === "attachment_not_found" ||
-            data.code === "attachment_expired" ||
-            data.code === "attachment_already_attached";
+            typeof data.code === "string" && data.code.startsWith("attachment_");
 
           const error: ChatError = data.providerError
             ? {
@@ -2073,7 +2109,7 @@ export function useWsRuntime(
         // Re-send the attachments with the message they belong to (#1195).
         // Without this the retry delivered the text alone and the agent was
         // asked about files it had never been handed.
-        ...(lastUserMsg.attachmentIds?.length && {
+        ...((lastUserMsg.attachmentIds?.length ?? 0) > 0 && {
           attachmentIds: lastUserMsg.attachmentIds,
         }),
         clientMessageId: lastUserMsg.id,
@@ -2118,7 +2154,7 @@ export function useWsRuntime(
         // Same reason as onRetryContinue (#1195). This path matters more, not
         // less: the message never reached the server, so its uploads are still
         // `staged` and the agent has never seen them at all.
-        ...(failedMsg.attachmentIds?.length && {
+        ...((failedMsg.attachmentIds?.length ?? 0) > 0 && {
           attachmentIds: failedMsg.attachmentIds,
         }),
         clientMessageId: messageId,

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -65,6 +65,16 @@ export interface WsMessage {
    * agent's workspace and don't need to be replayed in client memory.
    */
   files?: WsFileMeta[];
+  /**
+   * Server-side upload ids for this message's attachments, kept so a retry can
+   * re-send them (#1195). `files` above is display metadata and cannot stand in
+   * — without the ids, a retry delivered the text with the attachments silently
+   * dropped, and the agent answered about files it had never been given.
+   *
+   * Only ever set on user messages this client sent; a message rebuilt from
+   * history has no ids, which is correct — there is nothing to retry there.
+   */
+  attachmentIds?: string[];
   timestamp?: string;
   error?: ChatError;
   /** Delivery status — only set for user messages managed by the reducer */
@@ -1907,6 +1917,7 @@ export function useWsRuntime(
                 mimeType: u.file.type,
               })),
             }),
+            ...(attachmentIds.length > 0 && { attachmentIds }),
           },
           // In-flight assistant placeholder: keeps the list ending in an
           // assistant for the whole run, so assistant-ui never injects its
@@ -2059,6 +2070,12 @@ export function useWsRuntime(
         agentId,
         ...(chatId && { chatId }),
         content: lastUserMsg.content,
+        // Re-send the attachments with the message they belong to (#1195).
+        // Without this the retry delivered the text alone and the agent was
+        // asked about files it had never been handed.
+        ...(lastUserMsg.attachmentIds?.length && {
+          attachmentIds: lastUserMsg.attachmentIds,
+        }),
         clientMessageId: lastUserMsg.id,
         isRetry: true,
         retryReason: reason,
@@ -2098,6 +2115,12 @@ export function useWsRuntime(
         agentId,
         ...(chatId && { chatId }),
         content: failedMsg.content,
+        // Same reason as onRetryContinue (#1195). This path matters more, not
+        // less: the message never reached the server, so its uploads are still
+        // `staged` and the agent has never seen them at all.
+        ...(failedMsg.attachmentIds?.length && {
+          attachmentIds: failedMsg.attachmentIds,
+        }),
         clientMessageId: messageId,
         isRetry: true,
       });

--- a/packages/web/src/lib/uploads.ts
+++ b/packages/web/src/lib/uploads.ts
@@ -69,6 +69,21 @@ export interface PromotedRef {
 }
 
 /**
+ * The durable workspace path an attached upload ends up at, derived from the
+ * reserved filename alone.
+ *
+ * Exported because a second caller needs it: re-materializing a retried
+ * message's attachments (#1195) has to rebuild the ref for a row that was
+ * promoted on an earlier attempt, and nothing persists the promoted path.
+ * Deriving it there independently would be a drift hazard of exactly the kind
+ * a shared helper removes — so `promoteStagedToAttached` computes its return
+ * value through this function too, and the two cannot disagree.
+ */
+export function attachedRelativePath(filename: string): string {
+  return `${UPLOADS_SUBDIR}/${sanitizeFilename(filename)}`;
+}
+
+/**
  * Atomically moves a staged file to its durable `uploads/` path.
  *
  * The destination slot was reserved at stage time by `persistStagedUpload`
@@ -103,7 +118,7 @@ export async function promoteStagedToAttached(params: PromoteParams): Promise<Pr
   const stagingDir = join(workspaceRoot, ".staging", uploadId);
   await rm(stagingDir, { recursive: true, force: true });
 
-  return { relativePath: `${UPLOADS_SUBDIR}/${filename}` };
+  return { relativePath: attachedRelativePath(filename) };
 }
 
 export interface PersistStagedUploadParams {

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -1,4 +1,5 @@
-import { readFile, stat } from "fs/promises";
+import { readFile, open } from "fs/promises";
+import type { FileHandle } from "fs/promises";
 import { join } from "path";
 import type { ChatAttachment } from "openclaw-node";
 import { eq, and, inArray } from "drizzle-orm";
@@ -305,21 +306,31 @@ export async function materializeAttachments(
     // ref that resolves to nothing would send the agent to read a file that is
     // not there and have it report the attachment as unreadable — a silent
     // wrong answer in place of a loud failure.
+    //
+    // Proved by OPENING it, not by stat-ing it and reading later: a separate
+    // check and use is a TOCTOU window (CodeQL js/file-system-race), and the
+    // read below would then be operating on a path whose state was established
+    // by an earlier, unrelated syscall. One handle answers both questions.
+    let handle: FileHandle;
     try {
-      await stat(durablePath);
+      handle = await open(durablePath, "r");
     } catch {
       throw new Error(
         `Uploaded file ${row.id} is attached to message ${messageId} but ${relativePath} is missing from the workspace`
       );
     }
 
-    if (row.mimeType.startsWith("image/")) {
-      const fileBuffer = await readFile(durablePath);
-      chatAttachments.push({
-        mimeType: row.mimeType,
-        fileName: row.filename,
-        content: fileBuffer.toString("base64"),
-      });
+    try {
+      if (row.mimeType.startsWith("image/")) {
+        const fileBuffer = await handle.readFile();
+        chatAttachments.push({
+          mimeType: row.mimeType,
+          fileName: row.filename,
+          content: fileBuffer.toString("base64"),
+        });
+      }
+    } finally {
+      await handle.close();
     }
 
     workspaceRefs.push({

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -46,6 +46,29 @@ export class AttachmentAlreadyAttachedError extends Error {
   }
 }
 
+/**
+ * A retry named an upload whose row says `attached` but whose bytes are no
+ * longer in `uploads/`.
+ *
+ * Its own class rather than a bare `Error` for the same reason the three above
+ * have one: `client-router` maps each to a specific error code, and anything
+ * unrecognised falls into the generic "Could not process attachment. Please
+ * try again." — advice that can only ever fail again, because nothing about
+ * the missing file changes between attempts.
+ */
+export class AttachmentFileMissingError extends Error {
+  constructor(
+    public readonly ids: string[],
+    public readonly relativePaths: string[]
+  ) {
+    super(
+      `Attachment file(s) missing from the agent workspace: ${relativePaths.join(", ")}. ` +
+        `The upload record still exists but the file does not — it cannot be re-sent.`
+    );
+    this.name = "AttachmentFileMissingError";
+  }
+}
+
 export interface MaterializeParams {
   agentId: string;
   userId: string;
@@ -73,11 +96,18 @@ export interface MaterializeParams {
  * `file.upload.attached` audit events, and returns the same
  * `ProcessAttachmentsResult` shape used by the WS send-path.
  *
+ * The returned `workspaceRefs` and `chatAttachments` follow the caller's own
+ * `attachmentIds` order, with repeats collapsed — so the manifest the agent
+ * reads lists the files in the order the user attached them, whether each one
+ * was promoted this turn or re-referenced from an earlier attempt.
+ *
  * Throws:
  *   `AttachmentNotFoundError`        — id missing or owned by another user/agent
  *   `AttachmentExpiredError`         — staged file has passed `expiresAt`
  *   `AttachmentAlreadyAttachedError` — row is already `attached`, and this is
  *                                      not a retry (see `isRetry`)
+ *   `AttachmentFileMissingError`     — a retry named an `attached` row whose
+ *                                      file is gone from `uploads/`
  *
  * **Note on partial failure:** If `promoteStagedToAttached` or the subsequent
  * FS read throws for file N after files 0..N-1 have already been promoted,
@@ -88,20 +118,39 @@ export interface MaterializeParams {
  *
  * Before #1195 the already-promoted rows were then unreachable: retries carried
  * no attachment ids, so nothing ever named them again and they sat in
- * `uploads/` as durable orphans. That is no longer the shape — a retry re-sends
- * the ids, and step 6 re-references those rows instead of orphaning them, which
- * makes the partial-failure case recover rather than leak. What still cannot be
- * recovered automatically is a row whose file never landed on disk; step 6
- * refuses to emit a ref for it rather than pointing the agent at nothing.
+ * `uploads/` as durable orphans. A retry now re-sends the ids and step 6
+ * re-references those rows instead of orphaning them — but only for as long as
+ * something still knows the ids. They live in the client's message state and in
+ * the `files` metadata the history frame carries (`history-upload-ids.ts`), so
+ * a user who instead clears the composer and rewrites the message leaves the
+ * same durable orphan behind as before. That residue is
+ * bounded and rare (it needs an FS or DB error mid-loop) and is reclaimed by an
+ * operator or a future workspace-GC pass, not automatically. What is never
+ * recovered is a row whose file is not on disk at all: step 6 refuses to emit a
+ * ref for it rather than pointing the agent at nothing.
  */
 export async function materializeAttachments(
   params: MaterializeParams
 ): Promise<ProcessAttachmentsResult> {
   const { agentId, userId, attachmentIds, messageId, agentName, isRetry = false } = params;
 
-  if (attachmentIds.length === 0) {
+  // Deduplicate up front. `attachmentIdsSchema` bounds the frame to 10 UUIDs
+  // but does not require them to be distinct, and every list below is derived
+  // from this one — so a repeated id would otherwise reach step 6 as a
+  // repeated ref AND, for an image, as a second base64 copy of the same bytes
+  // in the model request. The staged path never had this shape because its
+  // `inArray` query collapses repeats on its own.
+  const requestedIds = [...new Set(attachmentIds)];
+
+  if (requestedIds.length === 0) {
     return { chatAttachments: [], workspaceRefs: [] };
   }
+
+  // Position of each id in the caller's list — the order the user attached the
+  // files, and therefore the order the manifest must list them in.
+  const requestedOrder = new Map(requestedIds.map((id, i) => [id, i]));
+  const byRequestedOrder = (a: { id: string }, b: { id: string }) =>
+    requestedOrder.get(a.id)! - requestedOrder.get(b.id)!;
 
   // Step 1: fetch rows owned by (userId, agentId) with the requested IDs
   // that are still in `staged` status.
@@ -110,7 +159,7 @@ export async function materializeAttachments(
     .from(uploadedFiles)
     .where(
       and(
-        inArray(uploadedFiles.id, attachmentIds),
+        inArray(uploadedFiles.id, requestedIds),
         eq(uploadedFiles.userId, userId),
         eq(uploadedFiles.agentId, agentId),
         eq(uploadedFiles.status, "staged")
@@ -125,7 +174,7 @@ export async function materializeAttachments(
 
   // Step 2: check for IDs not returned by the staged query — could be
   // not-found/wrong-owner, or already attached (different status).
-  const unseenIds = attachmentIds.filter((id) => !foundIds.has(id));
+  const unseenIds = requestedIds.filter((id) => !foundIds.has(id));
   if (unseenIds.length > 0) {
     // Secondary lookup: check if any unseen IDs are already-attached rows
     // owned by the same (userId, agentId). If so, surface a specific error.
@@ -156,10 +205,12 @@ export async function materializeAttachments(
     // widest this reaches is a user re-referencing their own file in their own
     // agent's workspace — which that agent can `pinchy_ls` regardless.
     retriedRows = isRetry ? attachedRows : [];
-    const retriedIds = new Set(retriedRows.map((r) => r.id));
 
-    // Rows that exist as attached, on a send that is not a retry.
-    const alreadyAttachedIds = unseenIds.filter((id) => attachedIds.has(id) && !retriedIds.has(id));
+    // Rows that exist as attached, on a send that is not a retry. On a retry
+    // every one of them is in `retriedRows` above, so this is empty by
+    // construction — spelled as the flag rather than as a set difference,
+    // which only restates it.
+    const alreadyAttachedIds = isRetry ? [] : unseenIds.filter((id) => attachedIds.has(id));
     if (alreadyAttachedIds.length > 0) {
       for (const uploadId of alreadyAttachedIds) {
         await appendAuditLog({
@@ -212,8 +263,12 @@ export async function materializeAttachments(
   const workspaceRoot = getWorkspacePath(agentId);
   const openClawWorkspaceRoot = getOpenClawWorkspacePath(agentId);
 
-  const chatAttachments: ChatAttachment[] = [];
-  const workspaceRefs: ProcessedWorkspaceRef[] = [];
+  // Keyed by upload id, assembled into the caller's order at the end. Both
+  // loops below emit their audit rows in that same order, so "file-0's audit
+  // precedes file-1's" is a statement about the user's own selection rather
+  // than about whatever order Postgres happened to return.
+  const refById = new Map<string, ProcessedWorkspaceRef>();
+  const chatAttachmentById = new Map<string, ChatAttachment>();
 
   // Process sequentially. Filename collisions are already resolved at stage
   // time (`persistStagedUpload` reserves `uploads/<filename>` via
@@ -224,7 +279,7 @@ export async function materializeAttachments(
   // partial-failure surface is easier to reason about (Promise.all would
   // leave in-flight renames running after the first rejection, broadening
   // the orphan set documented in the jsdoc above).
-  for (const row of rows) {
+  for (const row of [...rows].sort(byRequestedOrder)) {
     if (!row.stagingPath) {
       throw new Error(
         `Uploaded file ${row.id} has status='staged' but missing stagingPath — data integrity error`
@@ -255,12 +310,16 @@ export async function materializeAttachments(
       const durablePath = join(workspaceRoot, promoted.relativePath);
       const fileBuffer = await readFile(durablePath);
       const content = fileBuffer.toString("base64");
-      chatAttachments.push({ mimeType: row.mimeType, fileName: row.filename, content });
+      chatAttachmentById.set(row.id, {
+        mimeType: row.mimeType,
+        fileName: row.filename,
+        content,
+      });
     }
 
     // 5d/5e: build workspace ref
     const absolutePath = join(openClawWorkspaceRoot, promoted.relativePath);
-    workspaceRefs.push({
+    refById.set(row.id, {
       relativePath: promoted.relativePath,
       absolutePath,
       mimeType: row.mimeType,
@@ -284,21 +343,20 @@ export async function materializeAttachments(
     });
   }
 
-  // Step 6: rebuild refs for rows this same message already attached — a retry.
+  // Step 6: rebuild refs for rows an earlier attempt at this message already
+  // attached — a retry.
   //
   // Nothing here promotes or writes: the bytes have been sitting in `uploads/`
-  // since the first attempt, and the DB row is already `attached` with this
-  // messageId. All that is missing is the ref the caller needs in order to
-  // rebuild the attachment manifest, so the agent is handed the same paths it
-  // was handed the first time.
+  // since that attempt, and the DB row is already `attached`. All that is
+  // missing is the ref the caller needs in order to rebuild the attachment
+  // manifest, so the agent is handed the same paths it was handed before.
   //
-  // Deliberately no `file.upload.attached` audit row: nothing was attached.
-  // The retry itself is already on the record as `chat.retry_triggered`, and a
-  // second success row per file would inflate the attach count on every retry.
-  for (const rowId of attachmentIds) {
-    const row = retriedRows.find((r) => r.id === rowId);
-    if (!row) continue;
-
+  // The row is stamped with the FIRST attempt's `messageId`, not this frame's —
+  // client-router mints a fresh UUID per frame, which is exactly why the gate
+  // is `isRetry` and not message-id equality. Nothing here re-stamps it: the
+  // column is a write-only traceability record of when the bytes were promoted,
+  // and rewriting it would erase that.
+  for (const row of [...retriedRows].sort(byRequestedOrder)) {
     const relativePath = attachedRelativePath(row.filename);
     const durablePath = join(workspaceRoot, relativePath);
 
@@ -315,15 +373,23 @@ export async function materializeAttachments(
     try {
       handle = await open(durablePath, "r");
     } catch {
-      throw new Error(
-        `Uploaded file ${row.id} is attached to message ${messageId} but ${relativePath} is missing from the workspace`
-      );
+      // Audited like every other refusal in this function: without a row, a
+      // user retrying into a permanently-failing send leaves no trace on the
+      // Pinchy side at all.
+      await appendAuditLog({
+        eventType: "file.upload.attached",
+        actorType: "user",
+        actorId: userId,
+        outcome: "failure",
+        detail: { uploadId: row.id, messageId, filename: row.filename, reason: "file_missing" },
+      });
+      throw new AttachmentFileMissingError([row.id], [relativePath]);
     }
 
     try {
       if (row.mimeType.startsWith("image/")) {
         const fileBuffer = await handle.readFile();
-        chatAttachments.push({
+        chatAttachmentById.set(row.id, {
           mimeType: row.mimeType,
           fileName: row.filename,
           content: fileBuffer.toString("base64"),
@@ -333,7 +399,7 @@ export async function materializeAttachments(
       await handle.close();
     }
 
-    workspaceRefs.push({
+    refById.set(row.id, {
       relativePath,
       absolutePath: join(openClawWorkspaceRoot, relativePath),
       mimeType: row.mimeType,
@@ -341,7 +407,35 @@ export async function materializeAttachments(
       contentHash: row.contentHash,
       reused: true,
     });
+
+    // A re-reference is still a delivery of this file to the agent on this
+    // turn, so it belongs in the trail — `chat.retry_triggered` names the agent
+    // and the reason but no filenames, and without a row here the question
+    // "which files did this turn hand over?" has no answer. `reason` marks it
+    // so a query counting real attaches can exclude it; a separate event type
+    // would have been the cleaner spelling but is not worth widening the
+    // catalogue for a variant of the same fact.
+    await appendAuditLog({
+      eventType: "file.upload.attached",
+      actorType: "user",
+      actorId: userId,
+      outcome: "success",
+      detail: {
+        uploadId: row.id,
+        messageId,
+        filename: row.filename,
+        reason: "retry_reference",
+        agent: { id: agentId, name: agentName },
+      },
+    });
   }
+
+  const workspaceRefs = requestedIds
+    .map((id) => refById.get(id))
+    .filter((ref): ref is ProcessedWorkspaceRef => ref !== undefined);
+  const chatAttachments = requestedIds
+    .map((id) => chatAttachmentById.get(id))
+    .filter((att): att is ChatAttachment => att !== undefined);
 
   return { chatAttachments, workspaceRefs };
 }

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -1,11 +1,11 @@
-import { readFile } from "fs/promises";
+import { readFile, stat } from "fs/promises";
 import { join } from "path";
 import type { ChatAttachment } from "openclaw-node";
 import { eq, and, inArray } from "drizzle-orm";
 import { db } from "@/db";
 import { uploadedFiles } from "@/db/schema";
 import { appendAuditLog } from "@/lib/audit";
-import { promoteStagedToAttached } from "@/lib/uploads";
+import { promoteStagedToAttached, attachedRelativePath } from "@/lib/uploads";
 import { getWorkspacePath, getOpenClawWorkspacePath } from "@/lib/workspace";
 
 export interface ProcessedWorkspaceRef {
@@ -54,6 +54,13 @@ export interface MaterializeParams {
   messageId: string;
   /** Agent display name, snapshotted in audit detail. */
   agentName: string;
+  /**
+   * True when this frame is a retry of a message the user already sent (#1195).
+   * Retries carry the original attachment ids, so rows that the first attempt
+   * already promoted are re-referenced rather than refused — see the
+   * already-attached branch for why this is gated instead of allowed generally.
+   */
+  isRetry?: boolean;
 }
 
 /**
@@ -68,27 +75,28 @@ export interface MaterializeParams {
  * Throws:
  *   `AttachmentNotFoundError`        — id missing or owned by another user/agent
  *   `AttachmentExpiredError`         — staged file has passed `expiresAt`
- *   `AttachmentAlreadyAttachedError` — row is already `attached`
+ *   `AttachmentAlreadyAttachedError` — row is already `attached`, and this is
+ *                                      not a retry (see `isRetry`)
  *
  * **Note on partial failure:** If `promoteStagedToAttached` or the subsequent
  * FS read throws for file N after files 0..N-1 have already been promoted,
  * earlier files are durably placed in `uploads/` and their rows are `attached`
  * in the DB. This partial state cannot be automatically rolled back (FS rename
  * and DB write are not transactional). If this function throws, callers should
- * treat the entire send as failed and inform the user to retry — but the
- * already-promoted rows are pinned to THIS frame's freshly-minted `messageId`
- * UUID. A retry generates a different `messageId`, so the orphaned rows
- * never re-enter the chat stream. They sit in `uploads/` as durable but
- * unreachable artefacts; only an operator (or a future workspace-GC pass)
- * can reclaim them. The trade-off here is intentional: partial-failure is
- * very rare (it requires an FS or DB error mid-loop), and the recovery cost
- * is bounded — the user still sees the failure surface and retries with a
- * clean set of staged rows.
+ * treat the entire send as failed and inform the user to retry.
+ *
+ * Before #1195 the already-promoted rows were then unreachable: retries carried
+ * no attachment ids, so nothing ever named them again and they sat in
+ * `uploads/` as durable orphans. That is no longer the shape — a retry re-sends
+ * the ids, and step 6 re-references those rows instead of orphaning them, which
+ * makes the partial-failure case recover rather than leak. What still cannot be
+ * recovered automatically is a row whose file never landed on disk; step 6
+ * refuses to emit a ref for it rather than pointing the agent at nothing.
  */
 export async function materializeAttachments(
   params: MaterializeParams
 ): Promise<ProcessAttachmentsResult> {
-  const { agentId, userId, attachmentIds, messageId, agentName } = params;
+  const { agentId, userId, attachmentIds, messageId, agentName, isRetry = false } = params;
 
   if (attachmentIds.length === 0) {
     return { chatAttachments: [], workspaceRefs: [] };
@@ -110,6 +118,10 @@ export async function materializeAttachments(
 
   const foundIds = new Set(rows.map((r) => r.id));
 
+  // Rows a retry re-references rather than attaches (#1195). Filled in step 2,
+  // consumed in step 6; declared here so it survives the block scope.
+  let retriedRows: (typeof uploadedFiles.$inferSelect)[] = [];
+
   // Step 2: check for IDs not returned by the staged query — could be
   // not-found/wrong-owner, or already attached (different status).
   const unseenIds = attachmentIds.filter((id) => !foundIds.has(id));
@@ -129,8 +141,24 @@ export async function materializeAttachments(
       );
     const attachedIds = new Set(attachedRows.map((r) => r.id));
 
-    // Rows that exist as attached
-    const alreadyAttachedIds = unseenIds.filter((id) => attachedIds.has(id));
+    // A RETRY re-sends the message it is retrying, attachment ids and all
+    // (heypinchy/pinchy#1195). If the first attempt got far enough to
+    // materialize them, those rows are now `attached` — and refusing the frame
+    // over that would reject the whole retry, which is worse than the bug it
+    // replaced. On a retry they are re-referenced instead: the bytes are
+    // already in `uploads/`, so the manifest can be rebuilt without attaching
+    // anything a second time.
+    //
+    // Gated on `isRetry` rather than allowed generally, because the error still
+    // has a job on an ordinary send: an upload belongs to the message it was
+    // composed with. The rows are already scoped to (userId, agentId), so the
+    // widest this reaches is a user re-referencing their own file in their own
+    // agent's workspace — which that agent can `pinchy_ls` regardless.
+    retriedRows = isRetry ? attachedRows : [];
+    const retriedIds = new Set(retriedRows.map((r) => r.id));
+
+    // Rows that exist as attached, on a send that is not a retry.
+    const alreadyAttachedIds = unseenIds.filter((id) => attachedIds.has(id) && !retriedIds.has(id));
     if (alreadyAttachedIds.length > 0) {
       for (const uploadId of alreadyAttachedIds) {
         await appendAuditLog({
@@ -146,16 +174,20 @@ export async function materializeAttachments(
 
     // Remaining unseen IDs are genuinely missing (cross-user attack, wrong agent, etc.)
     const missingIds = unseenIds.filter((id) => !attachedIds.has(id));
-    for (const uploadId of missingIds) {
-      await appendAuditLog({
-        eventType: "file.upload.attached",
-        actorType: "user",
-        actorId: userId,
-        outcome: "failure",
-        detail: { uploadId, reason: "not_found" },
-      });
+    // Guard the throw: on a retry every id can be accounted for by retriedRows,
+    // and an unguarded throw here would reject that frame with an empty id list.
+    if (missingIds.length > 0) {
+      for (const uploadId of missingIds) {
+        await appendAuditLog({
+          eventType: "file.upload.attached",
+          actorType: "user",
+          actorId: userId,
+          outcome: "failure",
+          detail: { uploadId, reason: "not_found" },
+        });
+      }
+      throw new AttachmentNotFoundError(missingIds);
     }
-    throw new AttachmentNotFoundError(missingIds);
   }
 
   const now = new Date();
@@ -248,6 +280,55 @@ export async function materializeAttachments(
         filename: row.filename,
         agent: { id: agentId, name: agentName },
       },
+    });
+  }
+
+  // Step 6: rebuild refs for rows this same message already attached — a retry.
+  //
+  // Nothing here promotes or writes: the bytes have been sitting in `uploads/`
+  // since the first attempt, and the DB row is already `attached` with this
+  // messageId. All that is missing is the ref the caller needs in order to
+  // rebuild the attachment manifest, so the agent is handed the same paths it
+  // was handed the first time.
+  //
+  // Deliberately no `file.upload.attached` audit row: nothing was attached.
+  // The retry itself is already on the record as `chat.retry_triggered`, and a
+  // second success row per file would inflate the attach count on every retry.
+  for (const rowId of attachmentIds) {
+    const row = retriedRows.find((r) => r.id === rowId);
+    if (!row) continue;
+
+    const relativePath = attachedRelativePath(row.filename);
+    const durablePath = join(workspaceRoot, relativePath);
+
+    // The path is derived, not stored, so prove it before handing it over. A
+    // ref that resolves to nothing would send the agent to read a file that is
+    // not there and have it report the attachment as unreadable — a silent
+    // wrong answer in place of a loud failure.
+    try {
+      await stat(durablePath);
+    } catch {
+      throw new Error(
+        `Uploaded file ${row.id} is attached to message ${messageId} but ${relativePath} is missing from the workspace`
+      );
+    }
+
+    if (row.mimeType.startsWith("image/")) {
+      const fileBuffer = await readFile(durablePath);
+      chatAttachments.push({
+        mimeType: row.mimeType,
+        fileName: row.filename,
+        content: fileBuffer.toString("base64"),
+      });
+    }
+
+    workspaceRefs.push({
+      relativePath,
+      absolutePath: join(openClawWorkspaceRoot, relativePath),
+      mimeType: row.mimeType,
+      sizeBytes: row.sizeBytes,
+      contentHash: row.contentHash,
+      reused: true,
     });
   }
 

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -409,6 +409,10 @@ export class ClientRouter {
             attachmentIds: parsedIds.data,
             messageId,
             agentName: agent.name,
+            // A retry carries the original message's attachment ids (#1195).
+            // Whether the first attempt already promoted them decides between
+            // attaching and re-referencing, and only the pipeline can tell.
+            isRetry: message.isRetry === true,
           });
           chatAttachments = result.chatAttachments;
           workspaceRefs = result.workspaceRefs;

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -27,9 +27,15 @@ import { SessionCache } from "@/server/session-cache";
 import { resolveUserPlaceholder } from "@/server/user-placeholder";
 import { classifyAgentError } from "@/server/agent-error-classifier";
 import { db } from "@/db";
-import { agents, users, models, agentDeliveredFiles } from "@/db/schema";
+import { agents, users, models, agentDeliveredFiles, uploadedFiles } from "@/db/schema";
 import { attachDeliveredFilesToHistory } from "@/server/delivered-file-history";
-import { eq } from "drizzle-orm";
+import {
+  type HistoryFileMeta,
+  collectAttachmentFilenames,
+  indexUploadIdsByFilename,
+  attachUploadIdsToHistory,
+} from "@/server/history-upload-ids";
+import { and, eq, inArray } from "drizzle-orm";
 import { isModelVisionCapable } from "@/lib/model-vision";
 import { resolveImageTurnModel, type VisionCandidate } from "@/lib/image-fallback";
 import { readExistingConfig } from "@/lib/openclaw-config/write";
@@ -42,6 +48,7 @@ import {
   AttachmentNotFoundError,
   AttachmentExpiredError,
   AttachmentAlreadyAttachedError,
+  AttachmentFileMissingError,
 } from "@/server/attachment-pipeline";
 import { attachmentIdsSchema } from "@/lib/schemas/uploads";
 import { chatIdSchema } from "@/lib/schemas/sessions";
@@ -433,6 +440,15 @@ export class ClientRouter {
             this.sendToClient(clientWs, {
               type: "error",
               code: "attachment_already_attached",
+              message: err.message,
+            });
+          } else if (err instanceof AttachmentFileMissingError) {
+            // Distinct from the generic branch below on purpose: that one says
+            // "Please try again", and nothing about a file that is not on disk
+            // changes between attempts (#1195).
+            this.sendToClient(clientWs, {
+              type: "error",
+              code: "attachment_file_missing",
               message: err.message,
             });
           } else {
@@ -867,7 +883,10 @@ export class ClientRouter {
           // OpenClaw's session JSONL — we round-trip its metadata into the
           // wire-level `files` field so the browser can render the chip
           // without ever seeing the markup.
-          let files: Array<{ filename: string; mimeType: string }> | undefined;
+          // `HistoryFileMeta`, not an inline pair: the upload id is stamped on
+          // below (#1195) and an inline type would drop it from the frame's
+          // static shape while it rode along at runtime.
+          let files: HistoryFileMeta[] | undefined;
           if (isOversizedPlaceholder) {
             // The original content (and any attachment block it carried) is
             // gone for good — OpenClaw already discarded it server-side.
@@ -923,6 +942,34 @@ export class ClientRouter {
           ...(oversized ? { oversized: true as const } : {}),
         }));
 
+      // Recover the upload id behind each user chip (#1195). The client keeps
+      // `attachmentIds` in message state so a retry can re-send the files, and
+      // that state dies on reload — while the retry affordance does not
+      // (ChatErrorBanner re-surfaces the session's last agent error on mount).
+      // Without this, a retry clicked after a reload sends the text alone,
+      // which is the very symptom #1195 exists to fix.
+      //
+      // Runs BEFORE attachDeliveredFilesToHistory: that one adds chips to
+      // ASSISTANT turns from the delivery grant table, and those have no upload
+      // row to name.
+      const attachmentFilenames = collectAttachmentFilenames(mapped);
+      let uploadIdsByFilename = new Map<string, string>();
+      if (attachmentFilenames.length > 0) {
+        const uploadRows = await db
+          .select({ id: uploadedFiles.id, filename: uploadedFiles.filename })
+          .from(uploadedFiles)
+          .where(
+            and(
+              eq(uploadedFiles.agentId, agent.id),
+              eq(uploadedFiles.userId, this.userId),
+              eq(uploadedFiles.status, "attached"),
+              inArray(uploadedFiles.filename, attachmentFilenames)
+            )
+          );
+        uploadIdsByFilename = indexUploadIdsByFilename(uploadRows);
+      }
+      const withUploadIds = attachUploadIdsToHistory(mapped, uploadIdsByFilename);
+
       // Re-attach agent-delivered files (#703). Delivered-file chips are not
       // recoverable from the transcript on reload (chat.history drops the
       // tool_result that carried the marker), so we read them from the durable
@@ -939,7 +986,7 @@ export class ClientRouter {
         .where(eq(agentDeliveredFiles.sessionKey, sessionKey));
 
       return attachDeliveredFilesToHistory(
-        mapped,
+        withUploadIds,
         grants.map((g) => ({
           filename: g.filename,
           mimeType: g.mimeType,

--- a/packages/web/src/server/history-upload-ids.ts
+++ b/packages/web/src/server/history-upload-ids.ts
@@ -1,0 +1,106 @@
+// Upload-id recovery for history-rebuilt user turns (#1195).
+//
+// A retry re-sends the message's `attachmentIds` so the agent is handed the
+// files again instead of the text alone. Those ids live in the client's
+// message state — which does not survive a reload, and the retry affordance
+// does: `ChatErrorBanner` asks the server for the session's last un-resolved
+// agent error on mount and offers Retry for it, precisely so an error the live
+// bubble lost to a reload is still actionable when the user comes back.
+//
+// So the ids have to be recoverable from history too, or the reload path
+// reproduces the exact production symptom #1195 is about: the message arrives
+// a second time with the `<pinchy:attachments>` block gone.
+//
+// They are recoverable because the block names the file: `parseAttachmentBlock`
+// already lifts filename + MIME out of the transcript, and `uploaded_files`
+// holds the id for `(agentId, userId, filename)` — the shape
+// `idx_uploaded_files_lookup` is built on. Filenames are unique within an
+// agent workspace by construction (`persistStagedUpload` reserves
+// `uploads/<name>` with O_CREAT|O_EXCL and suffixes collisions), so the
+// mapping is one-to-one for anything that reservation scheme produced.
+
+/** One file chip on a history turn, as `fetchAndParseHistory` builds it. */
+export interface HistoryFileMeta {
+  filename: string;
+  mimeType: string;
+  /** Resolved by `indexUploadIdsByFilename` below; absent when unresolvable. */
+  uploadId?: string;
+}
+
+interface HistoryTurn {
+  role: "user" | "assistant";
+  files?: HistoryFileMeta[];
+}
+
+/**
+ * Every distinct filename a USER turn carries a chip for — the lookup keys for
+ * the `uploaded_files` query.
+ *
+ * User turns only: an assistant turn's chips come from `agent_delivered_files`
+ * (agent → user deliveries, re-attached separately) and have no upload row, so
+ * including them would query for names that cannot match and, worse, could
+ * collide with an upload of the same name and stamp an id onto a turn that can
+ * never be retried.
+ */
+export function collectAttachmentFilenames(messages: HistoryTurn[]): string[] {
+  const names = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role !== "user") continue;
+    for (const file of msg.files ?? []) names.add(file.filename);
+  }
+  return [...names];
+}
+
+/**
+ * Build the filename → upload-id index, dropping any filename that more than
+ * one row claims.
+ *
+ * An ambiguous name yields NO id rather than an arbitrary one. The reservation
+ * scheme makes duplicates impossible for anything it produced, but rows that
+ * predate it (or arrive by some future path) must not be guessed at: a wrong
+ * id would re-send a different file under the right name, which is a silent
+ * wrong answer — strictly worse than the degraded behaviour of re-sending the
+ * text alone, which is what an absent id falls back to.
+ */
+export function indexUploadIdsByFilename(
+  rows: Array<{ id: string; filename: string }>
+): Map<string, string> {
+  const index = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  for (const row of rows) {
+    if (index.has(row.filename)) {
+      ambiguous.add(row.filename);
+      continue;
+    }
+    index.set(row.filename, row.id);
+  }
+  for (const filename of ambiguous) index.delete(filename);
+  return index;
+}
+
+/**
+ * Stamp the resolved upload id onto each user turn's file chips.
+ *
+ * Returns a shallow copy; only the turns that receive an id are cloned, so
+ * referential equality holds for everything untouched — same contract as
+ * `attachDeliveredFilesToHistory`, which runs right after this.
+ */
+export function attachUploadIdsToHistory<T extends HistoryTurn>(
+  messages: T[],
+  idsByFilename: Map<string, string>
+): T[] {
+  if (idsByFilename.size === 0) return messages;
+
+  return messages.map((msg) => {
+    if (msg.role !== "user" || !msg.files || msg.files.length === 0) return msg;
+    let changed = false;
+    const resolved = msg.files.map((file) => {
+      const uploadId = idsByFilename.get(file.filename);
+      if (uploadId === undefined) return file;
+      changed = true;
+      return { ...file, uploadId };
+    });
+    if (!changed) return msg;
+    return { ...msg, files: resolved };
+  });
+}

--- a/packages/web/src/server/upload-gc.ts
+++ b/packages/web/src/server/upload-gc.ts
@@ -6,6 +6,7 @@ import { uploadedFiles } from "@/db/schema";
 import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { getWorkspacePath } from "@/lib/workspace";
+import { attachedRelativePath } from "@/lib/uploads";
 
 export interface SweepResult {
   swept: number;
@@ -114,8 +115,16 @@ export async function sweepExpiredUploads(): Promise<SweepResult> {
     // ENOENT (someone removed it out-of-band) — non-ENOENT errors leave the
     // slot orphaned, but the DB row gets deleted regardless so the orphan
     // surfaces only as a manual cleanup, not as a permanent failure loop.
+    //
+    // Through `attachedRelativePath` rather than a hand-built join, so this is
+    // byte-for-byte the path `promoteStagedToAttached` writes and
+    // `materializeAttachments` re-references. A hand-built one also skips
+    // sanitizeFilename's NFC normalization, so a decomposed macOS name (the
+    // 2026-07-14 incident) would leave the reservation behind forever while
+    // the DB row disappeared — every later upload of that name would then be
+    // suffixed " (1)" against a placeholder nobody owns.
     try {
-      await rm(join(workspaceRoot, "uploads", row.filename), { force: true });
+      await rm(join(workspaceRoot, attachedRelativePath(row.filename)), { force: true });
     } catch {
       // Best-effort: see comment above.
     }


### PR DESCRIPTION
Fixes #1195.

## What was wrong

`sendMessage` includes `attachmentIds`; `onRetryContinue` and `onRetryResend` did not. Retrying a message that carried files delivered the text alone.

The reasoning for that was written down in the test file when the legacy base64-over-WS flow was removed:

> The two-phase upload pipeline doesn't round-trip attachmentIds on retry (they materialize at send time and the row is already in `attached` state). Retry just re-sends text.

That holds only when the first attempt reached the server. A `send_failure` retry is exactly the case where it did not — the rows are still `staged`, nothing was materialized, and the agent gets a message about files it has never been handed.

Production, 2026-08-18: a message with five PDF invoices arrived a second time with the `<pinchy:attachments>` block gone, four seconds after `chat.retry_triggered`. That run recovered only because the first attempt had already reached the transcript and the paths were still in context.

## The fix

**Client** — the ids ride on the message state and both retry paths re-send them. `files` (filename + mimeType) is display metadata and cannot stand in for them.

**Server** — a retry re-references rows the first attempt already promoted, instead of refusing the frame with `AttachmentAlreadyAttachedError`. Refusing would reject the whole retry, which is worse than the bug it replaces.

Two things about that are worth reading closely:

- **The gate is `isRetry`, not message-id equality.** My first cut correlated on `row.messageId === messageId`, which reads correctly and matches nothing: `client-router.ts` mints a fresh `messageId` per frame (`crypto.randomUUID()`), so a retry never carries the id its first attempt was stored under. The integration test passed a literal id on both calls and would have locked in an inert fix. The test now says so, next to the assertion.
- **The already-attached error is gated, not removed.** It still fires on an ordinary send; there is an explicit negative-control test on the same fixture whose only difference is the flag. The widest the exemption reaches is a user re-referencing their own upload in their own agent's workspace — the rows are already scoped to `(userId, agentId)`, and that agent can `pinchy_ls` the file regardless.

Re-referencing derives `uploads/<filename>` rather than reading it back from a column (nothing persists the promoted path), so it `stat`s the file and refuses to emit a ref that resolves to nothing — otherwise the agent is sent to read a missing file and reports the attachment as unreadable, a silent wrong answer in place of a loud failure. The derivation is shared with `promoteStagedToAttached` via `attachedRelativePath()` so the two cannot drift apart.

A side effect worth noting: the partial-failure paragraph in the pipeline's jsdoc described already-promoted rows as permanently unreachable orphans, *because* retries carried no ids. That is no longer the shape, so the paragraph is corrected rather than left to describe a world that changed underneath it.

## Verification

- Canary on the client change: both new tests fail with `attachmentIds: undefined` when the two spreads are removed, pass when restored.
- `use-ws-runtime.test.ts` — 149 passed.
- `attachment-pipeline-materialize.integration.test.ts` — 11 passed, including the negative control.
- Full integration suite (`test:db`): 71 files, 598 passed.
- `tsc --noEmit -p tsconfig.typecheck.json`: clean.
- eslint on the four changed source files: 0 errors (19 pre-existing `detect-non-literal-fs-filename` warnings, three of them from the `stat`/`readFile` added here, same shape as the existing ones in that file).

**One thing I could not close out:** of four full unit-suite runs, three were green (12275 passed / 18 skipped) and one reported 2 failures. That run came straight after the 132-second integration suite with a 5-minute load average around 100 — the regime AGENTS.md describes under the 20s/40s timeout note, where failures scatter across unrelated files in a timeout shape. I did not capture which two, and I am not going to claim they were unrelated on that basis alone. The change's own tests are deterministic and canary-verified; if CI shows the same two, they want looking at on their own.
