### PR TITLE
feat(odoo): resolve a many2one by its natural-key code, not just by name

### DIFF
--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -156,6 +156,39 @@ If your Odoo database hosts more than one `res.company`, Pinchy adds two layers 
 
 The stock **Finance Controller** and **Bookkeeper** templates also include guidance that teaches the agent to disambiguate multi-company records up front. (Finance Controller suggests **Penny** as one of its agent names, so you may see this agent under that name.) Newly-created agents pick this up automatically; existing agents keep their stored `AGENTS.md` until you recreate them, but the runtime cross-company guard applies regardless.
 
+## How an agent names a record
+
+Every `odoo_create` and `odoo_write` has to turn what the agent knows into an
+Odoo record. Four forms resolve, and none of them is a database id:
+
+- **An opaque reference** returned by `odoo_read` (`_pinchy_ref`), passed back
+  verbatim. It names one record exactly, including the company it belongs to,
+  so it is the form that never collides.
+- **An exact name**, matched against the record's name or the display name Odoo
+  itself renders.
+- **A code**, where the relation has one. A GL account or a journal resolves
+  from its code alone — `"7660"` — or from the `"7660 Entertainment expenses"`
+  form a chart of accounts prints and most Odoo account pickers show. This is
+  how accountants address an account, and it is the one route a bare number
+  takes.
+- **A country code**, for `res.country`: `"AT"`, or a name Pinchy recognises.
+
+**A raw database id is refused**, and the refusal says so. An agent that has
+seen an id in a URL will try it, and a write that lands on whatever record
+happens to carry that id is worse than a failed one. The single exception is the
+code route above: on a relation that has a code, a number is matched against
+that column and never against the id.
+
+**An exact name wins over a code.** If the value matches a record's name
+outright, that record is used, even when its first word happens to be another
+record's code — so an analytic account called "IT Infrastructure" is never
+mistaken for whatever carries the code "IT".
+
+**A code that two companies share reports the collision** rather than picking
+one, and names both companies. Adding `company_id` to the same create scopes the
+lookup and resolves it; so does the fully qualified `"<code> <name>"` form, when
+the names differ.
+
 ## Duplicate vendor bills
 
 Filing the same supplier invoice twice is double payment — one of the failure modes teams fear most from an autonomous agent. So before an agent creates a vendor bill or vendor credit note (`account.move` with `move_type` `in_invoice` or `in_refund`), the `pinchy-odoo` plugin checks whether a bill with the same reference (`ref` — the supplier's invoice number) is already on file, scoped to the company and partner when the create supplies them.

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -51,6 +51,7 @@ import plugin, {
   findInvalidSelectionValues,
   formatInvalidSelectionError,
   PRODUCT_REF_DISAMBIGUATION_HINT,
+  MANY2ONE_VALUE_HINT,
   enforceReadResultBudget,
   ODOO_READ_RESULT_BUDGET_CHARS,
   ODOO_READ_TRUNCATION_HINT,
@@ -7462,19 +7463,22 @@ describe("many2one lookup by natural-key code (#1197)", () => {
     );
   });
 
+  // Asserted as the exact domain, not as a substring of the serialised one: a
+  // `JSON.stringify(...).toContain("code")` is green for `["code", "ilike", …]`,
+  // for a `code` that only appears in the field list, and for a domain missing
+  // the `"|"` operator — which is an implicit AND and a different query.
   it("asks Odoo for the code column and searches on it", async () => {
     mockAccountCandidates([ACCOUNT]);
 
     await createWithAccount("7660");
 
     const call = mockSearchRead.mock.calls.find((c) => c[0] === "account.account")!;
-    expect(call[0]).toBe("account.account");
     expect((call[2] as { fields: string[] }).fields).toContain("code");
-    expect(JSON.stringify(call[1])).toContain("code");
+    expect(call[1]).toEqual(["|", ["code", "=", "7660"], ["name", "ilike", "7660"]]);
   });
 
   // The guard that refuses a raw database id has to survive this. It is
-  // relaxed ONLY where the relation actually declares a `code`, and a numeric
+  // relaxed ONLY where the relation declares a searchable `code`, and a numeric
   // string is then matched against `code` — never against `id` — so "an agent
   // cannot address a record by its primary key" still holds.
   it("still refuses a numeric string for a relation that has no code column", async () => {
@@ -7504,6 +7508,9 @@ describe("many2one lookup by natural-key code (#1197)", () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
+  // The decoy's *name* starts with the code being looked up, so it is the
+  // `ilike` half of the search that produced it — nothing about it is an exact
+  // name, which is what the code token is allowed to outrank (#1206 review).
   it("prefers an exact code match over a name that merely matched the search", async () => {
     mockAccountCandidates([{ id: 55, name: "7660 reclass suspense", code: "9999" }, ACCOUNT]);
 
@@ -7524,5 +7531,368 @@ describe("many2one lookup by natural-key code (#1197)", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/Could not resolve account_id/);
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review of #1206 — the natural-key lookup, at the edges the first pass missed.
+//
+// Five of these are red without the follow-up: a `code` column that Odoo
+// cannot search (`product.product.code` is a non-stored compute aliasing
+// `default_code`), a derived code token outranking an exact name, a code-only
+// lookup still OR-ing `name ilike ""` (every row) into its domain, a duplicate
+// code aborting before the name that disambiguates it, and `parseLookup`'s
+// res.country upper-casing leaking onto every other relation.
+// ---------------------------------------------------------------------------
+describe("many2one natural-key lookup, edge cases (#1206 review)", () => {
+  const config = {
+    connectionId: "conn-test-1",
+    permissions: {
+      "account.move.line": ["read", "create", "write"],
+      "account.account": ["read"],
+      "account.journal": ["read"],
+      "product.product": ["read"],
+      "res.partner": ["read"],
+      "res.country": ["read"],
+    },
+  } as unknown as AgentOdooConfig;
+
+  const LINE_FIELDS = [
+    { name: "name", string: "Label", type: "char" },
+    { name: "account_id", string: "Account", type: "many2one", relation: "account.account" },
+    { name: "journal_id", string: "Journal", type: "many2one", relation: "account.journal" },
+    { name: "product_id", string: "Product", type: "many2one", relation: "product.product" },
+    { name: "partner_id", string: "Partner", type: "many2one", relation: "res.partner" },
+    { name: "country_id", string: "Country", type: "many2one", relation: "res.country" },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  const NAME_ONLY = [{ name: "name", string: "Name", type: "char" }];
+  const NAME_AND_CODE = [...NAME_ONLY, { name: "code", string: "Code", type: "char" }];
+
+  /**
+   * Schema per relation, keyed by model. The defaults mirror Odoo: accounts,
+   * journals and countries carry a `code`; partners and products do not
+   * (a product's human-readable key is `default_code`, and its `code` is the
+   * unsearchable compute these tests exist for). `relations` overrides one.
+   */
+  function mockSchema(relations: Record<string, Array<Record<string, unknown>>>) {
+    const defaults: Record<string, Array<Record<string, unknown>>> = {
+      "account.account": NAME_AND_CODE,
+      "account.journal": NAME_AND_CODE,
+      "res.country": NAME_AND_CODE,
+    };
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move.line") return LINE_FIELDS;
+      return relations[model] ?? defaults[model] ?? NAME_ONLY;
+    });
+  }
+
+  /**
+   * Candidate rows per relation. Anything else is the post-write read-back
+   * (#720), which compares the verbatim scalars it was sent — so it has to
+   * echo the label every `create` below writes, not the relation's rows. One
+   * blanket `mockResolvedValue` serves the relation rows to the read-back too
+   * and reports a mismatch that reads exactly like a product failure.
+   */
+  const WRITTEN_LABEL = "x";
+  function mockCandidates(byModel: Record<string, Array<Record<string, unknown>>>) {
+    mockSearchRead.mockImplementation(async (model: string) => {
+      const records = byModel[model];
+      if (records) return { records, total: records.length, limit: 20, offset: 0 };
+      return { records: [{ id: 1234, name: WRITTEN_LABEL }], total: 1, limit: 1, offset: 0 };
+    });
+  }
+
+  function create(values: Record<string, unknown>) {
+    mockCreate.mockResolvedValue(1234);
+    const tool = findTool(createApi({ [agentId]: config }), "odoo_create", agentId)!;
+    return tool.execute("call-1", { model: "account.move.line", values });
+  }
+
+  function domainFor(model: string): unknown {
+    return mockSearchRead.mock.calls.find((c) => c[0] === model)?.[1];
+  }
+
+  function fieldsFor(model: string): string[] | undefined {
+    const call = mockSearchRead.mock.calls.find((c) => c[0] === model);
+    return call ? (call[2] as { fields: string[] }).fields : undefined;
+  }
+
+  // `product.product.code` exists in every Odoo — a non-stored compute with no
+  // `search` method, mirroring `default_code`. `fields_get` reports it
+  // `searchable: false`, and a `["code", "=", …]` leaf on it is either refused
+  // outright or silently widened to every row, which would put 20 arbitrary
+  // products in front of a lookup that resolved by name before.
+  it("does not search a `code` column Odoo reports as unsearchable", async () => {
+    mockSchema({
+      "product.product": [
+        { name: "name", string: "Name", type: "char" },
+        { name: "code", string: "Reference", type: "char", searchable: false },
+        { name: "default_code", string: "Internal Reference", type: "char" },
+      ],
+    });
+    mockCandidates({ "product.product": [{ id: 8, name: "Office Chair" }] });
+
+    const result = await create({ name: WRITTEN_LABEL, product_id: "Office Chair" });
+
+    expect(result.isError).toBeFalsy();
+    expect(domainFor("product.product")).toEqual([["name", "ilike", "Office Chair"]]);
+    expect(fieldsFor("product.product")).not.toContain("code");
+  });
+
+  it("still refuses a numeric string when the `code` column is unsearchable", async () => {
+    mockSchema({
+      "product.product": [
+        { name: "name", string: "Name", type: "char" },
+        { name: "code", string: "Reference", type: "char", searchable: false },
+      ],
+    });
+
+    const result = await create({ name: "x", product_id: "42" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Raw numeric IDs are not accepted");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // The payload above is the one Odoo WOULD send; the one it actually sends
+  // today omits `searchable`, because odoo-node's `fields_get` does not ask for
+  // it. This is that payload — `code` beside `default_code`, which is the shape
+  // that says the stored natural key is `default_code` and `code` mirrors it.
+  it("declines a `code` that shadows a stored `default_code`", async () => {
+    mockSchema({
+      "product.product": [
+        { name: "name", string: "Name", type: "char" },
+        { name: "code", string: "Reference", type: "char" },
+        { name: "default_code", string: "Internal Reference", type: "char" },
+      ],
+    });
+    mockCandidates({ "product.product": [{ id: 8, name: "Office Chair" }] });
+
+    const byName = await create({ name: WRITTEN_LABEL, product_id: "Office Chair" });
+    expect(byName.isError).toBeFalsy();
+    expect(domainFor("product.product")).toEqual([["name", "ilike", "Office Chair"]]);
+
+    vi.clearAllMocks();
+    mockSchema({
+      "product.product": [
+        { name: "name", string: "Name", type: "char" },
+        { name: "code", string: "Reference", type: "char" },
+        { name: "default_code", string: "Internal Reference", type: "char" },
+      ],
+    });
+    const byNumber = await create({ name: "x", product_id: "42" });
+    expect(byNumber.isError).toBe(true);
+    expect(byNumber.content[0].text).toContain("Raw numeric IDs are not accepted");
+  });
+
+  // Same question one attribute over: `findCompanyIdField` has always checked
+  // the field TYPE as well as the name, and a `code` that is not a char column
+  // is not a natural key either.
+  it("still refuses a numeric string when `code` is not a char column", async () => {
+    mockSchema({
+      "product.product": [
+        { name: "name", string: "Name", type: "char" },
+        { name: "code", string: "Code", type: "selection", selection: [["a", "A"]] },
+      ],
+    });
+
+    const result = await create({ name: "x", product_id: "42" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Raw numeric IDs are not accepted");
+  });
+
+  // The claim "relations without a code are untouched — same fields, same
+  // domain as before" was a comment. Here it is a checked one.
+  it("leaves the domain and field list of a code-less relation untouched", async () => {
+    mockSchema({ "res.partner": [{ name: "name", string: "Name", type: "char" }] });
+    mockCandidates({ "res.partner": [{ id: 5, name: "Acme GmbH" }] });
+
+    const result = await create({ name: "x", partner_id: "Acme GmbH" });
+
+    expect(result.isError).toBeFalsy();
+    expect(domainFor("res.partner")).toEqual([["name", "ilike", "Acme GmbH"]]);
+    expect(fieldsFor("res.partner")).toEqual(["id", "name", "display_name"]);
+  });
+
+  // An exact name is a fact about the input; a leading token is a guess about
+  // its shape. Analytic-style codes ("IT", "HR", "R&D") collide with the first
+  // word of ordinary names, and picking the code match writes to the wrong
+  // record with no error at all.
+  it("resolves an exact name ahead of a record whose code is its leading word", async () => {
+    mockSchema({});
+    mockCandidates({
+      "account.account": [
+        { id: 70, name: "IT Infrastructure", code: "INFRA" },
+        { id: 71, name: "Support", code: "IT" },
+      ],
+    });
+
+    const result = await create({ name: "x", account_id: "IT Infrastructure" });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ account_id: 70 })
+    );
+  });
+
+  // `ilike ""` is `LIKE '%%'` — every row. OR-ed against the code leaf it puts
+  // the whole table in front of the one record that was asked for, and
+  // `limit: 20` then decides whether the answer is in the window.
+  it("queries the code alone when the lookup carries no name", async () => {
+    mockSchema({});
+    mockCandidates({
+      "account.account": [{ id: 91, name: "Entertainment expenses", code: "7660" }],
+    });
+
+    const result = await create({ name: "x", account_id: { lookup: { code: "7660" } } });
+
+    expect(result.isError).toBeFalsy();
+    expect(domainFor("account.account")).toEqual([["code", "=", "7660"]]);
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ account_id: 91 })
+    );
+  });
+
+  // A duplicate code is the multi-company case, and the composite form carries
+  // exactly what tells the two apart. Throwing on the code discards it.
+  it("falls through to the name when the code alone is ambiguous", async () => {
+    mockSchema({});
+    mockCandidates({
+      "account.account": [
+        { id: 40, name: "Bank Helmcraft", display_name: "1800 Bank Helmcraft", code: "1800" },
+        { id: 41, name: "Bank Clemens", display_name: "1800 Bank Clemens", code: "1800" },
+      ],
+    });
+
+    const result = await create({ name: "x", account_id: "1800 Bank Helmcraft" });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ account_id: 40 })
+    );
+  });
+
+  // When nothing tells them apart, the message has to be the one the codebase
+  // already writes for this: name the companies and the `company_id` remedy,
+  // not a deduplicated suggestion list of one.
+  it("explains a duplicate code across companies as a multi-company collision", async () => {
+    mockSchema({
+      "account.account": [
+        { name: "name", string: "Name", type: "char" },
+        { name: "code", string: "Code", type: "char" },
+        { name: "company_id", string: "Company", type: "many2one", relation: "res.company" },
+      ],
+    });
+    mockCandidates({
+      "account.account": [
+        { id: 40, name: "Bank", code: "1800", company_id: [1, "Helmcraft GmbH"] },
+        { id: 41, name: "Bank", code: "1800", company_id: [2, "Clemens Helm"] },
+      ],
+    });
+
+    const result = await create({ name: "x", account_id: "1800" });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain("multi-company collision");
+    expect(text).toContain("Helmcraft GmbH");
+    expect(text).toContain("Clemens Helm");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // `parseLookup` upper-cases `lookup.code` because ISO 3166-1 alpha-2 is
+  // upper-case. Journal and account codes are not, and `=` on a char column is
+  // case-sensitive in Postgres — so the normalisation has to stay where the
+  // fact it encodes is true.
+  it("passes an explicit code to Odoo verbatim on a non-country relation", async () => {
+    mockSchema({});
+    mockCandidates({ "account.journal": [{ id: 17, name: "Bank", code: "bnk1" }] });
+
+    const result = await create({ name: "x", journal_id: { lookup: { code: "bnk1" } } });
+
+    expect(result.isError).toBeFalsy();
+    expect(domainFor("account.journal")).toEqual([["code", "=", "bnk1"]]);
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ journal_id: 17 })
+    );
+  });
+
+  it("still normalises a country code to upper case", async () => {
+    mockSchema({});
+    mockCandidates({ "res.country": [{ id: 14, name: "Austria", code: "AT" }] });
+
+    const result = await create({ name: "x", country_id: { lookup: { code: "at" } } });
+
+    expect(result.isError).toBeFalsy();
+    expect(domainFor("res.country")).toEqual([["code", "=", "AT"]]);
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ country_id: 14 })
+    );
+  });
+
+  // The candidate arrived through the NAME leg, so the case difference is real
+  // rather than a fixture: only the client-side comparison can close it.
+  it("matches an explicit code against a record whose code differs only in case", async () => {
+    mockSchema({});
+    mockCandidates({
+      "account.journal": [{ id: 17, name: "Miscellaneous Operations", code: "BNK1" }],
+    });
+
+    const result = await create({
+      name: "x",
+      journal_id: { lookup: { code: "bnk1", name: "Miscellaneous" } },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ journal_id: 17 })
+    );
+  });
+
+  // A country code is ISO 3166-1 alpha-2 and never numeric, so a numeric
+  // country value is a raw database id and nothing else. Relaxing the guard
+  // there traded a precise refusal for a generic "could not resolve" — and an
+  // Odoo round trip to reach it.
+  it("refuses a numeric country value outright, without querying Odoo", async () => {
+    mockSchema({});
+
+    const result = await create({ name: "x", country_id: "42" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Raw numeric IDs are not accepted");
+    expect(mockSearchRead.mock.calls.filter((c) => c[0] === "res.country")).toHaveLength(0);
+  });
+});
+
+// The route the resolver gained is worth nothing until the model is told about
+// it — and the description it reads said the opposite: "do not pass raw numeric
+// IDs", which is exactly what a bare GL account code looks like. One shared
+// constant so the two tools cannot drift, mirroring
+// PRODUCT_REF_DISAMBIGUATION_HINT.
+describe("MANY2ONE_VALUE_HINT (#1206 review)", () => {
+  it("names the code route the resolver now supports", () => {
+    expect(MANY2ONE_VALUE_HINT).toContain("code");
+    expect(MANY2ONE_VALUE_HINT).toContain("7660 Entertainment expenses");
+  });
+
+  it("is spliced into both writing tools", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    for (const name of ["odoo_create", "odoo_write"]) {
+      const tool = findTool(tools, name, agentId)!;
+      expect(tool.description).toContain(MANY2ONE_VALUE_HINT);
+    }
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -7340,3 +7340,189 @@ describe("odoo_set_approval", () => {
     expect(mockCallMethod).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// heypinchy/pinchy#1197 — many2one lookup by natural-key code.
+//
+// `resolveReferenceFromRecords` matched `name`/`display_name` only, and codes
+// were special-cased for exactly one relation (res.country). So an accounting
+// agent could not address a GL account the way accountants do: by its number.
+//
+// Production, 2026-08-17: five consecutive odoo_create failures, all
+// "Could not resolve account_id from '<code> <name>'. Provide an exact Account
+// name or ref." — the string a human reads off a chart of accounts, and the one
+// Odoo itself renders in most account pickers. The model then tried a bare code
+// and hit "Raw numeric IDs are not accepted", which closed the last route.
+// ---------------------------------------------------------------------------
+describe("many2one lookup by natural-key code (#1197)", () => {
+  const accountingConfig = {
+    connectionId: "conn-test-1",
+    permissions: {
+      "account.move.line": ["read", "create", "write"],
+      "account.account": ["read"],
+    },
+  } as unknown as AgentOdooConfig;
+
+  const ACCOUNT = { id: 91, name: "Entertainment expenses", code: "7660" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  function mockAccountingSchema() {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move.line") {
+        return [
+          { name: "name", string: "Label", type: "char" },
+          {
+            name: "account_id",
+            string: "Account",
+            type: "many2one",
+            relation: "account.account",
+          },
+        ];
+      }
+      if (model === "account.account") {
+        return [
+          { name: "name", string: "Name", type: "char" },
+          { name: "code", string: "Code", type: "char" },
+        ];
+      }
+      return [];
+    });
+  }
+
+  /**
+   * `searchRead` is called twice per create here and the two calls want
+   * different answers: once against account.account to find the m2o candidates,
+   * and once against account.move.line for the post-write read-back
+   * verification (#720). One blanket mockResolvedValue serves the account rows
+   * to the read-back too, which then reports the created label as mismatched —
+   * a fixture artefact that looks exactly like a product failure.
+   */
+  function mockAccountCandidates(records: Array<Record<string, unknown>>) {
+    mockSearchRead.mockImplementation(async (model: string) => {
+      if (model === "account.account") {
+        return { records, total: records.length, limit: 20, offset: 0 };
+      }
+      // read-back: the row as written
+      return {
+        records: [{ id: 1234, name: "Business lunch", account_id: [91, "Entertainment expenses"] }],
+        total: 1,
+        limit: 1,
+        offset: 0,
+      };
+    });
+  }
+
+  async function createWithAccount(accountValue: unknown) {
+    mockAccountingSchema();
+    mockCreate.mockResolvedValue(1234);
+    const tool = findTool(createApi({ [agentId]: accountingConfig }), "odoo_create", agentId)!;
+    return tool.execute("call-1", {
+      model: "account.move.line",
+      values: { name: "Business lunch", account_id: accountValue },
+    });
+  }
+
+  it("resolves an account from its bare code", async () => {
+    mockAccountCandidates([ACCOUNT]);
+
+    const result = await createWithAccount("7660");
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ account_id: 91 })
+    );
+  });
+
+  it("resolves the '<code> <name>' form a chart of accounts prints", async () => {
+    mockAccountCandidates([ACCOUNT]);
+
+    const result = await createWithAccount("7660 Entertainment expenses");
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ account_id: 91 })
+    );
+  });
+
+  it("still resolves by name alone", async () => {
+    mockAccountCandidates([ACCOUNT]);
+
+    const result = await createWithAccount("Entertainment expenses");
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ account_id: 91 })
+    );
+  });
+
+  it("asks Odoo for the code column and searches on it", async () => {
+    mockAccountCandidates([ACCOUNT]);
+
+    await createWithAccount("7660");
+
+    const call = mockSearchRead.mock.calls.find((c) => c[0] === "account.account")!;
+    expect(call[0]).toBe("account.account");
+    expect((call[2] as { fields: string[] }).fields).toContain("code");
+    expect(JSON.stringify(call[1])).toContain("code");
+  });
+
+  // The guard that refuses a raw database id has to survive this. It is
+  // relaxed ONLY where the relation actually declares a `code`, and a numeric
+  // string is then matched against `code` — never against `id` — so "an agent
+  // cannot address a record by its primary key" still holds.
+  it("still refuses a numeric string for a relation that has no code column", async () => {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move.line") {
+        return [
+          { name: "name", string: "Label", type: "char" },
+          {
+            name: "partner_id",
+            string: "Partner",
+            type: "many2one",
+            relation: "res.partner",
+          },
+        ];
+      }
+      return [{ name: "name", string: "Name", type: "char" }];
+    });
+    const tool = findTool(createApi({ [agentId]: accountingConfig }), "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      model: "account.move.line",
+      values: { name: "x", partner_id: "42" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Raw numeric IDs are not accepted");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("prefers an exact code match over a name that merely matched the search", async () => {
+    mockAccountCandidates([{ id: 55, name: "7660 reclass suspense", code: "9999" }, ACCOUNT]);
+
+    const result = await createWithAccount("7660");
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move.line",
+      expect.objectContaining({ account_id: 91 })
+    );
+  });
+
+  it("reports an ambiguity rather than guessing when two accounts share the code", async () => {
+    mockAccountCandidates([ACCOUNT, { id: 92, name: "Entertainment (branch)", code: "7660" }]);
+
+    const result = await createWithAccount("7660");
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Could not resolve account_id/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -552,6 +552,16 @@ export function relationHasCompanyId(fields: OdooField[]): boolean {
   return findCompanyIdField(fields) !== undefined;
 }
 
+/**
+ * Does this relation carry a `code` column — the natural key a user actually
+ * quotes (account.account, account.journal, account.tax)? Decides both whether
+ * the lookup searches it and whether a numeric string may be a code rather than
+ * an illegal raw id (heypinchy/pinchy#1197).
+ */
+export function relationHasCode(fields: OdooField[]): boolean {
+  return fields.some((f) => f.name === "code");
+}
+
 export function augmentFieldsWithCompanyId(
   requested: string[] | undefined,
   modelFields: OdooField[]
@@ -823,6 +833,26 @@ function parseLookup(field: OdooField, value: unknown): RelationLookup | null {
   };
 }
 
+/**
+ * The natural-key token of a lookup string (heypinchy/pinchy#1197).
+ *
+ * Accountants address a GL account by its number, and a chart of accounts
+ * prints `"7660 Entertainment expenses"` — which is also what Odoo renders in
+ * most account pickers. Both forms have to resolve, so the leading whitespace-
+ * delimited token is what gets compared against `code`.
+ *
+ * An explicit `{lookup: {code}}` wins outright; otherwise the first token of
+ * the name is tried. A plain name simply yields a token that matches no code
+ * and falls through to the existing name matching.
+ */
+function codeTokenOf(lookup: RelationLookup): string | null {
+  if (lookup.code) return lookup.code;
+  const name = lookup.name?.trim();
+  if (!name) return null;
+  const [head] = name.split(/\s+/, 1);
+  return head || null;
+}
+
 function resolveReferenceFromRecords(
   field: OdooField,
   lookup: RelationLookup,
@@ -840,6 +870,21 @@ function resolveReferenceFromRecords(
     if (ids.length > 1) {
       throw new Error(
         `Could not resolve ${field.name}: multiple countries match code "${lookup.code}".`
+      );
+    }
+  }
+
+  // Natural-key match, before the name match so an exact code beats a record
+  // that merely turned up in the `ilike` half of the search (#1197).
+  const codeToken = codeTokenOf(lookup);
+  if (codeToken) {
+    const codeMatches = records.filter((record) => recordText(record, "code") === codeToken);
+    const codeIds = uniqueIds(codeMatches);
+    if (codeIds.length === 1) return codeIds[0];
+    if (codeIds.length > 1) {
+      throw new Error(
+        `Could not resolve ${field.name}: multiple ${label} records share the code "${codeToken}".` +
+          `${formatSuggestions(codeMatches)} Pass the ref returned by odoo_read instead.`
       );
     }
   }
@@ -1226,11 +1271,19 @@ async function searchRelationByName(
 ): Promise<unknown> {
   const relation = field.relation as string;
   const relationFields = await loadFields(client, relation, fieldsCache);
-  const lookupFields = augmentFieldsWithCompanyId(
-    ["id", "name", "display_name"],
-    relationFields
-  ) ?? ["id", "name", "display_name"];
-  const domain: OdooDomain = [["name", "ilike", lookup.name ?? ""]];
+  // Relations with a natural key (account.account.code, account.journal.code,
+  // product.product.default_code) are addressed by that key in practice, so ask
+  // for the column and search it alongside the name (#1197). Relations without
+  // one are untouched — same fields, same domain as before.
+  const hasCode = relationHasCode(relationFields);
+  const baseFields = hasCode
+    ? ["id", "name", "display_name", "code"]
+    : ["id", "name", "display_name"];
+  const lookupFields = augmentFieldsWithCompanyId(baseFields, relationFields) ?? baseFields;
+  const codeToken = hasCode ? codeTokenOf(lookup) : null;
+  const domain: OdooDomain = codeToken
+    ? ["|", ["name", "ilike", lookup.name ?? ""], ["code", "=", codeToken]]
+    : [["name", "ilike", lookup.name ?? ""]];
   if (scopeCompanyId !== null && relationHasCompanyId(relationFields)) {
     // Mirror Odoo's `_check_company_domain`: include SHARED records
     // (company_id = false), not just the target company. A strict
@@ -1351,9 +1404,20 @@ async function resolveRelationValue(
   if (!lookup) return value;
   if (lookup.name === "") return false;
   if (lookup.name && /^\d+$/.test(lookup.name)) {
-    throw new Error(
-      `Raw numeric IDs are not accepted for ${field.name}. Use an opaque ref or lookup.`
-    );
+    // A GL account code IS numeric ("7660"), so refusing every numeric string
+    // left an accountant's most natural input with no route at all — and the
+    // ref-corruption workaround the model reached for next hit this same wall
+    // (#1197, #1193). Relaxed ONLY where the relation declares a `code`, and
+    // even then the value is matched against `code`, never against `id`: "an
+    // agent cannot address a record by its primary key" still holds.
+    const relationHasCodeColumn = field.relation
+      ? relationHasCode(await loadFields(client, field.relation, fieldsCache))
+      : false;
+    if (!relationHasCodeColumn) {
+      throw new Error(
+        `Raw numeric IDs are not accepted for ${field.name}. Use an opaque ref or lookup.`
+      );
+    }
   }
   if (!field.relation) return value;
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -119,6 +119,16 @@ export interface OdooField {
   selection?: Array<[string, string]>;
   readonly?: boolean;
   required?: boolean;
+  /**
+   * `fields_get`'s own verdict on whether a domain may reference this field:
+   * `bool(field.store or field.search)`. Carried because `store` alone answers
+   * the wrong question — `account.account.code` is non-stored from Odoo 18 (the
+   * value lives in `account.code.mapping`) yet declares `_search_code`, while
+   * `product.product.code` is a non-stored compute with no search method at
+   * all. Absent from a payload means "unknown", which is treated as searchable
+   * so an older `fields_get` behaves as it always did.
+   */
+  searchable?: boolean;
 }
 
 type OdooRecord = Record<string, unknown>;
@@ -406,6 +416,21 @@ const DEFAULT_CODE_DISAMBIGUATION_NOTE =
   "Human-readable internal reference / SKU. NOT the database id.";
 
 /**
+ * Shared many2one guidance for the two writing tools (`odoo_create`,
+ * `odoo_write`). Spliced verbatim into both so the wording cannot drift, and
+ * so a test can pin it in one place — same contract as
+ * {@link PRODUCT_REF_DISAMBIGUATION_HINT}.
+ *
+ * The code half is not decoration. #1197 gave the resolver a natural-key route,
+ * and the description the model actually reads still said "do not pass raw
+ * numeric IDs" and named country codes as the only supported lookup — which is
+ * precisely what a bare GL account code looks like from the outside. A route
+ * the caller is told not to take is not a route.
+ */
+export const MANY2ONE_VALUE_HINT =
+  'For many2one fields, do not pass raw database IDs; use an opaque ref from odoo_read, an exact display name, or the record\'s own code where it has one. A GL account or journal resolves from its code alone ("7660") or from the "<code> <name>" form a chart of accounts prints ("7660 Entertainment expenses"), and a country from its ISO code.';
+
+/**
  * Shared hint for tool descriptions whose tools accept domain filters
  * (`odoo_read`, `odoo_count`, `odoo_aggregate`). Spliced verbatim into every
  * such description so the disambiguation wording stays in lockstep across
@@ -553,13 +578,49 @@ export function relationHasCompanyId(fields: OdooField[]): boolean {
 }
 
 /**
- * Does this relation carry a `code` column — the natural key a user actually
- * quotes (account.account, account.journal, account.tax)? Decides both whether
- * the lookup searches it and whether a numeric string may be a code rather than
- * an illegal raw id (heypinchy/pinchy#1197).
+ * The relation's natural-key column: a `code` a lookup may actually search —
+ * the number a user quotes for a GL account or a journal (heypinchy/pinchy#1197).
+ *
+ * The name alone is not the question, and neither is storage. Every Odoo
+ * defines `product.product.code`, a non-stored compute mirroring `default_code`
+ * with no `search` method, so a `["code", "=", …]` leaf on it is either refused
+ * or silently widened to every row — and `product_id` is one of the most-used
+ * many2one lookups there is. `account.account.code` is *also* non-stored from
+ * Odoo 18 (the value moved to `account.code.mapping`) but declares
+ * `_search_code`. `fields_get` collapses exactly that distinction into
+ * `searchable`, so that is the question to ask. The type check mirrors
+ * {@link findCompanyIdField}: a `code` that is not a char column is not a
+ * natural key either.
+ *
+ * Two readings, because today only one of them can fire. `odoo-node`'s
+ * `client.fields()` asks `fields_get` for a fixed attribute list — string,
+ * type, required, readonly, relation, selection — and Odoo returns only what is
+ * asked for, so `searchable` never arrives. Adding it there is a one-line change
+ * in that package and this function honours it the moment it does. Until then
+ * the schema still answers the question for the case that matters: a relation
+ * exposing `default_code` has its stored natural key in THAT column, and its
+ * `code` is the compute mirroring it. That is `product.product` exactly, and
+ * nothing else in Odoo's core carries both.
+ *
+ * Getting it wrong is silent in the worst direction: Odoo answers a domain leaf
+ * on an unsearchable field by substituting a TRUE leaf and logging
+ * `Non-stored field … cannot be searched` server-side. The caller sees no
+ * error — just a search that matched every row, with `limit` deciding the
+ * answer.
+ */
+function findCodeField(fields: OdooField[]): OdooField | undefined {
+  const code = fields.find((f) => f.name === "code" && f.type === "char");
+  if (!code || code.searchable === false) return undefined;
+  return fields.some((f) => f.name === "default_code") ? undefined : code;
+}
+
+/**
+ * Boolean form of {@link findCodeField}. Decides both whether the lookup
+ * searches the code column and whether a numeric string may be a code rather
+ * than an illegal raw id.
  */
 export function relationHasCode(fields: OdooField[]): boolean {
-  return fields.some((f) => f.name === "code");
+  return findCodeField(fields) !== undefined;
 }
 
 export function augmentFieldsWithCompanyId(
@@ -664,6 +725,7 @@ export function normalizeFields(fields: unknown): OdooField[] {
             : undefined,
           readonly: typeof field.readonly === "boolean" ? field.readonly : undefined,
           required: typeof field.required === "boolean" ? field.required : undefined,
+          searchable: typeof field.searchable === "boolean" ? field.searchable : undefined,
         },
       ];
     });
@@ -684,6 +746,7 @@ export function normalizeFields(fields: unknown): OdooField[] {
           : undefined,
         readonly: typeof field.readonly === "boolean" ? field.readonly : undefined,
         required: typeof field.required === "boolean" ? field.required : undefined,
+        searchable: typeof field.searchable === "boolean" ? field.searchable : undefined,
       },
     ];
   });
@@ -829,7 +892,18 @@ function parseLookup(field: OdooField, value: unknown): RelationLookup | null {
   const lookup = value.lookup;
   return {
     name: typeof lookup.name === "string" ? lookup.name.trim() : undefined,
-    code: typeof lookup.code === "string" ? lookup.code.trim().toUpperCase() : undefined,
+    // Upper-cased for `res.country` only, because that is the one relation
+    // where it states a fact: ISO 3166-1 alpha-2 is upper-case, and the domain
+    // leaf is a case-sensitive `=` on a char column. Journal and account codes
+    // are not upper-case by rule, so normalising them here turned a correctly
+    // typed `{lookup: {code: "bnk1"}}` into a query for "BNK1" that matches
+    // nothing (#1206 review).
+    code:
+      typeof lookup.code === "string"
+        ? field.relation === "res.country"
+          ? lookup.code.trim().toUpperCase()
+          : lookup.code.trim()
+        : undefined,
   };
 }
 
@@ -839,11 +913,13 @@ function parseLookup(field: OdooField, value: unknown): RelationLookup | null {
  * Accountants address a GL account by its number, and a chart of accounts
  * prints `"7660 Entertainment expenses"` — which is also what Odoo renders in
  * most account pickers. Both forms have to resolve, so the leading whitespace-
- * delimited token is what gets compared against `code`.
+ * delimited token is what gets compared against `code`. A bare code is that
+ * same form with the name left off.
  *
- * An explicit `{lookup: {code}}` wins outright; otherwise the first token of
- * the name is tried. A plain name simply yields a token that matches no code
- * and falls through to the existing name matching.
+ * An explicit `{lookup: {code}}` is returned as-is. Otherwise the token is a
+ * *guess* about the input's shape, which is why {@link resolveReferenceFromRecords}
+ * only reaches for it once an exact name has failed: "IT Infrastructure" must
+ * not resolve to whatever record happens to carry the code "IT".
  */
 function codeTokenOf(lookup: RelationLookup): string | null {
   if (lookup.code) return lookup.code;
@@ -853,6 +929,49 @@ function codeTokenOf(lookup: RelationLookup): string | null {
   return head || null;
 }
 
+/**
+ * The single record whose `code` equals `code`, or `null` when none does.
+ * Compared case-insensitively, like every other text match here — the domain
+ * leaf that fetched these candidates is a case-sensitive `=`, but a record
+ * pulled in by the *name* leg can still differ in case from the code it was
+ * asked for.
+ *
+ * Throws on more than one, through the shared multi-match formatter: duplicate
+ * codes are the multi-company case, and that message names the `company_id`
+ * remedy instead of leaving the caller to guess.
+ */
+function matchByCode(
+  field: OdooField,
+  lookup: RelationLookup,
+  code: string,
+  records: OdooRecord[]
+): number | null {
+  const wanted = normalizeLookupText(code);
+  const matches = records.filter((record) => {
+    const value = recordText(record, "code");
+    return value !== null && normalizeLookupText(value) === wanted;
+  });
+  const ids = uniqueIds(matches);
+  if (ids.length === 1) return ids[0];
+  if (ids.length > 1) throw new Error(formatMultiMatchError(field, { ...lookup, code }, matches));
+  return null;
+}
+
+/**
+ * Pick the one record a lookup names, in order of how much the caller actually
+ * told us (heypinchy/pinchy#1197, precedence corrected in the #1206 review):
+ *
+ * 1. An explicit `{lookup: {code}}` names the column it means. Nothing beats it.
+ * 2. An exact `name`/`display_name` match. This sits ABOVE the derived code
+ *    token on purpose: the token is a guess about the input's shape, an exact
+ *    name is not. With the order reversed, `"IT Infrastructure"` resolves to
+ *    whatever record carries the code `"IT"` — a write to the wrong record,
+ *    with no error anywhere.
+ * 3. The leading token, which is the `"<code> <name>"` form a chart of accounts
+ *    prints, and a bare code. Reached only once an exact name has failed, so
+ *    the composite form that carries a disambiguating name still resolves when
+ *    two companies share a code.
+ */
 function resolveReferenceFromRecords(
   field: OdooField,
   lookup: RelationLookup,
@@ -861,32 +980,9 @@ function resolveReferenceFromRecords(
   const label = field.string ?? field.name;
   const input = lookup.code ?? lookup.name ?? "";
 
-  if (field.relation === "res.country" && lookup.code) {
-    const codeMatches = records.filter(
-      (record) => recordText(record, "code")?.toUpperCase() === lookup.code
-    );
-    const ids = uniqueIds(codeMatches);
-    if (ids.length === 1) return ids[0];
-    if (ids.length > 1) {
-      throw new Error(
-        `Could not resolve ${field.name}: multiple countries match code "${lookup.code}".`
-      );
-    }
-  }
-
-  // Natural-key match, before the name match so an exact code beats a record
-  // that merely turned up in the `ilike` half of the search (#1197).
-  const codeToken = codeTokenOf(lookup);
-  if (codeToken) {
-    const codeMatches = records.filter((record) => recordText(record, "code") === codeToken);
-    const codeIds = uniqueIds(codeMatches);
-    if (codeIds.length === 1) return codeIds[0];
-    if (codeIds.length > 1) {
-      throw new Error(
-        `Could not resolve ${field.name}: multiple ${label} records share the code "${codeToken}".` +
-          `${formatSuggestions(codeMatches)} Pass the ref returned by odoo_read instead.`
-      );
-    }
+  if (lookup.code) {
+    const byExplicitCode = matchByCode(field, lookup, lookup.code, records);
+    if (byExplicitCode !== null) return byExplicitCode;
   }
 
   if (!lookup.name) {
@@ -908,6 +1004,12 @@ function resolveReferenceFromRecords(
   if (ids.length === 1) return ids[0];
   if (ids.length > 1) {
     throw new Error(formatMultiMatchError(field, lookup, exactMatches));
+  }
+
+  const codeToken = codeTokenOf(lookup);
+  if (codeToken) {
+    const byCodeToken = matchByCode(field, lookup, codeToken, records);
+    if (byCodeToken !== null) return byCodeToken;
   }
 
   throw new Error(
@@ -1271,19 +1373,18 @@ async function searchRelationByName(
 ): Promise<unknown> {
   const relation = field.relation as string;
   const relationFields = await loadFields(client, relation, fieldsCache);
-  // Relations with a natural key (account.account.code, account.journal.code,
-  // product.product.default_code) are addressed by that key in practice, so ask
-  // for the column and search it alongside the name (#1197). Relations without
-  // one are untouched — same fields, same domain as before.
+  // A relation with a searchable natural key (account.account.code,
+  // account.journal.code) is addressed by that key in practice, so ask for the
+  // column and search it alongside the name (#1197). Relations without one are
+  // untouched — same fields, same domain as before, which the test named
+  // "leaves the domain and field list of a code-less relation untouched" pins.
   const hasCode = relationHasCode(relationFields);
   const baseFields = hasCode
     ? ["id", "name", "display_name", "code"]
     : ["id", "name", "display_name"];
   const lookupFields = augmentFieldsWithCompanyId(baseFields, relationFields) ?? baseFields;
-  const codeToken = hasCode ? codeTokenOf(lookup) : null;
-  const domain: OdooDomain = codeToken
-    ? ["|", ["name", "ilike", lookup.name ?? ""], ["code", "=", codeToken]]
-    : [["name", "ilike", lookup.name ?? ""]];
+  const domain = relationLookupDomain(lookup, hasCode ? codeTokenOf(lookup) : null);
+  if (!domain) return { records: [] };
   if (scopeCompanyId !== null && relationHasCompanyId(relationFields)) {
     // Mirror Odoo's `_check_company_domain`: include SHARED records
     // (company_id = false), not just the target company. A strict
@@ -1301,42 +1402,50 @@ async function searchRelationByName(
 }
 
 /**
- * Domain for the `res.country` lookup, scoped to the parsed
- * {@link RelationLookup} instead of matching every row — or `null` when the
- * lookup carries nothing to scope on.
- *
- * `res.country` is excluded from {@link searchRelationByName} only because
- * that helper's field list omits `code` (it always requests `["id", "name",
- * "display_name"]`) — but that made every unresolved country value fetch the
- * *entire* table (empty domain, `limit: 1000`) on every call.
+ * Search domain for a many2one lookup: the OR of the legs it actually carries,
+ * or `null` when it carries none.
  *
  * Three shapes, and each one exists because of how
  * {@link resolveReferenceFromRecords} consumes the result:
  *
- * - A `code` (explicit `{lookup:{code}}`, or a recognized alias/ISO input via
- *   `countryCodeForInput`) narrows to an exact `code` match.
- * - A `name` narrows to an `ilike` match, mirroring `searchRelationByName`'s
- *   domain. `name` only, deliberately: no other search domain in this plugin
- *   touches `display_name`, which is a computed non-stored field whose
- *   searchability depends on the Odoo version — and for `res.country`
- *   (`_rec_name` is `name`) it would match nothing `name` doesn't. The
- *   client-side matcher still compares both.
+ * - A `code` narrows to an exact `code` match — an explicit `{lookup:{code}}`,
+ *   a recognized alias/ISO country input via `countryCodeForInput`, or the
+ *   leading token of the `"<code> <name>"` form a chart of accounts prints.
+ * - A `name` narrows to an `ilike` match. `name` only, deliberately: no other
+ *   search domain in this plugin touches `display_name`, which is a computed
+ *   non-stored field whose searchability depends on the Odoo version — and for
+ *   `res.country` (`_rec_name` is `name`) it would match nothing `name`
+ *   doesn't. The client-side matcher still compares both.
  * - BOTH are OR-ed rather than letting `code` win, because
- *   `resolveReferenceFromRecords` falls through from its code branch to its
- *   exact-name branch. A code-only domain never fetches the records that
+ *   `resolveReferenceFromRecords` falls through from a failed code match to
+ *   its exact-name branch. A code-only domain never fetches the records that
  *   fallback needs, so a wrong code would make a correct name unresolvable.
  *
  * `null` is the neither case (`{lookup: {}}`, or a non-string `name` that
  * `parseLookup` drops). An `ilike ""` there is `LIKE '%%'`, i.e. every row —
- * the full-table scan this function exists to remove, reached through the one
- * input that carries no information to scan for. The caller resolves against
- * no records instead, which produces the identical error unqueried.
+ * a full-table scan reached through the one input that carries no information
+ * to scan for, with `limit` deciding whether the answer is in the window. The
+ * caller resolves against no records instead, which produces the identical
+ * error unqueried. `res.country` had this right since the P3 fix; the #1197
+ * generic path reintroduced it by keeping `["name", "ilike", lookup.name ?? ""]`
+ * unconditionally, which is why both callers now share this one builder.
  */
-function countryLookupDomain(lookup: RelationLookup): OdooDomain | null {
-  const byCode: OdooDomain | null = lookup.code ? [["code", "=", lookup.code]] : null;
+function relationLookupDomain(lookup: RelationLookup, codeToken: string | null): OdooDomain | null {
+  const byCode: OdooDomain | null = codeToken ? [["code", "=", codeToken]] : null;
   const byName: OdooDomain | null = lookup.name ? [["name", "ilike", lookup.name]] : null;
   if (byCode && byName) return ["|", ...byCode, ...byName];
   return byCode ?? byName;
+}
+
+/**
+ * The `res.country` case of {@link relationLookupDomain}. Countries take their
+ * own search path rather than {@link searchRelationByName} because they need a
+ * far larger `limit` and no company scoping; only an EXPLICIT code is searched,
+ * since a country name's leading token ("United" of "United States") is never
+ * an ISO code.
+ */
+function countryLookupDomain(lookup: RelationLookup): OdooDomain | null {
+  return relationLookupDomain(lookup, lookup.code ?? null);
 }
 
 /**
@@ -1407,13 +1516,21 @@ async function resolveRelationValue(
     // A GL account code IS numeric ("7660"), so refusing every numeric string
     // left an accountant's most natural input with no route at all — and the
     // ref-corruption workaround the model reached for next hit this same wall
-    // (#1197, #1193). Relaxed ONLY where the relation declares a `code`, and
-    // even then the value is matched against `code`, never against `id`: "an
-    // agent cannot address a record by its primary key" still holds.
-    const relationHasCodeColumn = field.relation
-      ? relationHasCode(await loadFields(client, field.relation, fieldsCache))
-      : false;
-    if (!relationHasCodeColumn) {
+    // (#1197, #1193). Relaxed ONLY where the relation declares a SEARCHABLE
+    // `code` the lookup will really search, and even then the value is matched
+    // against `code`, never against `id`: "an agent cannot address a record by
+    // its primary key" still holds.
+    //
+    // `res.country` is excluded outright rather than by its schema. Its `code`
+    // is ISO 3166-1 alpha-2 and can never be numeric, so a numeric country
+    // value is a raw database id and nothing else — relaxing there bought a
+    // vaguer error and an Odoo round trip to reach it (#1206 review). The
+    // check short-circuits before the `fields_get`, so that trip is not paid.
+    const codeIsAddressable =
+      field.relation !== undefined &&
+      field.relation !== "res.country" &&
+      relationHasCode(await loadFields(client, field.relation, fieldsCache));
+    if (!codeIsAddressable) {
       throw new Error(
         `Raw numeric IDs are not accepted for ${field.name}. Use an opaque ref or lookup.`
       );
@@ -3412,7 +3529,9 @@ const plugin = {
           name: "odoo_create",
           label: "Odoo Create",
           description:
-            'Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing. Vendor bills and vendor credit notes (account.move `in_invoice` / `in_refund`) are duplicate-guarded: a create whose `ref` already exists on file is BLOCKED and the existing bill returned so you can relay it to the user instead of double-booking. Set `allow_duplicate: true` only to deliberately re-file a bill you have confirmed should exist twice.',
+            "Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). " +
+            MANY2ONE_VALUE_HINT +
+            ' One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing. Vendor bills and vendor credit notes (account.move `in_invoice` / `in_refund`) are duplicate-guarded: a create whose `ref` already exists on file is BLOCKED and the existing bill returned so you can relay it to the user instead of double-booking. Set `allow_duplicate: true` only to deliberately re-file a bill you have confirmed should exist twice.',
           parameters: {
             type: "object",
             properties: {
@@ -4751,7 +4870,9 @@ const plugin = {
           name: "odoo_write",
           label: "Odoo Write",
           description:
-            'Update an existing record in Odoo. For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.',
+            "Update an existing record in Odoo. " +
+            MANY2ONE_VALUE_HINT +
+            ' One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.',
           parameters: {
             type: "object",
             properties: {


### PR DESCRIPTION
Fixes #1197.

## What was wrong

`resolveReferenceFromRecords` matched `name` and `display_name` only. Codes were special-cased for exactly one relation — `res.country`. So an accounting agent could not address a GL account the way accountants actually do: by its number.

Production, 2026-08-17 — five consecutive `odoo_create` failures:

```
Could not resolve account_id from "<code> <name>". Provide an exact Account name or ref.
```

That string is what a chart of accounts prints, and what Odoo renders in most account pickers. With no suggestions attached, the model had nothing to correct toward. It then tried a bare code and hit `Raw numeric IDs are not accepted for account_id` — which closed the last route. Together with the ref failures (#1193) this is the bulk of that session's booking failures.

## The fix, in three parts

1. **The search asks for what it needs.** Where the relation declares a `code`, the lookup requests that column and ORs it into the domain instead of searching `name` alone. Relations without one are untouched — same fields, same domain as before.
2. **The natural key is tried first.** An exact `code` match beats a record that merely turned up in the `ilike` half of the search — there is a test with a decoy whose *name* starts with the code being looked up. The composite `"<code> <name>"` form resolves through its leading token. Duplicate codes report an ambiguity and point at the ref rather than picking one.
3. **The numeric guard is narrowed, not removed.** A GL account code *is* numeric, so refusing every numeric string left the most natural input with no route at all. It is now relaxed **only** where the relation actually declares a `code` column — and even then the value is matched against `code`, never against `id`. "An agent cannot address a record by its primary key" still holds, and there is an explicit test on a relation without a code column that keeps the original refusal.

## Verification

- 7 new tests, all red before the change and green after. Two of them are negative controls that were green throughout — name-only resolution, and the numeric refusal on a code-less relation — which is what makes them controls.
- pinchy-odoo package suite: 546 passed.
- `pnpm test`: 12280 passed / 18 skipped.
- `pnpm typecheck:plugins`: all 10 clean.

## A note on the fixture, because it cost me two wrong reds

`searchRead` is called twice per create and the two calls want different answers: once against `account.account` for the m2o candidates, once against the written model for the post-write read-back verification (#720). A blanket `mockResolvedValue` serves the account rows to the read-back as well, which then reports the created label as mismatched — a fixture artefact that reads exactly like a product failure. The helper is keyed by model and says so in a comment, so the next person does not spend the same two rounds on it.

## Not in scope

The adjacent Odoo 19 finding from the same issue — `account.account` moved off `company_id` to a many2many, and two production `odoo_read` calls failed with `Invalid field account.account.company_id in condition` — is untouched here. It belongs with the multi-company scoping helper, not with name resolution.
