### PR TITLE
feat(uploads): name a file the browser did not name

### DIFF
--- a/docs/src/content/docs/guides/file-uploads.mdx
+++ b/docs/src/content/docs/guides/file-uploads.mdx
@@ -97,6 +97,8 @@ Pinchy validates every uploaded file against its actual content, not just the br
 
 ### Files your browser doesn't name
 
-Paste a screenshot, or drag a PDF straight out of a viewer, and the browser hands us `blob` — no name, no extension. Pinchy gives those a dated name instead, based on what the file actually turned out to be: `upload-2026-08-20.pdf`. A file you named yourself keeps its name; if it arrived without an extension, it gains the right one so it opens.
+Paste a screenshot, or drag a PDF straight out of a viewer, and the browser hands us `blob` — no name, no extension. Pinchy names those itself, from the moment you sent the file and what it actually turned out to be: `upload-2026-08-20-1432.pdf`. The time of day is in there because a working day produces a lot of these, and a date alone would leave you with a list you still can't tell apart.
 
-This is why a pasted file can appear in `uploads/` under a different name than the one you saw on your desktop — the agent and the chip both use the stored name, so they always agree.
+A name you chose is kept as it is. The exception is a name that says nothing either: `image.png`, `download.pdf`, `untitled.pdf` and the like are treated exactly like `blob`, because the stem tells you no more than the browser's own placeholder does. And a name you chose that arrived **without** an extension keeps its stem and gains the extension its contents call for — `Scan001` becomes `Scan001.pdf`, so it opens.
+
+This is why a pasted file can appear in `uploads/` under a different name than the one you saw on your desktop. The chat chip, the agent and the workspace all use the stored name, so they always agree.

--- a/docs/src/content/docs/guides/file-uploads.mdx
+++ b/docs/src/content/docs/guides/file-uploads.mdx
@@ -94,3 +94,9 @@ What that means in practice depends on who replaced the file:
 ## Security
 
 Pinchy validates every uploaded file against its actual content, not just the browser-reported MIME type. A file renamed to `.pdf` that contains executable code will be rejected. Filenames are also sanitized before being written to disk.
+
+### Files your browser doesn't name
+
+Paste a screenshot, or drag a PDF straight out of a viewer, and the browser hands us `blob` — no name, no extension. Pinchy gives those a dated name instead, based on what the file actually turned out to be: `upload-2026-08-20.pdf`. A file you named yourself keeps its name; if it arrived without an extension, it gains the right one so it opens.
+
+This is why a pasted file can appear in `uploads/` under a different name than the one you saw on your desktop — the agent and the chip both use the stored name, so they always agree.

--- a/docs/src/content/docs/guides/image-attachments.mdx
+++ b/docs/src/content/docs/guides/image-attachments.mdx
@@ -32,7 +32,7 @@ You can verify the conversion worked: the agent's response should reference what
 Each image you attach travels two routes simultaneously:
 
 1. **Inline to the model** — the resized version is sent with the message itself, so a vision-capable model can "see" the image immediately without an extra step.
-2. **Saved to the agent's [workspace](/concepts/workspaces/)** — the **original** file lands in `uploads/<filename>` so the agent can re-read it later (e.g. when you ask follow-up questions about details, or when a sub-agent needs the full-resolution version). A pasted screenshot arrives without a real name, so it is stored under a dated one — see [Files your browser doesn't name](/guides/file-uploads/#files-your-browser-doesnt-name).
+2. **Saved to the agent's [workspace](/concepts/workspaces/)** — the **original** file lands in `uploads/<filename>` so the agent can re-read it later (e.g. when you ask follow-up questions about details, or when a sub-agent needs the full-resolution version). A pasted screenshot arrives without a real name, so it is stored under a generated one — see [Files your browser doesn't name](/guides/file-uploads/#files-your-browser-doesnt-name).
 
 Most of the time you don't need to think about this — the agent picks the right path. The workspace copy matters mainly for shared agents, where it's visible to anyone with access to the agent.
 

--- a/docs/src/content/docs/guides/image-attachments.mdx
+++ b/docs/src/content/docs/guides/image-attachments.mdx
@@ -32,7 +32,7 @@ You can verify the conversion worked: the agent's response should reference what
 Each image you attach travels two routes simultaneously:
 
 1. **Inline to the model** — the resized version is sent with the message itself, so a vision-capable model can "see" the image immediately without an extra step.
-2. **Saved to the agent's [workspace](/concepts/workspaces/)** — the **original** file lands in `uploads/<filename>` so the agent can re-read it later (e.g. when you ask follow-up questions about details, or when a sub-agent needs the full-resolution version).
+2. **Saved to the agent's [workspace](/concepts/workspaces/)** — the **original** file lands in `uploads/<filename>` so the agent can re-read it later (e.g. when you ask follow-up questions about details, or when a sub-agent needs the full-resolution version). A pasted screenshot arrives without a real name, so it is stored under a dated one — see [Files your browser doesn't name](/guides/file-uploads/#files-your-browser-doesnt-name).
 
 Most of the time you don't need to think about this — the agent picks the right path. The workspace copy matters mainly for shared agents, where it's visible to anyone with access to the agent.
 

--- a/packages/web/src/__tests__/api/uploads-post.integration.test.ts
+++ b/packages/web/src/__tests__/api/uploads-post.integration.test.ts
@@ -395,4 +395,54 @@ describe("POST /api/agents/[agentId]/uploads", () => {
     expect(detail.contentHash).toMatch(/^[a-f0-9]{64}$/);
     expect((detail.agent as { id: string }).id).toBe(agent.id);
   });
+
+  // #1199 — the naming rule is unit-tested in upload-validation.test.ts; this
+  // pins the WIRING, which is the half that can silently come undone: the
+  // stored file, the DB row, the response body and the audit row all have to
+  // agree, because the agent is handed one of them and the user sees another.
+  it("gives a browser-named 'blob' a real filename everywhere it is recorded", async () => {
+    const user = await seedUser();
+    mockGetSession.mockResolvedValue({
+      user: { id: user.id, email: user.email, role: "admin" },
+    });
+    const agent = await seedAgent(null);
+
+    // What a paste or a drag out of a PDF viewer actually sends.
+    const blob = new File([VALID_PDF], "blob", { type: "application/pdf" });
+
+    const resp = await POST(makeRequest(agent.id, { file: blob }), makeParams(agent.id));
+
+    expect(resp.status).toBe(201);
+    const body = await resp.json();
+    expect(body.filename).toMatch(/^upload-\d{4}-\d{2}-\d{2}\.pdf$/);
+
+    const [dbRow] = await db.select().from(uploadedFiles).where(eq(uploadedFiles.id, body.id));
+    expect(dbRow.filename).toBe(body.filename);
+
+    const uploadId = dbRow.stagingPath!.split("/")[1];
+    expect(existsSync(join(tmpRoot, agent.id, ".staging", uploadId, body.filename))).toBe(true);
+
+    const [auditRow] = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.actorId, user.auditPseudonym));
+    expect((auditRow.detail as Record<string, unknown>).filename).toBe(body.filename);
+  });
+
+  it("leaves a filename the user chose exactly as it was", async () => {
+    const user = await seedUser();
+    mockGetSession.mockResolvedValue({
+      user: { id: user.id, email: user.email, role: "admin" },
+    });
+    const agent = await seedAgent(null);
+
+    const named = new File([VALID_PDF], "Rechnung_919278810726.pdf", {
+      type: "application/pdf",
+    });
+
+    const resp = await POST(makeRequest(agent.id, { file: named }), makeParams(agent.id));
+
+    expect(resp.status).toBe(201);
+    expect((await resp.json()).filename).toBe("Rechnung_919278810726.pdf");
+  });
 });

--- a/packages/web/src/__tests__/api/uploads-post.integration.test.ts
+++ b/packages/web/src/__tests__/api/uploads-post.integration.test.ts
@@ -21,7 +21,7 @@ import { NextRequest } from "next/server";
 import { mkdtempSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -414,7 +414,7 @@ describe("POST /api/agents/[agentId]/uploads", () => {
 
     expect(resp.status).toBe(201);
     const body = await resp.json();
-    expect(body.filename).toMatch(/^upload-\d{4}-\d{2}-\d{2}\.pdf$/);
+    expect(body.filename).toMatch(/^upload-\d{4}-\d{2}-\d{2}-\d{4}\.pdf$/);
 
     const [dbRow] = await db.select().from(uploadedFiles).where(eq(uploadedFiles.id, body.id));
     expect(dbRow.filename).toBe(body.filename);
@@ -422,27 +422,14 @@ describe("POST /api/agents/[agentId]/uploads", () => {
     const uploadId = dbRow.stagingPath!.split("/")[1];
     expect(existsSync(join(tmpRoot, agent.id, ".staging", uploadId, body.filename))).toBe(true);
 
+    // Ordered and narrowed to the success row: an unordered single-column
+    // select would silently assert against whichever row came back first the
+    // moment anything else audits under this actor.
     const [auditRow] = await db
       .select()
       .from(auditLog)
-      .where(eq(auditLog.actorId, user.auditPseudonym));
+      .where(and(eq(auditLog.actorId, user.auditPseudonym), eq(auditLog.outcome, "success")))
+      .orderBy(desc(auditLog.id));
     expect((auditRow.detail as Record<string, unknown>).filename).toBe(body.filename);
-  });
-
-  it("leaves a filename the user chose exactly as it was", async () => {
-    const user = await seedUser();
-    mockGetSession.mockResolvedValue({
-      user: { id: user.id, email: user.email, role: "admin" },
-    });
-    const agent = await seedAgent(null);
-
-    const named = new File([VALID_PDF], "Rechnung_919278810726.pdf", {
-      type: "application/pdf",
-    });
-
-    const resp = await POST(makeRequest(agent.id, { file: named }), makeParams(agent.id));
-
-    expect(resp.status).toBe(201);
-    expect((await resp.json()).filename).toBe("Rechnung_919278810726.pdf");
   });
 });

--- a/packages/web/src/__tests__/hooks/use-pending-uploads.test.ts
+++ b/packages/web/src/__tests__/hooks/use-pending-uploads.test.ts
@@ -485,4 +485,83 @@ describe("PendingUpload state machine", () => {
     const uploadCall = vi.mocked(uploadModule.uploadAttachment).mock.calls[0];
     expect(uploadCall[2]).toBe(smallOriginal);
   });
+
+  // #1199. The route renames a file the browser did not name, so `file.name`
+  // and the name on disk are no longer the same string. The chip builds
+  // `/api/agents/<id>/uploads/<filename>` from whatever this hook puts in the
+  // message: read `file.name` there and the preview probes a path that does
+  // not exist, burns its five HEAD retries and falls back to a chip labelled
+  // `blob` — until a history frame silently swaps the name under the user.
+  describe("the server's stored filename", () => {
+    function mockUpload(filename: string) {
+      vi.mocked(uploadModule.uploadAttachment).mockResolvedValue({
+        id: "upload-id-123",
+        filename,
+        mimeType: "application/pdf",
+        sizeBytes: 1024,
+      });
+    }
+
+    it("is kept on the pending upload", async () => {
+      mockUpload("upload-2026-08-20-1432.pdf");
+
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      await act(async () => {
+        result.current.addPendingUpload(makeFile("blob"));
+      });
+
+      const upload = result.current.pendingUploads[0] as PendingUpload;
+      expect(upload.state).toBe("ready");
+      expect(upload.storedFilename).toBe("upload-2026-08-20-1432.pdf");
+    });
+
+    it("survives a retry", async () => {
+      vi.mocked(uploadModule.uploadAttachment).mockRejectedValueOnce(new Error("boom"));
+
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      await act(async () => {
+        result.current.addPendingUpload(makeFile("blob"));
+      });
+      expect(result.current.pendingUploads[0].state).toBe("failed");
+
+      mockUpload("upload-2026-08-20-1432.pdf");
+      await act(async () => {
+        result.current.retryPendingUpload(result.current.pendingUploads[0].localId);
+      });
+
+      const upload = result.current.pendingUploads[0] as PendingUpload;
+      expect(upload.state).toBe("ready");
+      expect(upload.storedFilename).toBe("upload-2026-08-20-1432.pdf");
+    });
+
+    it("is the name the sent message carries, not the browser's", async () => {
+      mockUpload("upload-2026-08-20-1432.pdf");
+
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      await act(async () => {
+        result.current.addPendingUpload(makeFile("blob"));
+      });
+
+      type StoreConfig = {
+        messages: { role: string; content: { type: string; filename?: string }[] }[];
+        onNew(message: unknown): void | Promise<void>;
+      };
+      await act(async () => {
+        (result.current.runtime as unknown as StoreConfig).onNew({
+          content: [{ type: "text", text: "here you go" }],
+          attachments: [],
+        });
+      });
+
+      // Read the converted FilePart, not the raw WsMessage: this is the exact
+      // value `useMessagePartFile()` hands AttachmentPreview, which feeds it
+      // straight into buildFileUrl. Re-read `runtime` after the send — the
+      // store config is rebuilt each render and the pre-send snapshot holds a
+      // stale `messages` array.
+      const config = result.current.runtime as unknown as StoreConfig;
+      const sent = config.messages.filter((m) => m.role === "user").at(-1);
+      const fileParts = (sent?.content ?? []).filter((part) => part.type === "file");
+      expect(fileParts.map((part) => part.filename)).toEqual(["upload-2026-08-20-1432.pdf"]);
+    });
+  });
 });

--- a/packages/web/src/__tests__/lib/upload-validation.test.ts
+++ b/packages/web/src/__tests__/lib/upload-validation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   sanitizeFilename,
   meaningfulUploadName,
+  EXT_BY_MIME,
   validateUploadBuffer,
   ALLOWED_ATTACHMENT_MIMES,
   ALLOWED_TEXT_MIMES,
@@ -273,7 +274,10 @@ describe("vCard support", () => {
 // already under pressure. `pinchy_ls` is close to useless on that listing, and
 // so is asking the user "did you send me the receipt".
 describe("meaningfulUploadName", () => {
-  const day = new Date("2026-08-20T09:15:00Z");
+  // Constructed from local components on purpose: the stamp is local wall
+  // clock, so a `Z` literal would make these assertions depend on the machine's
+  // timezone — green in a UTC container, red on a laptop west of Greenwich.
+  const day = new Date(2026, 7, 20, 14, 32);
 
   it("leaves a real filename alone", () => {
     expect(meaningfulUploadName("Rechnung_919278810726.pdf", "application/pdf", day)).toBe(
@@ -284,18 +288,66 @@ describe("meaningfulUploadName", () => {
     );
   });
 
-  it("gives a generic name a dated stem and the real extension", () => {
-    expect(meaningfulUploadName("blob", "application/pdf", day)).toBe("upload-2026-08-20.pdf");
-    expect(meaningfulUploadName("blob (17)", "image/png", day)).toBe("upload-2026-08-20.png");
+  it("gives a generic name a stamped stem and the real extension", () => {
+    expect(meaningfulUploadName("blob", "application/pdf", day)).toBe("upload-2026-08-20-1432.pdf");
+    expect(meaningfulUploadName("blob (17)", "image/png", day)).toBe("upload-2026-08-20-1432.png");
     expect(meaningfulUploadName("upload (3)", "application/pdf", day)).toBe(
-      "upload-2026-08-20.pdf"
+      "upload-2026-08-20-1432.pdf"
+    );
+  });
+
+  // The stamp carries the minute, not just the day. The workspace this issue
+  // is about took 36 generic uploads on one working day: a day-only stem
+  // collides for every one of them, and `buildNextFreeFilename` then hands back
+  // `upload-2026-08-20 (35).pdf` — the `blob (17)` listing under a new name.
+  it("distinguishes two uploads made on the same day", () => {
+    const morning = new Date(2026, 7, 20, 9, 15);
+    const afternoon = new Date(2026, 7, 20, 14, 32);
+    expect(meaningfulUploadName("blob", "application/pdf", morning)).not.toBe(
+      meaningfulUploadName("blob", "application/pdf", afternoon)
+    );
+  });
+
+  // Local wall clock, not UTC: 23:30 in Vienna is already tomorrow in Zulu, and
+  // the date is the only information the generated name carries.
+  it("stamps the local day, not the UTC one", () => {
+    const lateEvening = new Date(2026, 7, 20, 23, 30);
+    expect(meaningfulUploadName("blob", "application/pdf", lateEvening)).toBe(
+      "upload-2026-08-20-2330.pdf"
     );
   });
 
   // A pasted screenshot arrives as "image.png": the extension is right, the
-  // stem says nothing. The date is strictly more informative.
+  // stem says nothing. The stamp is strictly more informative.
   it("renames a generic stem that already carries an extension", () => {
-    expect(meaningfulUploadName("image.png", "image/png", day)).toBe("upload-2026-08-20.png");
+    expect(meaningfulUploadName("image.png", "image/png", day)).toBe("upload-2026-08-20-1432.png");
+  });
+
+  // The extension on a generic name gets no benefit of the doubt either — the
+  // premise of this branch is that nothing the client sent about the name is
+  // worth keeping, and `validateUploadBuffer` compares bytes against the
+  // CLAIMED MIME, never against the extension. So `blob.txt` holding PDF bytes
+  // reaches here as (name `blob.txt`, mime `application/pdf`).
+  it("takes a generic name's extension from the validated mime, not the name", () => {
+    expect(meaningfulUploadName("blob.txt", "application/pdf", day)).toBe(
+      "upload-2026-08-20-1432.pdf"
+    );
+  });
+
+  // `dot > 0` alone is true for a trailing dot, and the extension it slices out
+  // is the empty string — storing `upload-2026-08-20-1432.`, a file with no
+  // extension, which is the outcome this function exists to prevent.
+  it("does not produce a name ending in a bare dot", () => {
+    expect(meaningfulUploadName("blob.", "application/pdf", day)).toBe(
+      "upload-2026-08-20-1432.pdf"
+    );
+    expect(meaningfulUploadName("Scan001.", "application/pdf", day)).toBe("Scan001.pdf");
+  });
+
+  // sanitizeFilename lets "..." through (only "." and ".." are reserved), and
+  // a stem of nothing but dots is as uninformative as `blob`.
+  it("treats an all-dots name as generic", () => {
+    expect(meaningfulUploadName("...", "application/pdf", day)).toBe("upload-2026-08-20-1432.pdf");
   });
 
   // A stem the user chose is information — keep it, just make the file
@@ -317,14 +369,53 @@ describe("meaningfulUploadName", () => {
     expect(meaningfulUploadName("invoice.txt", "application/pdf", day)).toBe("invoice.txt");
   });
 
+  // sanitizeFilename enforces a 255-character limit on the name it is handed.
+  // Appending an extension to an already-maximal stem would push the STORED
+  // name past it, and the `O_CREAT | O_EXCL` slot probe in persistStagedUpload
+  // then fails with ENAMETOOLONG — an unhandled 500 on a name the route had
+  // just accepted.
+  it("keeps an extended name within the length sanitizeFilename allows", () => {
+    const maximal = "a".repeat(255);
+    expect(sanitizeFilename(maximal)).toBe(maximal);
+
+    const named = meaningfulUploadName(maximal, "application/pdf", day);
+    expect(named.length).toBe(255);
+    expect(named.endsWith(".pdf")).toBe(true);
+  });
+
   it("falls back to .bin for a MIME with no known extension", () => {
     expect(meaningfulUploadName("blob", "application/octet-stream", day)).toBe(
-      "upload-2026-08-20.bin"
+      "upload-2026-08-20-1432.bin"
     );
   });
 
   it("is case-insensitive about the generic stem", () => {
-    expect(meaningfulUploadName("Blob", "image/jpeg", day)).toBe("upload-2026-08-20.jpg");
-    expect(meaningfulUploadName("DOWNLOAD", "image/jpeg", day)).toBe("upload-2026-08-20.jpg");
+    expect(meaningfulUploadName("Blob", "image/jpeg", day)).toBe("upload-2026-08-20-1432.jpg");
+    expect(meaningfulUploadName("DOWNLOAD", "image/jpeg", day)).toBe("upload-2026-08-20-1432.jpg");
+  });
+});
+
+// AGENTS.md § "A Hand-Maintained List That Mirrors Code Will Be Wrong":
+// EXT_BY_MIME mirrors the two allowlists, and the `?? "bin"` fallback in
+// meaningfulUploadName makes a gap SILENT — a MIME added to an allowlist and
+// forgotten here stores every such upload as `upload-….bin`, with nothing red.
+// Both directions, because a stale entry is the same drift one level up.
+describe("EXT_BY_MIME tracks the MIMEs the upload path accepts", () => {
+  const accepted = new Set([...ALLOWED_ATTACHMENT_MIMES, ...ALLOWED_TEXT_MIMES]);
+
+  it("has an extension for every accepted MIME", () => {
+    const missing = [...accepted].filter((mime) => !EXT_BY_MIME.has(mime)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it("names no MIME the upload path does not accept", () => {
+    const stale = [...EXT_BY_MIME.keys()].filter((mime) => !accepted.has(mime)).sort();
+    expect(stale).toEqual([]);
+  });
+
+  // A corpus floor: an empty comparison passes both checks above while
+  // asserting nothing, which is how a coverage gate becomes decoration.
+  it("checks a real corpus", () => {
+    expect(accepted.size).toBeGreaterThanOrEqual(13);
   });
 });

--- a/packages/web/src/__tests__/lib/upload-validation.test.ts
+++ b/packages/web/src/__tests__/lib/upload-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   sanitizeFilename,
+  meaningfulUploadName,
   validateUploadBuffer,
   ALLOWED_ATTACHMENT_MIMES,
   ALLOWED_TEXT_MIMES,
@@ -262,5 +263,68 @@ describe("vCard support", () => {
     await expect(validateUploadBuffer(lowercaseVcard, "text/x-vcard")).resolves.toBe(
       "text/x-vcard"
     );
+  });
+});
+
+// heypinchy/pinchy#1199. Browsers hand us `blob` for anything pasted from the
+// clipboard or dragged out of a viewer — no extension, no hint of content. One
+// production agent's workspace held 68 such files out of 253, and identifying
+// each one costs a `pinchy_read` against a vision model on a context that is
+// already under pressure. `pinchy_ls` is close to useless on that listing, and
+// so is asking the user "did you send me the receipt".
+describe("meaningfulUploadName", () => {
+  const day = new Date("2026-08-20T09:15:00Z");
+
+  it("leaves a real filename alone", () => {
+    expect(meaningfulUploadName("Rechnung_919278810726.pdf", "application/pdf", day)).toBe(
+      "Rechnung_919278810726.pdf"
+    );
+    expect(meaningfulUploadName("2026-02-20_nara_33.00.pdf", "application/pdf", day)).toBe(
+      "2026-02-20_nara_33.00.pdf"
+    );
+  });
+
+  it("gives a generic name a dated stem and the real extension", () => {
+    expect(meaningfulUploadName("blob", "application/pdf", day)).toBe("upload-2026-08-20.pdf");
+    expect(meaningfulUploadName("blob (17)", "image/png", day)).toBe("upload-2026-08-20.png");
+    expect(meaningfulUploadName("upload (3)", "application/pdf", day)).toBe(
+      "upload-2026-08-20.pdf"
+    );
+  });
+
+  // A pasted screenshot arrives as "image.png": the extension is right, the
+  // stem says nothing. The date is strictly more informative.
+  it("renames a generic stem that already carries an extension", () => {
+    expect(meaningfulUploadName("image.png", "image/png", day)).toBe("upload-2026-08-20.png");
+  });
+
+  // A stem the user chose is information — keep it, just make the file
+  // openable by giving it the extension its bytes say it has.
+  it("keeps a real stem and only adds the missing extension", () => {
+    expect(meaningfulUploadName("Scan001", "application/pdf", day)).toBe("Scan001.pdf");
+  });
+
+  it("does not double an extension that is already correct", () => {
+    expect(meaningfulUploadName("invoice.pdf", "application/pdf", day)).toBe("invoice.pdf");
+  });
+
+  // The sniffed MIME is the truth about the bytes; a wrong extension the
+  // sender attached is not something to preserve.
+  it("leaves a mismatched but present extension alone", () => {
+    // Deliberately NOT rewritten: renaming a user-named file on a MIME
+    // mismatch is a different decision (and a lossy one) from naming a file
+    // that has no name at all.
+    expect(meaningfulUploadName("invoice.txt", "application/pdf", day)).toBe("invoice.txt");
+  });
+
+  it("falls back to .bin for a MIME with no known extension", () => {
+    expect(meaningfulUploadName("blob", "application/octet-stream", day)).toBe(
+      "upload-2026-08-20.bin"
+    );
+  });
+
+  it("is case-insensitive about the generic stem", () => {
+    expect(meaningfulUploadName("Blob", "image/jpeg", day)).toBe("upload-2026-08-20.jpg");
+    expect(meaningfulUploadName("DOWNLOAD", "image/jpeg", day)).toBe("upload-2026-08-20.jpg");
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/uploads/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/uploads/route.ts
@@ -116,11 +116,16 @@ export const POST = withAuth<Params>(async (req, { params }, session) => {
     return NextResponse.json({ error: message }, { status: 415 });
   }
 
+  // One clock reading for the whole request: it stamps the generated filename
+  // AND starts the staging TTL, and two readings could straddle midnight —
+  // dating the file on one day and expiring it relative to the next.
+  const now = new Date();
+
   // Name a file the browser did not name (#1199). Runs here, after
   // validation, because the VALIDATED mime is what makes the extension
   // trustworthy — and before staging, so the reserved slot, the DB row, the
   // preview URL and the path the agent is handed all carry the same name.
-  const storedName = meaningfulUploadName(safeName, validatedMime, new Date());
+  const storedName = meaningfulUploadName(safeName, validatedMime, now);
 
   // Persist to staging. The returned `filename` is the slot reserved in
   // uploads/ — collision-suffixed up front so the client's preview URL is
@@ -130,7 +135,6 @@ export const POST = withAuth<Params>(async (req, { params }, session) => {
 
   // DB insert. If it fails after the FS write, we roll back both the
   // staging file AND the uploads/ placeholder so the disk doesn't leak.
-  const now = new Date();
   const expiresAt = new Date(now.getTime() + STAGED_TTL_MS);
   let row: typeof uploadedFiles.$inferSelect;
   try {

--- a/packages/web/src/app/api/agents/[agentId]/uploads/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/uploads/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/api-auth";
 import { getAgentWithAccess } from "@/lib/agent-access";
 import { getWorkspacePath } from "@/lib/workspace";
-import { sanitizeFilename, validateUploadBuffer } from "@/lib/upload-validation";
+import {
+  sanitizeFilename,
+  meaningfulUploadName,
+  validateUploadBuffer,
+} from "@/lib/upload-validation";
 import { persistStagedUpload } from "@/lib/uploads";
 import { appendAuditLog } from "@/lib/audit";
 import { draftIdSchema } from "@/lib/schemas/uploads";
@@ -112,11 +116,17 @@ export const POST = withAuth<Params>(async (req, { params }, session) => {
     return NextResponse.json({ error: message }, { status: 415 });
   }
 
+  // Name a file the browser did not name (#1199). Runs here, after
+  // validation, because the VALIDATED mime is what makes the extension
+  // trustworthy — and before staging, so the reserved slot, the DB row, the
+  // preview URL and the path the agent is handed all carry the same name.
+  const storedName = meaningfulUploadName(safeName, validatedMime, new Date());
+
   // Persist to staging. The returned `filename` is the slot reserved in
   // uploads/ — collision-suffixed up front so the client's preview URL is
   // already correct when the upload completes.
   const workspaceRoot = getWorkspacePath(agentId);
-  const staged = await persistStagedUpload({ workspaceRoot, filename: safeName, buffer });
+  const staged = await persistStagedUpload({ workspaceRoot, filename: storedName, buffer });
 
   // DB insert. If it fails after the FS write, we roll back both the
   // staging file AND the uploads/ placeholder so the disk doesn't leak.

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -51,6 +51,18 @@ export interface PendingUpload {
   objectUrl: string; // URL.createObjectURL — local preview, revoked on remove/send
   state: "uploading" | "ready" | "failed";
   uploadId?: string; // server-assigned, set when state = "ready"
+  /**
+   * Name the file was actually stored under, set when state = "ready" (#1199).
+   *
+   * NOT `file.name`: the route renames a file the browser did not name, so a
+   * pasted screenshot lands in `uploads/` as `upload-<stamp>.png` while
+   * `file.name` still says `image.png`. The chip builds
+   * `/api/agents/<id>/uploads/<filename>` from the name in the message, so
+   * sending the local one probes a path that does not exist — five HEAD
+   * retries, then a chip with no preview and the wrong label, until a history
+   * frame swaps the name under the user.
+   */
+  storedFilename?: string;
   progress: number; // 0-100
   error?: string; // set when state = "failed"
 }
@@ -1903,7 +1915,10 @@ export function useWsRuntime(
             status: "sending",
             ...(readyUploads.length > 0 && {
               files: readyUploads.map((u) => ({
-                filename: u.file.name,
+                // The name on disk (#1199) — see PendingUpload.storedFilename.
+                // The fallback only covers a chip that reached "ready" before
+                // this field existed; a live upload always carries it.
+                filename: u.storedFilename ?? u.file.name,
                 mimeType: u.file.type,
               })),
             }),
@@ -2212,6 +2227,7 @@ export function useWsRuntime(
                     ...u,
                     state: "ready",
                     uploadId: response.id,
+                    storedFilename: response.filename,
                     progress: 100,
                   }
                 : u
@@ -2319,6 +2335,7 @@ export function useWsRuntime(
                     ...u,
                     state: "ready",
                     uploadId: response.id,
+                    storedFilename: response.filename,
                     progress: 100,
                   }
                 : u

--- a/packages/web/src/lib/upload-validation.ts
+++ b/packages/web/src/lib/upload-validation.ts
@@ -80,78 +80,6 @@ export function sanitizeFilename(raw: string): string {
 //
 // text/vcard is ALSO listed in ALLOWED_TEXT_MIMES below; see isKnownMimeAlias
 // for why vCard lives in both allowlists.
-/**
- * Extension for each MIME the upload path accepts. Only used to NAME a file
- * that arrived without a usable name — never to re-type one that has an
- * extension already.
- */
-const EXT_BY_MIME = new Map<string, string>([
-  ["application/pdf", "pdf"],
-  ["image/jpeg", "jpg"],
-  ["image/png", "png"],
-  ["image/webp", "webp"],
-  ["image/gif", "gif"],
-  ["image/heic", "heic"],
-  ["image/heif", "heif"],
-  ["text/vcard", "vcf"],
-  ["text/x-vcard", "vcf"],
-  ["text/plain", "txt"],
-  ["text/csv", "csv"],
-  ["text/markdown", "md"],
-  ["application/json", "json"],
-  ["text/yaml", "yaml"],
-]);
-
-/**
- * Stems that carry no information about the file. Browsers produce these for
- * anything pasted from the clipboard or dragged out of a viewer.
- */
-const GENERIC_STEMS = new Set(["blob", "upload", "image", "download", "file", "untitled"]);
-
-/** Strip a trailing " (n)" collision suffix: "blob (17)" -> "blob". */
-function stripCollisionSuffix(stem: string): string {
-  return stem.replace(/ \(\d+\)$/, "");
-}
-
-/**
- * Give an upload a name worth having (heypinchy/pinchy#1199).
- *
- * A browser hands us `blob` for a pasted or dragged file — no extension, no
- * hint of content. On one production agent's workspace that was 68 of 253
- * files, and identifying each one costs a `pinchy_read` against a vision model
- * on a context that is already under pressure. `pinchy_ls` is close to useless
- * on such a listing, and so is asking the user "did you send me that receipt".
- *
- * Two narrow rules, both driven by the VALIDATED mime (the truth about the
- * bytes, known by the time this runs):
- *
- *  - a generic stem is replaced with a dated one, so a listing sorts and reads
- *    meaningfully;
- *  - a missing extension is filled in, so the file opens.
- *
- * A stem the user chose is information and is kept. A present-but-wrong
- * extension is left alone: renaming a user-named file on a MIME mismatch is a
- * different (and lossy) decision from naming a file that has no name at all.
- *
- * `now` is a parameter rather than read here so the behaviour is testable
- * without freezing the clock.
- */
-export function meaningfulUploadName(safeName: string, validatedMime: string, now: Date): string {
-  const dot = safeName.lastIndexOf(".");
-  const hasExtension = dot > 0;
-  const rawStem = hasExtension ? safeName.slice(0, dot) : safeName;
-  const extension = hasExtension ? safeName.slice(dot + 1) : "";
-
-  const isGeneric = GENERIC_STEMS.has(stripCollisionSuffix(rawStem).toLowerCase());
-  if (!isGeneric && hasExtension) return safeName;
-
-  const mimeExtension = EXT_BY_MIME.get(validatedMime) ?? "bin";
-  if (!isGeneric) return `${rawStem}.${mimeExtension}`;
-
-  const day = now.toISOString().slice(0, 10);
-  return `upload-${day}.${hasExtension ? extension : mimeExtension}`;
-}
-
 export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
   "application/pdf",
   "image/jpeg",
@@ -173,6 +101,8 @@ export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
 // would silently accept uploads the agent cannot read. If a future task wires
 // an xlsx reader (mirroring docx-extract.ts), add the MIME here too and it
 // will automatically also become servable via SERVABLE_DELIVERED_MIMES.
+// It also needs an entry in EXT_BY_MIME below — the drift guard in
+// __tests__/lib/upload-validation.test.ts fails until it has one.
 
 // Text formats have no magic bytes, so fileTypeFromBuffer returns undefined.
 // These are validated by UTF-8 null-byte guard instead.
@@ -242,4 +172,127 @@ export async function validateUploadBuffer(buffer: Buffer, claimedMime: string):
     return claimedMime; // preserve legacy spelling only for the alias case
   }
   return detected.mime;
+}
+
+/**
+ * Extension for each MIME the upload path accepts. Only used to NAME a file
+ * that arrived without a usable name — never to re-type one that has an
+ * extension already.
+ *
+ * This mirrors ALLOWED_ATTACHMENT_MIMES ∪ ALLOWED_TEXT_MIMES, which is the
+ * shape AGENTS.md § "A Hand-Maintained List That Mirrors Code Will Be Wrong"
+ * is about — so the drift guard in __tests__/lib/upload-validation.test.ts
+ * pins it in both directions. That guard is what keeps the `?? "bin"` fallback
+ * in `meaningfulUploadName` unreachable from the route: without it, a MIME
+ * added to an allowlist and forgotten here would silently store every such
+ * upload as `upload-….bin`, with nothing red.
+ */
+export const EXT_BY_MIME = new Map<string, string>([
+  ["application/pdf", "pdf"],
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+  ["image/gif", "gif"],
+  ["image/heic", "heic"],
+  ["image/heif", "heif"],
+  ["text/vcard", "vcf"],
+  ["text/x-vcard", "vcf"],
+  ["text/plain", "txt"],
+  ["text/csv", "csv"],
+  ["text/markdown", "md"],
+  ["application/json", "json"],
+  ["text/yaml", "yaml"],
+]);
+
+/**
+ * Stems that carry no information about the file. Browsers produce these for
+ * anything pasted from the clipboard or dragged out of a viewer.
+ */
+const GENERIC_STEMS = new Set(["blob", "upload", "image", "download", "file", "untitled"]);
+
+/** Strip a trailing " (n)" collision suffix: "blob (17)" -> "blob". */
+function stripCollisionSuffix(stem: string): string {
+  return stem.replace(/ \(\d+\)$/, "");
+}
+
+/**
+ * Local wall-clock stamp for a generated name: `2026-08-20-1432`.
+ *
+ * Local, not UTC: the date is the only information a generated name carries,
+ * and `toISOString()` files an evening upload under tomorrow east of UTC —
+ * 23:30 in Vienna is already the next day in Zulu. The stamp should read like
+ * the day the person remembers sending the file.
+ *
+ * Minute-granular, not day-granular: the workspace in #1199 took 36 such
+ * uploads on one working day. A day-only stem collides for every one of them,
+ * so `buildNextFreeFilename` would hand back `upload-2026-08-20 (35).pdf` —
+ * structurally the `blob (17)` listing this exists to remove. Two uploads
+ * inside the same minute still collide; that is rare enough to leave to the
+ * collision suffix.
+ */
+function localStamp(now: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  return `${date}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+}
+
+/**
+ * Keep a generated name inside the limit `sanitizeFilename` enforces on the
+ * name it was built from. Adding an extension to an already-maximal stem would
+ * otherwise push the stored name past NAME_MAX and fail the `O_CREAT | O_EXCL`
+ * probe with ENAMETOOLONG — a 500 on a filename the route accepted before.
+ */
+function capLength(name: string): string {
+  if (name.length <= MAX_FILENAME_LEN) return name;
+  const dot = name.lastIndexOf(".");
+  const ext = dot > 0 ? name.slice(dot) : "";
+  return name.slice(0, MAX_FILENAME_LEN - ext.length) + ext;
+}
+
+/**
+ * Give an upload a name worth having (heypinchy/pinchy#1199).
+ *
+ * A browser hands us `blob` for a pasted or dragged file — no extension, no
+ * hint of content. On one production agent's workspace that was 68 of 253
+ * files, and identifying each one costs a `pinchy_read` against a vision model
+ * on a context that is already under pressure. `pinchy_ls` is close to useless
+ * on such a listing, and so is asking the user "did you send me that receipt".
+ *
+ * Two narrow rules, both driven by the VALIDATED mime (the truth about the
+ * bytes, known by the time this runs):
+ *
+ *  - a generic stem is replaced with a stamped one, so a listing sorts
+ *    chronologically and its entries can be told apart;
+ *  - a missing extension is filled in, so the file opens.
+ *
+ * A stem the user chose is information and is kept. A present-but-wrong
+ * extension on such a name is left alone: renaming a user-named file on a MIME
+ * mismatch is a different (and lossy) decision from naming a file that has no
+ * name at all. A GENERIC stem gets no such benefit of the doubt — its
+ * extension is taken from the validated MIME too, because the whole premise of
+ * that branch is that nothing the client sent about this name is worth
+ * keeping.
+ *
+ * `now` is a parameter rather than read here so the behaviour is testable
+ * without freezing the clock.
+ */
+export function meaningfulUploadName(safeName: string, validatedMime: string, now: Date): string {
+  const dot = safeName.lastIndexOf(".");
+  // A leading dot is a dotfile, not an extension; a trailing one leaves the
+  // extension empty. Treating either as an extension stores `upload-….` —
+  // a file with no extension, which is what this function exists to prevent.
+  const hasExtension = dot > 0 && dot < safeName.length - 1;
+  // Trailing dots are not part of a stem, and a name that is nothing but dots
+  // leaves an empty one — which is as uninformative as `blob` and is treated
+  // the same way.
+  const rawStem = (hasExtension ? safeName.slice(0, dot) : safeName).replace(/\.+$/, "");
+
+  const isGeneric =
+    rawStem === "" || GENERIC_STEMS.has(stripCollisionSuffix(rawStem).toLowerCase());
+  if (!isGeneric && hasExtension) return safeName;
+
+  const mimeExtension = EXT_BY_MIME.get(validatedMime) ?? "bin";
+  if (!isGeneric) return capLength(`${rawStem}.${mimeExtension}`);
+
+  return `upload-${localStamp(now)}.${mimeExtension}`;
 }

--- a/packages/web/src/lib/upload-validation.ts
+++ b/packages/web/src/lib/upload-validation.ts
@@ -80,6 +80,78 @@ export function sanitizeFilename(raw: string): string {
 //
 // text/vcard is ALSO listed in ALLOWED_TEXT_MIMES below; see isKnownMimeAlias
 // for why vCard lives in both allowlists.
+/**
+ * Extension for each MIME the upload path accepts. Only used to NAME a file
+ * that arrived without a usable name — never to re-type one that has an
+ * extension already.
+ */
+const EXT_BY_MIME = new Map<string, string>([
+  ["application/pdf", "pdf"],
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+  ["image/gif", "gif"],
+  ["image/heic", "heic"],
+  ["image/heif", "heif"],
+  ["text/vcard", "vcf"],
+  ["text/x-vcard", "vcf"],
+  ["text/plain", "txt"],
+  ["text/csv", "csv"],
+  ["text/markdown", "md"],
+  ["application/json", "json"],
+  ["text/yaml", "yaml"],
+]);
+
+/**
+ * Stems that carry no information about the file. Browsers produce these for
+ * anything pasted from the clipboard or dragged out of a viewer.
+ */
+const GENERIC_STEMS = new Set(["blob", "upload", "image", "download", "file", "untitled"]);
+
+/** Strip a trailing " (n)" collision suffix: "blob (17)" -> "blob". */
+function stripCollisionSuffix(stem: string): string {
+  return stem.replace(/ \(\d+\)$/, "");
+}
+
+/**
+ * Give an upload a name worth having (heypinchy/pinchy#1199).
+ *
+ * A browser hands us `blob` for a pasted or dragged file — no extension, no
+ * hint of content. On one production agent's workspace that was 68 of 253
+ * files, and identifying each one costs a `pinchy_read` against a vision model
+ * on a context that is already under pressure. `pinchy_ls` is close to useless
+ * on such a listing, and so is asking the user "did you send me that receipt".
+ *
+ * Two narrow rules, both driven by the VALIDATED mime (the truth about the
+ * bytes, known by the time this runs):
+ *
+ *  - a generic stem is replaced with a dated one, so a listing sorts and reads
+ *    meaningfully;
+ *  - a missing extension is filled in, so the file opens.
+ *
+ * A stem the user chose is information and is kept. A present-but-wrong
+ * extension is left alone: renaming a user-named file on a MIME mismatch is a
+ * different (and lossy) decision from naming a file that has no name at all.
+ *
+ * `now` is a parameter rather than read here so the behaviour is testable
+ * without freezing the clock.
+ */
+export function meaningfulUploadName(safeName: string, validatedMime: string, now: Date): string {
+  const dot = safeName.lastIndexOf(".");
+  const hasExtension = dot > 0;
+  const rawStem = hasExtension ? safeName.slice(0, dot) : safeName;
+  const extension = hasExtension ? safeName.slice(dot + 1) : "";
+
+  const isGeneric = GENERIC_STEMS.has(stripCollisionSuffix(rawStem).toLowerCase());
+  if (!isGeneric && hasExtension) return safeName;
+
+  const mimeExtension = EXT_BY_MIME.get(validatedMime) ?? "bin";
+  if (!isGeneric) return `${rawStem}.${mimeExtension}`;
+
+  const day = now.toISOString().slice(0, 10);
+  return `upload-${day}.${hasExtension ? extension : mimeExtension}`;
+}
+
 export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
   "application/pdf",
   "image/jpeg",


### PR DESCRIPTION
Fixes #1199.

## What was wrong

The upload route stored `file.name` as given. Browsers hand us `blob` for anything pasted from the clipboard or dragged out of a viewer — no extension, no hint of content.

On one production agent's workspace that is **68 of 253 files**: `blob`, `blob (1)`, … `blob (17)`, `upload (19)`. Identifying each one costs a `pinchy_read` against a vision model, on a context that is already under pressure — 36 such reads on a single working day. `pinchy_ls` is close to useless on that listing, and so is asking the user "did you send me that receipt".

## The fix

`meaningfulUploadName(safeName, validatedMime, now)` — two narrow rules, both driven by the **validated** MIME (the truth about the bytes, and already known at that point in the route):

| in | out |
| --- | --- |
| `blob` | `upload-2026-08-20-1432.pdf` |
| `blob (17)` | `upload-2026-08-20-1432.png` |
| `image.png` | `upload-2026-08-20-1432.png` |
| `Scan001` | `Scan001.pdf` |
| `Rechnung_919278810726.pdf` | unchanged |

A stem the user chose is information and is kept — `Scan001` only gains the extension that makes it open. A present-but-wrong extension **on such a name** is left alone: renaming a user-named file on a MIME mismatch is a different, and lossier, decision from naming a file that has no name at all. A generic stem gets no such benefit of the doubt — its extension comes from the validated MIME too, because the premise of that branch is that nothing the client sent about the name is worth keeping.

**The stamp carries the minute, not just the day.** A day-granular stem collides for every generic upload that day, so the 36-in-a-day workspace above would have got `upload-2026-08-20 (35).pdf` — the `blob (17)` listing under a new name, with the extension as the only real gain. It is also **local wall clock rather than `toISOString()`**: 23:30 in Vienna is already tomorrow in Zulu, and the date is the only information a generated name carries.

`now` is a parameter rather than read inside, so the behaviour is testable without freezing the clock — and the route takes one clock reading for the whole request, so the filename's day and the staging TTL cannot straddle midnight separately.

## Where it runs, and why there

After MIME validation (the extension is only trustworthy once the bytes are), and **before** `persistStagedUpload` — so the reserved `uploads/` slot, the DB row, the preview URL, the audit row and the path handed to the agent all carry the same name.

That agreement is the half that can silently come undone, because the agent is handed one of those and the user sees another. **The first round of this branch came undone at exactly that seam, one layer further out than the route test looks:** `addPendingUpload` kept only `response.id` and dropped `response.filename`, so the sent message carried `file.name`. `AttachmentPreview` builds `/api/agents/<id>/uploads/<filename>` from the name in the message, so a pasted screenshot probed a path that does not exist — five HEAD retries over three seconds, then a chip with no preview and the browser's placeholder as its label, until a history frame swapped the name under the user. Before this branch the two names were equal and the preview rendered, so the rename introduced it.

`PendingUpload.storedFilename` now carries the server's name through both the first attempt and the retry, and the unit test asserts the value `useMessagePartFile()` actually hands the preview — not the raw message.

## Guards

`EXT_BY_MIME` mirrors `ALLOWED_ATTACHMENT_MIMES ∪ ALLOWED_TEXT_MIMES`, and the `?? "bin"` fallback makes a gap **silent** — a MIME added to an allowlist and forgotten here would store every such upload as `upload-….bin`, with nothing red. That is the shape AGENTS.md § "A Hand-Maintained List That Mirrors Code Will Be Wrong" is about, so it has a bidirectional drift guard with a corpus floor, and the xlsx note (which previously said "add the MIME here too" and meant only the allowlist) points at it.

## Edge cases the rule now covers

- `blob.` — `dot > 0` is true for a trailing dot and slices out an **empty** extension, storing `upload-….`: a file with no extension, which is the outcome the function exists to prevent.
- `...` — `sanitizeFilename` lets it through (only `.` and `..` are reserved); a stem of nothing but dots is as uninformative as `blob` and is treated the same way.
- A 255-character extensionless name — `sanitizeFilename` caps at 255, and appending `.pdf` pushed the **stored** name past NAME_MAX. The `O_CREAT | O_EXCL` slot probe then failed with ENAMETOOLONG: an unhandled 500 on a name the route had just accepted.

## Verification

- 17 unit cases on the naming rule (+3 on the drift guard); 3 on the client's handling of the stored name; 1 route-level case on the wiring.
- Canary: reverting the one-line route change turns the `blob` route test red; restoring it turns it green. The client test was red with `['blob']` before its fix.
- `pnpm test`, `pnpm test:scripts` (1241), `tsc --noEmit -p tsconfig.typecheck.json`, `prettier --check .`, eslint (0 errors).
- `vitest --config vitest.integration.config.ts` against a real Postgres — `uploads-post.integration.test.ts` 10/10. Worth noting that this gate earned its keep: the audit-row `orderBy` added in review named `createdAt`, a column that does not exist (it is `timestamp`), and only the DB run caught it.
- Docs build, `check:anchors` (74 pages — this also proves the `#files-your-browser-doesnt-name` anchor resolves, apostrophe and all), `check:rendered`, `check:llms`.

## Judgement call worth flagging

`image.png` **is** renamed, along with `download.pdf`, `file.pdf`, `upload.pdf` and `untitled.pdf`. The extension is right but the stem says nothing, and a stamp is strictly more informative — a pasted screenshot is exactly the case this issue is about. If you would rather leave anything with a valid extension untouched, that is a one-line change to the generic-stem set, and the test that pins it says which behaviour is intended. The docs name this exception explicitly rather than leaving a reader to discover it on their own file.

## Out of scope

Deriving a name from the document's *content* (vendor + date, the way the manually-named files in that same workspace look) would be better still, and the vision read already happens. That is a bigger change with a different failure mode and is noted in the issue rather than attempted here.

## Docs

The `review-docs` pass found two passages that the change makes incomplete, and one that it does not touch:

- **`guides/file-uploads.mdx`** — the Security section said filenames are "sanitized", which stays true and is no longer the whole story. A reader whose pasted screenshot turns up under a different name than the one on their desktop had nothing to look it up with. Added a short subsection, which now also names which self-chosen names are the exception and says the chip, the agent and the workspace all use the stored name.
- **`guides/image-attachments.mdx`** — "the **original** file lands in `uploads/<filename>`". The claim is about the original *bytes* (the contrast is with the resized copy sent inline), so it is not false — but a pasted screenshot is precisely the case where `<filename>` now differs, and that page is about pasted images. One clause, linking to the above.
- **`concepts/attachments.mdx`** — "lands in the same `uploads/` folder … with a sanitized filename" describes the **email** path, which uses pinchy-email's own sanitizer and is untouched here. Left alone.

Reverse direction: nothing was removed or renamed, so there is no doc describing something the code no longer has.
