### PR TITLE
fix(odoo): decode escaped domain operators instead of passing them to Odoo

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
@@ -27,7 +27,7 @@ vi.mock("odoo-node", () => {
 
 vi.mock("../io", () => ({ readFile: vi.fn(), stat: vi.fn() }));
 
-import { hasItemWrappedArray } from "../index";
+import { asDomain, decodeUnicodeEscapes, hasItemWrappedArray } from "../index";
 import plugin from "../index";
 
 // Pattern B: the plugin lazily fetches credentials, so a stubbed endpoint is
@@ -226,6 +226,111 @@ describe("odoo_read — {item: …} array-wrapping", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Unit: the domain normalizer itself. Driving it through a tool proves the
+// wiring; driving it directly is how the shapes below stay cheap to state —
+// the same split `hasItemWrappedArray` already has above.
+// ---------------------------------------------------------------------------
+describe("decodeUnicodeEscapes", () => {
+  it("turns a literal \\uXXXX sequence back into its character", () => {
+    expect(decodeUnicodeEscapes("\\u003c=")).toBe("<=");
+    expect(decodeUnicodeEscapes("\\u0026")).toBe("&");
+  });
+
+  it("accepts uppercase hex", () => {
+    expect(decodeUnicodeEscapes("\\u003C=")).toBe("<=");
+  });
+
+  it("leaves a string with no escape untouched", () => {
+    expect(decodeUnicodeEscapes("ilike")).toBe("ilike");
+    expect(decodeUnicodeEscapes("")).toBe("");
+  });
+});
+
+describe("asDomain", () => {
+  it("treats an omitted filter as match-everything", () => {
+    expect(asDomain(undefined)).toEqual([]);
+    expect(asDomain(null)).toEqual([]);
+  });
+
+  it("refuses a non-array, naming the parameter", () => {
+    expect(() => asDomain("account_id = 5")).toThrow(/`filters` must be an array/);
+  });
+
+  // Odoo lower-cases the operator and still accepts the legacy `<>` for `!=`,
+  // so refusing either spelling here would reject a domain Odoo runs happily.
+  // Sending the canonical form is never worse than sending the alias.
+  it("accepts the spellings Odoo normalizes away", () => {
+    expect(asDomain([["name", "ILIKE", "acme"]])).toEqual([["name", "ilike", "acme"]]);
+    expect(asDomain([["partner_id", "In", [1, 2]]])).toEqual([["partner_id", "in", [1, 2]]]);
+    expect(asDomain([["state", "<>", "draft"]])).toEqual([["state", "!=", "draft"]]);
+  });
+
+  // `&` is the character a model escapes most reflexively of all, so the
+  // operator position of a CONDITION is not the only place #1198 lands.
+  it("decodes an escaped logical operator", () => {
+    expect(
+      asDomain(["\\u0026", ["state", "=", "posted"], ["date", "\\u003e=", "2026-06-01"]])
+    ).toEqual(["&", ["state", "=", "posted"], ["date", ">=", "2026-06-01"]]);
+  });
+
+  it("refuses a bare string that is not a logical operator", () => {
+    expect(() => asDomain(["AND", ["state", "=", "posted"]])).toThrow(
+      /Unsupported domain term "AND"/
+    );
+  });
+
+  // `any` / `not any` carry a domain as their value, and the escape lands one
+  // level in as readily as at the top.
+  it("normalizes the sub-domain of any / not any", () => {
+    expect(asDomain([["invoice_line_ids", "any", [["date", "\\u003c=", "2026-06-30"]]]])).toEqual([
+      ["invoice_line_ids", "any", [["date", "<=", "2026-06-30"]]],
+    ]);
+  });
+
+  it("leaves a non-array `any` value alone rather than inventing a refusal", () => {
+    expect(asDomain([["invoice_line_ids", "any", 5]])).toEqual([["invoice_line_ids", "any", 5]]);
+  });
+
+  // A domain one level too deep is a shape models produce as readily as the
+  // {item: …} artifact. Reading the middle element of such an entry yields the
+  // honest-but-useless "the operator must be a string"; name the nesting.
+  it.each([
+    [[["&", ["state", "=", "posted"], ["date", ">=", "2026-06-01"]]]],
+    [
+      [
+        [
+          ["state", "=", "posted"],
+          ["date", ">=", "2026-06-01"],
+        ],
+      ],
+    ],
+    [[[["state", "=", "posted"]]]],
+  ])("refuses a domain nested one level too deep (%#)", (nested) => {
+    expect(() => asDomain(nested)).toThrow(/nested one level too deep/);
+  });
+
+  it("refuses a non-string operator without echoing the value", () => {
+    expect(() => asDomain([["date", 5, "2026-06-30"]])).toThrow(
+      /Invalid condition on field "date": the operator must be a string/
+    );
+  });
+
+  // The refusal names the field and the operator and NOT the value. The value
+  // is the caller's own search text; echoing it back into an error message is
+  // how caller-supplied prose ends up being read as a diagnosis downstream —
+  // `isAuthError` matches on words, and "unauthorized" is an ordinary thing to
+  // search an accounting database for.
+  it("does not echo the value into the refusal", () => {
+    expect(() => asDomain([["name", "contains", "Unauthorized charge dispute"]])).toThrow(
+      /Unsupported operator "contains" on field "name"/
+    );
+    expect(() => asDomain([["name", "contains", "Unauthorized charge dispute"]])).not.toThrow(
+      /Unauthorized/
+    );
+  });
+});
+
 // heypinchy/pinchy#1198. Some models emit `<` and `>` in their JSON-escaped
 // form, and when the escape is not decoded on the way in the six-character
 // literal `<=` arrives as the operator. Odoo then rejects the whole
@@ -283,7 +388,12 @@ describe("odoo_read — unicode-escaped domain operators", () => {
   // escape variant would still reach Odoo. An operator that is not one Odoo
   // accepts is refused HERE, with the list, so the model can correct itself
   // instead of reading a server error about a string it believes it never sent.
-  it("refuses an operator Odoo does not accept, before querying", async () => {
+  //
+  // "Before querying" has to mean before the FIRST call, not before
+  // search_read: odoo_read reads `fields_get` on the way in, so asserting only
+  // that search_read was skipped would leave a real Odoo round trip — and a
+  // credentials fetch — unaccounted for.
+  it("refuses an operator Odoo does not accept, before any Odoo call", async () => {
     const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
 
     const result = await tool.execute("c", {
@@ -295,6 +405,59 @@ describe("odoo_read — unicode-escaped domain operators", () => {
     expect(result.content[0].text).toMatch(/=</);
     expect(result.content[0].text).toMatch(/<=/); // names a valid one
     expect(mockSearchRead).not.toHaveBeenCalled();
+    expect(mockFields).not.toHaveBeenCalled();
+  });
+
+  it("refuses before querying in odoo_count too", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_count", agentId)!;
+
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: [["date", "=<", "2026-06-30"]],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockSearchCount).not.toHaveBeenCalled();
+  });
+
+  it("refuses before querying in odoo_aggregate too", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_aggregate", agentId)!;
+
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: [["date", "=<", "2026-06-30"]],
+      fields: ["amount_total:sum"],
+      groupby: ["partner_id"],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockReadGroup).not.toHaveBeenCalled();
+  });
+
+  it("decodes the domain for odoo_count and odoo_aggregate as well", async () => {
+    mockSearchCount.mockResolvedValue(3);
+    mockReadGroup.mockResolvedValue([]);
+    const tools = createApi({ [agentId]: cfg() });
+
+    await findTool(tools, "odoo_count", agentId)!.execute("c", {
+      model: "account.move",
+      filters: [["date", "\\u003c=", "2026-06-30"]],
+    });
+    expect(mockSearchCount).toHaveBeenCalledWith("account.move", [["date", "<=", "2026-06-30"]]);
+
+    await findTool(tools, "odoo_aggregate", agentId)!.execute("c", {
+      model: "account.move",
+      filters: [["date", "\\u003c=", "2026-06-30"]],
+      fields: ["amount_total:sum"],
+      groupby: ["partner_id"],
+    });
+    expect(mockReadGroup).toHaveBeenCalledWith(
+      "account.move",
+      [["date", "<=", "2026-06-30"]],
+      ["amount_total:sum"],
+      ["partner_id"],
+      expect.anything()
+    );
   });
 
   it("leaves logical operators and well-formed conditions untouched", async () => {
@@ -316,6 +479,11 @@ describe("odoo_read — unicode-escaped domain operators", () => {
   // A value that happens to contain a backslash-u sequence is legitimate; only
   // the OPERATOR position is normalized. Rewriting values would corrupt a
   // genuine search string, and no operator can ever legitimately be one.
+  //
+  // The value half of #1198 is NOT closed by that asymmetry — an escaped value
+  // matches nothing and the agent reads the empty result as "there is nothing
+  // there", which is worse than the loud failure this file fixes. Tracked in
+  // #1213; this test pins today's behaviour, not the desired end state.
   it("does not rewrite escape sequences in the value position", async () => {
     mockSearchRead.mockResolvedValue({ records: [], length: 0 });
     const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;

--- a/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
@@ -226,6 +226,113 @@ describe("odoo_read — {item: …} array-wrapping", () => {
   });
 });
 
+// heypinchy/pinchy#1198. Some models emit `<` and `>` in their JSON-escaped
+// form, and when the escape is not decoded on the way in the six-character
+// literal `<=` arrives as the operator. Odoo then rejects the whole
+// domain: `Invalid operator in condition ('date', '<=', '2026-06-30')`.
+// Observed twice on production in one booking session — the date-bounded query
+// the agent needed simply never ran.
+//
+// The escaping happens inside the provider's own tool-argument serialization,
+// not in anything the agent controls, so a prompt cannot suppress it — and the
+// error tells the model nothing it can act on, because the operator looks
+// correct in its own output.
+describe("odoo_read — unicode-escaped domain operators", () => {
+  const ESCAPED: Array<[string, string]> = [
+    ["\\u003c", "<"],
+    ["\\u003c=", "<="],
+    ["\\u003e", ">"],
+    ["\\u003e=", ">="],
+    ["\\u0021=", "!="],
+  ];
+
+  it.each(ESCAPED)("decodes %s to %s before querying Odoo", async (escaped, decoded) => {
+    mockSearchRead.mockResolvedValue({ records: [], length: 0 });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: [["date", escaped, "2026-06-30"]],
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "account.move",
+      [["date", decoded, "2026-06-30"]],
+      expect.anything()
+    );
+  });
+
+  it("decodes uppercase-hex escapes too", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], length: 0 });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+
+    await tool.execute("c", {
+      model: "account.move",
+      filters: [["date", "\\u003C=", "2026-06-30"]],
+    });
+
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "account.move",
+      [["date", "<=", "2026-06-30"]],
+      expect.anything()
+    );
+  });
+
+  // Decoding without validating just moves the dead end one step: the next
+  // escape variant would still reach Odoo. An operator that is not one Odoo
+  // accepts is refused HERE, with the list, so the model can correct itself
+  // instead of reading a server error about a string it believes it never sent.
+  it("refuses an operator Odoo does not accept, before querying", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: [["date", "=<", "2026-06-30"]],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/=</);
+    expect(result.content[0].text).toMatch(/<=/); // names a valid one
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("leaves logical operators and well-formed conditions untouched", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], length: 0 });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+
+    const domain = [
+      "&",
+      ["state", "=", "posted"],
+      "|",
+      ["date", ">=", "2026-06-01"],
+      ["partner_id", "ilike", "acme"],
+    ];
+    await tool.execute("c", { model: "account.move", filters: domain });
+
+    expect(mockSearchRead).toHaveBeenCalledWith("account.move", domain, expect.anything());
+  });
+
+  // A value that happens to contain a backslash-u sequence is legitimate; only
+  // the OPERATOR position is normalized. Rewriting values would corrupt a
+  // genuine search string, and no operator can ever legitimately be one.
+  it("does not rewrite escape sequences in the value position", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], length: 0 });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+
+    await tool.execute("c", {
+      model: "account.move",
+      filters: [["ref", "=", "\\u003cliteral\\u003e"]],
+    });
+
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "account.move",
+      [["ref", "=", "\\u003cliteral\\u003e"]],
+      expect.anything()
+    );
+  });
+});
+
 describe("odoo_write — {item: …} array-wrapping", () => {
   it("refuses item-wrapped values with an actionable message, before touching Odoo", async () => {
     const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_write", agentId)!;

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -362,17 +362,20 @@ export function sortFieldsByPriority(fields: OdooField[]): OdooField[] {
 }
 
 /**
- * Narrow an untrusted, tool-supplied `filters` value into an Odoo search
- * domain. A domain is always an array of `[field, op, value]` tuples plus
- * `&`/`|`/`!` operators; an omitted filter means "match everything" (`[]`).
- * Reject non-array input early with a clear message instead of forwarding
- * garbage to Odoo, where it surfaces as an opaque server error. Individual
- * tuple shapes are left to Odoo to validate.
+ * The logical operators an Odoo domain carries between its conditions, in the
+ * Polish notation Odoo expects.
  */
+const ODOO_LOGICAL_OPERATORS = new Set(["&", "|", "!"]);
+
 /**
  * Every comparison operator Odoo accepts in a search domain. Used to refuse an
  * operator here, with the list, rather than letting Odoo reject the whole
  * domain with a message the model cannot act on.
+ *
+ * This is also the ONE list the `filters` tool description is built from, so
+ * what the model is told and what it is held to cannot drift apart. It is
+ * hand-maintained against Odoo's condition-operator set; if a future Odoo adds
+ * one, it has to be added here.
  */
 const ODOO_DOMAIN_OPERATORS = new Set([
   "=",
@@ -397,61 +400,155 @@ const ODOO_DOMAIN_OPERATORS = new Set([
 ]);
 
 /**
+ * The operators whose VALUE is itself a domain. Their sub-domain gets exactly
+ * the same treatment as the top level: the #1198 escape lands one level in as
+ * readily as at the top, and nothing below here would decode it.
+ */
+const ODOO_NESTED_DOMAIN_OPERATORS = new Set(["any", "not any"]);
+
+/**
+ * Spellings Odoo normalizes away before matching its own operator set: it
+ * lower-cases the operator, and still accepts the legacy `<>` for `!=`.
+ * Refusing those here would reject a domain Odoo runs happily — and sending
+ * the canonical form is never worse than sending the alias, so this stays
+ * correct even if a future Odoo drops the leniency.
+ */
+const ODOO_OPERATOR_ALIASES = new Map([["<>", "!="]]);
+
+/**
  * Turn a literal `\uXXXX` sequence back into the character it denotes.
  *
  * Not a JSON parse — the input has already been through one. Some models emit
- * `<` and `>` in escaped form (the habit that stops you emitting markup), and
- * when that escape survives the provider's tool-argument serialization the
- * six-character string `<=` arrives where an operator belongs.
+ * `<`, `>` and `&` in escaped form (the habit that stops you emitting markup),
+ * and when that escape survives the provider's tool-argument serialization a
+ * six-character literal like `\u003c` arrives where an operator belongs.
  */
-function decodeUnicodeEscapes(value: string): string {
+export function decodeUnicodeEscapes(value: string): string {
   return value.replace(/\\u([0-9a-fA-F]{4})/g, (_match, hex: string) =>
     String.fromCharCode(parseInt(hex, 16))
   );
 }
 
+/** The operator Odoo will see, from the one the model actually sent. */
+function canonicalOperator(rawOperator: string): string {
+  const decoded = decodeUnicodeEscapes(rawOperator).toLowerCase();
+  return ODOO_OPERATOR_ALIASES.get(decoded) ?? decoded;
+}
+
 /**
- * Normalize the operator of one domain condition (heypinchy/pinchy#1198).
+ * Does this entry look like a domain that arrived one level too deep?
  *
- * Decoding alone would only move the dead end — the next escape variant would
- * still reach Odoo — so the decoded operator is validated against
- * `ODOO_DOMAIN_OPERATORS` and refused here if it is not one. The model then
- * gets a message naming what it sent and what it could send instead, at the
- * point where it can still fix it.
+ * `[["&", cond, cond]]` and `[[cond, cond]]` are shapes models produce as
+ * readily as the `{item: …}` artifact `hasItemWrappedArray` catches. Every
+ * element of a domain is either a condition (an array) or a logical operator;
+ * a real condition's first element is a field name, which is neither — so the
+ * two shapes are told apart without guessing. Saying "this is nested" beats
+ * the honest-but-useless "the operator must be a string" that reading the
+ * middle element of such an entry would otherwise produce.
+ */
+function looksLikeNestedDomain(entry: unknown[]): boolean {
+  return (
+    entry.length > 0 &&
+    entry.every(
+      (element) =>
+        Array.isArray(element) ||
+        (typeof element === "string" && ODOO_LOGICAL_OPERATORS.has(element))
+    )
+  );
+}
+
+/**
+ * Decode and validate a bare string entry — a domain's `&`, `|` or `!`.
  *
- * Only the OPERATOR position is touched. A value may legitimately contain a
- * backslash-u sequence — rewriting it would corrupt a genuine search string —
- * while an operator never can.
+ * `&` is the character a model escapes most reflexively of all, so the
+ * operator position of a CONDITION is not the only place #1198 lands.
+ */
+function normalizeLogicalOperator(entry: string): string {
+  const decoded = decodeUnicodeEscapes(entry);
+  if (!ODOO_LOGICAL_OPERATORS.has(decoded)) {
+    throw new Error(
+      `Unsupported domain term ${JSON.stringify(entry)}. A bare string in a domain must be one of ` +
+        `${[...ODOO_LOGICAL_OPERATORS].map((op) => JSON.stringify(op)).join(", ")}; anything else ` +
+        `has to be a [field, operator, value] condition.`
+    );
+  }
+  return decoded;
+}
+
+/**
+ * Normalize the operator of one domain condition, and recurse into the
+ * sub-domain of `any` / `not any`.
+ *
+ * The refusal names the field and the operator and NOT the value: the value is
+ * the model's own search text, it adds nothing to a message about the
+ * operator, and echoing it back into an error message is how caller-supplied
+ * prose ends up being read as a diagnosis by something downstream.
  */
 function normalizeDomainCondition(condition: unknown[]): unknown[] {
   const [field, rawOperator, value] = condition;
   if (typeof rawOperator !== "string") {
     throw new Error(
-      `Invalid operator in condition ${JSON.stringify(condition)}: the operator must be a string, e.g. "=", "in", "ilike".`
+      `Invalid condition on field ${JSON.stringify(field)}: the operator must be a string, ` +
+        `e.g. "=", "in", "ilike" — got ${rawOperator === null ? "null" : typeof rawOperator}.`
     );
   }
 
-  const operator = decodeUnicodeEscapes(rawOperator);
+  const operator = canonicalOperator(rawOperator);
   if (!ODOO_DOMAIN_OPERATORS.has(operator)) {
     throw new Error(
-      `Unsupported operator ${JSON.stringify(rawOperator)} in condition ${JSON.stringify(condition)}. ` +
+      `Unsupported operator ${JSON.stringify(rawOperator)} on field ${JSON.stringify(field)}. ` +
         `Use one of: ${[...ODOO_DOMAIN_OPERATORS].join(", ")}.`
     );
   }
 
-  return operator === rawOperator ? condition : [field, operator, value];
+  const normalizedValue =
+    ODOO_NESTED_DOMAIN_OPERATORS.has(operator) && Array.isArray(value)
+      ? asDomain(value, `the sub-domain of \`${operator}\``)
+      : value;
+
+  return operator === rawOperator && normalizedValue === value
+    ? condition
+    : [field, operator, normalizedValue];
 }
 
-function asDomain(value: unknown): OdooDomain {
+/**
+ * Narrow an untrusted, tool-supplied `filters` value into an Odoo search
+ * domain: a flat list of `&`/`|`/`!` operators and `[field, operator, value]`
+ * conditions, where an omitted filter means "match everything" (`[]`).
+ *
+ * Every OPERATOR position — logical and comparison alike — is decoded and then
+ * validated (heypinchy/pinchy#1198). Decoding alone would only move the dead
+ * end one variant along, so an operator that is still not one Odoo accepts is
+ * refused here, naming what was sent and what could be sent instead, at the
+ * point where the model can still fix it.
+ *
+ * Only operator positions are rewritten. A VALUE may legitimately contain a
+ * backslash-u sequence and rewriting it would corrupt a genuine search string,
+ * while an operator never can. The value half of #1198 is still open (#1213).
+ *
+ * Call this BEFORE `withAuthRetry`: a bad domain is the model's mistake and
+ * not the connection's, and an error raised inside that closure is put through
+ * `isAuthError` — which reads prose, and would spend a credential refresh and
+ * a `report-auth-failure` POST on it.
+ */
+export function asDomain(value: unknown, label = "`filters`"): OdooDomain {
   if (value === undefined || value === null) return [];
   if (!Array.isArray(value)) {
-    throw new Error("`filters` must be an array (an Odoo search domain).");
+    throw new Error(`${label} must be an array (an Odoo search domain).`);
   }
-  // A domain is a flat list of logical operators ("&", "|", "!") and 3-element
-  // conditions. Leave the former alone; normalize the operator of the latter.
-  return value.map((entry) =>
-    Array.isArray(entry) && entry.length === 3 ? normalizeDomainCondition(entry) : entry
-  ) as OdooDomain;
+  return value.map((entry) => {
+    if (typeof entry === "string") return normalizeLogicalOperator(entry);
+    if (Array.isArray(entry)) {
+      if (looksLikeNestedDomain(entry)) {
+        throw new Error(
+          `${label} is nested one level too deep: an entry is itself a list of conditions. ` +
+            `Pass a FLAT list of "&"/"|"/"!" operators and [field, operator, value] conditions.`
+        );
+      }
+      if (entry.length === 3) return normalizeDomainCondition(entry);
+    }
+    return entry;
+  }) as OdooDomain;
 }
 
 interface CompactSchemaOptions {
@@ -3187,7 +3284,8 @@ const plugin = {
                   description: "A [field, operator, value] tuple, e.g. ['state', '=', 'sale']",
                 },
                 description:
-                  'Odoo domain filter. A plain array of [field, operator, value] tuples, e.g. [["state", "=", "posted"]] — never wrap it as {"item": …}. Operators: =, !=, >, >=, <, <=, in, not in, like, ilike. Optional — omit or pass [] to match all records.',
+                  `Odoo domain filter. A plain array of [field, operator, value] tuples, e.g. [["state", "=", "posted"]] — never wrap it as {"item": …}. ` +
+                  `Operators: ${[...ODOO_DOMAIN_OPERATORS].join(", ")}. Optional — omit or pass [] to match all records.`,
               },
               fields: {
                 type: "array",
@@ -3225,13 +3323,20 @@ const plugin = {
                 throw itemWrappedError("fields");
               }
 
+              // Decode and validate the domain HERE, before a client exists (#1198).
+              // A bad operator is the model's mistake, not the connection's — and an
+              // error raised inside withAuthRetry is put through isAuthError, which
+              // reads prose and would spend a credential refresh plus a
+              // report-auth-failure POST on it.
+              const domain = asDomain(params.filters);
+
               const result = await withAuthRetry(agentId, config, async (client) => {
                 const modelFields = normalizeFields(await client.fields(model));
                 const effectiveFields = augmentFieldsWithCompanyId(
                   stripSyntheticFields(params.fields as string[] | undefined),
                   modelFields
                 );
-                const records = await client.searchRead(model, asDomain(params.filters), {
+                const records = await client.searchRead(model, domain, {
                   fields: effectiveFields,
                   limit: clampReadLimit(params.limit),
                   offset: params.offset as number | undefined,
@@ -3295,8 +3400,11 @@ const plugin = {
                 throw itemWrappedError("filters");
               }
 
+              // Decode and validate the domain before querying (see asDomain / odoo_read).
+              const domain = asDomain(params.filters);
+
               const count = await withAuthRetry(agentId, config, (client) =>
-                client.searchCount(model, asDomain(params.filters))
+                client.searchCount(model, domain)
               );
 
               return {
@@ -3375,11 +3483,14 @@ const plugin = {
                 throw itemWrappedError("filters");
               }
 
+              // Decode and validate the domain before querying (see asDomain / odoo_read).
+              const domain = asDomain(params.filters);
+
               const fields = prepareAggregateFields(params.fields, "fields");
               const groupby = prepareAggregateFields(params.groupby, "groupby");
 
               const result = await withAuthRetry(agentId, config, (client) =>
-                client.readGroup(model, asDomain(params.filters), fields, groupby, {
+                client.readGroup(model, domain, fields, groupby, {
                   limit: clampOptionalLimit(params.limit),
                   offset: params.offset as number | undefined,
                   orderby: params.orderby as string | undefined,

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -369,12 +369,89 @@ export function sortFieldsByPriority(fields: OdooField[]): OdooField[] {
  * garbage to Odoo, where it surfaces as an opaque server error. Individual
  * tuple shapes are left to Odoo to validate.
  */
+/**
+ * Every comparison operator Odoo accepts in a search domain. Used to refuse an
+ * operator here, with the list, rather than letting Odoo reject the whole
+ * domain with a message the model cannot act on.
+ */
+const ODOO_DOMAIN_OPERATORS = new Set([
+  "=",
+  "!=",
+  ">",
+  ">=",
+  "<",
+  "<=",
+  "=?",
+  "=like",
+  "=ilike",
+  "like",
+  "not like",
+  "ilike",
+  "not ilike",
+  "in",
+  "not in",
+  "child_of",
+  "parent_of",
+  "any",
+  "not any",
+]);
+
+/**
+ * Turn a literal `\uXXXX` sequence back into the character it denotes.
+ *
+ * Not a JSON parse — the input has already been through one. Some models emit
+ * `<` and `>` in escaped form (the habit that stops you emitting markup), and
+ * when that escape survives the provider's tool-argument serialization the
+ * six-character string `<=` arrives where an operator belongs.
+ */
+function decodeUnicodeEscapes(value: string): string {
+  return value.replace(/\\u([0-9a-fA-F]{4})/g, (_match, hex: string) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+}
+
+/**
+ * Normalize the operator of one domain condition (heypinchy/pinchy#1198).
+ *
+ * Decoding alone would only move the dead end — the next escape variant would
+ * still reach Odoo — so the decoded operator is validated against
+ * `ODOO_DOMAIN_OPERATORS` and refused here if it is not one. The model then
+ * gets a message naming what it sent and what it could send instead, at the
+ * point where it can still fix it.
+ *
+ * Only the OPERATOR position is touched. A value may legitimately contain a
+ * backslash-u sequence — rewriting it would corrupt a genuine search string —
+ * while an operator never can.
+ */
+function normalizeDomainCondition(condition: unknown[]): unknown[] {
+  const [field, rawOperator, value] = condition;
+  if (typeof rawOperator !== "string") {
+    throw new Error(
+      `Invalid operator in condition ${JSON.stringify(condition)}: the operator must be a string, e.g. "=", "in", "ilike".`
+    );
+  }
+
+  const operator = decodeUnicodeEscapes(rawOperator);
+  if (!ODOO_DOMAIN_OPERATORS.has(operator)) {
+    throw new Error(
+      `Unsupported operator ${JSON.stringify(rawOperator)} in condition ${JSON.stringify(condition)}. ` +
+        `Use one of: ${[...ODOO_DOMAIN_OPERATORS].join(", ")}.`
+    );
+  }
+
+  return operator === rawOperator ? condition : [field, operator, value];
+}
+
 function asDomain(value: unknown): OdooDomain {
   if (value === undefined || value === null) return [];
   if (!Array.isArray(value)) {
     throw new Error("`filters` must be an array (an Odoo search domain).");
   }
-  return value as OdooDomain;
+  // A domain is a flat list of logical operators ("&", "|", "!") and 3-element
+  // conditions. Leave the former alone; normalize the operator of the latter.
+  return value.map((entry) =>
+    Array.isArray(entry) && entry.length === 3 ? normalizeDomainCondition(entry) : entry
+  ) as OdooDomain;
 }
 
 interface CompactSchemaOptions {


### PR DESCRIPTION
Refs #1198. The value half of that issue stays open and is tracked separately in #1213.

## What was wrong

`asDomain()` cast `filters` to an `OdooDomain` without looking at it. When a model emits `<` / `>` in escaped form and the escape survives the provider's tool-argument serialization, the six-character literal `<=` lands where an operator belongs and Odoo rejects the whole domain.

Production, 2026-08-18 — the stored audit `params` show the literal, not the character:

```json
"filters": [["account_id", "in", [714, 968, 969, 954]],
            ["date", "\\u003e=", "2026-06-01"],
            ["date", "\\u003c=", "2026-06-30"]]
```

and Odoo's answer, echoing what we handed it:

```
Error: Invalid operator in condition ('date', '<=', '2026-06-30')
```

Twice in one booking session. The date-bounded query the agent needed simply never ran.

## Why a guard rather than a prompt

The escaping happens in the transport, not in anything the agent controls, and the resulting error is unactionable from the model's side — the operator looks correct in its own output, and the server is complaining about a string it does not believe it sent.

## The fix

`asDomain` walks the domain and normalizes **every operator position**, then validates what it decoded:

- **Conditions.** The operator is decoded, canonicalized and checked against `ODOO_DOMAIN_OPERATORS`.
- **Logical operators.** A bare `&` / `|` / `!` gets the same treatment. `&` is the character a model escapes most reflexively of all, so the condition's operator is not the only place this lands.
- **Sub-domains.** `any` / `not any` carry a domain as their value; it goes through the same walk, because the escape lands one level in as readily as at the top.

Validation is not optional garnish. Decoding alone would only move the dead end one variant along — the next escape shape would still reach Odoo. Refusing here names both what was sent and what could be sent instead, at the point where the model can still fix it.

Three things the refusal gets right that are easy to get wrong:

- **It runs before a client exists.** Validating inside the `withAuthRetry` closure costs a credentials round trip and, for `odoo_read`, a real `fields_get` RPC before the plugin says no — and an error raised in there is put through `isAuthError`, which reads prose. A domain like `[["name", "contains", "Unauthorized charge dispute"]]` would then be read as stale credentials, spend a credential refresh and POST `report-auth-failure`, flipping the connection to `auth_failed` with an admin banner and an audit row for an auth failure that never happened (AGENTS.md § "Three Digits Are Not A Status").
- **It names the field and the operator, never the value.** The value is the model's own search text; it adds nothing to a message about the operator, and echoing it back is how caller-supplied prose ends up being read as a diagnosis by something downstream.
- **It is lenient exactly where Odoo is.** Odoo lower-cases the operator and still accepts the legacy `<>` for `!=`, so `ILIKE`, `In` and `<>` are canonicalized rather than refused — all three reached Odoo happily before this PR. Sending the canonical form is never worse than sending the alias, so this stays correct even if a future Odoo drops the leniency.

A domain that arrived one level too deep (`[["&", cond, cond]]` — a shape models produce as readily as the `{item: …}` artifact) is told apart from a condition and refused by name, instead of yielding the true-but-useless "the operator must be a string".

Only **operator** positions are normalized. A value may legitimately contain a backslash-u sequence and rewriting it would corrupt a real search string; an operator never can. There is a test pinning that asymmetry — and it cites #1213, because the asymmetry is not a resolution: an escaped value matches nothing and the agent reads the empty result as "there is nothing there", which is worse than the loud failure this PR fixes.

The `filters` tool description is now built from `ODOO_DOMAIN_OPERATORS`. It advertised ten operators while the enforcer accepted nineteen; one list means the two cannot drift apart.

## Verification

- `arg-robustness.test.ts`: 48 passed. Six canaries, each reverting one half of the change, each turning the suite red on exactly the assertion that half exists for: no `toLowerCase`, no `<>` alias, logical operators passed through, no sub-domain recursion, no nested-shape detection, and validation moved back inside `withAuthRetry` (that last one fails on `expect(mockFields).not.toHaveBeenCalled()` — "before querying" has to mean before the *first* Odoo call, not before `search_read`).
- pinchy-odoo package suite: 566 passed.
- `pnpm test`: 12300 passed / 18 skipped. `pnpm test:scripts`: 1241 passed. `pnpm typecheck:plugins`: all 10 clean. `pnpm format:check`: clean.

## Behaviour change worth naming

An operator that is not in Odoo's set is now refused by the plugin instead of by Odoo. Same outcome, earlier and with a better message — but it does mean the plugin holds an opinion about the operator set. `ODOO_DOMAIN_OPERATORS` covers Odoo 19's comparison operators including `any` / `not any` and `=?`; if a future Odoo adds one, it has to be added there too. Nothing in the repo can catch that drift on its own — the odoo mock's `evaluateLeaf` falls through to `default: return true`, so an E2E stack accepts every operator, escaped ones included.
